### PR TITLE
Istio workload selector fetched from the gateway service spec

### DIFF
--- a/controllers/ratelimitpolicy_cluster_envoy_filter.go
+++ b/controllers/ratelimitpolicy_cluster_envoy_filter.go
@@ -65,9 +65,7 @@ func (r *RateLimitPolicyReconciler) reconcileRateLimitingClusterEnvoyFilter(ctx 
 	return nil
 }
 
-func (r *RateLimitPolicyReconciler) gatewayRateLimitingClusterEnvoyFilter(
-	ctx context.Context, gw *gatewayapiv1alpha2.Gateway,
-	rlpRefs []client.ObjectKey) (*istioclientnetworkingv1alpha3.EnvoyFilter, error) {
+func (r *RateLimitPolicyReconciler) gatewayRateLimitingClusterEnvoyFilter(ctx context.Context, gw *gatewayapiv1alpha2.Gateway, rlpRefs []client.ObjectKey) (*istioclientnetworkingv1alpha3.EnvoyFilter, error) {
 	logger, _ := logr.FromContext(ctx)
 	gwKey := client.ObjectKeyFromObject(gw)
 	logger.V(1).Info("gatewayRateLimitingClusterEnvoyFilter", "gwKey", gwKey, "rlpRefs", rlpRefs)
@@ -88,7 +86,7 @@ func (r *RateLimitPolicyReconciler) gatewayRateLimitingClusterEnvoyFilter(
 		},
 		Spec: istioapinetworkingv1alpha3.EnvoyFilter{
 			WorkloadSelector: &istioapinetworkingv1alpha3.WorkloadSelector{
-				Labels: gw.Labels, // FIXME: https://github.com/Kuadrant/kuadrant-operator/issues/141
+				Labels: common.IstioWorkloadSelectorFromGateway(ctx, r.Client(), gw).MatchLabels,
 			},
 			ConfigPatches: nil,
 		},

--- a/controllers/ratelimitpolicy_wasm_plugins.go
+++ b/controllers/ratelimitpolicy_wasm_plugins.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-logr/logr"
 	istioextensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
-	istiotypev1beta1 "istio.io/api/type/v1beta1"
 	istioclientgoextensionv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -86,9 +85,7 @@ func (r *RateLimitPolicyReconciler) gatewayWASMPlugin(ctx context.Context, gw co
 			Namespace: gw.Namespace,
 		},
 		Spec: istioextensionsv1alpha1.WasmPlugin{
-			Selector: &istiotypev1beta1.WorkloadSelector{
-				MatchLabels: gw.Labels, // FIXME: https://github.com/Kuadrant/kuadrant-operator/issues/141
-			},
+			Selector:     common.IstioWorkloadSelectorFromGateway(ctx, r.Client(), gw.Gateway),
 			Url:          rlptools.WASMFilterImageURL,
 			PluginConfig: nil,
 			// Insert plugin before Istio stats filters and after Istio authorization filters.

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -81,6 +81,15 @@ func Contains(slice []string, target string) bool {
 	return false
 }
 
+func Find[T any](slice []T, match func(T) bool) (*T, bool) {
+	for _, item := range slice {
+		if match(item) {
+			return &item, true
+		}
+	}
+	return nil, false
+}
+
 func Map[T, U any](slice []T, f func(T) U) []U {
 	arr := make([]U, len(slice))
 	for i, e := range slice {

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -37,3 +37,33 @@ func TestValidSubdomains(t *testing.T) {
 		})
 	}
 }
+
+func TestFind(t *testing.T) {
+	s := []string{"a", "ab", "abc"}
+
+	if r, found := Find(s, func(el string) bool { return el == "ab" }); !found || r == nil || *r != "ab" {
+		t.Error("should have found 'ab' in the slice")
+	}
+
+	if r, found := Find(s, func(el string) bool { return len(el) <= 3 }); !found || r == nil || *r != "a" {
+		t.Error("should have found 'a' in the slice")
+	}
+
+	if r, found := Find(s, func(el string) bool { return len(el) >= 3 }); !found || r == nil || *r != "abc" {
+		t.Error("should have found 'abc' in the slice")
+	}
+
+	if r, found := Find(s, func(el string) bool { return len(el) == 4 }); found || r != nil {
+		t.Error("should not have found anything in the slice")
+	}
+
+	i := []int{1, 2, 3}
+
+	if r, found := Find(i, func(el int) bool { return el/3 == 1 }); !found || r == nil || *r != 3 {
+		t.Error("should have found 3 in the slice")
+	}
+
+	if r, found := Find(i, func(el int) bool { return el == 75 }); found || r != nil {
+		t.Error("should not have found anything in the slice")
+	}
+}

--- a/pkg/common/istio_utils.go
+++ b/pkg/common/istio_utils.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	istiocommon "istio.io/api/type/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func IstioWorkloadSelectorFromGateway(ctx context.Context, k8sClient client.Client, gateway *gatewayapiv1alpha2.Gateway) *istiocommon.WorkloadSelector {
+	logger, _ := logr.FromContext(ctx)
+	gatewayWorkloadSelector, err := GetGatewayWorkloadSelector(ctx, k8sClient, gateway)
+	if err != nil {
+		logger.V(1).Info("failed to build Istio WorkloadSelector from Gateway service - falling back to Gateway labels")
+		gatewayWorkloadSelector = gateway.Labels
+	}
+	return &istiocommon.WorkloadSelector{
+		MatchLabels: gatewayWorkloadSelector,
+	}
+}

--- a/pkg/common/istio_utils_test.go
+++ b/pkg/common/istio_utils_test.go
@@ -1,0 +1,108 @@
+//go:build unit
+// +build unit
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	istiocommon "istio.io/api/type/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kuadrant/kuadrant-operator/pkg/log"
+)
+
+func TestIstioWorkloadSelectorFromGateway(t *testing.T) {
+	hostnameAddress := gatewayapiv1alpha2.AddressType("Hostname")
+	gateway := &gatewayapiv1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-gw",
+			Labels: map[string]string{
+				"app":           "foo",
+				"control-plane": "kuadrant",
+			},
+		},
+		Status: gatewayapiv1alpha2.GatewayStatus{
+			Addresses: []gatewayapiv1alpha2.GatewayAddress{
+				{
+					Type:  &hostnameAddress,
+					Value: "my-gw-svc.my-ns.svc.cluster.local:80",
+				},
+			},
+		},
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-gw-svc",
+			Labels: map[string]string{
+				"a-label": "irrelevant",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"a-selector": "what-we-are-looking-for",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = gatewayapiv1alpha2.AddToScheme(scheme)
+	k8sClient := fake.NewFakeClientWithScheme(scheme, gateway, service)
+
+	var selector *istiocommon.WorkloadSelector
+
+	selector = IstioWorkloadSelectorFromGateway(context.TODO(), k8sClient, gateway)
+	if selector == nil || len(selector.MatchLabels) != 1 || selector.MatchLabels["a-selector"] != "what-we-are-looking-for" {
+		t.Error("should have built the istio workload selector from the gateway service")
+	}
+}
+
+func TestIstioWorkloadSelectorFromGatewayMissingHostnameAddress(t *testing.T) {
+	gateway := &gatewayapiv1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-gw",
+			Labels: map[string]string{
+				"app":           "foo",
+				"control-plane": "kuadrant",
+			},
+		},
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-gw-svc",
+			Labels: map[string]string{
+				"a-label": "irrelevant",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"a-selector": "what-we-are-looking-for",
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = gatewayapiv1alpha2.AddToScheme(scheme)
+	k8sClient := fake.NewFakeClientWithScheme(scheme, gateway, service)
+
+	var selector *istiocommon.WorkloadSelector
+
+	selector = IstioWorkloadSelectorFromGateway(logr.NewContext(context.TODO(), log.Log), k8sClient, gateway)
+	if selector == nil || len(selector.MatchLabels) != 2 || selector.MatchLabels["app"] != "foo" || selector.MatchLabels["control-plane"] != "kuadrant" {
+		t.Error("should have built the istio workload selector from the gateway labels")
+	}
+}

--- a/pkg/common/k8s_utils.go
+++ b/pkg/common/k8s_utils.go
@@ -102,26 +102,42 @@ func IsOwnedBy(owned, owner client.Object) bool {
 
 // GetServicePortNumber returns the port number from the referenced key and port info
 // the port info can be named port or already a number.
-func GetServicePortNumber(ctx context.Context, k8sClient client.Client, svcKey client.ObjectKey, svcPort string) (int32, error) {
+func GetServicePortNumber(ctx context.Context, k8sClient client.Client, serviceKey client.ObjectKey, servicePort string) (int32, error) {
 	// check if the port is a number already.
-	if num, err := strconv.ParseInt(svcPort, 10, 32); err == nil {
+	if num, err := strconv.ParseInt(servicePort, 10, 32); err == nil {
 		return int32(num), nil
 	}
 
 	// As the port is name, resolv the port from the service
-	svc := &corev1.Service{}
-	if err := k8sClient.Get(ctx, svcKey, svc); err != nil {
+	service, err := GetService(ctx, k8sClient, serviceKey)
+	if err != nil {
 		// the service must exist
 		return 0, err
 	}
 
-	for _, p := range svc.Spec.Ports {
-		if p.Name == svcPort {
+	for _, p := range service.Spec.Ports {
+		if p.Name == servicePort {
 			return int32(p.TargetPort.IntValue()), nil
 		}
 	}
 
-	return 0, fmt.Errorf("service port %s was not found in %s", svcPort, svcKey.String())
+	return 0, fmt.Errorf("service port %s was not found in %s", servicePort, serviceKey.String())
+}
+
+func GetServiceWorkloadSelector(ctx context.Context, k8sClient client.Client, serviceKey client.ObjectKey) (map[string]string, error) {
+	service, err := GetService(ctx, k8sClient, serviceKey)
+	if err != nil {
+		return nil, err
+	}
+	return service.Spec.Selector, nil
+}
+
+func GetService(ctx context.Context, k8sClient client.Client, serviceKey client.ObjectKey) (*corev1.Service, error) {
+	service := &corev1.Service{}
+	if err := k8sClient.Get(ctx, serviceKey, service); err != nil {
+		return nil, err
+	}
+	return service, nil
 }
 
 // ObjectKeyListDifference computest a - b

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -4,9 +4,14 @@
 package common
 
 import (
+	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestObjectKeyListDifference(t *testing.T) {
@@ -66,5 +71,69 @@ func TestObjectKeyListDifference(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetService(t *testing.T) {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "svc-ns",
+			Name:      "my-svc",
+			Labels: map[string]string{
+				"a-label": "irrelevant",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"a-selector": "what-we-are-looking-for",
+			},
+		},
+	}
+
+	k8sClient := fake.NewFakeClient(service)
+
+	var svc *corev1.Service
+	var err error
+
+	svc, err = GetService(context.TODO(), k8sClient, client.ObjectKey{Namespace: "svc-ns", Name: "my-svc"})
+	if err != nil || svc == nil || svc.GetNamespace() != service.GetNamespace() || svc.GetName() != service.GetName() {
+		t.Error("should have gotten Service svc-ns/my-svc")
+	}
+
+	svc, err = GetService(context.TODO(), k8sClient, client.ObjectKey{Namespace: "svc-ns", Name: "unknown"})
+	if err == nil || !apierrors.IsNotFound(err) || svc != nil {
+		t.Error("should have gotten no Service")
+	}
+}
+
+func TestGetServiceWorkloadSelector(t *testing.T) {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "svc-ns",
+			Name:      "my-svc",
+			Labels: map[string]string{
+				"a-label": "irrelevant",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"a-selector": "what-we-are-looking-for",
+			},
+		},
+	}
+
+	k8sClient := fake.NewFakeClient(service)
+
+	var selector map[string]string
+	var err error
+
+	selector, err = GetServiceWorkloadSelector(context.TODO(), k8sClient, client.ObjectKey{Namespace: "svc-ns", Name: "my-svc"})
+	if err != nil || len(selector) != 1 || selector["a-selector"] != "what-we-are-looking-for" {
+		t.Error("should not have failed to get the service workload selector")
+	}
+
+	selector, err = GetServiceWorkloadSelector(context.TODO(), k8sClient, client.ObjectKey{Namespace: "svc-ns", Name: "unknown-svc"})
+	if err == nil || !apierrors.IsNotFound(err) || selector != nil {
+		t.Error("should have failed to get the service workload selector")
 	}
 }


### PR DESCRIPTION
Closes #141

### Verification steps

❶ Setup:

```sh
make local-setup

kubectl apply -f examples/toystore/toystore.yaml
kubectl apply -f examples/toystore/httproute.yaml

kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```

❷ Create the policies:

```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: AuthPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  authScheme: {}
---
apiVersion: kuadrant.io/v1beta1
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rateLimits:
    - rules:
        - hosts: ["rate-limited.toystore.com"]
      configurations:
        - actions:
            - generic_key:
                descriptor_key: "limited"
                descriptor_value: "1"
      limits:
        - conditions:
            - "limited == 1"
          maxValue: 5
          seconds: 10
          variables: []
EOF
```

❸ Check the workload selectors:

Check the Gateway status and Gateway Service's selector:

```sh
kubectl get gateway/istio-ingressgateway -n istio-system -o jsonpath='{.metadata.labels}' | jq .
```

```sh
kubectl get gateway/istio-ingressgateway -n istio-system -o jsonpath='{.status.addresses}' | jq .
```

```sh
kubectl get service/istio-ingressgateway -n istio-system -o jsonpath='{.spec.selector}' | jq .
```

Check the workload selectors added to the Istio resources:

AuthorizationPolicy:

```sh
kubectl get authorizationpolicy/on-istio-ingressgateway-using-toystore -n istio-system -o jsonpath='{.spec.selector}' | jq .
```

EnvoyFilter:

```sh
kubectl get envoyfilter/kuadrant-ratelimiting-cluster-istio-ingressgateway -n istio-system -o jsonpath='{.spec.workloadSelector}' | jq .
```

WasmPlugin:

```sh
kubectl get wasmplugin/kuadrant-istio-ingressgateway -n istio-system -o jsonpath='{.spec.selector}' | jq .
```

❹ Add a 2nd gateway:

```sh
kubectl apply -n istio-system -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: kuadrant-ingressgateway
  labels:
    app: kuadrant
  annotations:
    kuadrant.io/namespace: default
spec:
  gatewayClassName: istio
  listeners:
    - name: default
      protocol: HTTP
      hostname: "*.kuadrant.io"
      port: 8080
      allowedRoutes:
        namespaces:
          from: All
EOF
```

```sh
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1alpha2
kind: HTTPRoute
metadata:
  name: toystore
  labels:
    app: toystore
  annotations:
    kuadrant.io/ratelimitpolicy: 'default/toystore'
    kuadrant.io/authpolicy: 'default/toystore'
spec:
  parentRefs:
    - name: istio-ingressgateway
      namespace: istio-system
    - name: kuadrant-ingressgateway
      namespace: istio-system
  hostnames: ["*.toystore.com", "*.toystore.kuadrant.io"]
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: "/toy"
          method: GET
        - path:
            type: Exact
            value: "/admin/toy"
          method: POST
        - path:
            type: Exact
            value: "/admin/toy"
          method: DELETE
      backendRefs:
        - name: toystore
          port: 80
EOF
```

❺ Check the workload selectors:

Check the 2nd Gateway status and 2nd Gateway Service's selector:

```sh
kubectl get gateway/kuadrant-ingressgateway -n istio-system -o jsonpath='{.metadata.labels}' | jq .
```

```sh
kubectl get gateway/kuadrant-ingressgateway -n istio-system -o jsonpath='{.status.addresses}' | jq .
```

```sh
kubectl get service/kuadrant-ingressgateway -n istio-system -o jsonpath='{.spec.selector}' | jq .
```

Check the workload selectors added to the Istio resources:

AuthorizationPolicy:

```sh
kubectl get authorizationpolicy/on-kuadrant-ingressgateway-using-toystore -n istio-system -o jsonpath='{.spec.selector}' | jq .
```

EnvoyFilter:

```sh
kubectl get envoyfilter/kuadrant-ratelimiting-cluster-kuadrant-ingressgateway -n istio-system -o jsonpath='{.spec.workloadSelector}' | jq .
```

WasmPlugin:

```sh
kubectl get wasmplugin/kuadrant-kuadrant-ingressgateway -n istio-system -o jsonpath='{.spec.selector}' | jq .
```