### PR TITLE
[test] Unit-tests for common/k8s_utils.go (part 1 of 3)

### DIFF
--- a/pkg/common/k8s_utils.go
+++ b/pkg/common/k8s_utils.go
@@ -42,6 +42,8 @@ func ObjectInfo(obj client.Object) string {
 	return fmt.Sprintf("%s/%s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
 }
 
+// ReadAnnotationsFromObject reads the annotations from a Kubernetes object
+// and returns them as a map. If the object has no annotations, it returns an empty map.
 func ReadAnnotationsFromObject(obj client.Object) map[string]string {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {

--- a/pkg/common/k8s_utils.go
+++ b/pkg/common/k8s_utils.go
@@ -52,6 +52,8 @@ func ReadAnnotationsFromObject(obj client.Object) map[string]string {
 	return annotations
 }
 
+// TagObjectToDelete adds a special 'delete' tag to the object's annotations.
+// If the object's annotations are nil, it first initializes the Annotations field with an empty map.
 func TagObjectToDelete(obj client.Object) {
 	// Add custom annotation
 	annotations := obj.GetAnnotations()

--- a/pkg/common/k8s_utils.go
+++ b/pkg/common/k8s_utils.go
@@ -35,6 +35,9 @@ const (
 	ReadyStatusConditionType = "Ready"
 )
 
+// ObjectInfo generates a string representation of the provided Kubernetes object, including its kind and name.
+// The object must implement the client.Object interface, which provides access to the object's metadata.
+// The generated string follows the format: "kind/name".
 func ObjectInfo(obj client.Object) string {
 	return fmt.Sprintf("%s/%s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
 }

--- a/pkg/common/k8s_utils.go
+++ b/pkg/common/k8s_utils.go
@@ -52,7 +52,7 @@ func ReadAnnotationsFromObject(obj client.Object) map[string]string {
 	return annotations
 }
 
-// TagObjectToDelete adds a special 'delete' tag to the object's annotations.
+// TagObjectToDelete adds a special DeleteTagAnnotation to the object's annotations.
 // If the object's annotations are nil, it first initializes the Annotations field with an empty map.
 func TagObjectToDelete(obj client.Object) {
 	// Add custom annotation
@@ -64,6 +64,9 @@ func TagObjectToDelete(obj client.Object) {
 	annotations[DeleteTagAnnotation] = "true"
 }
 
+// IsObjectTaggedToDelete checks if the given object is tagged for deletion.
+// It looks for the DeleteTagAnnotation in the object's annotations
+// and returns true if the annotation value is set to "true", false otherwise.
 func IsObjectTaggedToDelete(obj client.Object) bool {
 	annotations := obj.GetAnnotations()
 	if annotations == nil {

--- a/pkg/common/k8s_utils.go
+++ b/pkg/common/k8s_utils.go
@@ -36,7 +36,6 @@ const (
 )
 
 // ObjectInfo generates a string representation of the provided Kubernetes object, including its kind and name.
-// The object must implement the client.Object interface, which provides access to the object's metadata.
 // The generated string follows the format: "kind/name".
 func ObjectInfo(obj client.Object) string {
 	return fmt.Sprintf("%s/%s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -6,6 +6,7 @@ package common
 import (
 	"context"
 	"github.com/kuadrant/limitador-operator/api/v1alpha1"
+	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -201,6 +202,46 @@ func TestObjectInfo(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if actual := ObjectInfo(c.input); actual != c.expected {
 				t.Errorf("Expected %q, got %q", c.expected, actual)
+			}
+		})
+	}
+}
+
+func TestReadAnnotationsFromObject(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    client.Object
+		expected map[string]string
+	}{
+		{
+			name: "when object has annotations then return the annotations",
+			input: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			},
+			expected: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+		{
+			name: "when object has no annotations then return an empty map",
+			input: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expected: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := ReadAnnotationsFromObject(tc.input)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("Expected annotations %v, but got %v", tc.expected, actual)
 			}
 		})
 	}

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -318,3 +318,62 @@ func TestTagObjectToDelete(t *testing.T) {
 		})
 	}
 }
+
+func TestIsObjectTaggedToDelete(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       client.Object
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name: "when object has delete tag annotation set to true then return true",
+			input: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						DeleteTagAnnotation: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "when object has delete tag annotation set to false then return false",
+			input: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						DeleteTagAnnotation: "false",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "when object has no delete tag annotation then return false",
+			input: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "when object annotations are nil then return false",
+			input: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: nil,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := IsObjectTaggedToDelete(c.input)
+			if actual != c.expected {
+				t.Errorf("Expected %v, but got %v", c.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -306,15 +306,8 @@ func TestTagObjectToDelete(t *testing.T) {
 				t.Fatal("Expected annotations to be not nil, but got nil")
 			}
 
-			for key, expectedValue := range tc.expectedTags {
-				value, ok := annotations[key]
-				if !ok {
-					t.Errorf("Expected annotation key '%s' to exist, but it doesn't", key)
-				}
-
-				if value != expectedValue {
-					t.Errorf("Expected annotation value for key '%s' to be '%s', but got '%s'", key, expectedValue, value)
-				}
+			if !reflect.DeepEqual(annotations, tc.expectedTags) {
+				t.Errorf("Expected annotations to be '%v', but got '%v'", tc.expectedTags, annotations)
 			}
 		})
 	}

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -151,25 +151,25 @@ func TestObjectInfo(t *testing.T) {
 			name: "when given Kuadrant Limitador object then return formatted string",
 			input: &v1alpha1.Limitador{
 				TypeMeta: metav1.TypeMeta{
-					Kind: "limitador",
+					Kind: "Limitador",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-limitador",
 				},
 			},
-			expected: "limitador/test-limitador",
+			expected: "Limitador/test-limitador",
 		},
 		{
 			name: "when given k8s Pod object then return formatted string",
 			input: &corev1.Pod{
 				TypeMeta: metav1.TypeMeta{
-					Kind: "pod",
+					Kind: "Pod",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-pod",
 				},
 			},
-			expected: "pod/test-pod",
+			expected: "Pod/test-pod",
 		},
 		{
 			name: "when given k8s Service object with empty Kind then return formatted string",
@@ -184,13 +184,13 @@ func TestObjectInfo(t *testing.T) {
 			name: "when given k8s Namespace object with empty Name then return formatted string",
 			input: &corev1.Namespace{
 				TypeMeta: metav1.TypeMeta{
-					Kind: "namespace",
+					Kind: "Namespace",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "",
 				},
 			},
-			expected: "namespace/",
+			expected: "Namespace/",
 		},
 		{
 			name:     "when given empty object then return formatted string (separator only)",

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -148,7 +148,7 @@ func TestObjectInfo(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "when given Kuadrant Limitador object then return formatted string",
+			name: "when given a Kubernetes object then return formatted string",
 			input: &v1alpha1.Limitador{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Limitador",
@@ -160,19 +160,7 @@ func TestObjectInfo(t *testing.T) {
 			expected: "Limitador/test-limitador",
 		},
 		{
-			name: "when given k8s Pod object then return formatted string",
-			input: &corev1.Pod{
-				TypeMeta: metav1.TypeMeta{
-					Kind: "Pod",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-pod",
-				},
-			},
-			expected: "Pod/test-pod",
-		},
-		{
-			name: "when given k8s Service object with empty Kind then return formatted string",
+			name: "when given a Kubernetes object with empty Kind then return formatted string",
 			input: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-service",
@@ -181,7 +169,7 @@ func TestObjectInfo(t *testing.T) {
 			expected: "/test-service",
 		},
 		{
-			name: "when given k8s Namespace object with empty Name then return formatted string",
+			name: "when given a Kubernetes object with empty Name then return formatted string",
 			input: &corev1.Namespace{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "Namespace",
@@ -193,7 +181,7 @@ func TestObjectInfo(t *testing.T) {
 			expected: "Namespace/",
 		},
 		{
-			name:     "when given empty object then return formatted string (separator only)",
+			name:     "when given empty Kubernetes object then return formatted string (separator only)",
 			input:    &corev1.Pod{},
 			expected: "/",
 		},

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -5,9 +5,10 @@ package common
 
 import (
 	"context"
-	"github.com/kuadrant/limitador-operator/api/v1alpha1"
 	"reflect"
 	"testing"
+
+	"github.com/kuadrant/limitador-operator/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"


### PR DESCRIPTION
This pull request includes code refactorings and the addition of unit tests for multiple functions in common/k8s_utils.go. Comments and unit tests were added to functions:

- IsObjectTaggedToDelete
- TagObjectToDelete
- ReadAnnotationsFromObject
- ObjectInfo

Note: This is the part 1 of 3 of testing the k8s_utils.go. This pull request only partially closes issue https://github.com/Kuadrant/kuadrant-operator/issues/167, and there may be further updates needed in the future.

Coverage: 71.1%