### PR TITLE
ignore: vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ tmp
 
 /catalog/kuadrant-operator-catalog
 /catalog/kuadrant-operator-catalog.Dockerfile
+
+# Vendor dependencies
+vendor


### PR DESCRIPTION
* Ignore vendor directory since it's not specifically committed anyhow. This prevents a contributor from accidently commiting it if generated by them