### PR TITLE
[authpolicy-v2] AuthPolicy validation rules

### DIFF
--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -115,8 +115,17 @@ type CallbackSpec struct {
 	CommonAuthRuleSpec        `json:""`
 }
 
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.routeSelectors)",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.rules.authentication) || !self.rules.authentication.exists(x, has(self.rules.authentication[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.rules.metadata) || !self.rules.metadata.exists(x, has(self.rules.metadata[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.rules.authorization) || !self.rules.authorization.exists(x, has(self.rules.authorization[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.rules.response) || !has(self.rules.response.success) || self.rules.response.success.headers.exists(x, has(self.rules.response.success.headers[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.rules.response) || !has(self.rules.response.success) || self.rules.response.success.dynamicMetadata.exists(x, has(self.rules.response.success.dynamicMetadata[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.rules.callbacks) || !self.rules.callbacks.exists(x, has(self.rules.callbacks[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
 type AuthPolicySpec struct {
 	// TargetRef identifies an API object to apply policy to.
+	// +kubebuilder:validation:XValidation:rule="self.group == 'gateway.networking.k8s.io'",message="Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'"
+	// +kubebuilder:validation:XValidation:rule="self.kind == 'HTTPRoute' || self.kind == 'Gateway'",message="Invalid targetRef.kind. The only supported values are 'HTTPRoute' and 'Gateway'"
 	TargetRef gatewayapiv1alpha2.PolicyTargetReference `json:"targetRef"`
 
 	// Top-level route selectors.

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2023-10-20T10:36:08Z"
+    createdAt: "2023-10-20T10:46:36Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/manifests/kuadrant.io_authpolicies.yaml
+++ b/bundle/manifests/kuadrant.io_authpolicies.yaml
@@ -4121,6 +4121,12 @@ spec:
                 - kind
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
               when:
                 description: Overall conditions for the AuthPolicy to be enforced.
                   If omitted, the AuthPolicy will be enforced at all requests to the
@@ -4177,6 +4183,29 @@ spec:
             required:
             - targetRef
             type: object
+            x-kubernetes-validations:
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.routeSelectors)
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.authentication)
+                || !self.rules.authentication.exists(x, has(self.rules.authentication[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.metadata)
+                || !self.rules.metadata.exists(x, has(self.rules.metadata[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.authorization)
+                || !self.rules.authorization.exists(x, has(self.rules.authorization[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.response)
+                || !has(self.rules.response.success) || self.rules.response.success.headers.exists(x,
+                has(self.rules.response.success.headers[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.response)
+                || !has(self.rules.response.success) || self.rules.response.success.dynamicMetadata.exists(x,
+                has(self.rules.response.success.dynamicMetadata[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.callbacks)
+                || !self.rules.callbacks.exists(x, has(self.rules.callbacks[x].routeSelectors))
           status:
             properties:
               conditions:

--- a/config/crd/bases/kuadrant.io_authpolicies.yaml
+++ b/config/crd/bases/kuadrant.io_authpolicies.yaml
@@ -4120,6 +4120,12 @@ spec:
                 - kind
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                  rule: self.group == 'gateway.networking.k8s.io'
+                - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                    and 'Gateway'
+                  rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
               when:
                 description: Overall conditions for the AuthPolicy to be enforced.
                   If omitted, the AuthPolicy will be enforced at all requests to the
@@ -4176,6 +4182,29 @@ spec:
             required:
             - targetRef
             type: object
+            x-kubernetes-validations:
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.routeSelectors)
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.authentication)
+                || !self.rules.authentication.exists(x, has(self.rules.authentication[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.metadata)
+                || !self.rules.metadata.exists(x, has(self.rules.metadata[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.authorization)
+                || !self.rules.authorization.exists(x, has(self.rules.authorization[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.response)
+                || !has(self.rules.response.success) || self.rules.response.success.headers.exists(x,
+                has(self.rules.response.success.headers[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.response)
+                || !has(self.rules.response.success) || self.rules.response.success.dynamicMetadata.exists(x,
+                has(self.rules.response.success.dynamicMetadata[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.rules.callbacks)
+                || !self.rules.callbacks.exists(x, has(self.rules.callbacks[x].routeSelectors))
           status:
             properties:
               conditions:


### PR DESCRIPTION
- Prevent usage of `routeSelectors` in a gateway AuthPolicy _(enforced at reconciliation time)_
- AuthPolicy validation rules using Common Language Expression (CEL) _(enforced at the level of the API)_
  - Invalid `targetRef.group`
  - Invalid `targetRef.kind`
  - Route selectors not supported when targeting a Gateway
  - **Note:** cannot set a validation rule for `!has(spec.targetRef.namespace) || spec.targetRef.namespace == metadata.namespace`, because Kubernetes does not allow accessing `metadata.namespace` ([ref](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules))
  - **Note:** kubebuilder currently does not support other validation rules fields such as [`reason`](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-reason) and [`fieldPath`](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#field-field-path) that would allow improving error messages

### Verification steps

❶ Setup

```sh
make local-setup
```

```sh
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```

```sh
kubectl apply -f examples/toystore/toystore.yaml

kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - method: GET
      path:
        type: PathPrefix
        value: "/cars"
    - method: GET
      path:
        type: PathPrefix
        value: "/dolls"
    backendRefs:
    - name: toystore
      port: 80
  - matches:
    - path:
        type: PathPrefix
        value: "/admin"
    backendRefs:
    - name: toystore
      port: 80
EOF
```

❷ AuthPolicies

```sh
kubectl apply -f -<<EOF
# The AuthPolicy "gw-auth-1" is invalid: spec.targetRef: Invalid value: "object": Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gw-auth-1
  namespace: istio-system
spec:
  targetRef:
    group: networking.istio.io # invalid
    kind: Gateway
    name: istio-ingressgateway
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
---
# The AuthPolicy "gw-auth-2" is invalid: spec.targetRef: Invalid value: "object": Invalid targetRef.kind. The only supported values are 'HTTPRoute' and 'Gateway'
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gw-auth-2
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Service # invalid
    name: istio-ingressgateway
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
---
# The AuthPolicy "gw-auth-3" is invalid: spec: Invalid value: "object": route selectors not supported when targeting a Gateway
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gw-auth-3
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  routeSelectors: # invalid
  - hostnames: ["api.toystore.com"]
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
---
# The AuthPolicy "gw-auth-4" is invalid: spec: Invalid value: "object": route selectors not supported when targeting a Gateway
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gw-auth-4
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
        routeSelectors: # invalid
        - hostnames: ["api.toystore.com"]
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
---
# authpolicy.kuadrant.io/gw-auth-5 created
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gw-auth-5
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
---
# authpolicy.kuadrant.io/toystore created
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: toystore
  namespace: default
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authentication:
      "api-key-authn":
        apiKey:
          selector: {}
        credentials:
          authorizationHeader:
            prefix: APIKEY
    authorization:
      "only-admins":
        opa:
          rego: |
            groups := split(object.get(input.auth.identity.metadata.annotations, "kuadrant.io/groups", ""), ",")
            allow { groups[_] == "admins" }
        routeSelectors:
        - matches:
          - path:
              type: PathPrefix
              value: "/admin"
EOF
```

Expected:

```
authpolicy.kuadrant.io/gw-auth-5 created
authpolicy.kuadrant.io/toystore created
AuthPolicy.kuadrant.io "gw-auth-1" is invalid: spec.targetRef: Invalid value: "object": Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
AuthPolicy.kuadrant.io "gw-auth-2" is invalid: spec.targetRef: Invalid value: "object": Invalid targetRef.kind. The only supported values are 'HTTPRoute' and 'Gateway'
AuthPolicy.kuadrant.io "gw-auth-3" is invalid: spec: Invalid value: "object": route selectors not supported when targeting a Gateway
AuthPolicy.kuadrant.io "gw-auth-4" is invalid: spec: Invalid value: "object": route selectors not supported when targeting a Gateway
```