### PR TITLE
Providing required permissions

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -121,6 +121,18 @@ spec:
           - update
           - watch
         - apiGroups:
+          - authorino.kuadrant.io
+          resources:
+          - authconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - coordination.k8s.io
           resources:
           - configmaps
@@ -148,12 +160,28 @@ spec:
           - update
           - watch
         - apiGroups:
+          - extensions.istio.io
+          resources:
+          - wasmplugins
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - gateway.networking.k8s.io
           resources:
           - gateways
           verbs:
+          - create
+          - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - gateway.networking.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -91,6 +91,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - authorino.kuadrant.io
+  resources:
+  - authconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - configmaps
@@ -118,12 +130,28 @@ rules:
   - update
   - watch
 - apiGroups:
+  - extensions.istio.io
+  resources:
+  - wasmplugins
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - gateway.networking.k8s.io
   resources:
   - gateways
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - gateway.networking.k8s.io

--- a/controllers/kuadrant_controller.go
+++ b/controllers/kuadrant_controller.go
@@ -77,6 +77,9 @@ type KuadrantReconciler struct {
 //+kubebuilder:rbac:groups="networking.istio.io",resources=gateways,verbs=get;list;watch
 //+kubebuilder:rbac:groups="security.istio.io",resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=operator.authorino.kuadrant.io,resources=authorinos,verbs=get;list;watch;create;update;delete;patch
+//+kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;delete;patch
+//+kubebuilder:rbac:groups=extensions.istio.io,resources=wasmplugins,verbs=get;list;watch;create;update;delete;patch
+//+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gateways,verbs=get;list;watch;create;update;delete;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
The Kuadrant Controller (control plane) requires more permissions after some changes that makes it possible to manage wasmplugins, authconfigs and gateway obj... which makes the Operator kuadrant controller permissions not enough. This PR addresses the situation giving the required permissions.