### PR TITLE
Fix OLM install

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -122,7 +122,7 @@ jobs:
           image: kuadrant-operator-catalog
           tags: ${{ env.IMG_TAGS }}
           dockerfiles: |
-            ./index.Dockerfile
+            ./catalog.Dockerfile
       - name: Push Image
         if: ${{ !env.ACT }}
         id: push-to-quay

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -23,12 +23,17 @@ jobs:
         id: add-latest-tag
         run: |
           echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
           image: kuadrant-operator
           tags: ${{ env.IMG_TAGS }}
+          platforms: linux/amd64,linux/arm64
           dockerfiles: |
             ./Dockerfile
       - name: Push Image
@@ -69,12 +74,17 @@ jobs:
         run: make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=latest VERSION=0.0.0
       - name: Git diff
         run: git diff
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
           image: kuadrant-operator-bundle
           tags: ${{ env.IMG_TAGS }}
+          platforms: linux/amd64,linux/arm64
           dockerfiles: |
             ./bundle.Dockerfile
       - name: Push Image
@@ -115,12 +125,17 @@ jobs:
         run: make catalog-generate REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} IMAGE_TAG=latest VERSION=0.0.0
       - name: Git diff
         run: git diff
+      - name: Install qemu dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
           image: kuadrant-operator-catalog
           tags: ${{ env.IMG_TAGS }}
+          platforms: linux/amd64,linux/arm64
           dockerfiles: |
             ./catalog.Dockerfile
       - name: Push Image

--- a/Makefile
+++ b/Makefile
@@ -377,6 +377,11 @@ ifneq ($(origin CATALOG_BASE_IMG), undefined)
 FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
 endif
 
+PLATFORM_PARAM =
+ifeq ($(shell uname -sm),Darwin arm64)
+	PLATFORM_PARAM = --platform=linux/arm64
+endif
+
 # Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
 # This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
@@ -386,7 +391,7 @@ catalog-build: opm ## Build a catalog image.
 
 .PHONY: catalog-custom-build
 catalog-custom-build: ## Build the bundle image.
-	docker build -f catalog.Dockerfile -t $(CATALOG_IMG) .
+	docker build $(PLATFORM_PARAM) -f catalog.Dockerfile -t $(CATALOG_IMG) .
 
 
 .PHONY: catalog-generate

--- a/catalog.Dockerfile
+++ b/catalog.Dockerfile
@@ -1,0 +1,8 @@
+FROM quay.io/operator-framework/upstream-opm-builder
+LABEL operators.operatorframework.io.index.database.v1=/database/index.db
+ADD database/index.db /database/index.db
+RUN mkdir /registry && chmod 775 /registry
+EXPOSE 50051
+WORKDIR /registry
+ENTRYPOINT ["/bin/opm"]
+CMD ["registry", "serve", "--database", "/database/index.db"]


### PR DESCRIPTION
This PR provides a way to test Kuadrant OLM installation locally. It mitigates the issue https://github.com/operator-framework/operator-registry/issues/619 (among others). It mitigates the limitation building the catalog image with a custom Dockerfile granting specific permissions to the registry directory, until what's been discussed in https://hackmd.io/@of-olm/HJgJWEjsq#CatalogSource-Pods is finally applied or we migrate to file based catalogs (most probably) https://olm.operatorframework.io/docs/tasks/creating-a-catalog/. 

Note: Enabling the _PodSecurity_ feature in the  local Kind cluster  and labeling the namespace with `pod-security.kubernetes.io/enforce` labels didn't make any difference, the pod spawn by the _CatalogSource_ marks it with`allowPrivilegeEscalation: false` and there's no way around it.

**Verification Steps:**
1. Modify the CatalogSource image:
```sh
diff --git a/config/deploy/olm/catalogsource.yaml b/config/deploy/olm/catalogsource.yaml
index 0e65bac..32ef972 100644
--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,6 +4,6 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:latest
+  image: quay.io/kuadrant/kuadrant-operator-catalog:fix-olm-install
   displayName: Kuadrant Operators
   publisher: grpc
```

2. Run the new task to setup the OLM installation locally:
```sh
make local-olm-setup
```

3. When it finish installing, you should see the following deployments listed:

```sh
kubbectl get deployments -A
NAMESPACE            NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
istio-operator       istio-operator                          1/1     1            1           11m
istio-system         istio-ingressgateway                    1/1     1            1           10m
istio-system         istiod                                  1/1     1            1           10m
kuadrant-system      authorino-operator                      1/1     1            1           9m20s
kuadrant-system      kuadrant-operator-controller-manager    1/1     1            1           9m23s
kuadrant-system      limitador-operator-controller-manager   1/1     1            1           9m25s
kube-system          coredns                                 2/2     2            2           11m
local-path-storage   local-path-provisioner                  1/1     1            1           11m
olm                  catalog-operator                        1/1     1            1           10m
olm                  olm-operator                            1/1     1            1           10m
olm                  packageserver                           2/2     2            2           10m
```

This might solve https://github.com/Kuadrant/kuadrant-operator/issues/102 after the catalogs have been updated
BONUS: Now it's building linux amd64 and arm64 images