### PR TITLE
reduce dev env resource requirements

### DIFF
--- a/config/dependencies/istio/istio-operator.yaml
+++ b/config/dependencies/istio/istio-operator.yaml
@@ -18,8 +18,16 @@ spec:
     ingressGateways:
       - enabled: true
         name: istio-ingressgateway
+        k8s:
+          resources:
+            requests:
+              cpu: "0"
     pilot:
       enabled: true
+      k8s:
+        resources:
+          requests:
+            cpu: "0"
   values:
     pilot:
       autoscaleEnabled: false


### PR DESCRIPTION
### what

GH action hosts have 2 cores. When running kind cluster, k8s and istio cpu requests are 1600 mCores, so there is only 400 mCores left for kuadrant. That's too few. Hence, reducing istio cpu requests requirements to have more room for kuadrant resources.