### PR TITLE
docs: minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The Operator to install and manage the lifecycle of the [Kuadrant](https://githu
       * [If you are an <em>API Provider</em>](#if-you-are-an-api-provider)
       * [If you are a <em>Cluster Operator</em>](#if-you-are-a-cluster-operator)
 * [User guides](#user-guides)
-* [<a href="/doc/rate-limiting.md">Kuadrant Rate Limiting</a>](#kuadrant-rate-limiting)
+* [<a href="doc/rate-limiting.md">Kuadrant Rate Limiting</a>](#kuadrant-rate-limiting)
 * [Documentation](#documentation)
 * [Contributing](#contributing)
 * [Licensing](#licensing)
@@ -32,29 +32,30 @@ more reusable and leverage the underlying kubernetes platform. It aims to delive
 of applications & services when it comes to rate limiting, authentication, authorization, discoverability, change management, usage contracts, insights, etc.
 
 Kuadrant aims to produce a set of loosely coupled functionalities built directly on top of Kubernetes.
-Furthermore it only strives to provide what Kubernetes doesn’t offer out of the box, i.e. Kuadrant won’t be designing a new Gateway/proxy,
+Furthermore, it only strives to provide what Kubernetes doesn’t offer out of the box, i.e. Kuadrant won’t be designing a new Gateway/proxy,
 instead it will opt to connect with what’s there and what’s being developed (think Envoy, Istio, GatewayAPI).
 
 Kuadrant is a system of cloud-native k8s components that grows as users’ needs grow.
+
 * From simple protection of a Service (via **AuthN**) that is used by teammates working on the same cluster, or “sibling” services, up to **AuthZ** of users using OIDC plus custom policies.
 * From no rate-limiting to rate-limiting for global service protection on to rate-limiting by users/plans
 
 ## Architecture
 
 Kuadrant relies on [Istio](https://istio.io/) and the [Gateway API](https://gateway-api.sigs.k8s.io/)
-to operate the cluster (istio's) ingress gateway to provide API management with **authentication** (authN),
+to operate the cluster (Istio's) ingress gateway to provide API management with **authentication** (authN),
 **authorization** (authZ) and **rate limiting** capabilities.
 
 ### Kuadrant components
 
-| CRD | Description                                                                                                                                                                                                                                                                     |
-| --- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Control Plane | The control plane takes the customer desired configuration (declaratively as kubernetes custom resources) as input and ensures all components are configured to obey customer's desired behavior.<br> This repository contains the source code of the kuadrant control plane    |
-| [Kuadrant Operator](https://github.com/Kuadrant/kuadrant-operator) | A Kubernetes Operator to manage the lifecycle of the kuadrant deployment                                                                                                                                                                                                        |
-| [Authorino](https://github.com/Kuadrant/authorino) | The AuthN/AuthZ enforcer. As the [external istio authorizer](https://istio.io/latest/docs/tasks/security/authorization/authz-custom/) ([envoy external authorization](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter) serving gRPC service) |
-| [Limitador](https://github.com/Kuadrant/limitador) | The external rate limiting service. It exposes a gRPC service implementing the [Envoy Rate Limit protocol (v3)](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ratelimit/v3/rls.proto)                                                                              |
-| [Authorino Operator](https://github.com/Kuadrant/authorino-operator) | A Kubernetes Operator to manage Authorino instances                                                                                                                                                                                                                             |
-| [Limitador Operator](https://github.com/Kuadrant/limitador-operator) | A Kubernetes Operator to manage Limitador instances                                                                                                                                                                                                                             |
+| CRD                                                                  | Description                                                                                                                                                                                                                                                                               |
+|----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Control Plane                                                        | The control plane takes the customer desired configuration (declaratively as kubernetes custom resources) as input and ensures all components are configured to obey customer's desired behavior.<br> This repository contains the source code of the kuadrant control plane              |
+| [Kuadrant Operator](https://github.com/Kuadrant/kuadrant-operator)   | A Kubernetes Operator to manage the lifecycle of the kuadrant deployment                                                                                                                                                                                                                  |
+| [Authorino](https://github.com/Kuadrant/authorino)                   | The AuthN/AuthZ enforcer. As the [external istio authorizer](https://istio.io/latest/docs/tasks/security/authorization/authz-custom/) ([envoy external authorization](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter) serving gRPC service) |
+| [Limitador](https://github.com/Kuadrant/limitador)                   | The external rate limiting service. It exposes a gRPC service implementing the [Envoy Rate Limit protocol (v3)](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ratelimit/v3/rls.proto)                                                                                        |
+| [Authorino Operator](https://github.com/Kuadrant/authorino-operator) | A Kubernetes Operator to manage Authorino instances                                                                                                                                                                                                                                       |
+| [Limitador Operator](https://github.com/Kuadrant/limitador-operator) | A Kubernetes Operator to manage Limitador instances                                                                                                                                                                                                                                       |
 
 ### Provided APIs
 
@@ -86,7 +87,7 @@ Additionally, Kuadrant provides the following CRDs
 
 ### Installing Kuadrant
 
-Installing Kuadrant is a two-step procedure. Firstly, install the Kuadrant Operator and seconly,
+Installing Kuadrant is a two-step procedure. Firstly, install the Kuadrant Operator and secondly,
 request a Kuadrant instance by creating a *Kuadrant* custom resource.
 
 #### 1. Install the Kuadrant Operator
@@ -98,14 +99,14 @@ The Kuadrant Operator is available in public community operator catalogs, such a
 The operator is available from [OperatorHub.io](https://operatorhub.io/operator/kuadrant-operator).
 Just go to the linked page and follow installation steps (or just run these two commands):
 
-```
+```sh
 # Install Operator Lifecycle Manager (OLM), a tool to help manage the operators running on your cluster.
 
-$ curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.23.1/install.sh | bash -s v0.23.1
+curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.23.1/install.sh | bash -s v0.23.1
 
 # Install the operator by running the following command:
 
-$ kubectl create -f https://operatorhub.io/install/kuadrant-operator.yaml
+kubectl create -f https://operatorhub.io/install/kuadrant-operator.yaml
 ```
 
 **Openshift**
@@ -125,12 +126,13 @@ kubectl create namespace kuadrant
 
 Apply the `Kuadrant` custom resource:
 
-```yaml
-kubectl apply -n kuadrant -f -<<EOF
+```sh
+kubectl -n kuadrant apply -f - <<EOF
+---
 apiVersion: kuadrant.io/v1beta1
 kind: Kuadrant
 metadata:
-  name: kuadrant
+  name: kuadrant-sample
 spec: {}
 EOF
 ```
@@ -142,16 +144,16 @@ EOF
 * Deploy the service/API to be protected ("Upstream")
 * Expose the service/API using the kubernetes Gateway API, ie
   [HTTPRoute](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute) object.
-* Write and apply the Kuadrant's [RateLimitPolicy](/doc/rate-limiting.md) and/or
-  [AuthPolicy](apis/apim/v1alpha1/authpolicy_types.go) custom resources targeting the HTTPRoute resource
+* Write and apply the Kuadrant's [RateLimitPolicy](doc/rate-limiting.md) and/or
+  [AuthPolicy](api/v1beta1/authpolicy_types.go) custom resources targeting the HTTPRoute resource
   to have your API protected.
 
 #### If you are a *Cluster Operator*
 
 * (Optionally) deploy istio ingress gateway using the
   [Gateway](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.Gateway) resource.
-* Write and apply the Kuadrant's [RateLimitPolicy](/doc/rate-limiting.md) and/or
-  [AuthPolicy](apis/apim/v1alpha1/authpolicy_types.go) custom resources targeting the Gateway resource
+* Write and apply the Kuadrant's [RateLimitPolicy](doc/rate-limiting.md) and/or
+  [AuthPolicy](api/v1beta1/authpolicy_types.go) custom resources targeting the Gateway resource
   to have your gateway traffic protected.
 
 ## User guides
@@ -163,7 +165,7 @@ The user guides section of the docs gathers several use-cases as well as the ins
 * [Gateway rate limiting for cluster operators](doc/user-guides/gateway-rl-for-cluster-operators.md)
 * [Authenticated rate limiting with JWTs and Kubernetes authnz](doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md)
 
-## [Kuadrant Rate Limiting](/doc/rate-limiting.md)
+## [Kuadrant Rate Limiting](doc/rate-limiting.md)
 
 ## Documentation
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -9,7 +9,6 @@
    * [Build custom OLM catalog](#build-custom-olm-catalog)
       * [Build kuadrant operator bundle image](#build-kuadrant-operator-bundle-image)
       * [Build custom catalog](#build-custom-catalog)
-      * [Deploy kuadrant operator using OLM](#deploy-kuadrant-operator-using-olm-1)
    * [Cleaning up](#cleaning-up)
    * [Run tests](#run-tests)
       * [Unit tests](#unittests)
@@ -89,9 +88,9 @@ make install-olm
 
 Deploy kuadrant using OLM. The `make deploy-catalog` target accepts the following variables:
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `CATALOG_IMG` | Kuadrant operator catalog image URL | `quay.io/kuadrant/kuadrant-operator-catalog:latest` |
+| **Makefile Variable** | **Description**                     | **Default value**                                   |
+|-----------------------|-------------------------------------|-----------------------------------------------------|
+| `CATALOG_IMG`         | Kuadrant operator catalog image URL | `quay.io/kuadrant/kuadrant-operator-catalog:latest` |
 
 ```sh
 make deploy-catalog [CATALOG_IMG=quay.io/kuadrant/kuadrant-operator-catalog:latest]
@@ -130,9 +129,9 @@ make bundle [IMG=quay.io/kuadrant/kuadrant-operator:latest] \
 
 * Build the bundle image from the manifests
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `BUNDLE_IMG` | Kuadrant operator bundle image URL | `quay.io/kuadrant/kuadrant-operator-bundle:latest` |
+| **Makefile Variable** | **Description**                    | **Default value**                                  |
+|-----------------------|------------------------------------|----------------------------------------------------|
+| `BUNDLE_IMG`          | Kuadrant operator bundle image URL | `quay.io/kuadrant/kuadrant-operator-bundle:latest` |
 
 ```sh
 make bundle-build [BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:latest]
@@ -140,9 +139,9 @@ make bundle-build [BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:latest]
 
 * Push the bundle image to a registry
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `BUNDLE_IMG` | Kuadrant operator bundle image URL | `quay.io/kuadrant/kuadrant-operator-bundle:latest` |
+| **Makefile Variable** | **Description**                    | **Default value**                                  |
+|-----------------------|------------------------------------|----------------------------------------------------|
+| `BUNDLE_IMG`          | Kuadrant operator bundle image URL | `quay.io/kuadrant/kuadrant-operator-bundle:latest` |
 
 ```sh
 make bundle-push [BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:latest]
@@ -150,7 +149,7 @@ make bundle-push [BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:latest]
 
 Frequently, you may need to build custom kuadrant bundle with the default (`latest`) Limitador and
 Authorino bundles. These are the example commands to build the manifests, build the bundle image
-and push to the regitry.
+and push to the registry.
 
 In the example, a new kuadrant operator bundle version `0.8.0` will be created that references
 the kuadrant operator image `quay.io/kuadrant/kuadrant-operator:v0.5.0` and latest Limitador and
@@ -169,17 +168,17 @@ make bundle-push BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:my-bundle
 
 ### Build custom catalog
 
-The catalog's format will be [File-based Catalg](https://olm.operatorframework.io/docs/reference/file-based-catalogs/).
+The catalog's format will be [File-based Catalog](https://olm.operatorframework.io/docs/reference/file-based-catalogs/).
 
 Make sure all the required bundles are pushed to the registry. It is required by the `opm` tool.
 
 The `make catalog` target accepts the following variables:
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `BUNDLE_IMG` | Kuadrant operator bundle image URL | `quay.io/kuadrant/kuadrant-operator-bundle:latest` |
-| `LIMITADOR_OPERATOR_BUNDLE_IMG` | Limitador operator bundle URL | `quay.io/kuadrant/limitador-operator-bundle:latest` |
-| `AUTHORINO_OPERATOR_BUNDLE_IMG` | Authorino operator bundle URL | `quay.io/kuadrant/authorino-operator-bundle:latest` |
+| **Makefile Variable**           | **Description**                    | **Default value**                                   |
+|---------------------------------|------------------------------------|-----------------------------------------------------|
+| `BUNDLE_IMG`                    | Kuadrant operator bundle image URL | `quay.io/kuadrant/kuadrant-operator-bundle:latest`  |
+| `LIMITADOR_OPERATOR_BUNDLE_IMG` | Limitador operator bundle URL      | `quay.io/kuadrant/limitador-operator-bundle:latest` |
+| `AUTHORINO_OPERATOR_BUNDLE_IMG` | Authorino operator bundle URL      | `quay.io/kuadrant/authorino-operator-bundle:latest` |
 
 ```sh
 make catalog [BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:latest] \
@@ -189,9 +188,9 @@ make catalog [BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:latest] \
 
 * Build the catalog image from the manifests
 
-| **Makefile Variable** | **Description** | **Default value** |
-| --- | --- | --- |
-| `CATALOG_IMG` | Kuadrant operator catalog image URL | `quay.io/kuadrant/kuadrant-operator-catalog:latest` |
+| **Makefile Variable** | **Description**                     | **Default value**                                   |
+|-----------------------|-------------------------------------|-----------------------------------------------------|
+| `CATALOG_IMG`         | Kuadrant operator catalog image URL | `quay.io/kuadrant/kuadrant-operator-catalog:latest` |
 
 ```sh
 make catalog-build [CATALOG_IMG=quay.io/kuadrant/kuadrant-operator-catalog:latest]

--- a/doc/logging.md
+++ b/doc/logging.md
@@ -1,6 +1,7 @@
 # Logging
 
 The kuadrant operator outputs 3 levels of log messages: (from lowest to highest level)
+
 1. `debug`
 2. `info` (default)
 3. `error`
@@ -12,6 +13,7 @@ Only `debug` logging will include processing details.
 To configure the desired log level, set the environment variable `LOG_LEVEL` to one of the supported values listed above. Default log level is `info`.
 
 Apart from log level, the operator can output messages to the logs in 2 different formats:
+
 - `production` (default): each line is a parseable JSON object with properties `{"level":string, "ts":int, "msg":string, "logger":string, extra values...}`
 - `development`: more human-readable outputs, extra stack traces and logging info, plus extra values output as JSON, in the format: `<timestamp-iso-8601>\t<log-level>\t<logger>\t<message>\t{extra-values-as-json}`
 

--- a/doc/proposals/authpolicy-crd.md
+++ b/doc/proposals/authpolicy-crd.md
@@ -9,14 +9,14 @@ The new [GatewayAPI](https://gateway-api.sigs.k8s.io/) defines a standard [polic
 ## Goals
 
 With `targetRef`  from policy attachment concept, following are the goals:
-- Application developer should be able target [`HTTPRoute`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute) object in their own namespace. This will define authorization policy at the hostname/domain/vHost level.
+- Application developer should be able to target [`HTTPRoute`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRoute) object in their own namespace. This will define authorization policy at the hostname/domain/vHost level.
 - Cluster operator should be able to target [`Gateway`](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.Gateway) object along with HTTPRoute in the gateway's namespace. This will define policy at the <ins>listener</ins> level.
 - To reduce context sharing at the gateway and external authorization provider, action type and auth-provider are defaulted to `CUSTOM` and authorino respectively.
 
 ## Proposed Solution
 Following is the proposed new CRD that combines policy attachment concepts with Istio's AuthorizationPolicy:
 
-```yaml=
+```yaml
 apiVersion: kuadrant.io/v1beta1
 kind: AuthPolicy
 metadata:
@@ -50,7 +50,7 @@ status:
       reason: HTTPRouteProtected/GatewayProtected/Error
       status: "True" | "False"
       type: Available
-    observedGeneration: 1
+  observedGeneration: 1
 ```
 
 ### Target Reference
@@ -84,7 +84,7 @@ status:
 - `methods`: a method matches over request method like `DELETE`.
 
 Fields in a rule object are ANDed together but inner fields follow OR semantics. For example,
-```
+```yaml
 hosts: ["*.toystore.com"]
 methods: ["GET", "POST"]
 paths: ["/admin"]
@@ -100,7 +100,7 @@ AuthScheme is embedded form of [Authorino's AuthConfig](https://github.com/Kuadr
 
 The example AuthPolicy showed above will create the following AuthConfig:
 
-```yaml=
+```yaml
 apiVersion: authorino.kuadrant.io/v1beta1
 kind: AuthConfig
 metadata:

--- a/doc/proposals/rlp-target-gateway-resource.md
+++ b/doc/proposals/rlp-target-gateway-resource.md
@@ -12,7 +12,7 @@ Having in place this HTTPRoute - Gateway hierarchy, we are also considering to a
 
 ![](https://i.imgur.com/UkivAqA.png)
 
-On designing kuadrant rate limiting and considering Istio/Envoy's rate limiting offering, we hit two limitations ([described here](https://docs.google.com/document/d/1ve_8ZBq8TK_wnAZHg69M6-f_q1w-mX4vuP1BC1EuEO8/edit#bookmark=id.5wyq2fj56u94)). Therefore, not giving up entirely in existing [Envoy's RateLimit Filter](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/ratelimit/v3/rate_limit.proto#extension-envoy-filters-network-ratelimit), we decided to move on and leverage the Envoy's [Wasm Network Filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/wasm_filter) and implement rate limiting [wasm-shim](https://github.com/Kuadrant/wasm-shim) module compliant with the Envoy's [Rate Limit Service (RLS)](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ratelimit/v3/rls.proto). This wasm-shim module accepts a [PluginConfig](https://github.com/Kuadrant/kuadrant-operator/blob/fa2b52967409b7c4ea2c2e3412ecf80a8ad2b802/pkg/istio/wasm.go#L24) struct object as input configuration object.
+On designing Kuadrant's rate limiting and considering Istio/Envoy's rate limiting offering, we hit two limitations ([described here](https://docs.google.com/document/d/1ve_8ZBq8TK_wnAZHg69M6-f_q1w-mX4vuP1BC1EuEO8/edit#bookmark=id.5wyq2fj56u94)). Therefore, not giving up entirely in existing [Envoy's RateLimit Filter](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/ratelimit/v3/rate_limit.proto#extension-envoy-filters-network-ratelimit), we decided to move on and leverage the Envoy's [Wasm Network Filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/wasm_filter) and implement rate limiting [wasm-shim](https://github.com/Kuadrant/wasm-shim) module compliant with the Envoy's [Rate Limit Service (RLS)](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ratelimit/v3/rls.proto). This wasm-shim module accepts a [PluginConfig](https://github.com/Kuadrant/kuadrant-operator/blob/fa2b52967409b7c4ea2c2e3412ecf80a8ad2b802/pkg/istio/wasm.go#L24) struct object as input configuration object.
 
 ## Use Cases targeting a gateway
 A key use case is being able to provide governance over what service providers can and cannot do when exposing a service via a shared ingress gateway. As well as providing certainty that no service is exposed without my ability as a cluster administrator to protect my infrastructure from unplanned load from badly behaving clients etc.
@@ -24,7 +24,7 @@ The goal of this document is to define:
 * The kuadrant-operator behavior filling the `PluginConfig` struct having as input the RateLimitPolicy k8s objects
 * The behavior of the wasm-shim having the `PluginConfig` struct as input.
 
-## Envoy's Rate Limit Service Potocol
+## Envoy's Rate Limit Service Protocol
 
 Kuadrant's rate limit relies on the [Rate Limit Service (RLS)](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/ratelimit/v3/rls.proto)
 protocol, hence the gateway generates, based on a set of

--- a/doc/ratelimitpolicy-reference.md
+++ b/doc/ratelimitpolicy-reference.md
@@ -18,64 +18,64 @@ Generated using [github-markdown-toc](https://github.com/ekalinin/github-markdow
 
 ## RateLimitPolicy
 
-| **json/yaml field**| **Type** | **Required** | **Description** |
-| --- | --- | --- | --- |
-| `spec` | [RateLimitPolicySpec](#RateLimitPolicySpec) | Yes | The specfication for RateLimitPolicy custom resource |
-| `status` | [RateLimitPolicyStatus](#RateLimitPolicyStatus) | No | The status for the custom resource  |
+| **json/yaml field** | **Type**                                        | **Required** | **Description**                                      |
+|---------------------|-------------------------------------------------|--------------|------------------------------------------------------|
+| `spec`              | [RateLimitPolicySpec](#RateLimitPolicySpec)     | Yes          | The specfication for RateLimitPolicy custom resource |
+| `status`            | [RateLimitPolicyStatus](#RateLimitPolicyStatus) | No           | The status for the custom resource                   |
 
 ## RateLimitPolicySpec
 
-| **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
-| --- | --- | --- | --- | --- |
-| `targetRef` | [gatewayapiv1alpha2.PolicyTargetReference](https://github.com/kubernetes-sigs/gateway-api/blob/main/apis/v1alpha2/policy_types.go) | Yes | N/A | identifies an API object to apply policy to |
-| `rateLimits` | [][RateLimit](#RateLimit) | No | empy list | list of rate limit configurations |
+| **json/yaml field** | **Type**                                                                                                                           | **Required** | **Default value** | **Description**                             |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------|--------------|-------------------|---------------------------------------------|
+| `targetRef`         | [gatewayapiv1alpha2.PolicyTargetReference](https://github.com/kubernetes-sigs/gateway-api/blob/main/apis/v1alpha2/policy_types.go) | Yes          | N/A               | identifies an API object to apply policy to |
+| `rateLimits`        | [][RateLimit](#RateLimit)                                                                                                          | No           | empy list         | list of rate limit configurations           |
 
 ### RateLimit
 
-| **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
-| --- | --- | --- | --- | --- |
-| `configurations` | [][Configuration](#Configuration) | No | Empty | list of action configurations |
-| `rules` | [][Rule](#Rule) | No | Empty. All configurations apply | list of action configurations rules. Rate limit configuration will apply when at least one rule matches the request |
-| `limits` | [][Limit](#Limit) | No | Empty | list of Limitador limit objects |
+| **json/yaml field** | **Type**                          | **Required** | **Default value**               | **Description**                                                                                                     |
+|---------------------|-----------------------------------|--------------|---------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `configurations`    | [][Configuration](#Configuration) | No           | Empty                           | list of action configurations                                                                                       |
+| `rules`             | [][Rule](#Rule)                   | No           | Empty. All configurations apply | list of action configurations rules. Rate limit configuration will apply when at least one rule matches the request |
+| `limits`            | [][Limit](#Limit)                 | No           | Empty                           | list of Limitador limit objects                                                                                     |
 
 #### Configuration
 
-| **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
-| --- | --- | --- | --- | --- |
-| `actions` | [][ActionSpecifier](#ActionSpecifier) | No | empty | list of action specifiers. Each action specifier can only define one action type. |
+| **json/yaml field** | **Type**                              | **Required** | **Default value** | **Description**                                                                   |
+|---------------------|---------------------------------------|--------------|-------------------|-----------------------------------------------------------------------------------|
+| `actions`           | [][ActionSpecifier](#ActionSpecifier) | No           | empty             | list of action specifiers. Each action specifier can only define one action type. |
 
 #### ActionSpecifier
 
-| **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
-| --- | --- | --- | --- | --- |
-| `generic_key` | [config.route.v3.RateLimit.Action.GenericKey](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-ratelimit-action-generickey) | No | null | generic key action |
-| `metadata` | [config.route.v3.RateLimit.Action.MetaData](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-ratelimit-action-metadata) | No | null | descriptor entry is appended when the metadata contains a key value |
-| `remote_address` | [config.route.v3.RateLimit.Action.RemoteAddress](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-ratelimit-action-remoteaddress) | No | null | descriptor entry is appended to the descriptor and is populated using the trusted address from x-forwarded-for |
-| `request_headers` | [config.route.v3.RateLimit.Action.RequestHeaders](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-ratelimit-action-requestheaders) | No | null | descriptor entry is appended when a header contains a key that matches the header_name |
+| **json/yaml field** | **Type**                                                                                                                                                                                     | **Required** | **Default value** | **Description**                                                                                                |
+|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------|-------------------|----------------------------------------------------------------------------------------------------------------|
+| `generic_key`       | [config.route.v3.RateLimit.Action.GenericKey](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-ratelimit-action-generickey)         | No           | null              | generic key action                                                                                             |
+| `metadata`          | [config.route.v3.RateLimit.Action.MetaData](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-ratelimit-action-metadata)             | No           | null              | descriptor entry is appended when the metadata contains a key value                                            |
+| `remote_address`    | [config.route.v3.RateLimit.Action.RemoteAddress](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-ratelimit-action-remoteaddress)   | No           | null              | descriptor entry is appended to the descriptor and is populated using the trusted address from x-forwarded-for |
+| `request_headers`   | [config.route.v3.RateLimit.Action.RequestHeaders](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-ratelimit-action-requestheaders) | No           | null              | descriptor entry is appended when a header contains a key that matches the header_name                         |
 
 #### Rule
 
-| **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
-| --- | --- | --- | --- | --- |
-| `paths` | []string | No | null | list of paths. Request matches when one from the list matches |
-| `methods` | []string | No | null | list of methods to match. Request matches when one from the list matches |
-| `hosts` | []string | No | null | list of hostnames to match. Wildcard hostnames are valid. Request matches when one from the list matches. Each defined hostname must be subset of one of the hostnames defined by the targeted network resource |
+| **json/yaml field** | **Type** | **Required** | **Default value** | **Description**                                                                                                                                                                                                 |
+|---------------------|----------|--------------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `paths`             | []string | No           | null              | list of paths. Request matches when one from the list matches                                                                                                                                                   |
+| `methods`           | []string | No           | null              | list of methods to match. Request matches when one from the list matches                                                                                                                                        |
+| `hosts`             | []string | No           | null              | list of hostnames to match. Wildcard hostnames are valid. Request matches when one from the list matches. Each defined hostname must be subset of one of the hostnames defined by the targeted network resource |
 
 #### Limit
 
-| **json/yaml field**| **Type** | **Required** | **Default value** | **Description** |
-| --- | --- | --- | --- | --- |
-| `maxValue` | int | Yes | N/A | max number of request for the specified time period |
-| `seconds` | int | Yes | N/A | time period in seconds |
-| `conditions` | []string | No | Empty list | Limit conditions. Check [Limitador](https://github.com/Kuadrant/limitador) for more information |
-| `variables` | []string | No | Empty list | Limit variables. Check [Limitador](https://github.com/Kuadrant/limitador) for more information |
+| **json/yaml field** | **Type** | **Required** | **Default value** | **Description**                                                                                 |
+|---------------------|----------|--------------|-------------------|-------------------------------------------------------------------------------------------------|
+| `maxValue`          | int      | Yes          | N/A               | max number of request for the specified time period                                             |
+| `seconds`           | int      | Yes          | N/A               | time period in seconds                                                                          |
+| `conditions`        | []string | No           | Empty list        | Limit conditions. Check [Limitador](https://github.com/Kuadrant/limitador) for more information |
+| `variables`         | []string | No           | Empty list        | Limit variables. Check [Limitador](https://github.com/Kuadrant/limitador) for more information  |
 
 ## RateLimitPolicyStatus
 
-| **json field **| **Type** | **Info** |
-| --- | --- | --- |
-| `observedGeneration` | string | helper field to see if status info is up to date with latest resource spec |
-| `conditions` | array of [condition](#ConditionSpec)s | resource conditions |
+| **json field**       | **Type**                              | **Info**                                                                   |
+|----------------------|---------------------------------------|----------------------------------------------------------------------------|
+| `observedGeneration` | string                                | helper field to see if status info is up to date with latest resource spec |
+| `conditions`         | array of [condition](#ConditionSpec)s | resource conditions                                                        |
 
 ### ConditionSpec
 
@@ -89,10 +89,10 @@ Each element of the Condition array has the following fields:
 * The *type* field is a string with the following possible values:
   * Available: the resource has successfully configured;
 
-| **Field** | **json field**| **Type** | **Info** |
-| --- | --- | --- | --- |
-| Type | `type` | string | Condition Type |
-| Status | `status` | string | Status: True, False, Unknown |
-| Reason | `reason` | string | Condition state reason |
-| Message | `message` | string | Condition state description |
-| LastTransitionTime | `lastTransitionTime` | timestamp | Last transition timestamp |
+| **Field**          | **json field**       | **Type**  | **Info**                     |
+|--------------------|----------------------|-----------|------------------------------|
+| Type               | `type`               | string    | Condition Type               |
+| Status             | `status`             | string    | Status: True, False, Unknown |
+| Reason             | `reason`             | string    | Condition state reason       |
+| Message            | `message`            | string    | Condition state description  |
+| LastTransitionTime | `lastTransitionTime` | timestamp | Last transition timestamp    |

--- a/doc/user-guides/authenticated-rl-for-api-owners.md
+++ b/doc/user-guides/authenticated-rl-for-api-owners.md
@@ -1,4 +1,4 @@
-## Authenticated Rate Limit For API Owners
+# Authenticated Rate Limit For API Owners
 
 This user guide shows how to configure authenticated rate limiting.
 Authenticated rate limiting allows to specify rate limiting configurations
@@ -7,8 +7,8 @@ Authentication method used will be the API key.
 
 ### Clone the project
 
-```
-git clone https://github.com/Kuadrant/kuadrant-operator
+```sh
+git clone https://github.com/Kuadrant/kuadrant-operator && cd kuadrant-operator
 ```
 
 ### Setup environment
@@ -22,7 +22,7 @@ make local-setup
 
 ### Apply Kuadrant CR
 
-```yaml
+```sh
 kubectl -n kuadrant-system apply -f - <<EOF
 ---
 apiVersion: kuadrant.io/v1beta1
@@ -43,7 +43,7 @@ kubectl apply -f examples/toystore/toystore.yaml
 
 ![](https://i.imgur.com/rdN8lo3.png)
 
-```yaml
+```sh
 kubectl apply -f - <<EOF
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -86,8 +86,8 @@ kubectl port-forward -n istio-system service/istio-ingressgateway 9080:80 &
 
 ### Create API keys for user `Bob` and `Alice`
 
-```yaml
-kubectl apply -f -<<EOF
+```sh
+kubectl apply -f - <<EOF
 ---
 apiVersion: v1
 kind: Secret
@@ -119,7 +119,7 @@ EOF
 
 ### Create Kuadrant's `AuthPolicy` to configure API key based authentication
 
-```yaml
+```sh
 kubectl apply -f - <<EOF
 ---
 apiVersion: kuadrant.io/v1beta1
@@ -161,13 +161,13 @@ EOF
 
 ![](https://i.imgur.com/2A9sXXs.png)
 
-| User | Rate Limits |
-| ------------- | -----: |
-| `Bob` | **2** reqs / **10** secs (0.2 rps) |
+| User    |                        Rate Limits |
+|---------|-----------------------------------:|
+| `Bob`   | **2** reqs / **10** secs (0.2 rps) |
 | `Alice` | **5** reqs / **10** secs (0.5 rps) |
 
-```yaml
-kubectl apply -f -<<EOF
+```sh
+kubectl apply -f - <<EOF
 ---
 apiVersion: kuadrant.io/v1beta1
 kind: RateLimitPolicy
@@ -209,12 +209,12 @@ EOF
 
 Only 2 requests every 10 allowed for Bob.
 
-```
+```sh
 curl -v -H 'Authorization: APIKEY IAMBOB' -H 'Host: api.toystore.com' http://localhost:9080/toy
 ```
 
 Only 5 requests every 10 allowed for Alice.
 
-```
+```sh
 curl -v -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://localhost:9080/toy
 ```

--- a/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
+++ b/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
@@ -114,6 +114,10 @@ spec:
         kubernetes:
           audiences:
             - https://kubernetes.default.svc.cluster.local
+        extendedProperties:
+          - name: sub
+            valueFrom:
+              authJSON: auth.identity.user.username
     authorization:
       - name: k8s-rbac
         kubernetes:

--- a/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
+++ b/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
@@ -10,32 +10,24 @@ based on Kubernetes RBAC, with permissions (bindings) stored as Kubernetes Roles
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/) command-line tool
 - [jq](https://stedolan.github.io/jq/)
 
-## Run the guide ❶ → ❼
+## Run the guide ❶ → ❽
 
-### ❶ Setup the environment
-
-Clone the project:
+### ❶ Clone the project
 
 ```sh
 git clone https://github.com/Kuadrant/kuadrant-operator && cd kuadrant-operator
 ```
 
-Spin-up the cluster with all dependencies installed:
+### ❷ Setup environment
+
+This step creates a containerized Kubernetes server locally using [Kind](https://kind.sigs.k8s.io),
+then it installs Istio, Kubernetes Gateway API and kuadrant.
 
 ```sh
-make local-env-setup deploy
+make local-setup
 ```
 
-<details>
-  <summary>🤔 What exactly does the step above do?</summary>
-
-  1. Creates a containerized Kuberentes server using [Kind](https://kind.sigs.k8s.io/)
-  2. Installs [Istio](https://istio.io)
-  3. Installs Kuberentes [Gateway API](https://gateway-api.sigs.k8s.io/concepts/api-overview)
-  4. Installs the Kuadrant system (CRDs and operators)
-</details>
-
-### ❷ Deploy the API
+### ❸ Deploy the API
 
 Deploy the application in the `default` namespace:
 
@@ -49,12 +41,6 @@ Create the `HTTPRoute`:
 kubectl apply -f examples/toystore/httproute.yaml
 ```
 
-Expose the API:
-
-```sh
-kubectl port-forward -n istio-system service/istio-ingressgateway 9080:80 2>&1 >/dev/null &
-```
-
 #### API lifecycle
 
 ![Lifecycle](http://www.plantuml.com/plantuml/png/hP7DIWD1383l-nHXJ_PGtFuSIsaH1F5WGRtjPJgJjg6pcPB9WFNf7LrXV_Ickp0Gyf5yIJPHZMXgV17Fn1SZfW671vEylk2RRZqTkK5MiFb1wL4I4hkx88m2iwee1AqQFdg4ShLVprQt-tNDszq3K8J45mcQ0NGrj_yqVpNFgmgU7aim0sPKQzxMUaQRXFGAqPwmGJW40JqXv1urHpMA3eZ1C9JbDkbf5ppPQrdMV9CY2XmC-GWQmEGaif8rYfFEPLdDu9K_aq7e7TstLPyUcot-RERnI0fVVjxOSuGBIaCnKk21sWBkW-p9EUJMgnCTIot_Prs3kJFceEiu-VM2uLmKlIl2TFrZVQCu8yD9kg1Dvf8RP9SQ_m40)
@@ -66,19 +52,29 @@ curl -H 'Host: api.toystore.com' http://localhost:9080/toy -i
 # HTTP/1.1 200 OK
 ```
 
-### ❸ Request the Kuadrant instance
+It should return `200 OK`.
+
+**Note**: This only works out of the box on linux environments. If not on linux,
+you may need to forward ports
+
+```bash
+kubectl port-forward -n istio-system service/istio-ingressgateway 9080:80 &
+```
+
+### ❹ Request the Kuadrant instance
 
 ```sh
-kubectl apply -f -<<EOF
+kubectl -n kuadrant-system apply -f - <<EOF
+---
 apiVersion: kuadrant.io/v1beta1
 kind: Kuadrant
 metadata:
-  name: kuadrant
+  name: kuadrant-sample
 spec: {}
 EOF
 ```
 
-### ❹ Deploy Keycloak
+### ❺ Deploy Keycloak
 
 Create the namesapce:
 
@@ -94,12 +90,12 @@ kubectl apply -n keycloak -f https://raw.githubusercontent.com/Kuadrant/authorin
 
 The step above deploys Keycloak with a [preconfigured](https://github.com/kuadrant/authorino-examples#keycloak) realm and a couple of clients and users created.
 
-The Keycloak server may take a couple minutes to be ready.
+The Keycloak server may take a couple of minutes to be ready.
 
-### ❺ Create the `AuthPolicy`
+### ❻ Create the `AuthPolicy`
 
 ```sh
-kubectl apply -f -<<EOF
+kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1beta1
 kind: AuthPolicy
 metadata:
@@ -164,7 +160,7 @@ curl -H "Authorization: Bearer $ACCESS_TOKEN" -H 'Host: api.toystore.com' http:/
 Create a Kubernetes Service Account to represent a user belonging to the other source of identities:
 
 ```sh
-kubectl apply -f -<<EOF
+kubectl apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -172,7 +168,7 @@ metadata:
 EOF
 ```
 
-Obtain an aaccess token for the `client-app-1` service account:
+Obtain an access token for the `client-app-1` service account:
 
 ```sh
 SA_TOKEN=$(kubectl create token client-app-1)
@@ -185,12 +181,12 @@ curl -H "Authorization: Bearer $SA_TOKEN" -H 'Host: api.toystore.com' http://loc
 # HTTP/1.1 403 Forbidden
 ```
 
-### ❻ Grant access to the API
+### ❼ Grant access to the API
 
 Create the `toystore-reader` and `toystore-writer` roles:
 
 ```sh
-kubectl apply -f -<<EOF
+kubectl apply -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -212,7 +208,7 @@ EOF
 Add permissions to the users and service accounts:
 
 ```sh
-kubectl apply -f -<<EOF
+kubectl apply -f - <<EOF
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -243,7 +239,7 @@ EOF
 ```
 
 <details>
-  <summary>🤔 Can I use <code>Roles</code> and <code>RoleBindings</code> instead of <code>ClusterRoles</code> and <code>ClusterRoleBindings</code>?</summary>
+  <summary>Can I use <code>Roles</code> and <code>RoleBindings</code> instead of <code>ClusterRoles</code> and <code>ClusterRoleBindings</code>?</summary>
 
   Yes, you can.
 
@@ -279,10 +275,10 @@ curl -H "Authorization: Bearer $SA_TOKEN" -H 'Host: api.toystore.com' -X POST ht
 # HTTP/1.1 403 Forbidden
 ```
 
-### ❼ Create the `RateLimitPolicy`
+### ❽ Create the `RateLimitPolicy`
 
 ```sh
-kubectl apply -f -<<EOF
+kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1beta1
 kind: RateLimitPolicy
 metadata:
@@ -314,7 +310,7 @@ spec:
 EOF
 ```
 
-> **Note:** It may take a couple minutes for the RateLimitPolicy to be applied depending on your cluster.
+> **Note:** It may take a couple of minutes for the RateLimitPolicy to be applied depending on your cluster.
 
 #### Try the API rate limited
 

--- a/doc/user-guides/gateway-rl-for-cluster-operators.md
+++ b/doc/user-guides/gateway-rl-for-cluster-operators.md
@@ -1,4 +1,4 @@
-## Gateway Rate Limit For Cluster Operators
+# Gateway Rate Limit For Cluster Operators
 
 This user guide shows how the kuadrant's control plane applies rate limit policy at
 [Gateway API's Gateway](https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1beta1.Gateway)
@@ -6,8 +6,8 @@ level.
 
 ### Clone the project
 
-```
-git clone https://github.com/Kuadrant/kuadrant-operator
+```sh
+git clone https://github.com/Kuadrant/kuadrant-operator && cd kuadrant-operator
 ```
 
 ### Setup environment
@@ -15,13 +15,13 @@ git clone https://github.com/Kuadrant/kuadrant-operator
 This step creates a containerized Kubernetes server locally using [Kind](https://kind.sigs.k8s.io),
 then it installs Istio, Kubernetes Gateway API and kuadrant.
 
-```
+```sh
 make local-setup
 ```
 
 ### Apply Kuadrant CR
 
-```yaml
+```sh
 kubectl -n kuadrant-system apply -f - <<EOF
 ---
 apiVersion: kuadrant.io/v1beta1
@@ -34,7 +34,7 @@ EOF
 
 ### Deploy toystore example deployment
 
-```
+```sh
 kubectl apply -f examples/toystore/toystore.yaml
 ```
 
@@ -42,7 +42,7 @@ kubectl apply -f examples/toystore/toystore.yaml
 
 ![](https://i.imgur.com/rdN8lo3.png)
 
-```yaml
+```sh
 kubectl apply -f - <<EOF
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -79,12 +79,12 @@ EOF
 ### Check `toystore` HTTPRoute works
 
 `GET /toy`: no rate limiting
-```
+```sh
 while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" http://localhost:9080/toy | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
 `POST /admin/toy`: no rate limiting
-```
+```sh
 while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" -X POST http://localhost:9080/admin/toy | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
@@ -101,13 +101,13 @@ kubectl port-forward -n istio-system service/istio-ingressgateway 9080:80
 
 RateLimitPolicy applied for the `toystore` HTTPRoute.
 
-| Endpoints | Rate Limits |
-| ------------- | -----: |
-| `POST /admin/toy` | **5** reqs / **10** secs (0.5 rps) |
-| `GET /toy` | **8** reqs / **10** secs (0.8 rps) |
-| `*` | **30** reqs / **10** secs (3.0 rps) |
+| Endpoints         |                         Rate Limits |
+|-------------------|------------------------------------:|
+| `POST /admin/toy` |  **5** reqs / **10** secs (0.5 rps) |
+| `GET /toy`        |  **8** reqs / **10** secs (0.8 rps) |
+| `*`               | **30** reqs / **10** secs (3.0 rps) |
 
-```yaml
+```sh
 kubectl apply -f - <<EOF
 ---
 apiVersion: kuadrant.io/v1beta1
@@ -164,12 +164,12 @@ EOF
 Validating the rate limit policy.
 
 `GET /toy` @ **1** rps (expected to be rate limited @ **8** reqs / **10** secs (0.8 rps))
-```
+```sh
 while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" http://localhost:9080/toy | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
 `POST /admin/toy` @ **1** rps (expected to be rate limited @ **5** reqs / **10** secs (0.5 rps))
-```
+```sh
 while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" -X POST http://localhost:9080/admin/toy | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
@@ -179,12 +179,12 @@ while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host
 
 RateLimitPolicy applied for the Gateway.
 
-| Policy | Rate Limits |
-| ------------- | -----: |
-| `POST /*` | **2** reqs / **10** secs (0.2 rps) |
+| Policy        |                         Rate Limits |
+|---------------|------------------------------------:|
+| `POST /*`     |  **2** reqs / **10** secs (0.2 rps) |
 | Per remote IP | **25** reqs / **10** secs (2.5 rps) |
 
-```yaml
+```sh
 kubectl apply -f - <<EOF
 ---
 apiVersion: kuadrant.io/v1beta1
@@ -224,12 +224,12 @@ EOF
 ### Validating the rate limit policies (HTTPRoute and Gateway).
 
 `GET /toy` @ **1** rps (expected to be rate limited @ **8** reqs / **10** secs (0.8 rps))
-```
+```sh
 while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" http://localhost:9080/toy | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
 `POST /admin/toy` @ **1** rps (expected to be rate limited @ **2** reqs / **10** secs (0.2 rps))
-```
+```sh
 while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H "Host: api.toystore.com" -X POST http://localhost:9080/admin/toy | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
@@ -239,6 +239,6 @@ Stop all traffic.
 
 `GET /free` @ **3** rps (expected to be rate limited @ **25** reqs / **10** secs (2.5 rps))
 
-```
+```sh
 while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Host: api.toystore.com" http://localhost:9080/free -: --write-out '%{http_code}\n' --silent --output /dev/null -H "Host: api.toystore.com" http://localhost:9080/free -: --write-out '%{http_code}\n' --silent --output /dev/null -H "Host: api.toystore.com" http://localhost:9080/free | egrep --color "\b(429)\b|$"; sleep 1; done
 ```

--- a/doc/user-guides/simple-rl-for-api-owners.md
+++ b/doc/user-guides/simple-rl-for-api-owners.md
@@ -4,7 +4,7 @@ This user guide shows how to configure rate limiting for one of the subdomains.
 
 ### Clone the project
 
-```
+```sh
 git clone https://github.com/Kuadrant/kuadrant-operator
 ```
 
@@ -13,13 +13,13 @@ git clone https://github.com/Kuadrant/kuadrant-operator
 This step creates a containerized Kubernetes server locally using [Kind](https://kind.sigs.k8s.io),
 then it installs Istio, Kubernetes Gateway API and kuadrant.
 
-```
+```sh
 make local-setup
 ```
 
 ### Apply Kuadrant CR
 
-```yaml
+```sh
 kubectl -n kuadrant-system apply -f - <<EOF
 ---
 apiVersion: kuadrant.io/v1beta1
@@ -32,7 +32,7 @@ EOF
 
 ### Deploy toystore example deployment
 
-```
+```sh
 kubectl apply -f examples/toystore/toystore.yaml
 ```
 
@@ -40,7 +40,7 @@ kubectl apply -f examples/toystore/toystore.yaml
 
 ![](https://i.imgur.com/rdN8lo3.png)
 
-```yaml
+```sh
 kubectl apply -f - <<EOF
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
@@ -68,7 +68,7 @@ EOF
 
 ### Check `toystore` HTTPRoute works
 
-```
+```sh
 curl -v -H 'Host: api.toystore.com' http://localhost:9080/toy
 ```
 
@@ -88,12 +88,12 @@ kubectl port-forward -n istio-system service/istio-ingressgateway 9080:80 &
 
 RateLimitPolicy applied for the `toystore` HTTPRoute.
 
-| Hostname | Rate Limits |
-| ------------- | -----: |
+| Hostname                    |                        Rate Limits |
+|-----------------------------|-----------------------------------:|
 | `rate-limited.toystore.com` | **5** reqs / **10** secs (0.5 rps) |
-| `*.toystore.com` | not rate limited |
+| `*.toystore.com`            |                   not rate limited |
 
-```yaml
+```sh
 kubectl apply -f - <<EOF
 ---
 apiVersion: kuadrant.io/v1beta1
@@ -126,12 +126,12 @@ EOF
 
 Only 5 requests every 10 secs on `rate-limited.toystore.com` allowed.
 
-```
+```sh
 curl -v -H 'Host: rate-limited.toystore.com' http://localhost:9080/toy
 ```
 
 Whereas `other.toystore.com` is not rate limited.
 
-```
+```sh
 curl -v -H 'Host: other.toystore.com' http://localhost:9080/toy
 ```


### PR DESCRIPTION
General improvements in docs:

* Fix some typos
* Fix general linking to resources
* Consistent spacing for tables so markdowns can be read easier
* Add code type to code blocks for syntax highlighting
* Some consitency in docs / guides for creating `Kuadrant` instance
* Fix some spacing for proper display in the website (potentially)
* Consitent heading sizes in user guides
* Consistent inital setup in user guides
* Closes https://github.com/Kuadrant/kuadrant-operator/issues/216