### PR TITLE
Fix GH Workflow inputs error

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -131,9 +131,9 @@ jobs:
         run: |
           make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
             VERSION=${TAG_NAME/v/} IMAGE_TAG=${{ github.sha }} \
-            AUTHORINO_OPERATOR_VERSION=${github.event.inputs.authorinoOperatorBundleVersion} \
-            LIMITADOR_OPERATOR_VERSION=${github.event.inputs.limitadorOperatorBundleVersion} \
-            WASM_SHIM_VERSION=${github.event.inputs.wasmShimVersion}
+            AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorBundleVersion }} \
+            LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorBundleVersion }} \
+            WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }}
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2


### PR DESCRIPTION
In order to fix:

https://github.com/Kuadrant/kuadrant-operator/actions/runs/4541635369/workflow

```sh
The workflow is not valid. Kuadrant/kuadrant-operator/.github/workflows/build-images.yaml@511decdf7458f0f83c3e247a1675532b383c5381 (Line: 10, Col: 9): Required property is missing: type Kuadrant/kuadrant-operator/.github/workflows/build-images.yaml@511decdf7458f0f83c3e247a1675532b383c5381 (Line: 13, Col: 9): Required property is missing: type
```