### PR TITLE
wasm shim image from env var

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -338,6 +338,9 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
+                env:
+                - name: RELATED_IMAGE_WASMSHIM
+                  value: oci://quay.io/kuadrant/wasm-shim:latest
                 image: quay.io/kuadrant/kuadrant-operator:latest
                 livenessProbe:
                   httpGet:
@@ -433,4 +436,7 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
+  relatedImages:
+  - image: oci://quay.io/kuadrant/wasm-shim:latest
+    name: wasmshim
   version: 0.0.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,6 +29,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        env:
+        - name: RELATED_IMAGE_WASMSHIM
+          value: "oci://quay.io/kuadrant/wasm-shim:latest"
         image: controller:latest
         name: manager
         securityContext:

--- a/controllers/kuadrant_controller.go
+++ b/controllers/kuadrant_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	authorinov1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
@@ -405,6 +406,8 @@ func (r *KuadrantReconciler) createOnlyInKuadrantNSCb(ctx context.Context, kObj 
 				obj.Spec.Template.Spec.Containers[0].Env,
 				v1.EnvVar{Name: envLimitadorNamespace, Value: kObj.Namespace},
 				v1.EnvVar{Name: envLimitadorName, Value: limitadorName},
+				// env var name taken from https://github.com/Kuadrant/kuadrant-controller/blob/4e9763bbabc8a7b5f7695aa4f53d9edc0c376ba3/pkg/rlptools/wasm_utils.go#L18
+				v1.EnvVar{Name: "WASM_FILTER_IMAGE", Value: common.GetWASMShimImageVersion()},
 			)
 			newObj = obj
 		// TODO: DRY the following 2 case switches

--- a/pkg/common/wasm_shim_image.go
+++ b/pkg/common/wasm_shim_image.go
@@ -1,0 +1,10 @@
+package common
+
+const (
+	DEFAULT_WASMSHIM_IMAGE_VERSION = "oci://quay.io/kuadrant/wasm-shim:latest"
+	WASM_SHIM_IMAGE_ENV_NAME       = "RELATED_IMAGE_WASMSHIM"
+)
+
+func GetWASMShimImageVersion() string {
+	return FetchEnv(WASM_SHIM_IMAGE_ENV_NAME, DEFAULT_WASMSHIM_IMAGE_VERSION)
+}


### PR DESCRIPTION
### what

In order to pin the wasm shim image from the manifest bundle, the image needs to be exposed in the manifests and read from an env var by the controller

Additionally, the operator configures the kuadrant core controller (aka kuadrant-controller) with the `WASM_FILTER_IMAGE` env var.

### verification steps

run dev env

```
make kind-create-kuadrant-cluster
```

Create kuadrant CR

```yaml
k apply -f - <<EOF
---
apiVersion: kuadrant.kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
spec: {}
EOF
```
Check that the kuadrant core controller has the wasm shim image url specified in the deployment object

```yaml
k get deployments kuadrant-controller-manager -o jsonpath='{.spec.template.spec.containers[].env}' | yq_pretty
- name: LIMITADOR_NAMESPACE
  value: default
- name: LIMITADOR_NAME
  value: limitador
- name: WASM_FILTER_IMAGE
  value: oci://quay.io/kuadrant/wasm-shim:latest
```



