### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,79 @@
+name: Test
+
+on:
+  push:
+    branches: [ 'main', 'master' ]
+
+  pull_request:
+    branches: [ 'main', 'master' ]
+
+env:
+  IMG: quay.io/kuadrant/kuadrant-operator:${{ github.sha }}
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    strategy:
+      matrix:
+        go-version: [ 1.16.x ]
+        platform: [ ubuntu-latest ]
+    runs-on: ${{ matrix.platform }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make test
+        run: |
+          make test
+
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    env:
+      KIND_CLUSTER_NAME: kuadrant-test
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make docker-build
+        run: |
+          make docker-build
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          version: v0.11.0
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          wait: 120s
+      - name: Check cluster info
+        run: |
+          kubectl cluster-info dump
+      - name: Run make install
+        run: |
+          make install
+      - name: Load test image
+        run: |
+          kind load docker-image ${{ env.IMG }} --name ${{ env.KIND_CLUSTER_NAME }}
+      - name: Run make deploy
+        run: |
+          make deploy
+      - name: Wait for deployment
+        run: |
+          kubectl -n kuadrant-operator-system wait --timeout=300s --for=condition=Available deployments --all
+      # Note: This doesn't run any actual tests yet!
+      - name: Run make undeploy
+        run: |
+          make undeploy

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ all: build
 # http://linuxcommand.org/lc3_adv_awk.php
 
 help: ## Display this help.
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 ##@ Development
 
@@ -199,3 +199,6 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+# Include last to avoid changing MAKEFILE_LIST used above
+include ./make/*.mk

--- a/make/act.mk
+++ b/make/act.mk
@@ -1,0 +1,22 @@
+
+##@ GitHub Actions
+
+## Targets to help test GitHub Actions locally using act https://github.com/nektos/act
+
+ACT = $(shell pwd)/bin/act
+act: ## Download act locally if necessary.
+	$(call go-get-tool,$(ACT),github.com/nektos/act@latest)
+
+.PHONY: act-pull-request-jobs
+act-pull-request-jobs: act kind ## Run pull request jobs.
+	$(ACT) pull_request --privileged
+	$(KIND) delete cluster --name kuadrant-test
+
+.PHONY: act-test-unit-tests
+act-test-unit-tests: act ## Run unit tests job.
+	$(ACT) -j unit-tests
+
+.PHONY: act-test-integration-tests
+act-test-integration-tests: act kind ## Run integration tests job.
+	$(ACT) -j integration-tests --privileged
+	$(KIND) delete cluster --name kuadrant-test

--- a/make/kind.mk
+++ b/make/kind.mk
@@ -1,0 +1,27 @@
+
+##@ Kind
+
+## Targets to help install and use kind for development https://kind.sigs.k8s.io
+
+KIND = $(shell pwd)/bin/kind
+kind: ## Download kind locally if necessary.
+	$(call go-get-tool,$(KIND),sigs.k8s.io/kind@v0.11.1)
+
+KIND_CLUSTER_NAME = kuadrant-local
+
+.PHONY: kind-create-cluster
+kind-create-cluster: kind ## Create the "kuadrant-local" kind cluster.
+	$(KIND) create cluster --name $(KIND_CLUSTER_NAME)
+
+.PHONY: kind-delete-cluster
+kind-delete-cluster: ## Delete the "kuadrant-local" kind cluster.
+	$(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
+
+.PHONY: kind-create-kuadrant-cluster
+kind-create-kuadrant-cluster: export IMG := quay.io/kuadrant/kuadrant-operator:dev
+kind-create-kuadrant-cluster: kind-create-cluster ## Create a kind cluster with kuadrant deployed.
+	$(MAKE) docker-build
+	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)
+	$(MAKE) install
+	$(MAKE) deploy
+	kubectl -n kuadrant-operator-system wait --timeout=300s --for=condition=Available deployments --all


### PR DESCRIPTION
Test workflow tested here https://github.com/mikenairn/kuadrant-operator/actions/runs/1554995574

Added new make targets to help dev/test locally:
```
make help
...
GitHub Actions
  act                             Download act locally if necessary.
  act-pull-request-jobs           Run pull request jobs.
  act-test-unit-tests             Run unit tests job
  act-test-integration-tests      Run integration tests job

Kind
  kind                            Download kind locally if necessary.
  kind-create-cluster             Create the "kuadrant-local" kind cluster.
  kind-delete-cluster             Delete the "kuadrant-local" kind cluster.
  kind-create-kuadrant-cluster    Create a kind cluster with kuadrant deployed.
```