### PR TITLE
Release v0.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.0
+VERSION ?= 0.2.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -80,7 +80,7 @@ KUADRANT_NAMESPACE ?= kuadrant-system
 # Kuadrant component versions
 ## authorino
 #ToDo Pin this version once we have an initial release of authorino
-AUTHORINO_OPERATOR_VERSION ?= latest
+AUTHORINO_OPERATOR_VERSION ?= 0.5.0
 ifeq (latest,$(AUTHORINO_OPERATOR_VERSION))
 AUTHORINO_OPERATOR_BUNDLE_VERSION = 0.0.0
 AUTHORINO_OPERATOR_BUNDLE_IMG_TAG = latest
@@ -93,7 +93,7 @@ endif
 AUTHORINO_OPERATOR_BUNDLE_IMG ?= quay.io/kuadrant/authorino-operator-bundle:$(AUTHORINO_OPERATOR_BUNDLE_IMG_TAG)
 ## limitador
 #ToDo Pin this version once we have an initial release of limitador
-LIMITADOR_OPERATOR_VERSION ?= latest
+LIMITADOR_OPERATOR_VERSION ?= 0.4.0
 ifeq (latest,$(LIMITADOR_OPERATOR_VERSION))
 LIMITADOR_OPERATOR_BUNDLE_VERSION = 0.0.0
 LIMITADOR_OPERATOR_BUNDLE_IMG_TAG = latest

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -121,12 +121,12 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:latest
+    containerImage: quay.io/kuadrant/kuadrant-operator:v0.2.1
     operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v0.0.0
+  name: kuadrant-operator.v0.2.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -502,8 +502,8 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_WASMSHIM
-                  value: oci://quay.io/kuadrant/wasm-shim:latest
-                image: quay.io/kuadrant/kuadrant-operator:latest
+                  value: oci://quay.io/kuadrant/wasm-shim:v0.1.0
+                image: quay.io/kuadrant/kuadrant-operator:v0.2.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -613,6 +613,7 @@ spec:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
   relatedImages:
-  - image: oci://quay.io/kuadrant/wasm-shim:latest
+  - image: oci://quay.io/kuadrant/wasm-shim:v0.1.0
     name: wasmshim
-  version: 0.0.0
+  replaces: kuadrant-operator.v0.2.0
+  version: 0.2.1

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -2,8 +2,8 @@ dependencies:
   - type: olm.package
     value:
       packageName: authorino-operator
-      version: "0.0.0"
+      version: "0.5.0"
   - type: olm.package
     value:
       packageName: limitador-operator
-      version: "0.0.0"
+      version: "0.4.0"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,4 +14,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: latest
+  newTag: v0.2.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - /manager
         env:
         - name: RELATED_IMAGE_WASMSHIM
-          value: "oci://quay.io/kuadrant/wasm-shim:latest"
+          value: "oci://quay.io/kuadrant/wasm-shim:v0.1.0"
         image: controller:latest
         name: manager
         securityContext:

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -5,12 +5,12 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:latest
+    containerImage: quay.io/kuadrant/kuadrant-operator:v0.2.1
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v0.0.0
+  name: kuadrant-operator.v0.2.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -76,4 +76,5 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 0.0.0
+  replaces: kuadrant-operator.v0.2.0
+  version: 0.2.1


### PR DESCRIPTION
New release v0.2.1 including a new kuadrant operator image v0.2.1 replacing v0.2.1. The dependencies versions remain the same.

kuadrant operator image v0.2.1 adds the following PRs:
* #123
* #136

### Compare with v0.2.0
```diff
diff -r bundle/manifests/kuadrant-operator.clusterserviceversion.yaml ../kuadrant-operator/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
124c124
<     containerImage: quay.io/kuadrant/kuadrant-operator:v0.2.0
---
>     containerImage: quay.io/kuadrant/kuadrant-operator:v0.2.1
129c129
<   name: kuadrant-operator.v0.2.0
---
>   name: kuadrant-operator.v0.2.1
506c506
<                 image: quay.io/kuadrant/kuadrant-operator:v0.2.0
---
>                 image: quay.io/kuadrant/kuadrant-operator:v0.2.1
618c618,619
<   version: 0.2.0
---
>   replaces: kuadrant-operator.v0.2.0
>   version: 0.2.1
```