### PR TITLE
kind: bump to 0.20.0 and pin image to kindest/node:v1.27.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
-          version: v0.11.0
+          version: v0.20.0
           config: utils/kind-cluster.yaml
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ $(OPM):
 opm: $(OPM) ## Download opm locally if necessary.
 
 KIND = $(PROJECT_PATH)/bin/kind
-KIND_VERSION = v0.17.0
+KIND_VERSION = v0.20.0
 $(KIND):
 	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@$(KIND_VERSION))
 

--- a/utils/kind-cluster.yaml
+++ b/utils/kind-cluster.yaml
@@ -3,7 +3,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.22.7
+  image: kindest/node:v1.27.3
   # port forward 80 on the host to 80 on this node
   extraPortMappings:
     - containerPort: 30950


### PR DESCRIPTION
On Darwin arm64 using `cgroupv2` on docker, running `make local-setup` fails with the following:
```
 ✗ Preparing nodes 📦
ERROR: failed to create cluster: could not find a log line that matches "Reached target .*Multi-User System.*|detected cgroup v1"
```

Bumping the kind version to v0.20.0 and updating the default image to v1.27.3 looks to fix this when running the command locally for me 

* https://github.com/kubernetes-sigs/kind/releases/tag/v0.20.0