### PR TITLE
Inheriting all secrets from caller workflow

### DIFF
--- a/.github/workflows/scheduled-build.yaml
+++ b/.github/workflows/scheduled-build.yaml
@@ -11,6 +11,7 @@ jobs:
   workflow-build:
     name: Calls build-images workflow
     uses: ./.github/workflows/build-images.yaml
+    secrets: inherit
     with:
       authorinoOperatorBundleVersion: ${vars.AUTHORINO_OPERATOR_BUNDLE_SHA}
       limitadorOperatorBundleVersion: ${vars.LIMITADOR_OPERATOR_BUNDLE_SHA}

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ is_semantic_version = $(shell [[ $(1) =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$ ]] && e
 # BUNDLE_VERSION defines the version for the kuadrant-operator bundle.
 # If the version is not semantic, will use the default one
 bundle_is_semantic := $(call is_semantic_version,$(VERSION))
-ifdef bundle_is_semantic
+ifeq ($(bundle_is_semantic),true)
 BUNDLE_VERSION = $(VERSION)
 IMAGE_TAG = v$(VERSION)
 else


### PR DESCRIPTION
Aiming to fix the following error when pushing to Quay:

```
Error: writing blob: initiating layer upload to /v2/kuadrant/kuadrant-operator/blobs/uploads/ in quay.io: unauthorized: access to the requested resource is not authorized
```

It should be fixed using [secrets: inherit](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit)

Apparently the only secret available on the called workflow is the `secrets.GITHUB_TOKEN`

Note: It's not possible to check this out using act.
