### PR TITLE
Only reconcile Authorino if Istio

### DIFF
--- a/controllers/kuadrant_controller.go
+++ b/controllers/kuadrant_controller.go
@@ -299,10 +299,6 @@ func hasKuadrantAuthorizer(extensionProviders []*istiomeshv1alpha1.MeshConfig_Ex
 	//          service: AUTHORINO SERVICE
 	//        name: kuadrant-authorization
 
-	if len(extensionProviders) == 0 {
-		return false
-	}
-
 	for _, extensionProvider := range extensionProviders {
 		if extensionProvider.Name == extAuthorizerName {
 			return true

--- a/controllers/kuadrant_controller.go
+++ b/controllers/kuadrant_controller.go
@@ -258,16 +258,24 @@ func (r *KuadrantReconciler) registerExternalAuthorizer(ctx context.Context, kOb
 }
 
 func (r *KuadrantReconciler) reconcileSpec(ctx context.Context, kObj *kuadrantv1beta1.Kuadrant) (ctrl.Result, error) {
+	var reconcileAuthorino = true
+
 	if err := r.registerExternalAuthorizer(ctx, kObj); err != nil {
-		return ctrl.Result{}, err
+		if apierrors.IsNotFound(err) {
+			reconcileAuthorino = false
+		} else {
+			return ctrl.Result{}, err
+		}
 	}
 
 	if err := r.reconcileLimitador(ctx, kObj); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	if err := r.reconcileAuthorino(ctx, kObj); err != nil {
-		return ctrl.Result{}, err
+	if reconcileAuthorino {
+		if err := r.reconcileAuthorino(ctx, kObj); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
So I absolutely do not think this is the way to fix #103 on the long term, but this could help us make progress until we test OSSM

### What's wrong?

 - The `Status` needs to reflect this.
 - The `IstioOperator` could have disappeared, while an `Authorino` was already running… I don't even know what this means to be honest!
 - I wouldn't be surprised if this breaks more stuff… started with the tests 🤦 

### So what?!

We need to figure things out like these I think:

- [ ] Should it be lazy and only happen when a `Policy` requiring something appears? 
- [ ] Be lazy always, yet make sure we have all dependencies resolvable, and report on that? 
- [ ] Expose it through the CR as to what is lazily or eagerly deployed?
- [ ] Should for now add a way to disable auth and/or rl entirely?
- [ ] … Others? 
