### PR TITLE
doc: #kuadrant channel on kubernetes.slack.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Docs can be found on the [Kuadrant website](https://kuadrant.io/).
 The [Development guide](doc/development.md) describes how to build the kuadrant operator and
 how to test your changes before submitting a patch or opening a PR.
 
-Join us on [kuadrant.slack.com](https://kuadrant.slack.com/)
+Join us on the [#kuadrant](https://kubernetes.slack.com/archives/C05J0D0V525) channel in the Kubernetes Slack workspace, 
 for live discussions about the roadmap and more.
 
 ## Licensing


### PR DESCRIPTION
Point people interested to reach out to the [#kuadrant](https://kubernetes.slack.com/archives/C05J0D0V525) channel in the Kubernetes Slack workspace.