### PR TITLE
[fix: integration-tests] Ensure Istio gateways are ready

### DIFF
--- a/controllers/ratelimitpolicy_controller_test.go
+++ b/controllers/ratelimitpolicy_controller_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	istioclientgoextensionv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	istioclientnetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,9 +32,10 @@ func testBuildBasicGateway(gwName, ns string) *gatewayapiv1alpha2.Gateway {
 			APIVersion: gatewayapiv1alpha2.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      gwName,
-			Namespace: ns,
-			Labels:    map[string]string{"app": "rlptest"},
+			Name:        gwName,
+			Namespace:   ns,
+			Labels:      map[string]string{"app": "rlptest"},
+			Annotations: map[string]string{"networking.istio.io/service-type": string(corev1.ServiceTypeClusterIP)},
 		},
 		Spec: gatewayapiv1alpha2.GatewaySpec{
 			GatewayClassName: gatewayapiv1alpha2.ObjectName("istio"),


### PR DESCRIPTION
Ensures Istio gateways created during the integration tests are ready (`Programmed == true`), by setting `ClusterIP` service type instead of `LoadBalancer`.

This is because in the Kubernetes clusters started with Kind, where no external load balancer has been configured, the `EXTERNAL-IP` of the `LoadBalancer`-type service created by default associated with each Gateway API gateway will remain in `<pending>` state forever (see https://github.com/istio/istio.io/issues/12630#issuecomment-1426402223). As a consequence, the `Programmed` condition of the gateway resource is invalid, failing with message: `Failed to assign to any requested addresses: no instances found for hostname […]`.

Fixes https://github.com/Kuadrant/kuadrant-operator/actions/runs/4932380443/jobs/8815343870.