### PR TITLE
fix e2e tests: do not use istio-ingressgateway in tests

### DIFF
--- a/controllers/authpolicy_controller_test.go
+++ b/controllers/authpolicy_controller_test.go
@@ -24,23 +24,21 @@ import (
 )
 
 const (
-	IstioGatewayName      = "istio-ingressgateway"
-	IstioGatewayNamespace = "istio-system"
-	CustomGatewayName     = "toystore-gw"
+	CustomGatewayName   = "toystore-gw"
+	CustomHTTPRouteName = "toystore-route"
 )
 
 var _ = Describe("AuthPolicy controller", func() {
 	var (
 		testNamespace string
-		routeName     = "toystore-route"
-		gwName        = CustomGatewayName
 	)
 
 	beforeEachCallback := func() {
 		CreateNamespace(&testNamespace)
-		gateway := testBuildBasicGateway(gwName, testNamespace)
+		gateway := testBuildBasicGateway(CustomGatewayName, testNamespace)
 		err := k8sClient.Create(context.Background(), gateway)
 		Expect(err).ToNot(HaveOccurred())
+		// TODO check gateway is Programmed
 		ApplyKuadrantCR(testNamespace)
 	}
 
@@ -53,8 +51,10 @@ var _ = Describe("AuthPolicy controller", func() {
 			err := ApplyResources(filepath.Join("..", "examples", "toystore", "toystore.yaml"), k8sClient, testNamespace)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = ApplyResources(filepath.Join("..", "examples", "toystore", "httproute.yaml"), k8sClient, testNamespace)
+			httpRoute := testBuildBasicHttpRoute(CustomHTTPRouteName, CustomGatewayName, testNamespace, []string{"*.toystore.com"})
+			err = k8sClient.Create(context.Background(), httpRoute)
 			Expect(err).ToNot(HaveOccurred())
+			// TODO check route is ready
 
 			authpolicies := authPolicies(testNamespace)
 
@@ -64,24 +64,34 @@ var _ = Describe("AuthPolicy controller", func() {
 				logf.Log.V(1).Info("Creating AuthPolicy", "key", client.ObjectKeyFromObject(authpolicies[idx]).String(), "error", err)
 				Expect(err).ToNot(HaveOccurred())
 
+				// Check AuthPolicy is ready
+				Eventually(func() bool {
+					existingKAP := &kuadrantv1beta1.AuthPolicy{}
+					err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(authpolicies[idx]), existingKAP)
+					if err != nil {
+						return false
+					}
+					if !meta.IsStatusConditionTrue(existingKAP.Status.Conditions, "Available") {
+						return false
+					}
+
+					return true
+				}, 30*time.Second, 5*time.Second).Should(BeTrue())
+
 				// check Istio's AuthorizationPolicy existence
-				iap := &secv1beta1resources.AuthorizationPolicy{}
-				namespace := IstioGatewayNamespace
-				name := IstioGatewayName
-				if authpolicies[idx].Spec.TargetRef.Kind == "Gateway" {
-					namespace = testNamespace
-					name = CustomGatewayName
-				}
 				iapKey := types.NamespacedName{
-					Name:      istioAuthorizationPolicyName(name, authpolicies[idx].Spec.TargetRef),
-					Namespace: namespace,
+					Name:      istioAuthorizationPolicyName(CustomGatewayName, authpolicies[idx].Spec.TargetRef),
+					Namespace: testNamespace,
 				}
 				Eventually(func() bool {
+					iap := &secv1beta1resources.AuthorizationPolicy{}
 					err := k8sClient.Get(context.Background(), iapKey, iap)
 					logf.Log.V(1).Info("Fetching Istio's AuthorizationPolicy", "key", iapKey.String(), "error", err)
 					if err != nil && !apierrors.IsAlreadyExists(err) {
 						return false
 					}
+
+					// TODO check it is Ready
 					return true
 				}, 2*time.Minute, 5*time.Second).Should(BeTrue())
 
@@ -97,6 +107,8 @@ var _ = Describe("AuthPolicy controller", func() {
 					if err != nil && !apierrors.IsAlreadyExists(err) {
 						return false
 					}
+
+					// TODO check it is Ready
 					return true
 				}, 2*time.Minute, 5*time.Second).Should(BeTrue())
 			}
@@ -108,19 +120,12 @@ var _ = Describe("AuthPolicy controller", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// check Istio's AuthorizationPolicy existence
-				iap := &secv1beta1resources.AuthorizationPolicy{}
-				namespace := IstioGatewayNamespace
-				name := IstioGatewayName
-				if authpolicies[idx].Spec.TargetRef.Kind == "Gateway" {
-					namespace = testNamespace
-					name = CustomGatewayName
-				}
 				iapKey := types.NamespacedName{
-					Name:      istioAuthorizationPolicyName(name, authpolicies[idx].Spec.TargetRef),
-					Namespace: namespace,
+					Name:      istioAuthorizationPolicyName(CustomGatewayName, authpolicies[idx].Spec.TargetRef),
+					Namespace: testNamespace,
 				}
 				Eventually(func() bool {
-					err := k8sClient.Get(context.Background(), iapKey, iap)
+					err := k8sClient.Get(context.Background(), iapKey, &secv1beta1resources.AuthorizationPolicy{})
 					logf.Log.V(1).Info("Fetching Istio's AuthorizationPolicy", "key", iapKey.String(), "error", err)
 					if err != nil && apierrors.IsNotFound(err) {
 						return true
@@ -129,13 +134,12 @@ var _ = Describe("AuthPolicy controller", func() {
 				}, 2*time.Minute, 5*time.Second).Should(BeTrue())
 
 				// check Authorino's AuthConfig existence
-				ac := &authorinov1beta1.AuthConfig{}
 				acKey := types.NamespacedName{
 					Name:      authConfigName(client.ObjectKeyFromObject(authpolicies[idx])),
 					Namespace: testNamespace,
 				}
 				Eventually(func() bool {
-					err := k8sClient.Get(context.Background(), acKey, ac)
+					err := k8sClient.Get(context.Background(), acKey, &authorinov1beta1.AuthConfig{})
 					logf.Log.V(1).Info("Fetching Authorino's AuthConfig", "key", acKey.String(), "error", err)
 					if err != nil && apierrors.IsNotFound(err) {
 						return true
@@ -149,7 +153,7 @@ var _ = Describe("AuthPolicy controller", func() {
 
 	Context("Some rules without hosts", func() {
 		BeforeEach(func() {
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.toystore.com"})
+			httpRoute := testBuildBasicHttpRoute(CustomHTTPRouteName, CustomGatewayName, testNamespace, []string{"*.toystore.com"})
 			err := k8sClient.Create(context.Background(), httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -163,7 +167,7 @@ var _ = Describe("AuthPolicy controller", func() {
 					TargetRef: v1alpha2.PolicyTargetReference{
 						Group:     gatewayapiv1alpha2.Group(gatewayapiv1alpha2.GroupVersion.Group),
 						Kind:      "HTTPRoute",
-						Name:      gatewayapiv1alpha2.ObjectName(routeName),
+						Name:      gatewayapiv1alpha2.ObjectName(CustomHTTPRouteName),
 						Namespace: &typedNamespace,
 					},
 					AuthRules: []kuadrantv1beta1.AuthRule{
@@ -217,14 +221,14 @@ var _ = Describe("AuthPolicy controller", func() {
 			targetRef := v1alpha2.PolicyTargetReference{
 				Group:     gatewayapiv1alpha2.Group(gatewayapiv1alpha2.GroupVersion.Group),
 				Kind:      "HTTPRoute",
-				Name:      gatewayapiv1alpha2.ObjectName(routeName),
+				Name:      gatewayapiv1alpha2.ObjectName(CustomHTTPRouteName),
 				Namespace: &typedNamespace,
 			}
 
 			// Check Istio's authorization policy rules
 			existingIAP := &secv1beta1resources.AuthorizationPolicy{}
 			key := types.NamespacedName{
-				Name:      istioAuthorizationPolicyName(gwName, targetRef),
+				Name:      istioAuthorizationPolicyName(CustomGatewayName, targetRef),
 				Namespace: testNamespace,
 			}
 
@@ -250,7 +254,7 @@ var _ = Describe("AuthPolicy controller", func() {
 
 	Context("All rules with subdomains", func() {
 		BeforeEach(func() {
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.toystore.com"})
+			httpRoute := testBuildBasicHttpRoute(CustomHTTPRouteName, CustomGatewayName, testNamespace, []string{"*.toystore.com"})
 			err := k8sClient.Create(context.Background(), httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -264,7 +268,7 @@ var _ = Describe("AuthPolicy controller", func() {
 					TargetRef: v1alpha2.PolicyTargetReference{
 						Group:     gatewayapiv1alpha2.Group(gatewayapiv1alpha2.GroupVersion.Group),
 						Kind:      "HTTPRoute",
-						Name:      gatewayapiv1alpha2.ObjectName(routeName),
+						Name:      gatewayapiv1alpha2.ObjectName(CustomHTTPRouteName),
 						Namespace: &typedNamespace,
 					},
 					AuthRules: []kuadrantv1beta1.AuthRule{
@@ -323,7 +327,7 @@ var _ = Describe("AuthPolicy controller", func() {
 
 	Context("No rules", func() {
 		BeforeEach(func() {
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.toystore.com"})
+			httpRoute := testBuildBasicHttpRoute(CustomHTTPRouteName, CustomGatewayName, testNamespace, []string{"*.toystore.com"})
 			err := k8sClient.Create(context.Background(), httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -337,7 +341,7 @@ var _ = Describe("AuthPolicy controller", func() {
 					TargetRef: v1alpha2.PolicyTargetReference{
 						Group:     gatewayapiv1alpha2.Group(gatewayapiv1alpha2.GroupVersion.Group),
 						Kind:      "HTTPRoute",
-						Name:      gatewayapiv1alpha2.ObjectName(routeName),
+						Name:      gatewayapiv1alpha2.ObjectName(CustomHTTPRouteName),
 						Namespace: &typedNamespace,
 					},
 					AuthRules:  nil,
@@ -411,7 +415,7 @@ func authPolicies(namespace string) []*kuadrantv1beta1.AuthPolicy {
 			TargetRef: v1alpha2.PolicyTargetReference{
 				Group:     "gateway.networking.k8s.io",
 				Kind:      "HTTPRoute",
-				Name:      "toystore",
+				Name:      CustomHTTPRouteName,
 				Namespace: &typedNamespace,
 			},
 			AuthRules: []kuadrantv1beta1.AuthRule{
@@ -450,7 +454,8 @@ func authPolicies(namespace string) []*kuadrantv1beta1.AuthPolicy {
 	gatewayPolicy.Spec.TargetRef.Name = CustomGatewayName
 	gatewayPolicy.Spec.TargetRef.Namespace = &typedNamespace
 	gatewayPolicy.Spec.AuthRules = []kuadrantv1beta1.AuthRule{
-		{Hosts: []string{"*.toystore.com"}},
+		// Must be different from the other KAP targeting the route, otherwise authconfigs will not be ready
+		{Hosts: []string{"*.com"}},
 	}
 	gatewayPolicy.Spec.AuthScheme.Identity[0].APIKey.Selector.MatchLabels["admin"] = "yes"
 

--- a/controllers/authpolicy_controller_test.go
+++ b/controllers/authpolicy_controller_test.go
@@ -42,7 +42,7 @@ var _ = Describe("AuthPolicy controller", func() {
 
 		Eventually(func() bool {
 			existingGateway := &gatewayapiv1alpha2.Gateway{}
-			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(gateway), existingGateway)
+			err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(gateway), existingGateway)
 			if err != nil {
 				logf.Log.V(1).Info("[WARN] Creating gateway failed", "error", err)
 				return false
@@ -74,7 +74,7 @@ var _ = Describe("AuthPolicy controller", func() {
 
 			Eventually(func() bool {
 				existingRoute := &gatewayapiv1alpha2.HTTPRoute{}
-				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(httpRoute), existingRoute)
+				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(httpRoute), existingRoute)
 				if err != nil {
 					logf.Log.V(1).Info("[WARN] Creating route failed", "error", err)
 					return false

--- a/controllers/ratelimitpolicy_controller_test.go
+++ b/controllers/ratelimitpolicy_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayapiv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
@@ -144,6 +145,52 @@ func testBuildBasicRoutePolicy(policyName, ns, routeName string) *kuadrantv1beta
 	}
 }
 
+func testBuildGatewayPolicy(policyName, ns, gwName string) *kuadrantv1beta1.RateLimitPolicy {
+	genericDescriptorKey := "op"
+
+	return &kuadrantv1beta1.RateLimitPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RateLimitPolicy",
+			APIVersion: kuadrantv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      policyName,
+			Namespace: ns,
+		},
+		Spec: kuadrantv1beta1.RateLimitPolicySpec{
+			TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
+				Group: gatewayapiv1alpha2.Group("gateway.networking.k8s.io"),
+				Kind:  "Gateway",
+				Name:  gatewayapiv1alpha2.ObjectName(gwName),
+			},
+			RateLimits: []kuadrantv1beta1.RateLimit{
+				{
+					Configurations: []kuadrantv1beta1.Configuration{
+						{
+							Actions: []kuadrantv1beta1.ActionSpecifier{
+								{
+									GenericKey: &kuadrantv1beta1.GenericKeySpec{
+										DescriptorValue: "1",
+										DescriptorKey:   &genericDescriptorKey,
+									},
+								},
+							},
+						},
+					},
+					Limits: []kuadrantv1beta1.Limit{
+						{
+							MaxValue:   5,
+							Seconds:    10,
+							Conditions: []string{"op == 1"},
+							Variables:  []string{},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 var _ = Describe("RateLimitPolicy controller", func() {
 	var (
 		testNamespace        string
@@ -159,6 +206,23 @@ var _ = Describe("RateLimitPolicy controller", func() {
 		gateway = testBuildBasicGateway(gwName, testNamespace)
 		err := k8sClient.Create(context.Background(), gateway)
 		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func() bool {
+			existingGateway := &gatewayapiv1alpha2.Gateway{}
+			err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(gateway), existingGateway)
+			if err != nil {
+				logf.Log.V(1).Info("[WARN] Creating gateway failed", "error", err)
+				return false
+			}
+
+			if meta.IsStatusConditionFalse(existingGateway.Status.Conditions, common.GatewayProgrammedConditionType) {
+				logf.Log.V(1).Info("[WARN] Gateway not ready")
+				return false
+			}
+
+			return true
+		}, 15*time.Second, 5*time.Second).Should(BeTrue())
+
 		ApplyKuadrantCR(testNamespace)
 	}
 
@@ -414,6 +478,120 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					},
 				},
 			}))
+		})
+	})
+
+	Context("Basic: RLP targeting Gateway", func() {
+		It("check created resources", func() {
+			// Check Limitador Status is Ready
+			Eventually(func() bool {
+				limitador := &limitadorv1alpha1.Limitador{}
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, limitador)
+				if err != nil {
+					return false
+				}
+				if !meta.IsStatusConditionTrue(limitador.Status.Conditions, "Ready") {
+					return false
+				}
+				return true
+			}, time.Minute, 5*time.Second).Should(BeTrue())
+
+			rlp := testBuildGatewayPolicy(rlpName, testNamespace, gwName)
+			rlpKey := client.ObjectKey{Name: rlpName, Namespace: testNamespace}
+			err := k8sClient.Create(context.Background(), rlp)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check RLP status is available
+			Eventually(func() bool {
+				existingRLP := &kuadrantv1beta1.RateLimitPolicy{}
+				err := k8sClient.Get(context.Background(), rlpKey, existingRLP)
+				if err != nil {
+					return false
+				}
+				if !meta.IsStatusConditionTrue(existingRLP.Status.Conditions, "Available") {
+					return false
+				}
+
+				return true
+			}, time.Minute, 5*time.Second).Should(BeTrue())
+
+			// Check Gateway direct back reference
+			gwKey := client.ObjectKeyFromObject(gateway)
+			existingGateway := &gatewayapiv1alpha2.Gateway{}
+			err = k8sClient.Get(context.Background(), gwKey, existingGateway)
+			// must exist
+			Expect(err).ToNot(HaveOccurred())
+			Expect(existingGateway.GetAnnotations()).To(HaveKeyWithValue(
+				common.RateLimitPolicyBackRefAnnotation, client.ObjectKeyFromObject(rlp).String()))
+
+			// check limits
+			limitadorKey := client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}
+			existingLimitador := &limitadorv1alpha1.Limitador{}
+			err = k8sClient.Get(context.Background(), limitadorKey, existingLimitador)
+			// must exist
+			Expect(err).ToNot(HaveOccurred())
+			Expect(existingLimitador.Spec.Limits).To(ContainElements(limitadorv1alpha1.RateLimit{
+				MaxValue:   5,
+				Seconds:    10,
+				Namespace:  common.MarshallNamespace(client.ObjectKeyFromObject(gateway), "*"),
+				Conditions: []string{"op == 1"},
+				Variables:  []string{},
+			}))
+
+			// Check envoy filter
+			efName := fmt.Sprintf("kuadrant-ratelimiting-cluster-%s", gwName)
+			efKey := client.ObjectKey{Name: efName, Namespace: testNamespace}
+			existingEF := &istioclientnetworkingv1alpha3.EnvoyFilter{}
+			err = k8sClient.Get(context.Background(), efKey, existingEF)
+			// must exist
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check wasm plugin
+			wpName := fmt.Sprintf("kuadrant-%s", gwName)
+			wasmPluginKey := client.ObjectKey{Name: wpName, Namespace: testNamespace}
+			existingWasmPlugin := &istioclientgoextensionv1alpha1.WasmPlugin{}
+			err = k8sClient.Get(context.Background(), wasmPluginKey, existingWasmPlugin)
+			// must exist
+			Expect(err).ToNot(HaveOccurred())
+			existingWASMConfig, err := rlptools.WASMPluginFromStruct(existingWasmPlugin.Spec.PluginConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(existingWASMConfig).To(Equal(&rlptools.WASMPlugin{
+				FailureModeDeny: true,
+				RateLimitPolicies: []rlptools.RateLimitPolicy{
+					{
+						Name:            "*",
+						RateLimitDomain: common.MarshallNamespace(client.ObjectKeyFromObject(gateway), "*"),
+						UpstreamCluster: common.KuadrantRateLimitClusterName,
+						Hostnames:       []string{"*"},
+						GatewayActions: []rlptools.GatewayAction{
+							{
+								Configurations: []kuadrantv1beta1.Configuration{
+									{
+										Actions: []kuadrantv1beta1.ActionSpecifier{
+											{
+												GenericKey: &kuadrantv1beta1.GenericKeySpec{
+													DescriptorValue: "1",
+													DescriptorKey:   &genericDescriptorKey,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}))
+
+			// Check gateway back references
+			err = k8sClient.Get(context.Background(), gwKey, existingGateway)
+			// must exist
+			Expect(err).ToNot(HaveOccurred())
+			refs := []client.ObjectKey{rlpKey}
+			serialized, err := json.Marshal(refs)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(existingGateway.GetAnnotations()).To(HaveKeyWithValue(
+				common.RateLimitPoliciesBackRefAnnotation, string(serialized)))
 		})
 	})
 })


### PR DESCRIPTION
### What 

Tests should be reproducible and independent from external factors such as the environment or running order. This PR removes the usage of the shared `istio-ingressgateway` Gateway in the namespace `istio-system`. The integration tests only work with resources in the temporary namespace created for each test. 

Additionally, new RLP integration test is added where the policy targets the custom gateway directly