### PR TITLE
Add istio dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,6 +64,9 @@ jobs:
       - name: Run make install
         run: |
           make install
+      - name: Run make istio-install
+        run: |
+          make istio-install
       - name: Load test image
         run: |
           kind load docker-image ${{ env.TEST_IMG }} --name ${{ env.KIND_CLUSTER_NAME }}
@@ -73,6 +76,9 @@ jobs:
       - name: Wait for deployment
         run: |
           kubectl -n kuadrant-system wait --timeout=300s --for=condition=Available deployments --all
+      - name: Run make istio-install-with-patch
+        run: |
+          make istio-install-with-patch
       # Note: This doesn't run any actual tests yet!
       - name: Run make undeploy
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,7 +72,7 @@ jobs:
           make deploy
       - name: Wait for deployment
         run: |
-          kubectl -n kuadrant-operator-system wait --timeout=300s --for=condition=Available deployments --all
+          kubectl -n kuadrant-system wait --timeout=300s --for=condition=Available deployments --all
       # Note: This doesn't run any actual tests yet!
       - name: Run make undeploy
         run: |

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -209,64 +209,6 @@ spec:
           - create
         serviceAccountName: kuadrant-operator-controller-manager
       deployments:
-      - name: kuadrant-operator-controller-manager
-        spec:
-          replicas: 1
-          selector:
-            matchLabels:
-              control-plane: controller-manager
-          strategy: {}
-          template:
-            metadata:
-              labels:
-                control-plane: controller-manager
-            spec:
-              containers:
-              - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources: {}
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
-                - --leader-elect
-                command:
-                - /manager
-                image: quay.io/kuadrant/kuadrant-operator:latest
-                livenessProbe:
-                  httpGet:
-                    path: /healthz
-                    port: 8081
-                  initialDelaySeconds: 15
-                  periodSeconds: 20
-                name: manager
-                readinessProbe:
-                  httpGet:
-                    path: /readyz
-                    port: 8081
-                  initialDelaySeconds: 5
-                  periodSeconds: 10
-                resources:
-                  limits:
-                    cpu: 200m
-                    memory: 100Mi
-                  requests:
-                    cpu: 100m
-                    memory: 20Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-              securityContext:
-                runAsNonRoot: true
-              serviceAccountName: kuadrant-operator-controller-manager
-              terminationGracePeriodSeconds: 10
       - name: kuadrant-controller-manager
         spec:
           replicas: 1
@@ -332,6 +274,64 @@ spec:
               - configMap:
                   name: kuadrant-manager-config
                 name: manager-config
+      - name: kuadrant-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources: {}
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                image: quay.io/kuadrant/kuadrant-operator:latest
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 100Mi
+                  requests:
+                    cpu: 100m
+                    memory: 20Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: kuadrant-operator-controller-manager
+              terminationGracePeriodSeconds: 10
       permissions:
       - rules:
         - apiGroups:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: kuadrant-operator-system
+namespace: kuadrant-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/dependencies/authorino/authorino.yaml
+++ b/config/dependencies/authorino/authorino.yaml
@@ -1,0 +1,14 @@
+apiVersion: operator.authorino.kuadrant.io/v1beta1
+kind: Authorino
+metadata:
+  name: authorino
+  namespace: kuadrant-system
+spec:
+  replicas: 1
+  clusterWide: false
+  listener:
+    tls:
+      enabled: false
+  oidcServer:
+    tls:
+      enabled: false

--- a/config/dependencies/controller/kustomization.template.yaml
+++ b/config/dependencies/controller/kustomization.template.yaml
@@ -1,2 +1,5 @@
 resources:
 - github.com/Kuadrant/kuadrant-controller/config/default?ref=${KUADRANT_CONTROLLER_GITREF}
+
+patchesStrategicMerge:
+  - delete-ns.yaml

--- a/config/dependencies/controller/kustomization.yaml
+++ b/config/dependencies/controller/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
 - github.com/Kuadrant/kuadrant-controller/config/default?ref=main
+
+patchesStrategicMerge:
+  - delete-ns.yaml

--- a/config/dependencies/istio/default-gateway.yaml
+++ b/config/dependencies/istio/default-gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: kuadrant-gateway
+  namespace: kuadrant-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"

--- a/config/dependencies/istio/patches/istio-externalProvider.yaml
+++ b/config/dependencies/istio/patches/istio-externalProvider.yaml
@@ -1,0 +1,9 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  meshConfig:
+    extensionProviders:
+      - name: "kuadrant-authorization"
+        envoyExtAuthzGrpc:
+          service: "authorino-authorino-authorization.kuadrant-system.svc.cluster.local"
+          port: 50051

--- a/config/dependencies/kustomization.yaml
+++ b/config/dependencies/kustomization.yaml
@@ -1,4 +1,4 @@
-namespace: kuadrant-operator-system
+namespace: kuadrant-system
 
 resources:
   - controller
@@ -6,6 +6,5 @@ resources:
   - limitador
 
 patchesStrategicMerge:
-  - controller/delete-ns.yaml
   - authorino/delete-ns.yaml
   - limitador/delete-ns.yaml

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -1,4 +1,4 @@
-namespace: kuadrant-operator-system
+namespace: kuadrant-system
 
 resources:
   - ../default

--- a/config/deploy/olm/kustomization.yaml
+++ b/config/deploy/olm/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: kuadrant-operator-system
+namespace: kuadrant-system
 
 resources:
 - namespace.yaml

--- a/config/deploy/olm/subscription.yaml
+++ b/config/deploy/olm/subscription.yaml
@@ -4,6 +4,6 @@ metadata:
   name: kuadrant
 spec:
   source: kuadrant-operator-catalog
-  sourceNamespace: kuadrant-operator-system
+  sourceNamespace: kuadrant-system
   name: kuadrant-operator
   channel: "alpha"

--- a/make/istio.mk
+++ b/make/istio.mk
@@ -1,0 +1,42 @@
+
+##@ Istio
+
+## Targets to help install and configure istio
+
+ISTIO_PATCHES_DIR = config/dependencies/istio/patches
+ISTIO_NAMESPACE = istio-system
+ISTIO_INSTALL_OPTIONS ?= --set profile=default \
+	--set values.gateways.istio-ingressgateway.autoscaleEnabled=false \
+	--set values.pilot.autoscaleEnabled=false \
+	--set values.global.istioNamespace=$(ISTIO_NAMESPACE)
+
+# istioctl tool
+ISTIOCTL=$(shell pwd)/bin/istioctl
+ISTIOVERSION = 1.12.1
+$(ISTIOCTL):
+	mkdir -p $(PROJECT_PATH)/bin
+	$(eval TMP := $(shell mktemp -d))
+	cd $(TMP); curl -sSL https://istio.io/downloadIstio | ISTIO_VERSION=$(ISTIOVERSION) sh -
+	cp $(TMP)/istio-$(ISTIOVERSION)/bin/istioctl ${ISTIOCTL}
+	-rm -rf $(TMP)
+
+.PHONY: istioctl
+istioctl: $(ISTIOCTL) ## Download istioctl locally if necessary.
+
+.PHONY: istio-install
+istio-install: istioctl ## Install istio.
+	$(ISTIOCTL) install -y $(ISTIO_INSTALL_OPTIONS)
+
+#Note: This target is here temporarily to aid dev/test of the operator. Eventually it will be the responsibility of the
+# operator itself to configure istio as part of the reconciliation of a kuadrant CR.
+.PHONY: istio-install-with-patch
+istio-install-with-patch: istioctl ## Install istio with patch to add authorino auth extension.
+	$(ISTIOCTL) install -y $(ISTIO_INSTALL_OPTIONS) -f $(ISTIO_PATCHES_DIR)/istio-externalProvider.yaml
+
+.PHONY: istio-uninstall
+istio-uninstall: istioctl ## Uninstall istio.
+	$(ISTIOCTL) x uninstall -y --purge
+
+.PHONY: istio-verify-install
+istio-verify-install: istioctl ## Verify istio installation.
+	$(ISTIOCTL) verify-install -i $(ISTIO_NAMESPACE)

--- a/make/kind.mk
+++ b/make/kind.mk
@@ -24,4 +24,4 @@ kind-create-kuadrant-cluster: kind-create-cluster ## Create a kind cluster with 
 	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)
 	$(MAKE) install
 	$(MAKE) deploy
-	kubectl -n kuadrant-operator-system wait --timeout=300s --for=condition=Available deployments --all
+	kubectl -n kuadrant-system wait --timeout=300s --for=condition=Available deployments --all

--- a/make/kind.mk
+++ b/make/kind.mk
@@ -19,9 +19,10 @@ kind-delete-cluster: ## Delete the "kuadrant-local" kind cluster.
 
 .PHONY: kind-create-kuadrant-cluster
 kind-create-kuadrant-cluster: export IMG := quay.io/kuadrant/kuadrant-operator:dev
-kind-create-kuadrant-cluster: kind-create-cluster ## Create a kind cluster with kuadrant deployed.
+kind-create-kuadrant-cluster: kind-create-cluster istio-install ## Create a kind cluster with kuadrant deployed.
 	$(MAKE) docker-build
 	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)
 	$(MAKE) install
 	$(MAKE) deploy
 	kubectl -n kuadrant-system wait --timeout=300s --for=condition=Available deployments --all
+	$(MAKE) istio-install-with-patch


### PR DESCRIPTION
**Update namespace to kuadrant-system**

Changes the default namespace from `kuadrant-operator-system` to `kuadrant-system`.  The kuadrant controller is currently hard coded to use `kuadrant-system` when creating resources, so using it here ensures all kuadrant resources end up in the same ns.  Will also make docs between the operator/controller/kuadrantcl repos more consistent.

**Add istio make commands**

Add istio makefile with targets to help install/uninstall istio using istoctl. The default is to install it in it's own namespace 
`istio-system` since this is more likely how it will be deployed in a real world scenario. The install is also using the `default` profile which installs an ingress controller into the istio namespace `istio-ingressgateway`. Any example port-forward commands need to point to this ingress service:

```
kubectl port-forward -n istio-system service/istio-ingressgateway 9080:80
```

A temporary patch for the istio install and make targets to configure a hard coded kuadrant/authorino setup for dev/test purposes is also added. These are triggered using seperate make targets `istio-install-with-patch` and `post-deploy-hacks` and will be removed once the operator itself has taken over the responsibility of creating/configuring these resources.

**Verification**

**Deploy no OLM:**
```
make kind-create-kuadrant-cluster
```
or 

**Deploy with OLM:**
```
make kind-create-cluster install-olm istio-install deploy-olm istio-install-with-patch
```

**Check deployment:**
Note: If you deployed via OLM there will be some additional deployments/pods in the kuadrant-system ns not listed here.

```
$ kubectl get deployments -n kuadrant-system
NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
authorino                               1/1     1            1           108s
authorino-operator-controller-manager   1/1     1            1           2m10s
kuadrant-controller-manager             1/1     1            1           2m10s
kuadrant-operator-controller-manager    1/1     1            1           2m10s
limitador-operator-controller-manager   1/1     1            1           2m10s
```

```
$ kubectl get pods -n kuadrant-system
NAME                                                     READY   STATUS    RESTARTS   AGE
authorino-5bfb56f59c-5xrrz                               1/1     Running   0          2m39s
authorino-operator-controller-manager-748fdd4494-cx9hf   2/2     Running   0          3m1s
kuadrant-controller-manager-5dbff54bdd-8w6p5             2/2     Running   0          3m1s
kuadrant-operator-controller-manager-9d9d56bcd-zlmw9     2/2     Running   0          3m1s
limitador-operator-controller-manager-584fd799fd-x84db   2/2     Running   0          3m1s
```

```
$ kubectl get deployments -n istio-system
NAME                   READY   UP-TO-DATE   AVAILABLE   AGE
istio-ingressgateway   1/1     1            1           3m55s
istiod                 1/1     1            1           4m41s
```

```
$ kubectl get gateways -n kuadrant-system
NAME               AGE
kuadrant-gateway   4m4s
```