### PR TITLE
Storing all dependencies sha

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -11,11 +11,11 @@ on:
         description: Kuadrant Operator version
         default: 0.0.0
         type: string
-      authorinoOperatorBundleVersion:
+      authorinoOperatorVersion:
         description: Authorino Operator bundle version
         default: latest
         type: string
-      limitadorOperatorBundleVersion:
+      limitadorOperatorVersion:
         description: Limitador Operator bundle version
         default: latest
         type: string
@@ -33,11 +33,11 @@ on:
         description: Kuadrant Operator version
         default: 0.0.0
         type: string
-      authorinoOperatorBundleVersion:
+      authorinoOperatorVersion:
         description: Authorino Operator bundle version
         default: latest
         type: string
-      limitadorOperatorBundleVersion:
+      limitadorOperatorVersion:
         description: Limitador Operator bundle version
         default: latest
         type: string
@@ -108,8 +108,8 @@ jobs:
         run: |
           make bundle REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
             VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.kuadrantOperatorTag }} \
-            AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorBundleVersion }} \
-            LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorBundleVersion }} \
+            AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorVersion }} \
+            LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }}
       - name: Build Image
         id: build-image
@@ -149,8 +149,8 @@ jobs:
         run: |
           make catalog REGISTRY=${{ env.IMG_REGISTRY_HOST }} ORG=${{ env.IMG_REGISTRY_ORG }} \
             VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.kuadrantOperatorTag }} \
-            AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorBundleVersion }} \
-            LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorBundleVersion }} \
+            AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorVersion }} \
+            LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }}
       - name: Install qemu dependency
         run: |

--- a/.github/workflows/build-images-scheduled.yaml
+++ b/.github/workflows/build-images-scheduled.yaml
@@ -12,6 +12,6 @@ jobs:
     with:
       kuadrantOperatorVersion: ${{ github.sha }}
       kuadrantOperatorTag: ${{ github.sha }}
-      authorinoOperatorBundleVersion: ${{ vars.AUTHORINO_OPERATOR_BUNDLE_SHA }}
-      limitadorOperatorBundleVersion: ${{ vars.LIMITADOR_OPERATOR_BUNDLE_SHA }}
+      authorinoOperatorVersion: ${{ vars.AUTHORINO_OPERATOR_SHA }}
+      limitadorOperatorVersion: ${{ vars.LIMITADOR_OPERATOR_SHA }}
       wasmShimVersion: ${{ vars.WASM_SHIM_SHA }}

--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -19,8 +19,10 @@ jobs:
       fail-fast: true
       matrix:
         repository:
-          - authorino-operator-bundle
-          - limitador-operator-bundle
+          - authorino
+          - authorino-operator
+          - limitador
+          - limitador-operator
           - wasm-shim
     steps:
       - name: Fetch dependencies images list

--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -6,11 +6,8 @@ on:
   repository_dispatch: {}
 
 env:
-  IMG_TAGS: ${{ github.sha }}
-  IMG_REGISTRY_HOST: quay.io
-  IMG_REGISTRY_ORG: kuadrant
-  MAIN_BRANCH_NAME: main
-  OPERATOR_NAME: kuadrant-operator
+  IMG_REPO_URL: https://kuadrant/api/v1/repository/kuadrant/
+  GH_API_ORG_ENDPOINT: https://api.github.com/orgs/Kuadrant/actions/variables/
 
 jobs:
   get-latest-sha:
@@ -31,7 +28,7 @@ jobs:
         uses: fjogeleit/http-request-action@master
         with:
           method: 'GET'
-          url: https://quay.io/api/v1/repository/kuadrant/${{ matrix.repository }}?includeTags=true
+          url: ${{env.IMG_REPO_URL}}${{ matrix.repository }}?includeTags=true
       - name: Parse the list to get the last SHA
         id: extract-sha-var
         run: |
@@ -41,7 +38,7 @@ jobs:
         id: update
         run: |
           var=$(echo ${{ matrix.repository }} | sed -E 's/-/_/g;s/[a-z]/\U&/g')_SHA
-          http_code=$(curl --write-out "%{http_code}\n" -L -X PATCH "https://api.github.com/repos/Kuadrant/kuadrant-operator/actions/variables/${{steps.extract-sha-var.outputs.var}}" -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.UPDATE_ACTION_VARS_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "${{ steps.extract-sha-var.outputs.sha }}" }')
+          http_code=$(curl --write-out "%{http_code}\n" -L -X PATCH "${{env.GH_API_ORG_ENDPOINT}}${{steps.extract-sha-var.outputs.var}}" -H "X-GitHub-Api-Version: 2022-11-28" -H 'Authorization: Bearer ${{ secrets.UPDATE_ACTION_VARS_TOKEN }}' -H 'Accept: application/vnd.github+json' -d '{ "value": "${{ steps.extract-sha-var.outputs.sha }}" }')
           if [[ $http_code != 204 ]]; then
             exit 1
           fi


### PR DESCRIPTION
This PR allows to keep track of every dependency _sha_ version needed in Kuadrant for other jobs to consume. The variables have been "hoisted" to Organization level.

The workflow updating the sha versions, and the base one for building images will be moved to a new repo in the near future for reusable actions.