### PR TITLE
Fix bundle generation

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -107,12 +107,17 @@ jobs:
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         id: add-latest-tag
         run: |
+          echo "TAG_NAME=latest" >> $GITHUB_ENV
           echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
-      - name: Add release tag
+      - name: Add tag based on branch
         if: ${{ github.ref_name != env.MAIN_BRANCH_NAME }}
         id: add-branch-tag
         run: |
+          if [[ ${GITHUB_REF_NAME/\//-} =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
           TAG_NAME=${GITHUB_REF_NAME/\//-}
+          else
+          TAG_NAME=${{ github.sha }}
+          fi
           echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
           echo "IMG_TAGS=${TAG_NAME} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
       - name: Set Operator version
@@ -130,7 +135,7 @@ jobs:
       - name: Run make bundle
         run: |
           make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
-            VERSION=${TAG_NAME/v/} IMAGE_TAG=${{ github.sha }} \
+            VERSION=${{ env.VERSION }} IMAGE_TAG=${{ env.TAG_NAME }} \
             AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorBundleVersion }} \
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorBundleVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }}

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -132,13 +132,20 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user-static
-      - name: Run make bundle
+      - name: Run make bundle for workflow dispatch and workflow call
+        id: workflow-dispatch-call
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' }}
         run: |
           make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
             VERSION=${{ env.VERSION }} IMAGE_TAG=${{ env.TAG_NAME }} \
             AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorBundleVersion }} \
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorBundleVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }}
+      - name: Run make bundle for regular events
+        id: workflow-regular-events
+        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'workflow_call' }}
+        run: |
+          make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} VERSION=${{ env.VERSION }}
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,10 @@ is_semantic_version = $(shell [[ $(1) =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$ ]] && e
 # BUNDLE_VERSION defines the version for the kuadrant-operator bundle.
 # If the version is not semantic, will use the default one
 bundle_is_semantic := $(call is_semantic_version,$(VERSION))
-ifeq ($(bundle_is_semantic),true)
+ifeq (0.0.0,$(VERSION))
+BUNDLE_VERSION = $(VERSION)
+IMAGE_TAG = latest
+else ifeq ($(bundle_is_semantic),true)
 BUNDLE_VERSION = $(VERSION)
 IMAGE_TAG = v$(VERSION)
 else
@@ -59,12 +62,6 @@ ORG ?= kuadrant
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # quay.io/kuadrant/kuadrant-operator-bundle:$VERSION and quay.io/kuadrant/kuadrant-operator-catalog:$VERSION.
 IMAGE_TAG_BASE ?= $(REGISTRY)/$(ORG)/kuadrant-operator
-
-ifeq (0.0.0,$(VERSION))
-IMAGE_TAG ?= latest
-else
-IMAGE_TAG ?= v$(VERSION)
-endif
 
 # kubebuilder-tools still doesn't support darwin/arm64. This is a workaround (https://github.com/kubernetes-sigs/controller-runtime/issues/1657)
 ARCH_PARAM =

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+# This is a requirement for 'setup-envtest.sh' in the test target.
+# Options are set to exit when a recipe line exits non-zero or a piped command fails.
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
@@ -80,12 +86,6 @@ GOBIN=$(shell go env GOPATH)/bin
 else
 GOBIN=$(shell go env GOBIN)
 endif
-
-# Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
-# Options are set to exit when a recipe line exits non-zero or a piped command fails.
-SHELL = /usr/bin/env bash -o pipefail
-.SHELLFLAGS = -ec
 
 # Kuadrant Namespace
 KUADRANT_NAMESPACE ?= kuadrant-system


### PR DESCRIPTION
This PR aims to fix the bundle image generation, which currently is listing wrong versions, then makes it fail the catalog generation:

https://github.com/Kuadrant/kuadrant-operator/actions/runs/4598777582/jobs/8123707273

```
[ERROR] Referenced Limitador version is , but found 0.0.0 in the bundle 
make[1]: *** [make/catalog.mk:26: /home/runner/work/kuadrant-operator/kuadrant-operator/catalog/kuadrant-operator-catalog/operator.yaml] Error 1
make[1]: Leaving directory '/home/runner/work/kuadrant-operator/kuadrant-operator'
make: *** [make/catalog.mk:35: catalog] Error 2
```

The following will be applied:

* Version will be either _semantic_ or _github.sha_
* Tag will be `latest` when main branch, `semantic` when release and `github.sha` as default
* The final images will be tagged with a combo of sha, latest, branch and semantic as applicable
