### PR TITLE
Fix update action variables for dependencies

### DIFF
--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Get projects latest SHA
     runs-on: ubuntu-latest
     permissions:
-      actions_variables: write
+      actions: write
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -35,12 +35,12 @@ jobs:
           method: 'GET'
           url: https://quay.io/api/v1/repository/kuadrant/${{ matrix.repository }}?includeTags=true
       - name: Parse the list to get the last SHA
-        id: parse
+        id: extract-sha-var
         run: |
           echo "sha=$(echo '${{ steps.fetch.outputs.response }}' | jq -c -r '.tags | keys_unsorted | .[] | select(.|test("[0-9a-f]{5,40}"))' | jq -Rn '[inputs]' | jq -c -r '.[0]')" >> $GITHUB_OUTPUT
+          echo "var=$(echo ${{ matrix.repository }} | sed -E 's/-/_/g;s/[a-z]/\U&/g')_SHA" >> $GITHUB_OUTPUT
       - name: Update stored variable
         id: update
         run: |
           var=$(echo ${{ matrix.repository }} | sed -E 's/-/_/g;s/[a-z]/\U&/g')_SHA
-          sha=${{ steps.parse.outputs.sha }}
-          curl -L -X PATCH "https://api.github.com/repos/kuadrant/kuadrant-operator/actions/variables/${var}" -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "${sha}" }'
+          curl -L -X PATCH "https://api.github.com/repos/kuadrant/kuadrant-operator/actions/variables/${{steps.extract-sha-var.outputs.var}}" -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "${{ steps.extract-sha-var.outputs.sha }}" }'

--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -41,6 +41,6 @@ jobs:
       - name: Update stored variable
         id: update
         run: |
-          var=$(echo ${{ matrix.repository }} | sed -E 's/-/_/;s/[a-z]/\U&/g')_SHA
+          var=$(echo ${{ matrix.repository }} | sed -E 's/-/_/g;s/[a-z]/\U&/g')_SHA
           sha=${{ steps.parse.outputs.sha }}
-          curl -L -X PATCH 'https://api.github.com/repos/kuadrant/kuadrant-operator/actions/variables/$var' -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "$sha" }'
+          curl -L -X PATCH "https://api.github.com/repos/kuadrant/kuadrant-operator/actions/variables/${var}" -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "${sha}" }'

--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -41,4 +41,7 @@ jobs:
         id: update
         run: |
           var=$(echo ${{ matrix.repository }} | sed -E 's/-/_/g;s/[a-z]/\U&/g')_SHA
-          curl -L -X PATCH "https://api.github.com/repos/Kuadrant/kuadrant-operator/actions/variables/${{steps.extract-sha-var.outputs.var}}" -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.UPDATE_ACTION_VARS_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "${{ steps.extract-sha-var.outputs.sha }}" }'
+          http_code=$(curl --write-out "%{http_code}\n" -L -X PATCH "https://api.github.com/repos/Kuadrant/kuadrant-operator/actions/variables/${{steps.extract-sha-var.outputs.var}}" -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.UPDATE_ACTION_VARS_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "${{ steps.extract-sha-var.outputs.sha }}" }')
+          if [[ $http_code != 204 ]]; then
+            exit 1
+          fi

--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -1,8 +1,6 @@
 name: Update dependencies image versions
 
 on:
-  push:
-    branches: ['**']
   schedule:
     - cron: '0 0 * * *'
   repository_dispatch: {}

--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -18,7 +18,6 @@ jobs:
   get-latest-sha:
     name: Get projects latest SHA
     runs-on: ubuntu-latest
-    shell: bash
     permissions:
       actions_variables: write
     strategy:

--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -43,4 +43,4 @@ jobs:
         id: update
         run: |
           var=$(echo ${{ matrix.repository }} | sed -E 's/-/_/g;s/[a-z]/\U&/g')_SHA
-          curl -L -X PATCH "https://api.github.com/repos/kuadrant/kuadrant-operator/actions/variables/${{steps.extract-sha-var.outputs.var}}" -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "${{ steps.extract-sha-var.outputs.sha }}" }'
+          curl -L -X PATCH "https://api.github.com/repos/Kuadrant/kuadrant-operator/actions/variables/${{steps.extract-sha-var.outputs.var}}" -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.UPDATE_ACTION_VARS_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "${{ steps.extract-sha-var.outputs.sha }}" }'


### PR DESCRIPTION
This PR fixes the workflow updating the GH action variables holding the dependencies last sha references

https://github.com/Kuadrant/kuadrant-operator/actions/runs/4684207614

```bash

The workflow is not valid. .github/workflows/update-stored-dependencies-version.yaml (Line: 21, Col: 5): Unexpected value 'shell' .github/workflows/update-stored-dependencies-version.yaml (Line: 23, Col: 7): Unexpected value 'actions_variables'

```