### PR TITLE
workflow: use go1.19 to align with go.mod go version used

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -100,10 +100,10 @@ jobs:
     name: Build Bundle
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2
@@ -147,10 +147,10 @@ jobs:
     needs: [build, build-bundle]
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -40,10 +40,10 @@ jobs:
             importpath: golang.org/x/tools/cmd/goimports@latest
 
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
 
       - name: Check out code
@@ -90,10 +90,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
 
       - name: Check out code

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: [ 1.18.x ]
+        go-version: [ 1.19.x ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     defaults:
@@ -46,10 +46,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2
@@ -80,10 +80,10 @@ jobs:
     name: Verify manifests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2
@@ -95,10 +95,10 @@ jobs:
     name: Verify bundle
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2
@@ -110,10 +110,10 @@ jobs:
     name: Verify fmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.18.x
+      - name: Set up Go 1.19.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
         id: go
       - name: Check out code
         uses: actions/checkout@v2
@@ -125,7 +125,7 @@ jobs:
     name: Test Scripts
     strategy:
       matrix:
-        go-version: [ 1.18.x ]
+        go-version: [ 1.19.x ]
         platform: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.platform }}
     defaults:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/doc/development.md
+++ b/doc/development.md
@@ -24,8 +24,8 @@
 
 ## Technology stack required for development
 
-* [operator-sdk] version v1.22.0
-* [kind] version v0.11.1
+* [operator-sdk] version v1.28.1
+* [kind] version v0.20.0
 * [git][git_tool]
 * [go] version 1.19+
 * [kubernetes] version v1.19+

--- a/doc/development.md
+++ b/doc/development.md
@@ -27,7 +27,7 @@
 * [operator-sdk] version v1.22.0
 * [kind] version v0.11.1
 * [git][git_tool]
-* [go] version 1.18+
+* [go] version 1.19+
 * [kubernetes] version v1.19+
 * [kubectl] version v1.19+
 


### PR DESCRIPTION
* As we use Go1.19 in `go.mod`, the workflows should be updated to align with this version
* Update the development doc to use the correct versions of kind and operator sdk used in the makefile