### PR TITLE
[test] Add tests for hostname.go in common package

### DIFF
--- a/pkg/common/hostname_test.go
+++ b/pkg/common/hostname_test.go
@@ -21,6 +21,12 @@ func TestNameSubsetOf(t *testing.T) {
 		{"hostname is not subset of wildcard subdomain", "foo.com", "*.foo.com", false},
 		{"global wildcard is not subset of wildcard hostname", "*", "*.com", false},
 		{"wildcard hostname is subset of global wildcard", "*.com", "*", true},
+		{"wildcards with different TLDs", "*.com", "*.org", false},
+		{"wildcards at different levels in domain hierarchy", "*.foo.com", "*.bar.foo.com", false},
+		{"wildcards with subdomains", "*.foo.com", "*.baz.foo.com", false},
+		{"empty hostnames", "", "", true},
+		{"one empty hostname", "", "foo.com", false},
+		{"multiple wildcards", "*.foo.*.com", "*.foo.*.com", true},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/common/hostname_test.go
+++ b/pkg/common/hostname_test.go
@@ -38,3 +38,47 @@ func TestNameSubsetOf(t *testing.T) {
 		})
 	}
 }
+
+func TestIsWildCarded(t *testing.T) {
+	testCases := []struct {
+		name     string
+		hostname Name
+		expected bool
+	}{
+		{"when wildcard at beginning then return true", "*.example.com", true},
+		{"when empty string then return false", "", false},
+		{"when no wildcard then return false", "example.com", false},
+		{"when wildcard in middle then return false", "subdomain.*.example.com", false},
+		{"when wildcard at end then return false", "subdomain.example.*", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			res := tc.hostname.IsWildCarded()
+			if res != tc.expected {
+				subT.Errorf("expected (%t) for hostname '%s', but got (%t)", tc.expected, tc.hostname, res)
+			}
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		actual   Name
+		expected string
+	}{
+		{"empty name", "", ""},
+		{"non-empty name", "example.com", "example.com"},
+		{"wildcarded name", "*.com", "*.com"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			res := tc.actual.String()
+			if res != tc.expected {
+				subT.Errorf("expected (%s), got (%s)", tc.expected, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request adds unit tests for the IsWildCarded, SubsetsOf and String function in hostname.go of the common package

Changes made:
- Added unit tests for IsWildCarded function
- Added unit tests for String function (these are not strictly necessary, added only to improve the overall test coverage percentage)
- Added six additional test cases for NameSubsetsOf function

This pull request partly closes issue #167. The work is still in progress and more changes will be made in subsequent pull requests.