### PR TITLE
Add image build GH action

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,137 @@
+name: Build Images
+
+on:
+  push:
+    branches: [ '*' ]
+    tags: [ '*' ]
+
+env:
+  IMG_TAGS: ${{ github.ref_name }}
+  IMG_REGISTRY_HOST: quay.io
+  IMG_REGISTRY_ORG: kuadrant
+  MAIN_BRANCH_NAME: main
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Add latest tag
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        id: add-latest-tag
+        run: |
+          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: kuadrant-operator
+          tags: ${{ env.IMG_TAGS }}
+          dockerfiles: |
+            ./Dockerfile
+      - name: Push Image
+        if: ${{ !env.ACT }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Print Image URL
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
+  build-bundle:
+    needs: build
+    name: Build Bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Add latest tag
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        id: add-latest-tag
+        run: |
+          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Run make bundle
+        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.ref_name }}
+      - name: Run make bundle (main)
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=latest VERSION=0.0.0
+      - name: Git diff
+        run: git diff
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: kuadrant-operator-bundle
+          tags: ${{ env.IMG_TAGS }}
+          dockerfiles: |
+            ./bundle.Dockerfile
+      - name: Push Image
+        if: ${{ !env.ACT }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Print Image URL
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
+  build-catalog:
+    name: Build Catalog
+    needs: [build, build-bundle]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Add latest tag
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        id: add-latest-tag
+        run: |
+          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Run make catalog-generate
+        if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=${{ github.ref_name }}
+      - name: Run make catalog-generate (main)
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=latest VERSION=0.0.0
+      - name: Git diff
+        run: git diff
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: kuadrant-operator-catalog
+          tags: ${{ env.IMG_TAGS }}
+          dockerfiles: |
+            ./index.Dockerfile
+      - name: Push Image
+        if: ${{ !env.ACT }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Print Image URL
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ testbin/*
 *.swp
 *.swo
 *~
+
+# ./bin/opm index add --generate output
+database/index.db
+index.Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ ORG ?= kuadrant
 IMAGE_TAG_BASE ?= $(REGISTRY)/$(ORG)/kuadrant-operator
 
 ifeq (0.0.0,$(VERSION))
-IMAGE_TAG = latest
+IMAGE_TAG ?= latest
 else
-IMAGE_TAG = v$(VERSION)
+IMAGE_TAG ?= v$(VERSION)
 endif
 
 # BUNDLE_IMG defines the image:tag used for the bundle.
@@ -281,6 +281,10 @@ endif
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
 	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+
+.PHONY: catalog-generate
+catalog-generate: opm ## Generate a catalog/index Dockerfile.
+	$(OPM) index add --generate --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push


### PR DESCRIPTION
Adds a GitHub action triggered on branch/tag creation that builds and pushes the operator, bundle and index images.

OLM Bundle version is always set to 0.0.0 for builds of 'main' branch.
Images built from the 'main' branch are also tagged as 'latest' and all images reference the 'latest' builds i.e. index(latest) ->
bundle(latest) -> operator(latest).

Tested here https://github.com/mikenairn/kuadrant-operator/actions

Example main branch build: https://github.com/mikenairn/kuadrant-operator/actions/runs/1778709855
Example tag build https://github.com/mikenairn/kuadrant-operator/actions/runs/1778795829