### PR TITLE
Install Cert Manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,7 @@ local-cluster-setup: ## Sets up Kind cluster with GatewayAPI manifests and istio
 	$(MAKE) namespace
 	$(MAKE) gateway-api-install
 	$(MAKE) istio-install
+	$(MAKE) install-cert-manager
 	$(MAKE) deploy-gateway
 
 # kuadrant is not deployed
@@ -320,6 +321,7 @@ test-env-setup: ## Deploys all services and manifests required by kuadrant to ru
 	$(MAKE) namespace
 	$(MAKE) gateway-api-install
 	$(MAKE) istio-install
+	$(MAKE) install-cert-manager
 	$(MAKE) deploy-gateway
 	$(MAKE) deploy-dependencies
 	$(MAKE) install

--- a/config/dependencies/cert-manager/kustomization.yaml
+++ b/config/dependencies/cert-manager/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- https://github.com/cert-manager/cert-manager/releases/download/v1.12.1/cert-manager.yaml

--- a/config/dependencies/kustomization.yaml
+++ b/config/dependencies/kustomization.yaml
@@ -7,3 +7,78 @@ resources:
 patchesStrategicMerge:
   - authorino/delete-ns.yaml
   - limitador/delete-ns.yaml
+
+replacements:
+- source:
+    fieldPath: .metadata.namespace
+    group: cert-manager.io
+    kind: Certificate
+    name: authorino-webhook-server-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io
+- source:
+    fieldPath: .metadata.name
+    group: cert-manager.io
+    kind: Certificate
+    name: authorino-webhook-server-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      create: true
+      delimiter: /
+      index: 1
+    select:
+      kind: CustomResourceDefinition
+      name: authconfigs.authorino.kuadrant.io
+- source:
+    fieldPath: .metadata.name
+    kind: Service
+    name: authorino-webhooks
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      create: true
+      delimiter: .
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: authorino-webhook-server-cert
+      version: v1
+- source:
+    fieldPath: .metadata.namespace
+    kind: Service
+    name: authorino-webhooks
+    version: v1
+  targets:
+  - fieldPaths:
+    - .spec.dnsNames.0
+    - .spec.dnsNames.1
+    options:
+      create: true
+      delimiter: .
+      index: 1
+    select:
+      group: cert-manager.io
+      kind: Certificate
+      name: authorino-webhook-server-cert
+      version: v1
+  - fieldPaths:
+    - subjects.0.namespace
+    select:
+      group: rbac.authorization.k8s.io
+      kind: RoleBinding
+      name: authorino-webhooks-manager
+

--- a/make/cert-manager.mk
+++ b/make/cert-manager.mk
@@ -1,0 +1,7 @@
+##@ Cert Manager resources
+
+.POHNY: install-cert-manager
+install-cert-manager: kustomize
+	$(KUSTOMIZE) build config/dependencies/cert-manager | kubectl apply -f -
+	kubectl -n cert-manager wait --timeout=300s --for=condition=Available deployments --all
+


### PR DESCRIPTION
Cert manager is required for the webhooks in local deployments.

# Validation 
* run `make local-setup`
* Expected: Installation to complete with a webhook pod running for authorino.
```
kubectl get deployment authorino-webhooks -n kuadrant-system
```

Closes: https://github.com/Kuadrant/kuadrant-operator/issues/257