### PR TITLE
Build images with replaces image

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -23,6 +23,10 @@ on:
         description: WASM Shim version
         default: latest
         type: string
+      replacesVersion:
+        description: Kuadrant Operator replaced version
+        default: 0.0.0
+        type: string
   workflow_dispatch:
     inputs:
       kuadrantOperatorTag:
@@ -44,6 +48,10 @@ on:
       wasmShimVersion:
         description: WASM Shim version
         default: latest
+        type: string
+      replacesVersion:
+        description: Kuadrant Operator replaced version
+        default: 0.0.0
         type: string
 
 env:
@@ -110,7 +118,8 @@ jobs:
             VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.kuadrantOperatorTag }} \
             AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorVersion }} \
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
-            WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }}
+            WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
+            REPLACES_VERSION=${{ inputs.replacesVersion }}
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
@@ -151,7 +160,8 @@ jobs:
             VERSION=${{ env.VERSION }} IMAGE_TAG=${{ inputs.kuadrantOperatorTag }} \
             AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorVersion }} \
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
-            WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }}
+            WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
+            REPLACES_VERSION=${{ inputs.replacesVersion }}
       - name: Install qemu dependency
         run: |
           sudo apt-get update

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 DEFAULT_IMAGE_TAG = latest
+DEFAULT_REPLACES_VERSION = 0.0.0
+
+REPLACES_VERSION ?= $(DEFAULT_REPLACES_VERSION)
 
 # Semantic versioning (i.e. Major.Minor.Patch)
 is_semantic_version = $(shell [[ $(1) =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$ ]] && echo "true")
@@ -396,6 +399,7 @@ bundle: $(OPM) $(YQ) manifests kustomize operator-sdk ## Generate bundle manifes
 	V="kuadrant-operator.v$(BUNDLE_VERSION)" $(YQ) eval '.metadata.name = strenv(V)' -i config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
 	V="$(BUNDLE_VERSION)" $(YQ) eval '.spec.version = strenv(V)' -i config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
 	V="$(IMG)" $(YQ) eval '.metadata.annotations.containerImage = strenv(V)' -i config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+	V="kuadrant-operator.v$(REPLACES_VERSION)" $(YQ) eval '.spec.replaces = strenv(V)' -i config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
 	# Generate bundle
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)
 	# Update operator dependencies

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -558,4 +558,5 @@ spec:
   relatedImages:
   - image: oci://quay.io/kuadrant/wasm-shim:latest
     name: wasmshim
+  replaces: kuadrant-operator.v0.0.0
   version: 0.0.0

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -76,4 +76,5 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
+  replaces: kuadrant-operator.v0.0.0
   version: 0.0.0


### PR DESCRIPTION
This PR fixes the discrepancy between the bundle `replaces` value provided to OperatorHub and our bundle images (missing until now). It aims to fix the failing tests in our QE cluster and both https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/2664 and https://github.com/k8s-operatorhub/community-operators/pull/2762

When drafting a release, the build workflow_dispatch should also provide the version to replace as `X.Y.Z`