### PR TITLE
[authpolicy-v2] Add Gateway API label to the AuthPolicy CRD

### DIFF
--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -182,6 +182,7 @@ func (s *AuthPolicyStatus) Equals(other *AuthPolicyStatus, logger logr.Logger) b
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=inherited"
 type AuthPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2023-10-18T09:47:11Z"
+    createdAt: "2023-10-18T14:03:29Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/manifests/kuadrant.io_authpolicies.yaml
+++ b/bundle/manifests/kuadrant.io_authpolicies.yaml
@@ -6,6 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: kuadrant
+    gateway.networking.k8s.io/policy: inherited
   name: authpolicies.kuadrant.io
 spec:
   group: kuadrant.io

--- a/config/crd/bases/kuadrant.io_authpolicies.yaml
+++ b/config/crd/bases/kuadrant.io_authpolicies.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
   name: authpolicies.kuadrant.io
 spec:
   group: kuadrant.io


### PR DESCRIPTION
Add mandatory Gateway API `gateway.networking.k8s.io/policy` label to the AuthPolicy CRD.

Ref.: https://github.com/youngnick/gateway-api/blob/main/geps/gep-713.md#standard-label-on-crd-objects

Closes #278