### PR TITLE
Add verify CI tests and SDK download

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ on:
     branches: [ 'main', 'master' ]
 
 env:
-  IMG: quay.io/kuadrant/kuadrant-operator:${{ github.sha }}
+  TEST_IMG: quay.io/kuadrant/kuadrant-operator:${{ github.sha }}
 
 jobs:
   unit-tests:
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run make docker-build
         run: |
-          make docker-build
+          make docker-build IMG=${{ env.TEST_IMG }}
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
@@ -66,7 +66,7 @@ jobs:
           make install
       - name: Load test image
         run: |
-          kind load docker-image ${{ env.IMG }} --name ${{ env.KIND_CLUSTER_NAME }}
+          kind load docker-image ${{ env.TEST_IMG }} --name ${{ env.KIND_CLUSTER_NAME }}
       - name: Run make deploy
         run: |
           make deploy
@@ -77,3 +77,48 @@ jobs:
       - name: Run make undeploy
         run: |
           make undeploy
+
+  verify-manifests:
+    name: Verify manifests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make verify-manifests
+        run: |
+          make verify-manifests
+
+  verify-bundle:
+    name: Verify bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make verify-bundle
+        run: |
+          make verify-bundle
+
+  verify-fmt:
+    name: Verify fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Run make verify-fmt
+        run: |
+          make verify-fmt

--- a/Makefile
+++ b/Makefile
@@ -144,12 +144,17 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
+OPERATOR_SDK_VERSION = v1.15.0
+operator-sdk: ## Download operator-sdk locally if necessary.
+	./utils/install-operator-sdk.sh $(OPERATOR_SDK) $(OPERATOR_SDK_VERSION)
+
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
+bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/make/act.mk
+++ b/make/act.mk
@@ -20,3 +20,18 @@ act-test-unit-tests: act ## Run unit tests job.
 act-test-integration-tests: act kind ## Run integration tests job.
 	$(ACT) -j integration-tests --privileged
 	$(KIND) delete cluster --name kuadrant-test
+
+.PHONY: act-test-verify-manifests
+act-test-verify-manifests: act kind ## Run verify manifests job.
+	$(ACT) -j verify-manifests
+	$(KIND) delete cluster --name kuadrant-test
+
+.PHONY: act-test-verify-bundle
+act-test-verify-bundle: act kind ## Run verify bundle job.
+	$(ACT) -j verify-bundle
+	$(KIND) delete cluster --name kuadrant-test
+
+.PHONY: act-test-verify-fmt
+act-test-verify-fmt: act kind ## Run verify fmt job.
+	$(ACT) -j verify-fmt
+	$(KIND) delete cluster --name kuadrant-test

--- a/make/verify.mk
+++ b/make/verify.mk
@@ -1,0 +1,18 @@
+
+##@ Verify
+
+## Targets to verify actions that generate/modify code have been executed and output committed
+
+.PHONY: verify-manifests
+verify-manifests: manifests ## Verify manifests update.
+	git diff --exit-code ./config
+	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./config)" ]
+
+.PHONY: verify-bundle
+verify-bundle: bundle ## Verify bundle update.
+	git diff --exit-code ./bundle
+	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle)" ]
+
+.PHONY: verify-fmt
+verify-fmt: fmt ## Verify fmt update.
+	git diff --exit-code ./api ./controllers

--- a/utils/install-operator-sdk.sh
+++ b/utils/install-operator-sdk.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Install a version of the operator sdk.
+# https://sdk.operatorframework.io/docs/installation/#install-from-github-release
+
+set -euo pipefail
+
+ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n "$(uname -m)" ;; esac)
+OS=$(uname | awk '{print tolower($0)}')
+OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${2}
+OPERATOR_SDK_DL_BINARY=${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
+
+if [ ! -f "$1" ]; then
+  TMP_DIR=$(mktemp -d)
+  cd $TMP_DIR
+
+  echo "Downloading $OPERATOR_SDK_DL_BINARY"
+  curl -sLO $OPERATOR_SDK_DL_BINARY
+  gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E
+  curl -sLO ${OPERATOR_SDK_DL_URL}/checksums.txt
+  curl -sLO ${OPERATOR_SDK_DL_URL}/checksums.txt.asc
+  gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify checksums.txt.asc
+  grep operator-sdk_${OS}_${ARCH} checksums.txt | sha256sum -c -
+  chmod +x operator-sdk_${OS}_${ARCH} && mv operator-sdk_${OS}_${ARCH} $1
+
+  rm -rf $TMP_DIR
+fi


### PR DESCRIPTION
Add verify-* make targets to check generate/modify code have been executed and output committed.
Add CI jobs to execute verify checks(verify-bundle, verify-manifests, verify-fmt)
Add script to install operator-sdk in repo ./bin directory, make targets updated accordingly.