### PR TITLE
 [test] Unit-tests for common/k8s_utils.go (part 3 of 3) & Unit-tests and improvements for common/yaml_decoder.go

### DIFF
--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -819,3 +819,79 @@ func TestFindObjectKey(t *testing.T) {
 		})
 	}
 }
+
+func TestFindDeploymentStatusCondition(t *testing.T) {
+	tests := []struct {
+		name          string
+		conditions    []appsv1.DeploymentCondition
+		conditionType string
+		expected      *appsv1.DeploymentCondition
+	}{
+		{
+			name: "when search condition exists then return the condition",
+			conditions: []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentConditionType("Ready"),
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   appsv1.DeploymentConditionType("Progressing"),
+					Status: corev1.ConditionFalse,
+				},
+			},
+			conditionType: "Ready",
+			expected: &appsv1.DeploymentCondition{
+				Type:   appsv1.DeploymentConditionType("Ready"),
+				Status: corev1.ConditionTrue,
+			},
+		},
+		{
+			name: "when search condition does not exist then return nil",
+			conditions: []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentConditionType("Progressing"),
+					Status: corev1.ConditionFalse,
+				},
+			},
+			conditionType: "Ready",
+			expected:      nil,
+		},
+		{
+			name:          "when conditions slice is empty then return nil",
+			conditions:    []appsv1.DeploymentCondition{},
+			conditionType: "Ready",
+			expected:      nil,
+		},
+		{
+			name: "when multiple conditions have the same type then return the first occurrence",
+			conditions: []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentConditionType("Ready"),
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   appsv1.DeploymentConditionType("Progressing"),
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   appsv1.DeploymentConditionType("Ready"),
+					Status: corev1.ConditionFalse,
+				},
+			},
+			conditionType: "Ready",
+			expected: &appsv1.DeploymentCondition{
+				Type:   appsv1.DeploymentConditionType("Ready"),
+				Status: corev1.ConditionTrue,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := FindDeploymentStatusCondition(tc.conditions, tc.conditionType)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("unexpected result: got %s, want %s", actual.String(), tc.expected.String())
+			}
+		})
+	}
+}

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -27,6 +27,7 @@ func TestObjectKeyListDifference(t *testing.T) {
 	key1 := client.ObjectKey{Namespace: "ns1", Name: "obj1"}
 	key2 := client.ObjectKey{Namespace: "ns2", Name: "obj2"}
 	key3 := client.ObjectKey{Namespace: "ns3", Name: "obj3"}
+	key4 := client.ObjectKey{Namespace: "ns4", Name: "obj4"}
 
 	testCases := []struct {
 		name     string
@@ -63,6 +64,12 @@ func TestObjectKeyListDifference(t *testing.T) {
 			[]client.ObjectKey{key1, key2, key3},
 			[]client.ObjectKey{key1, key3},
 			[]client.ObjectKey{key2},
+		},
+		{
+			"when inputA and inputB have no common elements then return inputA as the result",
+			[]client.ObjectKey{key1, key2},
+			[]client.ObjectKey{key3, key4},
+			[]client.ObjectKey{key1, key2},
 		},
 	}
 

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -773,3 +773,49 @@ func TestContainsObjectKey(t *testing.T) {
 		})
 	}
 }
+
+func TestFindObjectKey(t *testing.T) {
+	key1 := client.ObjectKey{Namespace: "ns1", Name: "obj1"}
+	key2 := client.ObjectKey{Namespace: "ns2", Name: "obj2"}
+	key3 := client.ObjectKey{Namespace: "ns3", Name: "obj3"}
+
+	testCases := []struct {
+		name     string
+		list     []client.ObjectKey
+		key      client.ObjectKey
+		expected int
+	}{
+		{
+			name:     "when input slice has one search ObjectKey then return its index",
+			list:     []client.ObjectKey{key1, key2, key3},
+			key:      key2,
+			expected: 1,
+		},
+		{
+			name:     "when input slice has no search ObjectKey then return length of input slice",
+			list:     []client.ObjectKey{key1, key3},
+			key:      key2,
+			expected: 2,
+		},
+		{
+			name:     "when input slice is empty then return 0",
+			list:     []client.ObjectKey{},
+			key:      key1,
+			expected: 0,
+		},
+		{
+			name:     "when there are multiple occurrences of the search ObjectKey then return the index of first occurrence",
+			list:     []client.ObjectKey{key1, key2, key1, key3},
+			key:      key2,
+			expected: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if output := FindObjectKey(tc.list, tc.key); output != tc.expected {
+				t.Errorf("expected %d but got %d", tc.expected, output)
+			}
+		})
+	}
+}

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -731,3 +731,45 @@ func TestGetServicePortNumber(t *testing.T) {
 		})
 	}
 }
+
+func TestContainsObjectKey(t *testing.T) {
+	key1 := client.ObjectKey{Namespace: "ns1", Name: "obj1"}
+	key2 := client.ObjectKey{Namespace: "ns2", Name: "obj2"}
+	key3 := client.ObjectKey{Namespace: "ns3", Name: "obj3"}
+	key4 := client.ObjectKey{Namespace: "ns4", Name: "obj4"}
+
+	testCases := []struct {
+		name     string
+		list     []client.ObjectKey
+		key      client.ObjectKey
+		expected bool
+	}{
+		{
+			name:     "when list contains key then return true",
+			list:     []client.ObjectKey{key1, key2, key3},
+			key:      key2,
+			expected: true,
+		},
+		{
+			name:     "when list does not contain key then return false",
+			list:     []client.ObjectKey{key1, key2, key3},
+			key:      key4,
+			expected: false,
+		},
+		{
+			name:     "when list is empty then return false",
+			list:     []client.ObjectKey{},
+			key:      key4,
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ContainsObjectKey(tc.list, tc.key)
+			if result != tc.expected {
+				t.Errorf("unexpected result: got %t, want %t", result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -36,31 +36,31 @@ func TestObjectKeyListDifference(t *testing.T) {
 		expected []client.ObjectKey
 	}{
 		{
-			"empty",
+			"when both input slices are empty then return an empty slice",
 			[]client.ObjectKey{},
 			[]client.ObjectKey{},
 			[]client.ObjectKey{},
 		},
 		{
-			"a empty",
+			"when inputA is empty and inputB has elements then return an empty slice",
 			[]client.ObjectKey{},
 			[]client.ObjectKey{key1},
 			[]client.ObjectKey{},
 		},
 		{
-			"b empty",
+			"when inputA has elements and inputB is empty then return inputA as the result",
 			[]client.ObjectKey{key1, key2},
 			[]client.ObjectKey{},
 			[]client.ObjectKey{key1, key2},
 		},
 		{
-			"equal",
+			"when inputA and inputB are equal then return an empty slice",
 			[]client.ObjectKey{key1, key2, key3},
 			[]client.ObjectKey{key1, key2, key3},
 			[]client.ObjectKey{},
 		},
 		{
-			"missing key2",
+			"when inputA and inputB have common elements then return the difference",
 			[]client.ObjectKey{key1, key2, key3},
 			[]client.ObjectKey{key1, key3},
 			[]client.ObjectKey{key2},

--- a/pkg/common/k8s_utils_test.go
+++ b/pkg/common/k8s_utils_test.go
@@ -383,7 +383,7 @@ func TestStatusConditionsMarshalJSON(t *testing.T) {
 		err      error
 	}{
 		{
-			name:     "when input is empty then return an empty JSON (empty byte array)",
+			name:     "when input is empty then return an empty JSON array",
 			input:    []metav1.Condition{},
 			expected: []byte("[]"),
 			err:      nil,

--- a/pkg/common/yaml_decoder_test.go
+++ b/pkg/common/yaml_decoder_test.go
@@ -1,0 +1,291 @@
+//go:build unit
+// +build unit
+
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/kuadrant-operator/pkg/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type testCase struct {
+	name       string
+	fileData   []byte
+	objects    []runtime.Object
+	expectErr  bool
+	expectLogs bool
+}
+
+func TestDecodeFile(t *testing.T) {
+	testCases := []testCase{
+		{
+			name: "when decoding doc with known valid Kubernetes object then return no error or logs",
+			fileData: []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-deployment
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+`),
+			objects: []runtime.Object{&appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+			}},
+			expectErr:  false,
+			expectLogs: false,
+		},
+		{
+			name: "when decoding multidoc YAML file with valid Kubernetes objects then return no error or logs",
+			fileData: []byte(`
+---
+apiVersion: apps/v1
+kind: Pod
+metadata:
+  name: example-pod
+spec:
+  containers:
+  - name: nginx
+    image: nginx:latest
+    ports:
+    - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Service
+metadata:
+  name: example-service
+spec:
+  selector:
+    app: nginx
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+`),
+			objects: []runtime.Object{&corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "apps/v1",
+				},
+			}, &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "apps/v1",
+				},
+			}},
+			expectErr:  false,
+			expectLogs: false,
+		},
+		{
+			name: "when decoding doc with invalid object then return error and logs",
+			fileData: []byte(`
+apiVersion: v1
+kind: InvalidObject
+metadata:
+  name: example-invalid
+spec:
+  invalidField: invalidValue
+`),
+			objects: []runtime.Object{&corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "apps/v1",
+				},
+			}, &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "apps/v1",
+				},
+			}},
+			expectErr:  true,
+			expectLogs: true,
+		},
+		{
+			name: "when decoding doc with known Kubernetes object which misses Kind then return error and logs",
+			fileData: []byte(`
+apiVersion: v1
+metadata:
+  name: example-object
+`),
+			objects:    []runtime.Object{},
+			expectErr:  true,
+			expectLogs: true,
+		},
+		{
+			name: "when decoding empty doc (consists of '---') then return error and logs",
+			fileData: []byte(`---
+---
+`),
+			objects: []runtime.Object{&corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "apps/v1",
+				},
+			}},
+			expectErr:  true,
+			expectLogs: true,
+		},
+		{
+			name:     "when decoding empty doc (empty file data) then return error and logs",
+			fileData: []byte(``),
+			objects: []runtime.Object{&corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "apps/v1",
+				},
+			}},
+			expectErr:  false,
+			expectLogs: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logBuffer := bytes.Buffer{}
+			logger := log.NewLogger(
+				log.WriteTo(&logBuffer),
+				log.SetLevel(log.DebugLevel),
+				log.SetMode(log.ModeDev))
+
+			scheme := runtime.NewScheme()
+
+			// Add the necessary scheme information for decoding objects
+			for _, obj := range tc.objects {
+				gvk := schema.GroupVersionKind{
+					Group:   obj.GetObjectKind().GroupVersionKind().Group,
+					Version: obj.GetObjectKind().GroupVersionKind().Version,
+					Kind:    obj.GetObjectKind().GroupVersionKind().Kind,
+				}
+				scheme.AddKnownTypeWithName(gvk, obj)
+			}
+
+			ctx := logr.NewContext(context.Background(), logger)
+
+			callback := func(obj runtime.Object) error {
+				// Fake callback function to handle the decoded object,
+				// perform validation and return an error if the object is invalid
+				switch obj := obj.(type) {
+				case *corev1.Pod, *appsv1.Deployment, *corev1.Service:
+					// valid object types
+				default:
+					return fmt.Errorf("unexpected object type: %T", obj)
+				}
+
+				return nil
+			}
+
+			// Call the DecodeFile function with the provided context, file data, scheme, and callback
+			err := DecodeFile(ctx, tc.fileData, scheme, callback)
+
+			if (err != nil) != tc.expectErr {
+				if tc.expectErr {
+					t.Errorf("expected error, but got nil")
+				} else {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+
+			if tc.expectLogs && logBuffer.Len() == 0 {
+				t.Errorf("expected logs, but got none")
+			}
+			if !tc.expectLogs && logBuffer.Len() > 0 {
+				t.Errorf("unexpected logs: %s", logBuffer.String())
+			}
+		})
+	}
+}
+
+func TestDecodeFileDetailedValidation(t *testing.T) {
+	t.Run("when decoding a valid Kubernetes object with detailed validation in callback then validate the object", func(t *testing.T) {
+		fileData := []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-deployment
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+`)
+
+		logBuffer := bytes.Buffer{}
+		logger := log.NewLogger(
+			log.WriteTo(&logBuffer),
+			log.SetLevel(log.DebugLevel),
+			log.SetMode(log.ModeDev))
+
+		scheme := runtime.NewScheme()
+		scheme.AddKnownTypes(schema.GroupVersion{
+			Group:   "apps",
+			Version: "v1",
+		}, &appsv1.Deployment{})
+
+		ctx := logr.NewContext(context.Background(), logger)
+
+		callback := func(obj runtime.Object) error {
+			deployment, ok := obj.(*appsv1.Deployment)
+			if !ok {
+				return fmt.Errorf("unexpected object type: %T", obj)
+			}
+
+			// Perform validations on the deployment object
+			if deployment.Name != "example-deployment" {
+				t.Errorf("unexpected deployment name: %s", deployment.Name)
+			}
+			if *deployment.Spec.Replicas != int32(3) {
+				t.Errorf("unexpected number of replicas: %d", *deployment.Spec.Replicas)
+			}
+			if len(deployment.Spec.Template.Spec.Containers) != 1 {
+				t.Errorf("unexpected number of containers: %d", len(deployment.Spec.Template.Spec.Containers))
+			}
+			if deployment.Spec.Template.Spec.Containers[0].Name != "nginx" {
+				t.Errorf("unexpected container name: %s", deployment.Spec.Template.Spec.Containers[0].Name)
+			}
+			if deployment.Spec.Template.Spec.Containers[0].Image != "nginx:latest" {
+				t.Errorf("unexpected container image: %s", deployment.Spec.Template.Spec.Containers[0].Image)
+			}
+			if deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort != 80 {
+				t.Errorf("unexpected container port: %d", deployment.Spec.Template.Spec.Containers[0].Ports[0].ContainerPort)
+			}
+
+			return nil
+		}
+
+		err := DecodeFile(ctx, fileData, scheme, callback)
+		if (err != nil) != false {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if logBuffer.Len() > 0 {
+			t.Errorf("unexpected logs: %s", logBuffer.String())
+		}
+	})
+}


### PR DESCRIPTION
This pull request completes the unit tests for the k8s_utils.go file, addressing the remaining functions and adding additional coverage and imporvements to the yaml_decoder.go file.

**Changes Made:**
_k8s_utils.go_
- Added unit test to `ObjectKeyListDifference`, `ContainsObjectKey`, `FindObjectKey`, `FindDeploymentStatusCondition`

_yaml_decoder.go_
- Added unit tests and comment `DecodeFile`

Changes made to DecodeFile, see https://github.com/Kuadrant/kuadrant-operator/commit/c1277317f5e3f827411c0e74d3e9b4f8153dbfae

**Additional Information:**

- This PR is the final part (part 3 of 3) of the unit tests and improvements for the k8s_utils.go file.
- It includes the unit-tests for the last function mentioned in issue #167,
- It also marks the **completion of the work** for issue #167. (closes #167)
- The final test coverage: 83.8% of statements, significantly improving the overall code quality (initial 52.0%).

**Please note that the previous PRs have been merged and this PR concludes the work for issue #167.**

Note also that this PR includes unmerged commits from https://github.com/Kuadrant/kuadrant-operator/pull/191

Coverage: 83.8%.