### PR TITLE
Update authorino kustomization

### DIFF
--- a/config/dependencies/authorino/kustomization.template.yaml
+++ b/config/dependencies/authorino/kustomization.template.yaml
@@ -1,4 +1,2 @@
 resources:
-- github.com/Kuadrant/authorino-operator/config/default?ref=${AUTHORINO_OPERATOR_GITREF}
-# The authorino CRDs/Roles also need to be included, but should eventually be included by the operator kustomization instead
-- github.com/Kuadrant/authorino/install?ref=main
+- github.com/Kuadrant/authorino-operator/config/deploy?ref=${AUTHORINO_OPERATOR_GITREF}

--- a/config/dependencies/authorino/kustomization.yaml
+++ b/config/dependencies/authorino/kustomization.yaml
@@ -1,4 +1,2 @@
 resources:
-- github.com/Kuadrant/authorino-operator/config/default?ref=main
-# The authorino CRDs/Roles also need to be included, but should eventually be included by the operator kustomization instead
-- github.com/Kuadrant/authorino/install?ref=main
+- github.com/Kuadrant/authorino-operator/config/deploy?ref=main


### PR DESCRIPTION
Authorino operator now has a deploy kustomization that includes the
authorino resources. This updates the dev deployment to use that instead
of explicitly including authorino resources.

Relates to https://github.com/Kuadrant/authorino-operator/pull/32