### PR TITLE
Bump Kind version from 0.11.1 to 0.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,9 @@ $(OPM):
 opm: $(OPM) ## Download opm locally if necessary.
 
 KIND = $(PROJECT_PATH)/bin/kind
+KIND_VERSION = v0.17.0
 $(KIND):
-	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@v0.11.1)
+	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@v$(KIND_VERSION))
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.


### PR DESCRIPTION
This PR updates the kind version from 0.11.1 to 0.17.0 in the Kuadrant Operator GitHub repository. The update introduces a new variable KIND to store the kind version and fixes an error that occurred when running the "make local-setup" target (see https://github.com/Kuadrant/kuadrant-operator/issues/151).

The update is necessary to avoid potential errors in the future, such as the one reported in the issue. Using the previous version of kind can cause the same issue to reoccur for developers using Fedora 37.

To review the changes, please follow the steps below:

    Checkout this branch
    Run the "make local-setup" command
    Verify that the command runs without errors

Additionally, reference is made to the related pull request that introduces the fix in the Kubernetes sigs/kind project (https://github.com/kubernetes-sigs/kind/pull/2165).