### PR TITLE
[test] Unit-tests for common/k8s_utils.go (part 2 of 3)

### DIFF
--- a/pkg/common/k8s_utils.go
+++ b/pkg/common/k8s_utils.go
@@ -91,6 +91,10 @@ func StatusConditionsMarshalJSON(input []metav1.Condition) ([]byte, error) {
 	return json.Marshal(conds)
 }
 
+// IsOwnedBy checks if the provided owned object is owned by the given owner object.
+// Ownership is determined based on matching the owner reference's group, kind, and name.
+// The version of the owner reference is not checked in this implementation.
+// Returns true if the owned object is owned by the owner object, false otherwise.
 func IsOwnedBy(owned, owner client.Object) bool {
 	ownerGVK := owner.GetObjectKind().GroupVersionKind()
 

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -5,10 +5,13 @@ package common
 
 import (
 	"context"
-	appsv1 "k8s.io/api/apps/v1"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kuadrant/limitador-operator/api/v1alpha1"
 
@@ -570,6 +573,153 @@ func TestIsOwnedBy(t *testing.T) {
 			actual := IsOwnedBy(tc.owned, tc.owner)
 			if actual != tc.expected {
 				t.Errorf("unexpected result: got %v, want %v", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetServicePortNumber(t *testing.T) {
+	ctx := context.TODO()
+	k8sClient := fake.NewClientBuilder().Build()
+
+	tests := []struct {
+		name        string
+		servicePort string
+		expected    int32
+		service     *corev1.Service
+		serviceKey  client.ObjectKey
+		expectedErr error
+	}{
+		{
+			name:        "when port is already a number then return the number",
+			servicePort: "8080",
+			expected:    8080,
+			serviceKey:  client.ObjectKey{Name: "my-service1", Namespace: "default"},
+		},
+		{
+			name:        "when port is a named existing port then return the target port",
+			servicePort: "http",
+			expected:    8080,
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-service2", Namespace: "default"},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+				},
+			},
+			serviceKey: client.ObjectKey{Name: "my-service2", Namespace: "default"},
+		},
+		{
+			name:        "when port not found then return an error",
+			servicePort: "unknown",
+			expectedErr: fmt.Errorf("service port unknown was not found in default/my-service3"),
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-service3", Namespace: "default"},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+				},
+			},
+			serviceKey: client.ObjectKey{Name: "my-service3", Namespace: "default"},
+		},
+		{
+			name:        "when service not found then return an error",
+			servicePort: "http",
+			expectedErr: fmt.Errorf("services \"my-service4\" not found"),
+			expected:    0,
+			serviceKey:  client.ObjectKey{Name: "my-service4", Namespace: "default"},
+		},
+		{
+			name:        "when multiple ports exist and the port is found then return the target port",
+			servicePort: "http2",
+			expected:    8090,
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-service5", Namespace: "default"},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http1",
+							Port:       8080,
+							TargetPort: intstr.FromInt(8080),
+						},
+						{
+							Name:       "http2",
+							Port:       8090,
+							TargetPort: intstr.FromInt(8090),
+						},
+						{
+							Name:       "http3",
+							Port:       8100,
+							TargetPort: intstr.FromInt(8100),
+						},
+					},
+				},
+			},
+			serviceKey: client.ObjectKey{Name: "my-service5", Namespace: "default"},
+		},
+		{
+			name:        "when multiple ports exist and the port is not found then return an error",
+			servicePort: "https2",
+			expectedErr: fmt.Errorf("service port https2 was not found in default/my-service6"),
+			service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-service6", Namespace: "default"},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http1",
+							Port:       8080,
+							TargetPort: intstr.FromInt(8080),
+						},
+						{
+							Name:       "http2",
+							Port:       8090,
+							TargetPort: intstr.FromInt(8090),
+						},
+						{
+							Name:       "http3",
+							Port:       8100,
+							TargetPort: intstr.FromInt(8100),
+						},
+					},
+				},
+			},
+			serviceKey: client.ObjectKey{Name: "my-service6", Namespace: "default"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.service != nil {
+				err := k8sClient.Create(ctx, tt.service)
+				if err != nil {
+					t.Fatalf("failed to create service: %v", err)
+				}
+			}
+
+			portNumber, err := GetServicePortNumber(ctx, k8sClient, tt.serviceKey, tt.servicePort)
+
+			if err != nil && tt.expectedErr == nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if err == nil && tt.expectedErr != nil {
+				t.Error("expected an error, but got nil")
+			}
+			if err != nil && tt.expectedErr != nil && err.Error() != tt.expectedErr.Error() {
+				t.Errorf("unexpected error: got %v, want %v", err, tt.expectedErr)
+			}
+
+			if portNumber != tt.expected {
+				t.Errorf("unexpected port number: got %d, want %d", portNumber, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request includes the addition of unit tests for three functions in the common/k8s_utils.go file.

**Changes Made:**

- Added unit test for the `GetServicePortNumber` function.
- Added unit tests and comments for the `IsOwnedBy` function.
- Added unit tests for the `StatusConditionsMarshalJSON` function.

Please note that this is an ongoing work (part 2 of 3), and this pull request only partly closes issue #167. There will be subsequent pull requests to cover the remaining functions and increase the overall test coverage.

**Coverage:** 77.0%.