### PR TITLE
Updating tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.5)
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \
@@ -222,7 +222,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ rm -rf $$TMP_DIR ;\
 endef
 
 OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
-OPERATOR_SDK_VERSION = v1.15.0
+OPERATOR_SDK_VERSION = v1.22.0
 operator-sdk: ## Download operator-sdk locally if necessary.
 	./utils/install-operator-sdk.sh $(OPERATOR_SDK) $(OPERATOR_SDK_VERSION)
 

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=kuadrant-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.14.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: kuadrant-operator.v0.0.0
   namespace: placeholder
@@ -299,7 +299,9 @@ spec:
           - create
         serviceAccountName: kuadrant-operator-controller-manager
       deployments:
-      - name: kuadrant-operator-controller-manager
+      - label:
+          control-plane: controller-manager
+        name: kuadrant-operator-controller-manager
         spec:
           replicas: 1
           selector:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kuadrant-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.14.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/kuadrantcontrollermanifests/autogenerated/kuadrant-controller.yaml
+++ b/kuadrantcontrollermanifests/autogenerated/kuadrant-controller.yaml
@@ -21,10 +21,14 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -34,15 +38,24 @@ spec:
                 description: AuthSchemes are embedded Authorino's AuthConfigs
                 properties:
                   authorization:
-                    description: Authorization is the list of authorization policies. All policies in this list MUST evaluate to "true" for a request be successful in the authorization phase.
+                    description: Authorization is the list of authorization policies.
+                      All policies in this list MUST evaluate to "true" for a request
+                      be successful in the authorization phase.
                     items:
-                      description: 'Authorization policy to be enforced. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "opa", "json" or "kubernetes".'
+                      description: 'Authorization policy to be enforced. Apart from
+                        "name", one of the following parameters is required and only
+                        one of the following parameters is allowed: "opa", "json"
+                        or "kubernetes".'
                       properties:
                         cache:
-                          description: Caching options for the policy evaluation results when enforcing this config. Omit it to avoid caching policy evaluation results for this config.
+                          description: Caching options for the policy evaluation results
+                            when enforcing this config. Omit it to avoid caching policy
+                            evaluation results for this config.
                           properties:
                             key:
-                              description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                              description: Key used to store the entry in the cache.
+                                Cache entries from different metadata configs are
+                                stored and managed separately regardless of the key.
                               properties:
                                 value:
                                   description: Static value
@@ -51,13 +64,23 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             ttl:
                               default: 60
-                              description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
                               type: integer
                           required:
                           - key
@@ -66,11 +89,17 @@ spec:
                           description: JSON pattern matching authorization policy.
                           properties:
                             rules:
-                              description: The rules that must all evaluate to "true" for the request to be authorized.
+                              description: The rules that must all evaluate to "true"
+                                for the request to be authorized.
                               items:
                                 properties:
                                   operator:
-                                    description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                                    description: 'The binary operator to be applied
+                                      to the content fetched from the authorization
+                                      JSON, for comparison with "value". Possible
+                                      values are: "eq" (equal to), "neq" (not equal
+                                      to), "incl" (includes; for arrays), "excl" (excludes;
+                                      for arrays), "matches" (regex)'
                                     enum:
                                     - eq
                                     - neq
@@ -82,10 +111,16 @@ spec:
                                     description: Name of a named pattern
                                     type: string
                                   selector:
-                                    description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                                    description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                      The value is used to fetch content from the
+                                      input authorization JSON built by Authorino
+                                      along the identity and metadata phases.
                                     type: string
                                   value:
-                                    description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    description: The value of reference for the comparison
+                                      with the content fetched from the authorization
+                                      JSON. If used with the "matches" operator, the
+                                      value must compile to a valid Golang regex.
                                     type: string
                                 type: object
                               type: array
@@ -93,7 +128,8 @@ spec:
                           - rules
                           type: object
                         kubernetes:
-                          description: Kubernetes authorization policy based on `SubjectAccessReview` Path and Verb are inferred from the request.
+                          description: Kubernetes authorization policy based on `SubjectAccessReview`
+                            Path and Verb are inferred from the request.
                           properties:
                             groups:
                               description: Groups to test for.
@@ -101,10 +137,16 @@ spec:
                                 type: string
                               type: array
                             resourceAttributes:
-                              description: Use ResourceAttributes for checking permissions on Kubernetes resources If omitted, it performs a non-resource `SubjectAccessReview`, with verb and path inferred from the request.
+                              description: Use ResourceAttributes for checking permissions
+                                on Kubernetes resources If omitted, it performs a
+                                non-resource `SubjectAccessReview`, with verb and
+                                path inferred from the request.
                               properties:
                                 group:
-                                  description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                                  description: StaticOrDynamicValue is either a constant
+                                    static string value or a config for fetching a
+                                    value from a dynamic source (e.g. a path pattern
+                                    of authorization JSON)
                                   properties:
                                     value:
                                       description: Static value
@@ -113,12 +155,26 @@ spec:
                                       description: Dynamic value
                                       properties:
                                         authJSON:
-                                          description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                          description: 'Selector to fetch a value
+                                            from the authorization JSON. It can be
+                                            any path pattern to fetch from the authorization
+                                            JSON (e.g. ''context.request.http.host'')
+                                            or a string template with variable placeholders
+                                            that resolve to patterns (e.g. "Hello,
+                                            {auth.identity.name}!"). Any patterns
+                                            supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                            can be used. The following string modifiers
+                                            are available: @extract:{sep:" ",pos:0},
+                                            @replace{old:"",new:""}, @case:upper|lower,
+                                            and @base64:encode|decode.'
                                           type: string
                                       type: object
                                   type: object
                                 name:
-                                  description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                                  description: StaticOrDynamicValue is either a constant
+                                    static string value or a config for fetching a
+                                    value from a dynamic source (e.g. a path pattern
+                                    of authorization JSON)
                                   properties:
                                     value:
                                       description: Static value
@@ -127,12 +183,26 @@ spec:
                                       description: Dynamic value
                                       properties:
                                         authJSON:
-                                          description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                          description: 'Selector to fetch a value
+                                            from the authorization JSON. It can be
+                                            any path pattern to fetch from the authorization
+                                            JSON (e.g. ''context.request.http.host'')
+                                            or a string template with variable placeholders
+                                            that resolve to patterns (e.g. "Hello,
+                                            {auth.identity.name}!"). Any patterns
+                                            supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                            can be used. The following string modifiers
+                                            are available: @extract:{sep:" ",pos:0},
+                                            @replace{old:"",new:""}, @case:upper|lower,
+                                            and @base64:encode|decode.'
                                           type: string
                                       type: object
                                   type: object
                                 namespace:
-                                  description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                                  description: StaticOrDynamicValue is either a constant
+                                    static string value or a config for fetching a
+                                    value from a dynamic source (e.g. a path pattern
+                                    of authorization JSON)
                                   properties:
                                     value:
                                       description: Static value
@@ -141,12 +211,26 @@ spec:
                                       description: Dynamic value
                                       properties:
                                         authJSON:
-                                          description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                          description: 'Selector to fetch a value
+                                            from the authorization JSON. It can be
+                                            any path pattern to fetch from the authorization
+                                            JSON (e.g. ''context.request.http.host'')
+                                            or a string template with variable placeholders
+                                            that resolve to patterns (e.g. "Hello,
+                                            {auth.identity.name}!"). Any patterns
+                                            supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                            can be used. The following string modifiers
+                                            are available: @extract:{sep:" ",pos:0},
+                                            @replace{old:"",new:""}, @case:upper|lower,
+                                            and @base64:encode|decode.'
                                           type: string
                                       type: object
                                   type: object
                                 resource:
-                                  description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                                  description: StaticOrDynamicValue is either a constant
+                                    static string value or a config for fetching a
+                                    value from a dynamic source (e.g. a path pattern
+                                    of authorization JSON)
                                   properties:
                                     value:
                                       description: Static value
@@ -155,12 +239,26 @@ spec:
                                       description: Dynamic value
                                       properties:
                                         authJSON:
-                                          description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                          description: 'Selector to fetch a value
+                                            from the authorization JSON. It can be
+                                            any path pattern to fetch from the authorization
+                                            JSON (e.g. ''context.request.http.host'')
+                                            or a string template with variable placeholders
+                                            that resolve to patterns (e.g. "Hello,
+                                            {auth.identity.name}!"). Any patterns
+                                            supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                            can be used. The following string modifiers
+                                            are available: @extract:{sep:" ",pos:0},
+                                            @replace{old:"",new:""}, @case:upper|lower,
+                                            and @base64:encode|decode.'
                                           type: string
                                       type: object
                                   type: object
                                 subresource:
-                                  description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                                  description: StaticOrDynamicValue is either a constant
+                                    static string value or a config for fetching a
+                                    value from a dynamic source (e.g. a path pattern
+                                    of authorization JSON)
                                   properties:
                                     value:
                                       description: Static value
@@ -169,12 +267,26 @@ spec:
                                       description: Dynamic value
                                       properties:
                                         authJSON:
-                                          description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                          description: 'Selector to fetch a value
+                                            from the authorization JSON. It can be
+                                            any path pattern to fetch from the authorization
+                                            JSON (e.g. ''context.request.http.host'')
+                                            or a string template with variable placeholders
+                                            that resolve to patterns (e.g. "Hello,
+                                            {auth.identity.name}!"). Any patterns
+                                            supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                            can be used. The following string modifiers
+                                            are available: @extract:{sep:" ",pos:0},
+                                            @replace{old:"",new:""}, @case:upper|lower,
+                                            and @base64:encode|decode.'
                                           type: string
                                       type: object
                                   type: object
                                 verb:
-                                  description: StaticOrDynamicValue is either a constant static string value or a config for fetching a value from a dynamic source (e.g. a path pattern of authorization JSON)
+                                  description: StaticOrDynamicValue is either a constant
+                                    static string value or a config for fetching a
+                                    value from a dynamic source (e.g. a path pattern
+                                    of authorization JSON)
                                   properties:
                                     value:
                                       description: Static value
@@ -183,13 +295,26 @@ spec:
                                       description: Dynamic value
                                       properties:
                                         authJSON:
-                                          description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                          description: 'Selector to fetch a value
+                                            from the authorization JSON. It can be
+                                            any path pattern to fetch from the authorization
+                                            JSON (e.g. ''context.request.http.host'')
+                                            or a string template with variable placeholders
+                                            that resolve to patterns (e.g. "Hello,
+                                            {auth.identity.name}!"). Any patterns
+                                            supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                            can be used. The following string modifiers
+                                            are available: @extract:{sep:" ",pos:0},
+                                            @replace{old:"",new:""}, @case:upper|lower,
+                                            and @base64:encode|decode.'
                                           type: string
                                       type: object
                                   type: object
                               type: object
                             user:
-                              description: User to test for. If without "Groups", then is it interpreted as "What if User were not a member of any groups"
+                              description: User to test for. If without "Groups",
+                                then is it interpreted as "What if User were not a
+                                member of any groups"
                               properties:
                                 value:
                                   description: Static value
@@ -198,7 +323,16 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
@@ -207,27 +341,42 @@ spec:
                           type: object
                         metrics:
                           default: false
-                          description: Whether this authorization config should generate individual observability metrics
+                          description: Whether this authorization config should generate
+                            individual observability metrics
                           type: boolean
                         name:
-                          description: Name of the authorization policy. It can be used to refer to the resolved authorization object in other configs.
+                          description: Name of the authorization policy. It can be
+                            used to refer to the resolved authorization object in
+                            other configs.
                           type: string
                         opa:
                           description: Open Policy Agent (OPA) authorization policy.
                           properties:
                             allValues:
                               default: false
-                              description: Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline. Otherwise, only the default `allow` rule will be exposed. Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
+                              description: Returns the value of all Rego rules in
+                                the virtual document. Values can be read in subsequent
+                                evaluators/phases of the Auth Pipeline. Otherwise,
+                                only the default `allow` rule will be exposed. Returning
+                                all Rego rules can affect performance of OPA policies
+                                during reconciliation (policy precompile) and at runtime.
                               type: boolean
                             externalRegistry:
                               description: External registry of OPA policies.
                               properties:
                                 credentials:
-                                  description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                                  description: Defines where client credentials will
+                                    be passed in the request to the service. If omitted,
+                                    it defaults to client credentials passed in the
+                                    HTTP Authorization header and the "Bearer" prefix
+                                    expected prepended to the secret value.
                                   properties:
                                     in:
                                       default: authorization_header
-                                      description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                                      description: The location in the request where
+                                        client credentials shall be passed on requests
+                                        authenticating with this identity source/authentication
+                                        mode.
                                       enum:
                                       - authorization_header
                                       - custom_header
@@ -235,45 +384,81 @@ spec:
                                       - cookie
                                       type: string
                                     keySelector:
-                                      description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                                      description: Used in conjunction with the `in`
+                                        parameter. When used with `authorization_header`,
+                                        the value is the prefix of the client credentials
+                                        string, separated by a white-space, in the
+                                        HTTP Authorization header (e.g. "Bearer",
+                                        "Basic"). When used with `custom_header`,
+                                        `query` or `cookie`, the value is the name
+                                        of the HTTP header, query string parameter
+                                        or cookie key, respectively.
                                       type: string
                                   required:
                                   - keySelector
                                   type: object
                                 endpoint:
-                                  description: Endpoint of the HTTP external registry. The endpoint must respond with either plain/text or application/json content-type. In the latter case, the JSON returned in the body must include a path `result.raw`, where the raw Rego policy will be extracted from. This complies with the specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
+                                  description: Endpoint of the HTTP external registry.
+                                    The endpoint must respond with either plain/text
+                                    or application/json content-type. In the latter
+                                    case, the JSON returned in the body must include
+                                    a path `result.raw`, where the raw Rego policy
+                                    will be extracted from. This complies with the
+                                    specification of the OPA REST API (https://www.openpolicyagent.org/docs/latest/rest-api/#get-a-policy).
                                   type: string
                                 sharedSecretRef:
-                                  description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
+                                  description: Reference to a Secret key whose value
+                                    will be passed by Authorino in the request. The
+                                    HTTP service can use the shared secret to authenticate
+                                    the origin of the request.
                                   properties:
                                     key:
-                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
                                       type: string
                                     name:
-                                      description: The name of the secret in the Authorino's namespace to select from.
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
                                       type: string
                                   required:
                                   - key
                                   - name
                                   type: object
                                 ttl:
-                                  description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
                                   type: integer
                               type: object
                             inlineRego:
-                              description: Authorization policy as a Rego language document. The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed). The Rego document must NOT include the "package" declaration in line 1.
+                              description: Authorization policy as a Rego language
+                                document. The Rego document must include the "allow"
+                                condition, set by Authorino to "false" by default
+                                (i.e. requests are unauthorized unless changed). The
+                                Rego document must NOT include the "package" declaration
+                                in line 1.
                               type: string
                           type: object
                         priority:
                           default: 0
-                          description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                          description: Priority group of the config. All configs in
+                            the same priority group are evaluated concurrently; consecutive
+                            priority groups are evaluated sequentially.
                           type: integer
                         when:
-                          description: Conditions for Authorino to enforce this authorization policy. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                          description: Conditions for Authorino to enforce this authorization
+                            policy. If omitted, the config will be enforced for all
+                            requests. If present, all conditions must match for the
+                            config to be enforced; otherwise, the config will be skipped.
                           items:
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -285,10 +470,16 @@ spec:
                                 description: Name of a named pattern
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                  The value is used to fetch content from the input
+                                  authorization JSON built by Authorino along the
+                                  identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  JSON. If used with the "matches" operator, the value
+                                  must compile to a valid Golang regex.
                                 type: string
                             type: object
                           type: array
@@ -297,13 +488,16 @@ spec:
                       type: object
                     type: array
                   denyWith:
-                    description: Custom denial response codes, statuses and headers to override default 40x's.
+                    description: Custom denial response codes, statuses and headers
+                      to override default 40x's.
                     properties:
                       unauthenticated:
-                        description: Denial status customization when the request is unauthenticated.
+                        description: Denial status customization when the request
+                          is unauthenticated.
                         properties:
                           body:
-                            description: HTTP response body to override the default denial body.
+                            description: HTTP response body to override the default
+                              denial body.
                             properties:
                               value:
                                 description: Static value
@@ -312,18 +506,28 @@ spec:
                                 description: Dynamic value
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             type: object
                           code:
-                            description: HTTP status code to override the default denial status code.
+                            description: HTTP status code to override the default
+                              denial status code.
                             format: int64
                             maximum: 599
                             minimum: 300
                             type: integer
                           headers:
-                            description: HTTP response headers to override the default denial headers.
+                            description: HTTP response headers to override the default
+                              denial headers.
                             items:
                               properties:
                                 name:
@@ -336,7 +540,16 @@ spec:
                                   description: Dynamic value of the JSON property
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               required:
@@ -344,7 +557,8 @@ spec:
                               type: object
                             type: array
                           message:
-                            description: HTTP message to override the default denial message.
+                            description: HTTP message to override the default denial
+                              message.
                             properties:
                               value:
                                 description: Static value
@@ -353,16 +567,26 @@ spec:
                                 description: Dynamic value
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             type: object
                         type: object
                       unauthorized:
-                        description: Denial status customization when the request is unauthorized.
+                        description: Denial status customization when the request
+                          is unauthorized.
                         properties:
                           body:
-                            description: HTTP response body to override the default denial body.
+                            description: HTTP response body to override the default
+                              denial body.
                             properties:
                               value:
                                 description: Static value
@@ -371,18 +595,28 @@ spec:
                                 description: Dynamic value
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             type: object
                           code:
-                            description: HTTP status code to override the default denial status code.
+                            description: HTTP status code to override the default
+                              denial status code.
                             format: int64
                             maximum: 599
                             minimum: 300
                             type: integer
                           headers:
-                            description: HTTP response headers to override the default denial headers.
+                            description: HTTP response headers to override the default
+                              denial headers.
                             items:
                               properties:
                                 name:
@@ -395,7 +629,16 @@ spec:
                                   description: Dynamic value of the JSON property
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               required:
@@ -403,7 +646,8 @@ spec:
                               type: object
                             type: array
                           message:
-                            description: HTTP message to override the default denial message.
+                            description: HTTP message to override the default denial
+                              message.
                             properties:
                               value:
                                 description: Static value
@@ -412,21 +656,38 @@ spec:
                                 description: Dynamic value
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             type: object
                         type: object
                     type: object
                   hosts:
-                    description: The list of public host names of the services protected by this authentication/authorization scheme. Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.
+                    description: The list of public host names of the services protected
+                      by this authentication/authorization scheme. Authorino uses
+                      the requested host to lookup for the corresponding authentication/authorization
+                      configs to enforce.
                     items:
                       type: string
                     type: array
                   identity:
-                    description: List of identity sources/authentication modes. At least one config of this list MUST evaluate to a valid identity for a request to be successful in the identity verification phase.
+                    description: List of identity sources/authentication modes. At
+                      least one config of this list MUST evaluate to a valid identity
+                      for a request to be successful in the identity verification
+                      phase.
                     items:
-                      description: 'The identity source/authentication mode config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "oicd", "apiKey" or "kubernetes".'
+                      description: 'The identity source/authentication mode config.
+                        Apart from "name", one of the following parameters is required
+                        and only one of the following parameters is allowed: "oicd",
+                        "apiKey" or "kubernetes".'
                       properties:
                         anonymous:
                           type: object
@@ -434,21 +695,30 @@ spec:
                           properties:
                             allNamespaces:
                               default: false
-                              description: Whether Authorino should look for API key secrets in all namespaces or only in the same namespace of the AuthConfig. Enabling this option in namespaced Authorino instances has no effect.
+                              description: Whether Authorino should look for API key
+                                secrets in all namespaces or only in the same namespace
+                                of the AuthConfig. Enabling this option in namespaced
+                                Authorino instances has no effect.
                               type: boolean
                             labelSelectors:
                               additionalProperties:
                                 type: string
-                              description: The map of label selectors used by Authorino to match secrets from the cluster storing valid credentials to authenticate to this service
+                              description: The map of label selectors used by Authorino
+                                to match secrets from the cluster storing valid credentials
+                                to authenticate to this service
                               type: object
                           required:
                           - labelSelectors
                           type: object
                         cache:
-                          description: Caching options for the identity resolved when applying this config. Omit it to avoid caching identity objects for this config.
+                          description: Caching options for the identity resolved when
+                            applying this config. Omit it to avoid caching identity
+                            objects for this config.
                           properties:
                             key:
-                              description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                              description: Key used to store the entry in the cache.
+                                Cache entries from different metadata configs are
+                                stored and managed separately regardless of the key.
                               properties:
                                 value:
                                   description: Static value
@@ -457,23 +727,40 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             ttl:
                               default: 60
-                              description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
                               type: integer
                           required:
                           - key
                           type: object
                         credentials:
-                          description: Defines where client credentials are required to be passed in the request for this identity source/authentication mode. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the credentials value (token, API key, etc).
+                          description: Defines where client credentials are required
+                            to be passed in the request for this identity source/authentication
+                            mode. If omitted, it defaults to client credentials passed
+                            in the HTTP Authorization header and the "Bearer" prefix
+                            expected prepended to the credentials value (token, API
+                            key, etc).
                           properties:
                             in:
                               default: authorization_header
-                              description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                              description: The location in the request where client
+                                credentials shall be passed on requests authenticating
+                                with this identity source/authentication mode.
                               enum:
                               - authorization_header
                               - custom_header
@@ -481,13 +768,24 @@ spec:
                               - cookie
                               type: string
                             keySelector:
-                              description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                              description: Used in conjunction with the `in` parameter.
+                                When used with `authorization_header`, the value is
+                                the prefix of the client credentials string, separated
+                                by a white-space, in the HTTP Authorization header
+                                (e.g. "Bearer", "Basic"). When used with `custom_header`,
+                                `query` or `cookie`, the value is the name of the
+                                HTTP header, query string parameter or cookie key,
+                                respectively.
                               type: string
                           required:
                           - keySelector
                           type: object
                         extendedProperties:
-                          description: Extends the resolved identity object with additional custom properties before appending to the authorization JSON. It requires the resolved identity object to always be of the JSON type 'object'. Other JSON types (array, string, etc) will break.
+                          description: Extends the resolved identity object with additional
+                            custom properties before appending to the authorization
+                            JSON. It requires the resolved identity object to always
+                            be of the JSON type 'object'. Other JSON types (array,
+                            string, etc) will break.
                           items:
                             properties:
                               name:
@@ -500,7 +798,15 @@ spec:
                                 description: Dynamic value of the JSON property
                                 properties:
                                   authJSON:
-                                    description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                    description: 'Selector to fetch a value from the
+                                      authorization JSON. It can be any path pattern
+                                      to fetch from the authorization JSON (e.g. ''context.request.http.host'')
+                                      or a string template with variable placeholders
+                                      that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                      can be used. The following string modifiers
+                                      are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                      @case:upper|lower, and @base64:encode|decode.'
                                     type: string
                                 type: object
                             required:
@@ -510,32 +816,47 @@ spec:
                         kubernetes:
                           properties:
                             audiences:
-                              description: The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino. If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
+                              description: The list of audiences (scopes) that must
+                                be claimed in a Kubernetes authentication token supplied
+                                in the request, and reviewed by Authorino. If omitted,
+                                Authorino will review tokens expecting the host name
+                                of the requested protected service amongst the audiences.
                               items:
                                 type: string
                               type: array
                           type: object
                         metrics:
                           default: false
-                          description: Whether this identity config should generate individual observability metrics
+                          description: Whether this identity config should generate
+                            individual observability metrics
                           type: boolean
                         name:
-                          description: The name of this identity source/authentication mode. It usually identifies a source of identities or group of users/clients of the protected service. It can be used to refer to the resolved identity object in other configs.
+                          description: The name of this identity source/authentication
+                            mode. It usually identifies a source of identities or
+                            group of users/clients of the protected service. It can
+                            be used to refer to the resolved identity object in other
+                            configs.
                           type: string
                         oauth2:
                           properties:
                             credentialsRef:
-                              description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the OAuth2 server.
+                              description: Reference to a Kubernetes secret in the
+                                same namespace, that stores client credentials to
+                                the OAuth2 server.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                             tokenIntrospectionUrl:
-                              description: The full URL of the token introspection endpoint.
+                              description: The full URL of the token introspection
+                                endpoint.
                               type: string
                             tokenTypeHint:
-                              description: The token type hint for the token introspection. If omitted, it defaults to "access_token".
+                              description: The token type hint for the token introspection.
+                                If omitted, it defaults to "access_token".
                               type: string
                           required:
                           - credentialsRef
@@ -544,24 +865,42 @@ spec:
                         oidc:
                           properties:
                             endpoint:
-                              description: Endpoint of the OIDC issuer. Authorino will append to this value the well-known path to the OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"), used to automatically discover the OpenID Connect configuration, whose set of claims is expected to include (among others) the "jkws_uri" claim. The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
+                              description: Endpoint of the OIDC issuer. Authorino
+                                will append to this value the well-known path to the
+                                OpenID Connect discovery endpoint (i.e. "/.well-known/openid-configuration"),
+                                used to automatically discover the OpenID Connect
+                                configuration, whose set of claims is expected to
+                                include (among others) the "jkws_uri" claim. The value
+                                must coincide with the value of  the "iss" (issuer)
+                                claim of the discovered OpenID Connect configuration.
                               type: string
                             ttl:
-                              description: Decides how long to wait before refreshing the OIDC configuration (in seconds).
+                              description: Decides how long to wait before refreshing
+                                the OIDC configuration (in seconds).
                               type: integer
                           required:
                           - endpoint
                           type: object
                         priority:
                           default: 0
-                          description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                          description: Priority group of the config. All configs in
+                            the same priority group are evaluated concurrently; consecutive
+                            priority groups are evaluated sequentially.
                           type: integer
                         when:
-                          description: Conditions for Authorino to enforce this identity config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                          description: Conditions for Authorino to enforce this identity
+                            config. If omitted, the config will be enforced for all
+                            requests. If present, all conditions must match for the
+                            config to be enforced; otherwise, the config will be skipped.
                           items:
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -573,10 +912,16 @@ spec:
                                 description: Name of a named pattern
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                  The value is used to fetch content from the input
+                                  authorization JSON built by Authorino along the
+                                  identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  JSON. If used with the "matches" operator, the value
+                                  must compile to a valid Golang regex.
                                 type: string
                             type: object
                           type: array
@@ -585,15 +930,22 @@ spec:
                       type: object
                     type: array
                   metadata:
-                    description: List of metadata source configs. Authorino fetches JSON content from sources on this list on every request.
+                    description: List of metadata source configs. Authorino fetches
+                      JSON content from sources on this list on every request.
                     items:
-                      description: 'The metadata config. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "http", userInfo" or "uma".'
+                      description: 'The metadata config. Apart from "name", one of
+                        the following parameters is required and only one of the following
+                        parameters is allowed: "http", userInfo" or "uma".'
                       properties:
                         cache:
-                          description: Caching options for the external metadata fetched when applying this config. Omit it to avoid caching metadata from this source.
+                          description: Caching options for the external metadata fetched
+                            when applying this config. Omit it to avoid caching metadata
+                            from this source.
                           properties:
                             key:
-                              description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                              description: Key used to store the entry in the cache.
+                                Cache entries from different metadata configs are
+                                stored and managed separately regardless of the key.
                               properties:
                                 value:
                                   description: Static value
@@ -602,22 +954,36 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             ttl:
                               default: 60
-                              description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
                               type: integer
                           required:
                           - key
                           type: object
                         http:
-                          description: Generic HTTP interface to obtain authorization metadata from a HTTP service.
+                          description: Generic HTTP interface to obtain authorization
+                            metadata from a HTTP service.
                           properties:
                             bodyParameters:
-                              description: Custom parameters to encode in the body of the HTTP request. Use it with method=POST; for GET requests, specify parameters using placeholders in the endpoint.
+                              description: Custom parameters to encode in the body
+                                of the HTTP request. Use it with method=POST; for
+                                GET requests, specify parameters using placeholders
+                                in the endpoint.
                               items:
                                 properties:
                                   name:
@@ -630,7 +996,17 @@ spec:
                                     description: Dynamic value of the JSON property
                                     properties:
                                       authJSON:
-                                        description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                        description: 'Selector to fetch a value from
+                                          the authorization JSON. It can be any path
+                                          pattern to fetch from the authorization
+                                          JSON (e.g. ''context.request.http.host'')
+                                          or a string template with variable placeholders
+                                          that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following string modifiers
+                                          are available: @extract:{sep:" ",pos:0},
+                                          @replace{old:"",new:""}, @case:upper|lower,
+                                          and @base64:encode|decode.'
                                         type: string
                                     type: object
                                 required:
@@ -645,11 +1021,17 @@ spec:
                               - application/json
                               type: string
                             credentials:
-                              description: Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                              description: Defines where client credentials will be
+                                passed in the request to the service. If omitted,
+                                it defaults to client credentials passed in the HTTP
+                                Authorization header and the "Bearer" prefix expected
+                                prepended to the secret value.
                               properties:
                                 in:
                                   default: authorization_header
-                                  description: The location in the request where client credentials shall be passed on requests authenticating with this identity source/authentication mode.
+                                  description: The location in the request where client
+                                    credentials shall be passed on requests authenticating
+                                    with this identity source/authentication mode.
                                   enum:
                                   - authorization_header
                                   - custom_header
@@ -657,13 +1039,24 @@ spec:
                                   - cookie
                                   type: string
                                 keySelector:
-                                  description: Used in conjunction with the `in` parameter. When used with `authorization_header`, the value is the prefix of the client credentials string, separated by a white-space, in the HTTP Authorization header (e.g. "Bearer", "Basic"). When used with `custom_header`, `query` or `cookie`, the value is the name of the HTTP header, query string parameter or cookie key, respectively.
+                                  description: Used in conjunction with the `in` parameter.
+                                    When used with `authorization_header`, the value
+                                    is the prefix of the client credentials string,
+                                    separated by a white-space, in the HTTP Authorization
+                                    header (e.g. "Bearer", "Basic"). When used with
+                                    `custom_header`, `query` or `cookie`, the value
+                                    is the name of the HTTP header, query string parameter
+                                    or cookie key, respectively.
                                   type: string
                               required:
                               - keySelector
                               type: object
                             endpoint:
-                              description: Endpoint of the HTTP service. The endpoint accepts variable placeholders in the format "{selector}", where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={context.request.http.path}
+                              description: Endpoint of the HTTP service. The endpoint
+                                accepts variable placeholders in the format "{selector}",
+                                where "selector" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                and selects value from the authorization JSON. E.g.
+                                https://ext-auth-server.io/metadata?p={context.request.http.path}
                               type: string
                             headers:
                               description: Custom headers in the HTTP request.
@@ -679,7 +1072,17 @@ spec:
                                     description: Dynamic value of the JSON property
                                     properties:
                                       authJSON:
-                                        description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                        description: 'Selector to fetch a value from
+                                          the authorization JSON. It can be any path
+                                          pattern to fetch from the authorization
+                                          JSON (e.g. ''context.request.http.host'')
+                                          or a string template with variable placeholders
+                                          that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following string modifiers
+                                          are available: @extract:{sep:" ",pos:0},
+                                          @replace{old:"",new:""}, @case:upper|lower,
+                                          and @base64:encode|decode.'
                                         type: string
                                     type: object
                                 required:
@@ -687,19 +1090,27 @@ spec:
                                 type: object
                               type: array
                             method:
-                              description: 'HTTP verb used in the request to the service. Accepted values: GET (default), POST. When the request method is POST, the authorization JSON is passed in the body of the request.'
+                              description: 'HTTP verb used in the request to the service.
+                                Accepted values: GET (default), POST. When the request
+                                method is POST, the authorization JSON is passed in
+                                the body of the request.'
                               enum:
                               - GET
                               - POST
                               type: string
                             sharedSecretRef:
-                              description: Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request.
+                              description: Reference to a Secret key whose value will
+                                be passed by Authorino in the request. The HTTP service
+                                can use the shared secret to authenticate the origin
+                                of the request.
                               properties:
                                 key:
-                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
                                   type: string
                                 name:
-                                  description: The name of the secret in the Authorino's namespace to select from.
+                                  description: The name of the secret in the Authorino's
+                                    namespace to select from.
                                   type: string
                               required:
                               - key
@@ -710,47 +1121,71 @@ spec:
                           type: object
                         metrics:
                           default: false
-                          description: Whether this metadata config should generate individual observability metrics
+                          description: Whether this metadata config should generate
+                            individual observability metrics
                           type: boolean
                         name:
-                          description: The name of the metadata source. It can be used to refer to the resolved metadata object in other configs.
+                          description: The name of the metadata source. It can be
+                            used to refer to the resolved metadata object in other
+                            configs.
                           type: string
                         priority:
                           default: 0
-                          description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                          description: Priority group of the config. All configs in
+                            the same priority group are evaluated concurrently; consecutive
+                            priority groups are evaluated sequentially.
                           type: integer
                         uma:
-                          description: User-Managed Access (UMA) source of resource data.
+                          description: User-Managed Access (UMA) source of resource
+                            data.
                           properties:
                             credentialsRef:
-                              description: Reference to a Kubernetes secret in the same namespace, that stores client credentials to the resource registration API of the UMA server.
+                              description: Reference to a Kubernetes secret in the
+                                same namespace, that stores client credentials to
+                                the resource registration API of the UMA server.
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                   type: string
                               type: object
                             endpoint:
-                              description: The endpoint of the UMA server. The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
+                              description: The endpoint of the UMA server. The value
+                                must coincide with the "issuer" claim of the UMA config
+                                discovered from the well-known uma configuration endpoint.
                               type: string
                           required:
                           - credentialsRef
                           - endpoint
                           type: object
                         userInfo:
-                          description: OpendID Connect UserInfo linked to an OIDC identity config of this same spec.
+                          description: OpendID Connect UserInfo linked to an OIDC
+                            identity config of this same spec.
                           properties:
                             identitySource:
-                              description: The name of an OIDC identity source included in the "identity" section and whose OpenID Connect configuration discovered includes the OIDC "userinfo_endpoint" claim.
+                              description: The name of an OIDC identity source included
+                                in the "identity" section and whose OpenID Connect
+                                configuration discovered includes the OIDC "userinfo_endpoint"
+                                claim.
                               type: string
                           required:
                           - identitySource
                           type: object
                         when:
-                          description: Conditions for Authorino to apply this metadata config. If omitted, the config will be applied for all requests. If present, all conditions must match for the config to be applied; otherwise, the config will be skipped.
+                          description: Conditions for Authorino to apply this metadata
+                            config. If omitted, the config will be applied for all
+                            requests. If present, all conditions must match for the
+                            config to be applied; otherwise, the config will be skipped.
                           items:
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -762,10 +1197,16 @@ spec:
                                 description: Name of a named pattern
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                  The value is used to fetch content from the input
+                                  authorization JSON built by Authorino along the
+                                  identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  JSON. If used with the "matches" operator, the value
+                                  must compile to a valid Golang regex.
                                 type: string
                             type: object
                           type: array
@@ -778,7 +1219,11 @@ spec:
                       items:
                         properties:
                           operator:
-                            description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                            description: 'The binary operator to be applied to the
+                              content fetched from the authorization JSON, for comparison
+                              with "value". Possible values are: "eq" (equal to),
+                              "neq" (not equal to), "incl" (includes; for arrays),
+                              "excl" (excludes; for arrays), "matches" (regex)'
                             enum:
                             - eq
                             - neq
@@ -787,25 +1232,40 @@ spec:
                             - matches
                             type: string
                           selector:
-                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                            description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                              The value is used to fetch content from the input authorization
+                              JSON built by Authorino along the identity and metadata
+                              phases.
                             type: string
                           value:
-                            description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            description: The value of reference for the comparison
+                              with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must
+                              compile to a valid Golang regex.
                             type: string
                         type: object
                       type: array
-                    description: Named sets of JSON patterns that can be referred in `when` conditionals and in JSON-pattern matching policy rules.
+                    description: Named sets of JSON patterns that can be referred
+                      in `when` conditionals and in JSON-pattern matching policy rules.
                     type: object
                   response:
-                    description: List of response configs. Authorino gathers data from the auth pipeline to build custom responses for the client.
+                    description: List of response configs. Authorino gathers data
+                      from the auth pipeline to build custom responses for the client.
                     items:
-                      description: 'Dynamic response to return to the client. Apart from "name", one of the following parameters is required and only one of the following parameters is allowed: "wristband" or "json".'
+                      description: 'Dynamic response to return to the client. Apart
+                        from "name", one of the following parameters is required and
+                        only one of the following parameters is allowed: "wristband"
+                        or "json".'
                       properties:
                         cache:
-                          description: Caching options for dynamic responses built when applying this config. Omit it to avoid caching dynamic responses for this config.
+                          description: Caching options for dynamic responses built
+                            when applying this config. Omit it to avoid caching dynamic
+                            responses for this config.
                           properties:
                             key:
-                              description: Key used to store the entry in the cache. Cache entries from different metadata configs are stored and managed separately regardless of the key.
+                              description: Key used to store the entry in the cache.
+                                Cache entries from different metadata configs are
+                                stored and managed separately regardless of the key.
                               properties:
                                 value:
                                   description: Static value
@@ -814,13 +1274,23 @@ spec:
                                   description: Dynamic value
                                   properties:
                                     authJSON:
-                                      description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                      description: 'Selector to fetch a value from
+                                        the authorization JSON. It can be any path
+                                        pattern to fetch from the authorization JSON
+                                        (e.g. ''context.request.http.host'') or a
+                                        string template with variable placeholders
+                                        that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                        can be used. The following string modifiers
+                                        are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""},
+                                        @case:upper|lower, and @base64:encode|decode.'
                                       type: string
                                   type: object
                               type: object
                             ttl:
                               default: 60
-                              description: Duration (in seconds) of the external data in the cache before pulled again from the source.
+                              description: Duration (in seconds) of the external data
+                                in the cache before pulled again from the source.
                               type: integer
                           required:
                           - key
@@ -828,7 +1298,8 @@ spec:
                         json:
                           properties:
                             properties:
-                              description: List of JSON property-value pairs to be added to the dynamic response.
+                              description: List of JSON property-value pairs to be
+                                added to the dynamic response.
                               items:
                                 properties:
                                   name:
@@ -841,7 +1312,17 @@ spec:
                                     description: Dynamic value of the JSON property
                                     properties:
                                       authJSON:
-                                        description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                        description: 'Selector to fetch a value from
+                                          the authorization JSON. It can be any path
+                                          pattern to fetch from the authorization
+                                          JSON (e.g. ''context.request.http.host'')
+                                          or a string template with variable placeholders
+                                          that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following string modifiers
+                                          are available: @extract:{sep:" ",pos:0},
+                                          @replace{old:"",new:""}, @case:upper|lower,
+                                          and @base64:encode|decode.'
                                         type: string
                                     type: object
                                 required:
@@ -853,21 +1334,34 @@ spec:
                           type: object
                         metrics:
                           default: false
-                          description: Whether this response config should generate individual observability metrics
+                          description: Whether this response config should generate
+                            individual observability metrics
                           type: boolean
                         name:
-                          description: Name of the custom response. It can be used to refer to the resolved response object in other configs.
+                          description: Name of the custom response. It can be used
+                            to refer to the resolved response object in other configs.
                           type: string
                         priority:
                           default: 0
-                          description: Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                          description: Priority group of the config. All configs in
+                            the same priority group are evaluated concurrently; consecutive
+                            priority groups are evaluated sequentially.
                           type: integer
                         when:
-                          description: Conditions for Authorino to enforce this custom response config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                          description: Conditions for Authorino to enforce this custom
+                            response config. If omitted, the config will be enforced
+                            for all requests. If present, all conditions must match
+                            for the config to be enforced; otherwise, the config will
+                            be skipped.
                           items:
                             properties:
                               operator:
-                                description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                                description: 'The binary operator to be applied to
+                                  the content fetched from the authorization JSON,
+                                  for comparison with "value". Possible values are:
+                                  "eq" (equal to), "neq" (not equal to), "incl" (includes;
+                                  for arrays), "excl" (excludes; for arrays), "matches"
+                                  (regex)'
                                 enum:
                                 - eq
                                 - neq
@@ -879,27 +1373,40 @@ spec:
                                 description: Name of a named pattern
                                 type: string
                               selector:
-                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                                description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                                  The value is used to fetch content from the input
+                                  authorization JSON built by Authorino along the
+                                  identity and metadata phases.
                                 type: string
                               value:
-                                description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                description: The value of reference for the comparison
+                                  with the content fetched from the authorization
+                                  JSON. If used with the "matches" operator, the value
+                                  must compile to a valid Golang regex.
                                 type: string
                             type: object
                           type: array
                         wrapper:
                           default: httpHeader
-                          description: How Authorino wraps the response. Use "httpHeader" (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata" to wrap the response as Envoy Dynamic Metadata
+                          description: How Authorino wraps the response. Use "httpHeader"
+                            (default) to wrap the response in an HTTP header; or "envoyDynamicMetadata"
+                            to wrap the response as Envoy Dynamic Metadata
                           enum:
                           - httpHeader
                           - envoyDynamicMetadata
                           type: string
                         wrapperKey:
-                          description: The name of key used in the wrapped response (name of the HTTP header or property of the Envoy Dynamic Metadata JSON). If omitted, it will be set to the name of the configuration.
+                          description: The name of key used in the wrapped response
+                            (name of the HTTP header or property of the Envoy Dynamic
+                            Metadata JSON). If omitted, it will be set to the name
+                            of the configuration.
                           type: string
                         wristband:
                           properties:
                             customClaims:
-                              description: Any claims to be added to the wristband token apart from the standard JWT claims (iss, iat, exp) added by default.
+                              description: Any claims to be added to the wristband
+                                token apart from the standard JWT claims (iss, iat,
+                                exp) added by default.
                               items:
                                 properties:
                                   name:
@@ -912,7 +1419,17 @@ spec:
                                     description: Dynamic value of the JSON property
                                     properties:
                                       authJSON:
-                                        description: 'Selector to fetch a value from the authorization JSON. It can be any path pattern to fetch from the authorization JSON (e.g. ''context.request.http.host'') or a string template with variable placeholders that resolve to patterns (e.g. "Hello, {auth.identity.name}!"). Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following string modifiers are available: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, and @base64:encode|decode.'
+                                        description: 'Selector to fetch a value from
+                                          the authorization JSON. It can be any path
+                                          pattern to fetch from the authorization
+                                          JSON (e.g. ''context.request.http.host'')
+                                          or a string template with variable placeholders
+                                          that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any patterns supported by https://pkg.go.dev/github.com/tidwall/gjson
+                                          can be used. The following string modifiers
+                                          are available: @extract:{sep:" ",pos:0},
+                                          @replace{old:"",new:""}, @case:upper|lower,
+                                          and @base64:encode|decode.'
                                         type: string
                                     type: object
                                 required:
@@ -920,14 +1437,20 @@ spec:
                                 type: object
                               type: array
                             issuer:
-                              description: 'The endpoint to the Authorino service that issues the wristband (format: <scheme>://<host>:<port>/<realm>, where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                              description: 'The endpoint to the Authorino service
+                                that issues the wristband (format: <scheme>://<host>:<port>/<realm>,
+                                where <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
                               type: string
                             signingKeyRefs:
-                              description: Reference by name to Kubernetes secrets and corresponding signing algorithms. The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                              description: Reference by name to Kubernetes secrets
+                                and corresponding signing algorithms. The secrets
+                                must contain a `key.pem` entry whose value is the
+                                signing key formatted as PEM.
                               items:
                                 properties:
                                   algorithm:
-                                    description: Algorithm to sign the wristband token using the signing key provided
+                                    description: Algorithm to sign the wristband token
+                                      using the signing key provided
                                     enum:
                                     - ES256
                                     - ES384
@@ -937,7 +1460,10 @@ spec:
                                     - RS512
                                     type: string
                                   name:
-                                    description: Name of the signing key. The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                    description: Name of the signing key. The value
+                                      is used to reference the Kubernetes secret that
+                                      stores the key and in the `kid` claim of the
+                                      wristband token header.
                                     type: string
                                 required:
                                 - algorithm
@@ -957,11 +1483,19 @@ spec:
                       type: object
                     type: array
                   when:
-                    description: Conditions for the AuthConfig to be enforced. If omitted, the AuthConfig will be enforced for all requests. If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns immediately with status OK.
+                    description: Conditions for the AuthConfig to be enforced. If
+                      omitted, the AuthConfig will be enforced for all requests. If
+                      present, all conditions must match for the AuthConfig to be
+                      enforced; otherwise, Authorino skips the AuthConfig and returns
+                      immediately with status OK.
                     items:
                       properties:
                         operator:
-                          description: 'The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value". Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)'
+                          description: 'The binary operator to be applied to the content
+                            fetched from the authorization JSON, for comparison with
+                            "value". Possible values are: "eq" (equal to), "neq" (not
+                            equal to), "incl" (includes; for arrays), "excl" (excludes;
+                            for arrays), "matches" (regex)'
                           enum:
                           - eq
                           - neq
@@ -973,10 +1507,16 @@ spec:
                           description: Name of a named pattern
                           type: string
                         selector:
-                          description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson. The value is used to fetch content from the input authorization JSON built by Authorino along the identity and metadata phases.
+                          description: Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson.
+                            The value is used to fetch content from the input authorization
+                            JSON built by Authorino along the identity and metadata
+                            phases.
                           type: string
                         value:
-                          description: The value of reference for the comparison with the content fetched from the authorization JSON. If used with the "matches" operator, the value must compile to a valid Golang regex.
+                          description: The value of reference for the comparison with
+                            the content fetched from the authorization JSON. If used
+                            with the "matches" operator, the value must compile to
+                            a valid Golang regex.
                           type: string
                       type: object
                     type: array
@@ -984,7 +1524,8 @@ spec:
                 - hosts
                 type: object
               rules:
-                description: Rule describe the requests that will be routed to external authorization provider
+                description: Rule describe the requests that will be routed to external
+                  authorization provider
                 items:
                   properties:
                     hosts:
@@ -1021,7 +1562,10 @@ spec:
                     minLength: 1
                     type: string
                   namespace:
-                    description: Namespace is the namespace of the referent. When unspecified, the local namespace is inferred. Even when policy targets a resource in a different namespace, it MUST only apply to traffic originating from the same namespace as the policy.
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1037,25 +1581,47 @@ spec:
           status:
             properties:
               conditions:
-                description: 'Represents the observations of a foo''s current state. Known .status.conditions.type are: "Available"'
+                description: 'Represents the observations of a foo''s current state.
+                  Known .status.conditions.type are: "Available"'
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1068,7 +1634,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1084,7 +1654,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               observedGeneration:
-                description: ObservedGeneration reflects the generation of the most recently observed spec.
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
                 format: int64
                 type: integer
             type: object
@@ -1124,158 +1695,40 @@ spec:
         description: RateLimitPolicy is the Schema for the ratelimitpolicies API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
             description: RateLimitPolicySpec defines the desired state of RateLimitPolicy
             properties:
-              domain:
-                type: string
-              limits:
-                items:
-                  description: RateLimitSpec defines the desired state of RateLimit
-                  properties:
-                    conditions:
-                      items:
-                        type: string
-                      type: array
-                    max_value:
-                      type: integer
-                    namespace:
-                      type: string
-                    seconds:
-                      type: integer
-                    variables:
-                      items:
-                        type: string
-                      type: array
-                  required:
-                  - conditions
-                  - max_value
-                  - namespace
-                  - seconds
-                  - variables
-                  type: object
-                type: array
               rateLimits:
+                description: RateLimits holds the list of rate limit configurations
                 items:
+                  description: RateLimit represents a complete rate limit configuration
                   properties:
-                    actions:
+                    configurations:
+                      description: Configurations holds list of (action) configuration.
                       items:
-                        description: Action_Specifier defines one envoy rate limit action
-                        oneOf:
-                        - required:
-                          - generic_key
-                        - required:
-                          - metadata
-                        - required:
-                          - remote_address
-                        - required:
-                          - request_headers
-                        properties:
-                          generic_key:
-                            properties:
-                              descriptor_key:
-                                type: string
-                              descriptor_value:
-                                type: string
-                            required:
-                            - descriptor_value
-                            type: object
-                          metadata:
-                            properties:
-                              default_value:
-                                type: string
-                              descriptor_key:
-                                type: string
-                              metadata_key:
-                                properties:
-                                  key:
-                                    type: string
-                                  path:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                      required:
-                                      - key
-                                      type: object
-                                    type: array
-                                required:
-                                - key
-                                - path
-                                type: object
-                              source:
-                                description: MetadataSource https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-enum-config-route-v3-ratelimit-action-metadata-source
-                                enum:
-                                - DYNAMIC
-                                - ROUTE_ENTRY
-                                type: string
-                            required:
-                            - descriptor_key
-                            - metadata_key
-                            type: object
-                          remote_address:
-                            description: RemoteAddressSpec no need to specify descriptor entry is populated using the trusted address from [x-forwarded-for](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#config-http-conn-man-headers-x-forwarded-for)
-                            type: object
-                          request_headers:
-                            description: RequestHeadersSpec Rate limit on request headers.
-                            properties:
-                              descriptor_key:
-                                type: string
-                              header_name:
-                                type: string
-                              skip_if_absent:
-                                type: boolean
-                            required:
-                            - descriptor_key
-                            - header_name
-                            type: object
-                        type: object
-                      type: array
-                    stage:
-                      description: 'Definfing phase at which rate limits will be applied. Valid values are: PREAUTH, POSTAUTH, BOTH'
-                      enum:
-                      - PREAUTH
-                      - POSTAUTH
-                      - BOTH
-                      type: string
-                  required:
-                  - stage
-                  type: object
-                type: array
-              rules:
-                items:
-                  properties:
-                    name:
-                      description: Name supports regex for fetching operations from routing resources For VirtualService, if route name matches, all the match requests are converted to operations internally. But specific match request names are also supported.
-                      type: string
-                    operations:
-                      description: Operation specifies the operations of a request
-                      items:
-                        description: Each operation type has OR semantics and overall AND semantics for a match.
-                        properties:
-                          methods:
-                            items:
-                              type: string
-                            type: array
-                          paths:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      type: array
-                    rateLimits:
-                      items:
+                        description: Configuration represents an action configuration.
+                          The equivalent of [config.route.v3.RateLimit](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-ratelimit)
+                          envoy object. Each action configuration produces, at most,
+                          one descriptor. Depending on the incoming request, one configuration
+                          may or may not produce a rate limit descriptor.
                         properties:
                           actions:
+                            description: Actions holds list of action specifiers.
+                              Each action specifier can only define one action type.
                             items:
-                              description: Action_Specifier defines one envoy rate limit action
+                              description: Action_Specifier defines one envoy rate
+                                limit action
                               oneOf:
                               - required:
                                 - generic_key
@@ -1308,10 +1761,15 @@ spec:
                                         path:
                                           items:
                                             properties:
-                                              key:
-                                                type: string
+                                              segment:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                required:
+                                                - key
+                                                type: object
                                             required:
-                                            - key
+                                            - segment
                                             type: object
                                           type: array
                                       required:
@@ -1319,7 +1777,7 @@ spec:
                                       - path
                                       type: object
                                     source:
-                                      description: MetadataSource https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-enum-config-route-v3-ratelimit-action-metadata-source
+                                      default: DYNAMIC
                                       enum:
                                       - DYNAMIC
                                       - ROUTE_ENTRY
@@ -1329,10 +1787,13 @@ spec:
                                   - metadata_key
                                   type: object
                                 remote_address:
-                                  description: RemoteAddressSpec no need to specify descriptor entry is populated using the trusted address from [x-forwarded-for](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#config-http-conn-man-headers-x-forwarded-for)
+                                  description: RemoteAddressSpec no need to specify
+                                    descriptor entry is populated using the trusted
+                                    address from [x-forwarded-for](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#config-http-conn-man-headers-x-forwarded-for)
                                   type: object
                                 request_headers:
-                                  description: RequestHeadersSpec Rate limit on request headers.
+                                  description: RequestHeadersSpec Rate limit on request
+                                    headers.
                                   properties:
                                     descriptor_key:
                                       type: string
@@ -1346,17 +1807,62 @@ spec:
                                   type: object
                               type: object
                             type: array
-                          stage:
-                            description: 'Definfing phase at which rate limits will be applied. Valid values are: PREAUTH, POSTAUTH, BOTH'
-                            enum:
-                            - PREAUTH
-                            - POSTAUTH
-                            - BOTH
-                            type: string
                         required:
-                        - stage
+                        - actions
                         type: object
                       type: array
+                    limits:
+                      description: Limits holds a list of Limitador limits
+                      items:
+                        description: Limit represents partially a Limitador limit.
+                        properties:
+                          conditions:
+                            items:
+                              type: string
+                            type: array
+                          maxValue:
+                            type: integer
+                          seconds:
+                            type: integer
+                          variables:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - conditions
+                        - maxValue
+                        - seconds
+                        - variables
+                        type: object
+                      type: array
+                    rules:
+                      description: Rules represents the definition of the scope of
+                        the rate limit object Defines a list of conditions for which
+                        rate limit configuration will apply Matching occurs when at
+                        least one rule applies against the incoming request. If rules
+                        are not set, or empty, it is equivalent to matching all the
+                        requests.
+                      items:
+                        description: Rule defines a single condition for the rate
+                          limit configuration All defined fields within the rule must
+                          be met to have a rule match
+                        properties:
+                          hosts:
+                            items:
+                              type: string
+                            type: array
+                          methods:
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                  required:
+                  - configurations
                   type: object
                 type: array
               targetRef:
@@ -1379,7 +1885,10 @@ spec:
                     minLength: 1
                     type: string
                   namespace:
-                    description: Namespace is the namespace of the referent. When unspecified, the local namespace is inferred. Even when policy targets a resource in a different namespace, it MUST only apply to traffic originating from the same namespace as the policy.
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
                     maxLength: 63
                     minLength: 1
                     pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
@@ -1390,32 +1899,53 @@ spec:
                 - name
                 type: object
             required:
-            - domain
             - targetRef
             type: object
           status:
             description: RateLimitPolicyStatus defines the observed state of RateLimitPolicy
             properties:
               conditions:
-                description: 'Represents the observations of a foo''s current state. Known .status.conditions.type are: "Available"'
+                description: 'Represents the observations of a foo''s current state.
+                  Known .status.conditions.type are: "Available"'
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1428,7 +1958,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1444,7 +1978,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               observedGeneration:
-                description: ObservedGeneration reflects the generation of the most recently observed spec.
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
                 format: int64
                 type: integer
             type: object
@@ -1603,7 +2138,7 @@ rules:
 - apiGroups:
   - limitador.kuadrant.io
   resources:
-  - ratelimits
+  - limitadors
   verbs:
   - create
   - delete

--- a/utils/install-operator-sdk.sh
+++ b/utils/install-operator-sdk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Install a version of the operator sdk.
 # https://sdk.operatorframework.io/docs/installation/#install-from-github-release


### PR DESCRIPTION
This PR bumps the versions of Kustomize and Operator SDK. It also replaces the go command `go get` by `go install` since the later is the recommended way to build and install packages in module mode, the project go.mod will stay intact. As a bonus, will update the manifests and bundle to solve the current check fail.