### PR TITLE
Change codeowners to team engineering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
 # Global owners
-*       @eguzki
-*       @didierofrivia
-*       @guicassolato
-*       @alexsnaps
+*       @Kuadrant/engineering


### PR DESCRIPTION
To make it possible to anyone from the team to approve PRs