### PR TITLE
[test] Improve test coverage and performance in apimachinery_status_conditions

### DIFF
--- a/pkg/common/apimachinery_status_conditions.go
+++ b/pkg/common/apimachinery_status_conditions.go
@@ -10,10 +10,7 @@ import (
 // CopyConditions copies the set of conditions
 func CopyConditions(conditions []metav1.Condition) []metav1.Condition {
 	newConditions := make([]metav1.Condition, len(conditions))
-	for idx := range conditions {
-		// copy
-		newConditions[idx] = conditions[idx]
-	}
+	copy(newConditions, conditions)
 	return newConditions
 }
 

--- a/pkg/common/apimachinery_status_conditions.go
+++ b/pkg/common/apimachinery_status_conditions.go
@@ -9,19 +9,17 @@ import (
 
 // CopyConditions copies the set of conditions
 func CopyConditions(conditions []metav1.Condition) []metav1.Condition {
-	newConditions := make([]metav1.Condition, 0)
+	newConditions := make([]metav1.Condition, len(conditions))
 	for idx := range conditions {
 		// copy
-		newCondition := conditions[idx]
-		newConditions = append(newConditions, newCondition)
+		newConditions[idx] = conditions[idx]
 	}
 	return newConditions
 }
 
 // ConditionMarshal marshals the set of conditions as a JSON array, sorted by condition type.
 func ConditionMarshal(conditions []metav1.Condition) ([]byte, error) {
-	var condCopy []metav1.Condition
-	condCopy = append(condCopy, conditions...)
+	condCopy := CopyConditions(conditions)
 	sort.Slice(condCopy, func(a, b int) bool {
 		return condCopy[a].Type < condCopy[b].Type
 	})

--- a/pkg/common/apimachinery_status_conditions_test.go
+++ b/pkg/common/apimachinery_status_conditions_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestCopyCondition(t *testing.T) {
+func TestCopyConditions(t *testing.T) {
 	now := metav1.Now()
 	testCases := []struct {
 		name               string
@@ -80,7 +80,7 @@ func TestCopyCondition(t *testing.T) {
 	}
 }
 
-func TestCopyCondition_OriginalConditionsNotModified(t *testing.T) {
+func TestCopyConditions_OriginalConditionsNotModified(t *testing.T) {
 	now := metav1.Now()
 	expectedConditions := []metav1.Condition{
 		metav1.Condition{

--- a/pkg/common/apimachinery_status_conditions_test.go
+++ b/pkg/common/apimachinery_status_conditions_test.go
@@ -3,10 +3,11 @@
 package common
 
 import (
-	goCmp "github.com/google/go-cmp/cmp"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 	"time"
+
+	goCmp "github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCopyConditions(t *testing.T) {
@@ -18,7 +19,7 @@ func TestCopyConditions(t *testing.T) {
 		{
 			name: "when multiple conditions then return copy",
 			expectedConditions: []metav1.Condition{
-				metav1.Condition{
+				{
 					Type:               "Installed",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,
@@ -26,7 +27,7 @@ func TestCopyConditions(t *testing.T) {
 					Reason:             "InstallSuccessful",
 					Message:            "Object successfully installed",
 				},
-				metav1.Condition{
+				{
 					Type:               "Reconciled",
 					Status:             metav1.ConditionFalse,
 					ObservedGeneration: 0,
@@ -34,7 +35,7 @@ func TestCopyConditions(t *testing.T) {
 					Reason:             "ReconcileError",
 					Message:            "Object failed to reconcile due to an error",
 				},
-				metav1.Condition{
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionFalse,
 					ObservedGeneration: 2,
@@ -42,7 +43,7 @@ func TestCopyConditions(t *testing.T) {
 					Reason:             "ComponentsNotReady",
 					Message:            "Object components are not ready",
 				},
-				metav1.Condition{
+				{
 					Type:               "Validated",
 					Status:             metav1.ConditionUnknown,
 					ObservedGeneration: 0,
@@ -55,7 +56,7 @@ func TestCopyConditions(t *testing.T) {
 		{
 			name: "when one condition then return copy",
 			expectedConditions: []metav1.Condition{
-				metav1.Condition{
+				{
 					Type:               "Validated",
 					Status:             metav1.ConditionUnknown,
 					ObservedGeneration: 0,
@@ -84,7 +85,7 @@ func TestCopyConditions(t *testing.T) {
 func TestCopyConditions_OriginalConditionsNotModified(t *testing.T) {
 	now := metav1.Now()
 	expectedConditions := []metav1.Condition{
-		metav1.Condition{
+		{
 			Type:               "Installed",
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: 1,
@@ -92,7 +93,7 @@ func TestCopyConditions_OriginalConditionsNotModified(t *testing.T) {
 			Reason:             "InstallSuccessful",
 			Message:            "Object successfully installed",
 		},
-		metav1.Condition{
+		{
 			Type:               "Reconciled",
 			Status:             metav1.ConditionFalse,
 			ObservedGeneration: 0,
@@ -135,7 +136,7 @@ func TestConditionMarshal(t *testing.T) {
 		{
 			name: "when single condition then return JSON",
 			conditions: []metav1.Condition{
-				metav1.Condition{
+				{
 					Type:               "Installed",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,
@@ -150,7 +151,7 @@ func TestConditionMarshal(t *testing.T) {
 		{
 			name: "when multiple conditions then return JSON",
 			conditions: []metav1.Condition{
-				metav1.Condition{
+				{
 					Type:               "Ready",
 					Status:             metav1.ConditionFalse,
 					ObservedGeneration: 2,
@@ -158,7 +159,7 @@ func TestConditionMarshal(t *testing.T) {
 					Reason:             "ComponentsNotReady",
 					Message:            "Object components are not ready",
 				},
-				metav1.Condition{
+				{
 					Type:               "Installed",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 1,
@@ -166,7 +167,7 @@ func TestConditionMarshal(t *testing.T) {
 					Reason:             "InstallSuccessful",
 					Message:            "Object successfully installed",
 				},
-				metav1.Condition{
+				{
 					Type:               "Validated",
 					Status:             metav1.ConditionUnknown,
 					ObservedGeneration: 3,
@@ -181,7 +182,7 @@ func TestConditionMarshal(t *testing.T) {
 		{
 			name: "when empty ObservedGeneration field (EQ 0) then it is omitted in JSON",
 			conditions: []metav1.Condition{
-				metav1.Condition{
+				{
 					Type:               "Installed",
 					Status:             metav1.ConditionTrue,
 					ObservedGeneration: 0,
@@ -189,7 +190,7 @@ func TestConditionMarshal(t *testing.T) {
 					Reason:             "InstallSuccessful",
 					Message:            "Object successfully installed",
 				},
-				metav1.Condition{
+				{
 					Type:               "Validated",
 					Status:             metav1.ConditionUnknown,
 					ObservedGeneration: 0,

--- a/pkg/common/apimachinery_status_conditions_test.go
+++ b/pkg/common/apimachinery_status_conditions_test.go
@@ -16,7 +16,7 @@ func TestCopyConditions(t *testing.T) {
 		expectedConditions []metav1.Condition
 	}{
 		{
-			name: "default conditions",
+			name: "when multiple conditions then return copy",
 			expectedConditions: []metav1.Condition{
 				metav1.Condition{
 					Type:               "Installed",
@@ -53,7 +53,7 @@ func TestCopyConditions(t *testing.T) {
 			},
 		},
 		{
-			name: "one condition",
+			name: "when one condition then return copy",
 			expectedConditions: []metav1.Condition{
 				metav1.Condition{
 					Type:               "Validated",
@@ -66,7 +66,7 @@ func TestCopyConditions(t *testing.T) {
 			},
 		},
 		{
-			name:               "empty slice",
+			name:               "when empty conditions slice return empty slice",
 			expectedConditions: []metav1.Condition{},
 		},
 	}
@@ -127,13 +127,13 @@ func TestConditionMarshal(t *testing.T) {
 		expectedError      error
 	}{
 		{
-			name:               "empty conditions slice",
+			name:               "when empty conditions slice then return (null,nil)",
 			conditions:         []metav1.Condition{},
 			expectedJSONOutput: "null",
 			expectedError:      nil,
 		},
 		{
-			name: "single condition",
+			name: "when single condition then return JSON",
 			conditions: []metav1.Condition{
 				metav1.Condition{
 					Type:               "Installed",
@@ -148,7 +148,7 @@ func TestConditionMarshal(t *testing.T) {
 			expectedError:      nil,
 		},
 		{
-			name: "multiple conditions",
+			name: "when multiple conditions then return JSON",
 			conditions: []metav1.Condition{
 				metav1.Condition{
 					Type:               "Ready",
@@ -179,7 +179,7 @@ func TestConditionMarshal(t *testing.T) {
 			expectedError:      nil,
 		},
 		{
-			name: "empty ObservedGeneration (EQ 0) is omitted by json.Marshal",
+			name: "when empty ObservedGeneration field (EQ 0) then it is omitted in JSON",
 			conditions: []metav1.Condition{
 				metav1.Condition{
 					Type:               "Installed",

--- a/pkg/common/apimachinery_status_conditions_test.go
+++ b/pkg/common/apimachinery_status_conditions_test.go
@@ -127,9 +127,9 @@ func TestConditionMarshal(t *testing.T) {
 		expectedError      error
 	}{
 		{
-			name:               "when empty conditions slice then return (null,nil)",
+			name:               "when empty conditions slice then return empty slice",
 			conditions:         []metav1.Condition{},
-			expectedJSONOutput: "null",
+			expectedJSONOutput: "[]",
 			expectedError:      nil,
 		},
 		{

--- a/pkg/common/apimachinery_status_conditions_test.go
+++ b/pkg/common/apimachinery_status_conditions_test.go
@@ -6,6 +6,7 @@ import (
 	goCmp "github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+	"time"
 )
 
 func TestCopyConditions(t *testing.T) {
@@ -112,5 +113,109 @@ func TestCopyConditions_OriginalConditionsNotModified(t *testing.T) {
 	// Check that the original conditions were not modified
 	if diff := goCmp.Diff(originalConditions, expectedConditions); diff != "" {
 		t.Errorf("Original conditions were modified (-want +got):\n%s", diff)
+	}
+}
+
+func TestConditionMarshal(t *testing.T) {
+	now := metav1.Now()
+	nowUTC := now.UTC().Format(time.RFC3339)
+
+	testCases := []struct {
+		name               string
+		conditions         []metav1.Condition
+		expectedJSONOutput string
+		expectedError      error
+	}{
+		{
+			name:               "empty conditions slice",
+			conditions:         []metav1.Condition{},
+			expectedJSONOutput: "null",
+			expectedError:      nil,
+		},
+		{
+			name: "single condition",
+			conditions: []metav1.Condition{
+				metav1.Condition{
+					Type:               "Installed",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+					Reason:             "InstallSuccessful",
+					Message:            "Object successfully installed",
+				},
+			},
+			expectedJSONOutput: `[{"type":"Installed","status":"True","observedGeneration":1,"lastTransitionTime":"` + nowUTC + `","reason":"InstallSuccessful","message":"Object successfully installed"}]`,
+			expectedError:      nil,
+		},
+		{
+			name: "multiple conditions",
+			conditions: []metav1.Condition{
+				metav1.Condition{
+					Type:               "Ready",
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 2,
+					LastTransitionTime: now,
+					Reason:             "ComponentsNotReady",
+					Message:            "Object components are not ready",
+				},
+				metav1.Condition{
+					Type:               "Installed",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+					Reason:             "InstallSuccessful",
+					Message:            "Object successfully installed",
+				},
+				metav1.Condition{
+					Type:               "Validated",
+					Status:             metav1.ConditionUnknown,
+					ObservedGeneration: 3,
+					LastTransitionTime: now,
+					Reason:             "ValidationError",
+					Message:            "Object validation failed",
+				},
+			},
+			expectedJSONOutput: `[{"type":"Installed","status":"True","observedGeneration":1,"lastTransitionTime":"` + nowUTC + `","reason":"InstallSuccessful","message":"Object successfully installed"},{"type":"Ready","status":"False","observedGeneration":2,"lastTransitionTime":"` + nowUTC + `","reason":"ComponentsNotReady","message":"Object components are not ready"},{"type":"Validated","status":"Unknown","observedGeneration":3,"lastTransitionTime":"` + nowUTC + `","reason":"ValidationError","message":"Object validation failed"}]`,
+			expectedError:      nil,
+		},
+		{
+			name: "empty ObservedGeneration (EQ 0) is omitted by json.Marshal",
+			conditions: []metav1.Condition{
+				metav1.Condition{
+					Type:               "Installed",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 0,
+					LastTransitionTime: now,
+					Reason:             "InstallSuccessful",
+					Message:            "Object successfully installed",
+				},
+				metav1.Condition{
+					Type:               "Validated",
+					Status:             metav1.ConditionUnknown,
+					ObservedGeneration: 0,
+					LastTransitionTime: now,
+					Reason:             "ValidationError",
+					Message:            "Object validation failed",
+				},
+			},
+			expectedJSONOutput: `[{"type":"Installed","status":"True","lastTransitionTime":"` + nowUTC + `","reason":"InstallSuccessful","message":"Object successfully installed"},{"type":"Validated","status":"Unknown","lastTransitionTime":"` + nowUTC + `","reason":"ValidationError","message":"Object validation failed"}]`,
+			expectedError:      nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			actualJSONOutput, actualError := ConditionMarshal(tc.conditions)
+
+			diff := goCmp.Diff(tc.expectedJSONOutput, string(actualJSONOutput))
+			if diff != "" {
+				subT.Errorf("Unexpected JSON output (-want +got):\n%s", diff)
+			}
+
+			diff = goCmp.Diff(tc.expectedError, actualError)
+			if diff != "" {
+				subT.Errorf("Unexpected error (-want +got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/common/apimachinery_status_conditions_test.go
+++ b/pkg/common/apimachinery_status_conditions_test.go
@@ -1,0 +1,116 @@
+//go:build unit
+
+package common
+
+import (
+	goCmp "github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestCopyCondition(t *testing.T) {
+	now := metav1.Now()
+	testCases := []struct {
+		name               string
+		expectedConditions []metav1.Condition
+	}{
+		{
+			name: "default conditions",
+			expectedConditions: []metav1.Condition{
+				metav1.Condition{
+					Type:               "Installed",
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: 1,
+					LastTransitionTime: now,
+					Reason:             "InstallSuccessful",
+					Message:            "Object successfully installed",
+				},
+				metav1.Condition{
+					Type:               "Reconciled",
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 0,
+					LastTransitionTime: now,
+					Reason:             "ReconcileError",
+					Message:            "Object failed to reconcile due to an error",
+				},
+				metav1.Condition{
+					Type:               "Ready",
+					Status:             metav1.ConditionFalse,
+					ObservedGeneration: 2,
+					LastTransitionTime: now,
+					Reason:             "ComponentsNotReady",
+					Message:            "Object components are not ready",
+				},
+				metav1.Condition{
+					Type:               "Validated",
+					Status:             metav1.ConditionUnknown,
+					ObservedGeneration: 0,
+					LastTransitionTime: now,
+					Reason:             "ValidationError",
+					Message:            "Object validation failed",
+				},
+			},
+		},
+		{
+			name: "one condition",
+			expectedConditions: []metav1.Condition{
+				metav1.Condition{
+					Type:               "Validated",
+					Status:             metav1.ConditionUnknown,
+					ObservedGeneration: 0,
+					LastTransitionTime: now,
+					Reason:             "ValidationError",
+					Message:            "Object validation failed",
+				},
+			},
+		},
+		{
+			name:               "empty slice",
+			expectedConditions: []metav1.Condition{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			actualConditions := CopyConditions(tc.expectedConditions)
+			if diff := goCmp.Diff(tc.expectedConditions, actualConditions); diff != "" {
+				subT.Errorf("Conditions mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCopyCondition_OriginalConditionsNotModified(t *testing.T) {
+	now := metav1.Now()
+	expectedConditions := []metav1.Condition{
+		metav1.Condition{
+			Type:               "Installed",
+			Status:             metav1.ConditionTrue,
+			ObservedGeneration: 1,
+			LastTransitionTime: now,
+			Reason:             "InstallSuccessful",
+			Message:            "Object successfully installed",
+		},
+		metav1.Condition{
+			Type:               "Reconciled",
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: 0,
+			LastTransitionTime: now,
+			Reason:             "ReconcileError",
+			Message:            "Object failed to reconcile due to an error",
+		},
+	}
+
+	originalConditions := append([]metav1.Condition{}, expectedConditions...)
+	actualConditions := CopyConditions(expectedConditions)
+
+	// Check that the copied conditions are equal to the original conditions
+	if diff := goCmp.Diff(expectedConditions, actualConditions); diff != "" {
+		t.Errorf("Conditions mismatch (-want +got):\n%s", diff)
+	}
+
+	// Check that the original conditions were not modified
+	if diff := goCmp.Diff(originalConditions, expectedConditions); diff != "" {
+		t.Errorf("Original conditions were modified (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
This pull request adds unit tests to verify the correctness of the CopyConditions and ConditionMarshal functions in the 'common' package's apimachinery_status_conditions.go file. 

It also refactors the CopyConditions function to avoid unnecessary appends and allocate a slice with the exact length. 

Finally, it reuses the CopyConditions function in ConditionMarshal instead of using append for performance improvement and null safety. This work partly addresses issue [#167](https://github.com/Kuadrant/kuadrant-operator/issues/167), and more work is still in progress.