### PR TITLE
codecov, fix: Fix the ignoring path regex pattern in codecov.yaml (#175)

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -11,9 +11,10 @@ codecov:
 comment:
   layout: "header, diff, flags, components, files"
 
+# Find more at https://docs.codecov.com/docs/ignoring-paths
 ignore:
   - api/external/** #  ignoring external vendor code
-  - **/*.deepcopy.go # ignore controller-gen generated code 
+  - "**/*.deepcopy.go" # ignore controller-gen generated code
 
 flag_management:
   individual_flags:


### PR DESCRIPTION
This PR introduces a fix to path ignoring regexp pattern in codecov.yaml.
The codecov.yaml was invalid because of missing double quotes in ```"**/*.deepcopy.go"``` path.

This PR is a part of #175, which just introduces a fix to a path for codecov.yaml so it can work correctly and be applied to the codecov configuration.

Read more at: https://docs.codecov.com/docs/ignoring-paths