### PR TITLE
Reconcile resources

### DIFF
--- a/controllers/authconfig_eventmapper.go
+++ b/controllers/authconfig_eventmapper.go
@@ -1,0 +1,29 @@
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// AuthConfigEventMapper is an EventHandler that maps AuthConfig objects events to Policy events.
+type AuthConfigEventMapper struct {
+	Logger logr.Logger
+}
+
+func (m *AuthConfigEventMapper) MapToAuthPolicy(obj client.Object) []reconcile.Request {
+	return m.mapToPolicyRequest(obj, "authpolicy", common.AuthPoliciesBackRefAnnotation)
+}
+
+func (m *AuthConfigEventMapper) mapToPolicyRequest(obj client.Object, policyKind string, policyBackRefAnnotationName string) []reconcile.Request {
+	policyRef, found := common.ReadAnnotationsFromObject(obj)[policyBackRefAnnotationName]
+	if !found {
+		return []reconcile.Request{}
+	}
+
+	policyKey := common.NamespacedNameToObjectKey(policyRef, obj.GetNamespace())
+
+	m.Logger.V(1).Info("Processing object", "object", client.ObjectKeyFromObject(obj), policyKind, policyKey)
+	return []reconcile.Request{{NamespacedName: policyKey}}
+}

--- a/controllers/authpolicy_auth_config.go
+++ b/controllers/authpolicy_auth_config.go
@@ -67,6 +67,8 @@ func (r *AuthPolicyReconciler) desiredAuthConfig(ap *api.AuthPolicy, targetNetwo
 		return nil, err
 	}
 
+	policyKey := client.ObjectKeyFromObject(ap)
+
 	return &authorinoapi.AuthConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AuthConfig",
@@ -75,6 +77,9 @@ func (r *AuthPolicyReconciler) desiredAuthConfig(ap *api.AuthPolicy, targetNetwo
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      authConfigName(client.ObjectKeyFromObject(ap)),
 			Namespace: ap.Namespace,
+			Annotations: map[string]string{
+				common.AuthPoliciesBackRefAnnotation: policyKey.String(),
+			},
 		},
 		Spec: authorinoapi.AuthConfigSpec{
 			Hosts:         hosts,

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+
 	authorinoapi "github.com/kuadrant/authorino/api/v1beta1"
 
 	"github.com/go-logr/logr"

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	authorinoapi "github.com/kuadrant/authorino/api/v1beta1"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -199,6 +200,10 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Logger: r.Logger().WithName("gatewayEventMapper"),
 	}
 
+	authConfigEventMapper := &AuthConfigEventMapper{
+		Logger: r.Logger().WithName("authConfigEventMapper"),
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&api.AuthPolicy{}).
 		Watches(
@@ -207,5 +212,7 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Watches(&source.Kind{Type: &gatewayapiv1beta1.Gateway{}},
 			handler.EnqueueRequestsFromMapFunc(gatewayEventMapper.MapToAuthPolicy)).
+		Watches(&source.Kind{Type: &authorinoapi.AuthConfig{}},
+			handler.EnqueueRequestsFromMapFunc(authConfigEventMapper.MapToAuthPolicy)).
 		Complete(r)
 }

--- a/controllers/limitador_eventmapper.go
+++ b/controllers/limitador_eventmapper.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"encoding/json"
+
 	"github.com/go-logr/logr"
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
@@ -37,6 +38,7 @@ func (m LimitadorEventMapper) MapToRateLimitPolicy(obj client.Object) []reconcil
 		requests = append(requests, reconcile.Request{
 			NamespacedName: ref,
 		})
+		break
 	}
 	return requests
 }

--- a/controllers/limitador_eventmapper.go
+++ b/controllers/limitador_eventmapper.go
@@ -1,0 +1,42 @@
+package controllers
+
+import (
+	"encoding/json"
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type LimitadorEventMapper struct {
+	Logger logr.Logger
+}
+
+func (m LimitadorEventMapper) MapToRateLimitPolicy(obj client.Object) []reconcile.Request {
+	limitador, ok := obj.(*limitadorv1alpha1.Limitador)
+	if !ok {
+		return []reconcile.Request{}
+	}
+
+	objAnnotations := limitador.GetAnnotations()
+	val, ok := objAnnotations[common.RateLimitPoliciesBackRefAnnotation]
+	if !ok {
+		return []reconcile.Request{}
+	}
+
+	var refs []client.ObjectKey
+	err := json.Unmarshal([]byte(val), &refs)
+	if err != nil {
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, 0)
+	for _, ref := range refs {
+		m.Logger.V(1).Info("MapRateLimitPolicy", "ratelimitpolicy", ref)
+		requests = append(requests, reconcile.Request{
+			NamespacedName: ref,
+		})
+	}
+	return requests
+}

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/go-logr/logr"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/common/annotations.go
+++ b/pkg/common/annotations.go
@@ -1,0 +1,32 @@
+package common
+
+func AddAnnotation(annotation string, value string, annotations map[string]string) map[string]string {
+	_, ok := annotations[annotation]
+	if !ok && len(value) == 0 {
+		return annotations
+	}
+
+	if len(value) == 0 {
+		delete(annotations, annotation)
+		return annotations
+	}
+
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[annotation] = value
+	return annotations
+}
+
+func AnnotationEqual(annotation string, value string, annotations map[string]string) bool {
+	val, ok := annotations[annotation]
+	if !ok && len(annotation) == 0 {
+		return true
+	}
+
+	if val == value {
+		return true
+	}
+
+	return false
+}

--- a/pkg/common/back_reference.go
+++ b/pkg/common/back_reference.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"encoding/json"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func BuildBackRefs(refs []client.ObjectKey) (string, error) {
+	if len(refs) == 0 {
+		return "", nil
+	}
+
+	var uniqueKeys []client.ObjectKey
+
+	for _, v := range refs {
+		if !Contains(uniqueKeys, v) {
+			uniqueKeys = append(uniqueKeys, v)
+		}
+	}
+
+	serialized, err := json.Marshal(uniqueKeys)
+	if err != nil {
+		return "", err
+	}
+	return string(serialized), nil
+}

--- a/pkg/rlptools/utils.go
+++ b/pkg/rlptools/utils.go
@@ -5,8 +5,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"unicode"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 

--- a/pkg/rlptools/utils_test.go
+++ b/pkg/rlptools/utils_test.go
@@ -5,8 +5,9 @@ package rlptools
 import (
 	"reflect"
 	"regexp"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
closes #234 

Reconcile changes made to the AuthConfig and Limitador CRs to reflect the configuration in AuthPolicy and RateLimitPolicy. Multiple rate limit policies can be configured in the on Limitador CR but it is only one rate limit policy per resource (http Route & gateway)

# Verification 

## Setup
* Install kuadrant operator using `make local-setup`
* Set up to gateway, routes and etc, etc
```sh
echo '
---
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
spec: {}
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: toystore
  labels:
    app: toystore
spec:
  selector:
    matchLabels:
      app: toystore
  template:
    metadata:
      labels:
        app: toystore
    spec:
      containers:
        - name: toystore
          image: quay.io/3scale/authorino:echo-api
          env:
            - name: PORT
              value: "3000"
          ports:
            - containerPort: 3000
              name: http
  replicas: 1
---
apiVersion: v1
kind: Service
metadata:
  name: toystore
spec:
  selector:
    app: toystore
  ports:
    - name: http
      port: 80
      protocol: TCP
      targetPort: 3000
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: toystore
  labels:
    app: toystore
spec:
  parentRefs:
    - name: istio-ingressgateway
      namespace: istio-system
  hostnames: ["*.toystore.com"]
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: "/toy"
          method: GET
      backendRefs:
        - name: toystore
          port: 80
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: dollstore
  labels:
    app: dollstore
spec:
  parentRefs:
    - name: istio-ingressgateway
      namespace: istio-system
  hostnames: ["*.toystore.com"]
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: "/doll"
          method: GET
      backendRefs:
        - name: toystore
          port: 80
---
apiVersion: v1
kind: Secret
metadata:
  annotations:
    secret.kuadrant.io/user-id: bob
  name: bob-key
  labels:
    authorino.kuadrant.io/managed-by: authorino
    app: toystore
stringData:
  api_key: IAMBOB
type: Opaque
---
apiVersion: v1
kind: Secret
metadata:
  annotations:
    secret.kuadrant.io/user-id: alice
  name: alice-key
  labels:
    authorino.kuadrant.io/managed-by: authorino
    app: toystore
stringData:
  api_key: IAMALICE
type: Opaque 
---
' | kubectl apply -f -

```

## AuthPolicy Reconcile
* create authPolicy
```sh
echo '
apiVersion: kuadrant.io/v1beta1
kind: AuthPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
  - paths: ["/toy*"]
  authScheme:
    identity:
    - name: friends
      apiKey:
        allNamespaces: true
        selector:
          matchLabels:
            app: toystore
      credentials:
        in: authorization_header
        keySelector: APIKEY
    response:
    - json:
        properties:
          - name: userID
            value: null
            valueFrom:
              authJSON: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
      name: rate-limit-apikey
      wrapper: envoyDynamicMetadata
      wrapperKey: ext_auth_data
' | kubectl apply -f -
```
* wait for reconcile to complete
```
watch kubectl get AuthPolicy toystore -o jsonpath='{.status.conditions[].status}'
```
Expect: True
* change part of the `AuthConfig` spec that was define as part of the AuthPolicy. Good example is `spec.identity.apikey.name = friend`
```sh 
kubectl edit AuthConfig ap-default-toystore  
```
* Check that the changes have being reverted. 
```
kubectl get AuthConfig ap-default-toystore -o yaml
```
* Expect changes should be reverted.
* Also not in the annotations a back reference to the authPolicy has being set.

## RateLimitPolicy Reconcile
### RateLimitPolicy at gateway level
* Create a RateLimitPolicy on the gateway
```sh
echo "
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: toystore
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  limits:
    toystore:
      rates:
        - limit: 5
          duration: 10
          unit: second
      counters:
        - context.request.http.path
" | kubectl apply -f -

```
* wait for reconcile to complete
```
watch kubectl get RateLimitPolicy toystore -o jsonpath='{.status.conditions[].status}' -n istio-system
```
Expect: True
* Modify part of the limitador CR, example change the `max_value` from 5 to 1.
```sh
kubectl edit limitador limitador -n default
```
* Expect the value to be reverted back 
* Note the a reference added to the annotations for the rateLimitPolicy
### RateLimitPolicy at http Route level
* Create RateLimitPolicies at the route level
```sh
echo '
---
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:
    toystore:
      routeSelectors:
        - hostnames:
          - "*.toystore.com"
          matches:
            - path:
                type: PathPrefix
                value: "/toy"
              method: GET
      rates:
        - limit: 5
          duration: 10
          unit: second
      counters:
        - context.request.http.path
---
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: dollstore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: dollstore
  limits:
    toystore:
      routeSelectors:
        - hostnames:
          - "*.toystore.com"
          matches:
            - path:
                type: PathPrefix
                value: "/dolls"
              method: GET
      rates:
        - limit: 1
          duration: 5
          unit: second
      counters:
        - context.request.http.path
' | kubectl apply -f - 
```
* once again view the limitador CR
* Notice the different reference in the annotations.
* Edit some parts of the spec 
* Expect the edits to be reverted.
* Start removing the ratelimitPolicies
* Expect: the annotations should only list the current RateLimitPolicies.
* Once all RateLimitPolicies have being removed from the cluster the reference annotation should be fully removed. 
  * NOTE: the limitador CR will not be removed. This needs to be discussed and is out of scope for this work.
