### PR TITLE
wasm shim image env var name does not match deployment var name

### DIFF
--- a/pkg/rlptools/wasm_utils.go
+++ b/pkg/rlptools/wasm_utils.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	WASMFilterImageURL = common.FetchEnv("WASM_FILTER_IMAGE", "oci://quay.io/kuadrant/wasm-shim:latest")
+	WASMFilterImageURL = common.FetchEnv("RELATED_IMAGE_WASMSHIM", "oci://quay.io/kuadrant/wasm-shim:latest")
 )
 
 type GatewayAction struct {


### PR DESCRIPTION
### What

Fixes https://github.com/Kuadrant/kuadrant-operator/issues/128

The deployment objects sets `RELATED_IMAGE_WASMSHIM`

```yaml
 env:                                                   
   - name: RELATED_IMAGE_WASMSHIM                         
     value: "oci://quay.io/kuadrant/wasm-shim:v0.1.0"     
 image: controller:latest                               
```

But the code *was* reading `WASM_FILTER_IMAGE`

### Verification Steps

run dev env

```
make local-env-setup
```

Run Operator's controllers with the env var name expected `RELATED_IMAGE_WASMSHIM`

```
RELATED_IMAGE_WASMSHIM=oci://quay.io/kuadrant/wasm-shim:v0.1.0 make run
```

Create kuadrant CR

```yaml
k apply -f - <<EOF
---
apiVersion: kuadrant.kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
spec: {}
EOF
```

Create some HTTPRoute and  RLP
```
k apply -f examples/toystore/httproute.yaml
k apply -f examples/toystore/ratelimitpolicy_httproute.yaml
```

Check wasmplugin for the wasm shim URL 

```
k get WasmPlugin -n istio-system kuadrant-istio-ingressgateway -o jsonpath="{.spec.url}" | yq e -P
oci://quay.io/kuadrant/wasm-shim:v0.1.0
```
It should be `oci://quay.io/kuadrant/wasm-shim:v0.1.0` instead of the *latest* `oci://quay.io/kuadrant/wasm-shim:latest`



