### PR TITLE
[workflow] Adding channels input for bundle creation

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -170,7 +170,8 @@ jobs:
             AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorVersion }} \
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
-            REPLACES_VERSION=${{ inputs.replacesVersion }}
+            REPLACES_VERSION=${{ inputs.replacesVersion }} \
+            CHANNELS=${{ inputs.channels }}
       - name: Install qemu dependency
         run: |
           sudo apt-get update

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -27,6 +27,10 @@ on:
         description: Kuadrant Operator replaced version
         default: 0.0.0-alpha
         type: string
+      channels:
+        description: Bundle and catalog channels, comma separated
+        default: preview
+        type: string
   workflow_dispatch:
     inputs:
       kuadrantOperatorTag:
@@ -52,6 +56,10 @@ on:
       replacesVersion:
         description: Kuadrant Operator replaced version
         default: 0.0.0-alpha
+        type: string
+      channels:
+        description: Bundle and catalog channels, comma separated
+        default: preview
         type: string
 
 env:
@@ -119,7 +127,8 @@ jobs:
             AUTHORINO_OPERATOR_VERSION=${{ inputs.authorinoOperatorVersion }} \
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
-            REPLACES_VERSION=${{ inputs.replacesVersion }}
+            REPLACES_VERSION=${{ inputs.replacesVersion }} \
+            CHANNELS=${{ inputs.channels }}
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -20,12 +20,13 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo REPLACES_VERSION               = $(REPLACES_VERSION)
 	@echo LIMITADOR_OPERATOR_BUNDLE_IMG  = $(LIMITADOR_OPERATOR_BUNDLE_IMG)
 	@echo AUTHORINO_OPERATOR_BUNDLE_IMG  = $(AUTHORINO_OPERATOR_BUNDLE_IMG)
+	@echo CHANNELS  					 = $(CHANNELS)
 	@echo "************************************************************"
 	@echo
 	@echo Please check this matches your expectations and override variables if needed.
 	@echo
 	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $(REPLACES_VERSION)\
-			$(LIMITADOR_OPERATOR_BUNDLE_IMG) $(AUTHORINO_OPERATOR_BUNDLE_IMG) $@
+			$(LIMITADOR_OPERATOR_BUNDLE_IMG) $(AUTHORINO_OPERATOR_BUNDLE_IMG) $(CHANNELS) $@
 
 .PHONY: catalog
 catalog: $(OPM) ## Generate catalog content and validate.

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 ### CONSTANTS
 # Used as well in the subscription object
-CHANNEL_NAME=preview
+DEFAULT_CHANNEL=preview
 ###
 
 OPM="${1?:Error \$OPM not set. Bye}"
@@ -15,7 +15,8 @@ BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
 REPLACES_VERSION="${4?:Error \$REPLACES_VERSION not set. Bye}"
 LIMITADOR_OPERATOR_BUNDLE_IMG="${5?:Error \$LIMITADOR_OPERATOR_BUNDLE_IMG not set. Bye}"
 AUTHORINO_OPERATOR_BUNDLE_IMG="${6?:Error \$AUTHORINO_OPERATOR_BUNDLE_IMG not set. Bye}"
-CATALOG_FILE="${7?:Error \$CATALOG_FILE not set. Bye}"
+CHANNELS="${7:-$DEFAULT_CHANNEL}"
+CATALOG_FILE="${8?:Error \$CATALOG_FILE not set. Bye}"
 
 CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE})" )" && pwd )"
 CATALOG_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE_BASEDIR})" )" && pwd )"
@@ -52,34 +53,37 @@ touch ${CATALOG_FILE}
 # Limitador Operator
 ###
 # Add the package
-${OPM} init limitador-operator --default-channel=${CHANNEL_NAME} --output yaml >> ${CATALOG_FILE}
+${OPM} init limitador-operator --default-channel=${CHANNELS} --output yaml >> ${CATALOG_FILE}
 # Add a bundles to the Catalog
 cat ${TMP_DIR}/limitador-operator-bundle.yaml >> ${CATALOG_FILE}
 # Add a channel entry for the bundle
 V=`${YQ} eval '.name' ${TMP_DIR}/limitador-operator-bundle.yaml` \
-    ${YQ} eval '(.entries[0].name = strenv(V))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
+CHANNELS=${CHANNELS} \
+    ${YQ} eval '(.entries[0].name = strenv(V)) | (.name = strenv(CHANNELS))' ${CATALOG_BASEDIR}/limitador-operator-channel-entry.yaml >> ${CATALOG_FILE}
 
 ###
 # Authorino Operator
 ###
 # Add the package
-${OPM} init authorino-operator --default-channel=${CHANNEL_NAME} --output yaml >> ${CATALOG_FILE}
+${OPM} init authorino-operator --default-channel=${CHANNELS} --output yaml >> ${CATALOG_FILE}
 # Add a bundles to the Catalog
 cat ${TMP_DIR}/authorino-operator-bundle.yaml >> ${CATALOG_FILE}
 # Add a channel entry for the bundle
 V=`${YQ} eval '.name' ${TMP_DIR}/authorino-operator-bundle.yaml` \
-    ${YQ} eval '(.entries[0].name = strenv(V))' ${CATALOG_BASEDIR}/authorino-operator-channel-entry.yaml >> ${CATALOG_FILE}
+CHANNELS=${CHANNELS} \
+    ${YQ} eval '(.entries[0].name = strenv(V)) | (.name = strenv(CHANNELS))' ${CATALOG_BASEDIR}/authorino-operator-channel-entry.yaml >> ${CATALOG_FILE}
 
 ###
 # Kuadrant Operator
 ###
 # Add the package
-${OPM} init kuadrant-operator --default-channel=${CHANNEL_NAME} --output yaml >> ${CATALOG_FILE}
+${OPM} init kuadrant-operator --default-channel=${CHANNELS} --output yaml >> ${CATALOG_FILE}
 # Add a bundles to the Catalog
 cat ${TMP_DIR}/kuadrant-operator-bundle.yaml >> ${CATALOG_FILE}
 # Add a channel entry for the bundle
 NAME=`${YQ} eval '.name' ${TMP_DIR}/kuadrant-operator-bundle.yaml` \
 REPLACES=kuadrant-operator.v${REPLACES_VERSION} \
-    ${YQ} eval '(.entries[0].name = strenv(NAME)) | (.entries[0].replaces = strenv(REPLACES))' ${CATALOG_BASEDIR}/kuadrant-operator-channel-entry.yaml >> ${CATALOG_FILE}
+CHANNELS=${CHANNELS} \
+    ${YQ} eval '(.entries[0].name = strenv(NAME)) | (.entries[0].replaces = strenv(REPLACES)) | (.name = strenv(CHANNELS))' ${CATALOG_BASEDIR}/kuadrant-operator-channel-entry.yaml >> ${CATALOG_FILE}
 
 rm -rf $TMP_DIR


### PR DESCRIPTION
This PR addresses partially issue https://github.com/Kuadrant/kuadrant-operator/issues/244, it will need to be applied also in Authorino and Limitador operators.


The workflow dispatch input _channels_ accepts comma separated values, i.e.: "stable,release". The Makefile target could be executed as:

```sh
make bundle REGISTRY=quay.io ORG=kuadrant \
    VERSION=0.3.1 \
    AUTHORINO_OPERATOR_VERSION=0.7.0 \
    LIMITADOR_OPERATOR_VERSION=0.5.0 \
    WASM_SHIM_VERSION=0.2.0 \
    REPLACES_VERSION=0.3.0 \
    CHANNELS=stable,release
```

And it will generate, among other changes, the following:

```sh
diff --git a/bundle.Dockerfile b/bundle.Dockerfile
index d1171ce..c6b110f 100644
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,7 +5,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channels.v1=stable,release

diff --git a/bundle/metadata/annotations.yaml b/bundle/metadata/annotations.yaml
index 34b5dfc..3f734c1 100644
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,7 +4,7 @@ annotations:
-  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channels.v1: stable,release
```

Notes:
- **ONLY WORKS WITH A SINGLE CHANNEL for the catalog creation**
- Default value chosen is _preview_ because it's the default channel previously chosen in the catalog file generator https://github.com/Kuadrant/kuadrant-operator/blob/main/utils/generate-catalog.sh#L8-L9