### PR TITLE
default dynamic wasm rule data to empty string

### DIFF
--- a/controllers/ratelimitpolicy_controller_test.go
+++ b/controllers/ratelimitpolicy_controller_test.go
@@ -457,6 +457,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					{
 						Selector: &wasm.SelectorSpec{
 							Selector: kuadrantv1beta2.ContextSelector("auth.identity.username"),
+							Default:  common.Ptr(""),
 						},
 					},
 				},

--- a/pkg/rlptools/wasm_utils.go
+++ b/pkg/rlptools/wasm_utils.go
@@ -245,7 +245,7 @@ func dataFromLimt(limitIdentifier string, limit *kuadrantv1beta2.Limit) (data []
 	data = append(data, wasm.DataItem{Static: &wasm.StaticSpec{Key: limitIdentifier, Value: "1"}})
 
 	for _, counter := range limit.Counters {
-		data = append(data, wasm.DataItem{Selector: &wasm.SelectorSpec{Selector: counter}})
+		data = append(data, wasm.DataItem{Selector: &wasm.SelectorSpec{Selector: counter, Default: common.Ptr("")}})
 	}
 
 	return data

--- a/pkg/rlptools/wasm_utils_test.go
+++ b/pkg/rlptools/wasm_utils_test.go
@@ -10,6 +10,7 @@ import (
 	gatewayapiv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	"github.com/kuadrant/kuadrant-operator/pkg/rlptools/wasm"
 )
 
@@ -318,6 +319,7 @@ func TestWasmRules(t *testing.T) {
 						{
 							Selector: &wasm.SelectorSpec{
 								Selector: "auth.identity.username",
+								Default:  common.Ptr(""),
 							},
 						},
 					},


### PR DESCRIPTION
Sets the empty string as the default value for the counter qualifiers ("wasm data items") in the wasm config, to prevent the selectors that fail to select a value to invalidate the limit.

Ref.: https://github.com/Kuadrant/wasm-shim/pull/39#discussion_r1301663487