### PR TITLE
Gh 639 policy controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,6 +368,14 @@ deploy-dependencies: kustomize dependencies-manifests ## Deploy dependencies to 
 	$(KUSTOMIZE) build config/dependencies | kubectl apply -f -
 	kubectl -n "$(KUADRANT_NAMESPACE)" wait --timeout=300s --for=condition=Available deployments --all
 
+.PHONY: install-metallb
+install-metallb: $(KUSTOMIZE) ## Installs the metallb load balancer allowing use of an LoadBalancer type with a gateway
+	$(KUSTOMIZE) build config/metallb | kubectl apply -f -
+
+.PHONY: uninstall-metallb
+uninstall-metallb: $(KUSTOMIZE) 
+	$(KUSTOMIZE) build config/metallb | kubectl delete -f -
+
 .PHONY: install-olm
 install-olm: $(OPERATOR_SDK)
 	$(OPERATOR_SDK) olm install

--- a/bundle/manifests/kuadrant-operator-dnsrecord-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kuadrant-operator-dnsrecord-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+  name: kuadrant-operator-dnsrecord-editor-role
+rules:
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords/status
+  verbs:
+  - get

--- a/bundle/manifests/kuadrant-operator-dnsrecord-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kuadrant-operator-dnsrecord-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+  name: kuadrant-operator-dnsrecord-viewer-role
+rules:
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords/status
+  verbs:
+  - get

--- a/bundle/manifests/kuadrant-operator-kuadrant-dnsrecord-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kuadrant-operator-kuadrant-dnsrecord-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: multicluster-gateway-controller
+    app.kubernetes.io/instance: dnsrecord-editor-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: multicluster-gateway-controller
+  name: kuadrant-operator-kuadrant-dnsrecord-editor-role
+rules:
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords/status
+  verbs:
+  - get

--- a/bundle/manifests/kuadrant-operator-kuadrant-dnsrecord-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kuadrant-operator-kuadrant-dnsrecord-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: multicluster-gateway-controller
+    app.kubernetes.io/instance: dnsrecord-viewer-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: multicluster-gateway-controller
+  name: kuadrant-operator-kuadrant-dnsrecord-viewer-role
+rules:
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords/status
+  verbs:
+  - get

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2023-11-14T13:20:04Z"
+    createdAt: "2023-11-16T10:36:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator
@@ -55,14 +55,29 @@ spec:
     - kind: AuthPolicy
       name: authpolicies.kuadrant.io
       version: v1beta2
+    - kind: DNSHealthCheckProbe
+      name: dnshealthcheckprobes.kuadrant.io
+      version: v1alpha1
+    - kind: DNSPolicy
+      name: dnspolicies.kuadrant.io
+      version: v1alpha1
+    - kind: DNSRecord
+      name: dnsrecords.kuadrant.io
+      version: v1alpha1
     - description: Kuadrant is the Schema for the kuadrants API
       displayName: Kuadrant
       kind: Kuadrant
       name: kuadrants.kuadrant.io
       version: v1beta1
+    - kind: ManagedZone
+      name: managedzones.kuadrant.io
+      version: v1alpha1
     - kind: RateLimitPolicy
       name: ratelimitpolicies.kuadrant.io
       version: v1beta2
+    - kind: TLSPolicy
+      name: tlspolicies.kuadrant.io
+      version: v1alpha1
   description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
   displayName: Kuadrant Operator
   icon:
@@ -343,6 +358,206 @@ spec:
           - update
           - watch
         serviceAccountName: kuadrant-operator-controller-manager
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - clusterissuers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - issuers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - gateway.networking.k8s.io
+          resources:
+          - gateways
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - gateway.networking.k8s.io
+          resources:
+          - gateways/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - gateway.networking.k8s.io
+          resources:
+          - gateways/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - dnshealthcheckprobes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - dnshealthcheckprobes/finalizers
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - dnshealthcheckprobes/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - dnspolicies
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - dnspolicies/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - dnspolicies/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - dnsrecords
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - dnsrecords/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - dnsrecords/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - managedzones
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - managedzones/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - managedzones/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - tlspolicies
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - tlspolicies/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - kuadrant.io
+          resources:
+          - tlspolicies/status
+          verbs:
+          - get
+          - patch
+          - update
+        serviceAccountName: kuadrant-operator-policy-controller
       deployments:
       - label:
           app: kuadrant
@@ -399,6 +614,62 @@ spec:
                 runAsNonRoot: true
               serviceAccountName: kuadrant-operator-controller-manager
               terminationGracePeriodSeconds: 10
+      - label:
+          app: kuadrant
+          control-plane: policy-controller
+        name: kuadrant-operator-policy-controller
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kuadrant
+              control-plane: policy-controller
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app: kuadrant
+                control-plane: policy-controller
+            spec:
+              containers:
+              - args:
+                - --leader-elect
+                - --ocm-hub=false
+                command:
+                - /policy_controller
+                image: quay.io/kuadrant/policy-controller:main
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: policy-controller
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 256Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: kuadrant-operator-policy-controller
+              terminationGracePeriodSeconds: 10
       permissions:
       - rules:
         - apiGroups:
@@ -433,6 +704,39 @@ spec:
           - create
           - patch
         serviceAccountName: kuadrant-operator-controller-manager
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: kuadrant-operator-policy-controller
     strategy: deployment
   installModes:
   - supported: false

--- a/bundle/manifests/kuadrant.io_dnshealthcheckprobes.yaml
+++ b/bundle/manifests/kuadrant.io_dnshealthcheckprobes.yaml
@@ -1,0 +1,107 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+  name: dnshealthcheckprobes.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: DNSHealthCheckProbe
+    listKind: DNSHealthCheckProbeList
+    plural: dnshealthcheckprobes
+    singular: dnshealthcheckprobe
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: DNSHealthCheckProbe healthy.
+      jsonPath: .status.healthy
+      name: Healthy
+      type: boolean
+    - description: Last checked at.
+      jsonPath: .status.lastCheckedAt
+      name: Last Checked
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNSHealthCheckProbe is the Schema for the dnshealthcheckprobes
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSHealthCheckProbeSpec defines the desired state of DNSHealthCheckProbe
+            properties:
+              additionalHeadersRef:
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              address:
+                type: string
+              allowInsecureCertificate:
+                type: boolean
+              expectedResponses:
+                items:
+                  type: integer
+                type: array
+              failureThreshold:
+                type: integer
+              host:
+                type: string
+              interval:
+                type: string
+              path:
+                type: string
+              port:
+                type: integer
+              protocol:
+                description: HealthProtocol represents the protocol to use when making
+                  a health check request
+                type: string
+            type: object
+          status:
+            description: DNSHealthCheckProbeStatus defines the observed state of DNSHealthCheckProbe
+            properties:
+              consecutiveFailures:
+                type: integer
+              healthy:
+                type: boolean
+              lastCheckedAt:
+                format: date-time
+                type: string
+              reason:
+                type: string
+              status:
+                type: integer
+            required:
+            - healthy
+            - lastCheckedAt
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -1,0 +1,373 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+    gateway.networking.k8s.io/policy: direct
+  name: dnspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: DNSPolicy
+    listKind: DNSPolicyList
+    plural: dnspolicies
+    singular: dnspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: DNSPolicy ready.
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNSPolicy is the Schema for the dnspolicies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSPolicySpec defines the desired state of DNSPolicy
+            properties:
+              healthCheck:
+                description: HealthCheckSpec configures health checks in the DNS provider.
+                  By default this health check will be applied to each unique DNS
+                  A Record for the listeners assigned to the target gateway
+                properties:
+                  additionalHeadersRef:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  allowInsecureCertificates:
+                    type: boolean
+                  endpoint:
+                    type: string
+                  expectedResponses:
+                    items:
+                      type: integer
+                    type: array
+                  failureThreshold:
+                    type: integer
+                  interval:
+                    type: string
+                  port:
+                    type: integer
+                  protocol:
+                    description: HealthProtocol represents the protocol to use when
+                      making a health check request
+                    type: string
+                type: object
+              loadBalancing:
+                properties:
+                  geo:
+                    properties:
+                      defaultGeo:
+                        description: "defaultGeo is the country/continent/region code
+                          to use when no other can be determined for a dns target
+                          cluster. \n The values accepted are determined by the target
+                          dns provider, please refer to the appropriate docs below.
+                          \n Route53: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-geo.html"
+                        type: string
+                    type: object
+                  weighted:
+                    properties:
+                      custom:
+                        items:
+                          properties:
+                            selector:
+                              description: 'Label selector used by MGC to match resource
+                                storing custom weight attribute values e.g. kuadrant.io/lb-attribute-custom-weight:
+                                AWS'
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              minimum: 0
+                              type: integer
+                          required:
+                          - selector
+                          type: object
+                        type: array
+                      defaultWeight:
+                        default: 120
+                        description: "defaultWeight is the record weight to use when
+                          no other can be determined for a dns target cluster. \n
+                          The maximum value accepted is determined by the target dns
+                          provider, please refer to the appropriate docs below. \n
+                          Route53: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-weighted.html"
+                        minimum: 0
+                        type: integer
+                    type: object
+                type: object
+              routingStrategy:
+                default: loadbalanced
+                enum:
+                - simple
+                - loadbalanced
+                type: string
+              targetRef:
+                description: PolicyTargetReference identifies an API object to apply
+                  policy to. This should be used as part of Policy resources that
+                  can target Gateway API resources. For more information on how this
+                  policy attachment model works, and a sample Policy resource, refer
+                  to the policy attachment documentation for Gateway API.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+            required:
+            - routingStrategy
+            - targetRef
+            type: object
+          status:
+            description: DNSPolicyStatus defines the observed state of DNSPolicy
+            properties:
+              conditions:
+                description: "conditions are any conditions associated with the policy
+                  \n If configuring the policy fails, the \"Failed\" condition will
+                  be set with a reason and message describing the cause of the failure."
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              healthCheck:
+                properties:
+                  conditions:
+                    items:
+                      description: "Condition contains details for one aspect of the
+                        current state of this API Resource. --- This struct is intended
+                        for direct use as an array at the field path .status.conditions.
+                        \ For example, \n type FooStatus struct{ // Represents the
+                        observations of a foo's current state. // Known .status.conditions.type
+                        are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type
+                        // +patchStrategy=merge // +listType=map // +listMapKey=type
+                        Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                        patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                        \n // other fields }"
+                      properties:
+                        lastTransitionTime:
+                          description: lastTransitionTime is the last time the condition
+                            transitioned from one status to another. This should be
+                            when the underlying condition changed.  If that is not
+                            known, then using the time when the API field changed
+                            is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: message is a human readable message indicating
+                            details about the transition. This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: observedGeneration represents the .metadata.generation
+                            that the condition was set based upon. For instance, if
+                            .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration
+                            is 9, the condition is out of date with respect to the
+                            current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: reason contains a programmatic identifier indicating
+                            the reason for the condition's last transition. Producers
+                            of specific condition types may define expected values
+                            and meanings for this field, and whether the values are
+                            considered a guaranteed API. The value should be a CamelCase
+                            string. This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            --- Many .condition.type values are consistent across
+                            resources like Available, but because arbitrary conditions
+                            can be useful (see .node.status.conditions), the ability
+                            to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                type: object
+              observedGeneration:
+                description: observedGeneration is the most recently observed generation
+                  of the DNSPolicy.  When the DNSPolicy is updated, the controller
+                  updates the corresponding configuration. If an update fails, that
+                  failure is recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/kuadrant.io_dnsrecords.yaml
+++ b/bundle/manifests/kuadrant.io_dnsrecords.yaml
@@ -1,0 +1,246 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+  name: dnsrecords.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: DNSRecord
+    listKind: DNSRecordList
+    plural: dnsrecords
+    singular: dnsrecord
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: DNSRecord ready.
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNSRecord is the Schema for the dnsrecords API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSRecordSpec defines the desired state of DNSRecord
+            properties:
+              endpoints:
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, SRV,
+                        TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                minItems: 1
+                type: array
+              managedZone:
+                description: ManagedZoneReference holds a reference to a ManagedZone
+                properties:
+                  name:
+                    description: '`name` is the name of the managed zone. Required'
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: DNSRecordStatus defines the observed state of DNSRecord
+            properties:
+              conditions:
+                description: "conditions are any conditions associated with the record
+                  in the managed zone. \n If publishing the record fails, the \"Failed\"
+                  condition will be set with a reason and message describing the cause
+                  of the failure."
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoints:
+                description: "endpoints are the last endpoints that were successfully
+                  published by the provider \n Provides a simple mechanism to store
+                  the current provider records in order to delete any that are no
+                  longer present in DNSRecordSpec.Endpoints \n Note: This will not
+                  be required if/when we switch to using external-dns since when running
+                  with a \"sync\" policy it will clean up unused records automatically."
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, SRV,
+                        TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recently observed generation
+                  of the DNSRecord.  When the DNSRecord is updated, the controller
+                  updates the corresponding record in each managed zone.  If an update
+                  for a particular zone fails, that failure is recorded in the status
+                  condition for the zone so that the controller can determine that
+                  it needs to retry the update for that specific zone.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/kuadrant.io_managedzones.yaml
+++ b/bundle/manifests/kuadrant.io_managedzones.yaml
@@ -1,0 +1,201 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+  name: managedzones.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: ManagedZone
+    listKind: ManagedZoneList
+    plural: managedzones
+    singular: managedzone
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Domain of this Managed Zone
+      jsonPath: .spec.domainName
+      name: Domain Name
+      type: string
+    - description: The ID assigned by this provider for this zone .
+      jsonPath: .status.id
+      name: ID
+      type: string
+    - description: Number of records in the provider zone.
+      jsonPath: .status.recordCount
+      name: Record Count
+      type: string
+    - description: The NameServers assigned by the provider for this zone.
+      jsonPath: .status.nameServers
+      name: NameServers
+      type: string
+    - description: Managed Zone ready.
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ManagedZone is the Schema for the managedzones API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagedZoneSpec defines the desired state of ManagedZone
+            properties:
+              description:
+                description: Description for this ManagedZone
+                type: string
+              dnsProviderSecretRef:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              domainName:
+                description: Domain name of this ManagedZone
+                pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$
+                type: string
+              id:
+                description: ID is the provider assigned id of this  zone (i.e. route53.HostedZone.ID).
+                type: string
+              parentManagedZone:
+                description: Reference to another managed zone that this managed zone
+                  belongs to.
+                properties:
+                  name:
+                    description: '`name` is the name of the managed zone. Required'
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - description
+            - dnsProviderSecretRef
+            - domainName
+            type: object
+          status:
+            description: ManagedZoneStatus defines the observed state of a Zone
+            properties:
+              conditions:
+                description: List of status conditions to indicate the status of a
+                  ManagedZone. Known condition types are `Ready`.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              id:
+                description: The ID assigned by this provider for this zone (i.e.
+                  route53.HostedZone.ID)
+                type: string
+              nameServers:
+                description: The NameServers assigned by the provider for this zone
+                  (i.e. route53.DelegationSet.NameServers)
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recently observed generation
+                  of the ManagedZone.
+                format: int64
+                type: integer
+              recordCount:
+                description: The number of records in the provider zone
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/kuadrant.io_tlspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_tlspolicies.yaml
@@ -1,0 +1,315 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.10.0
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+    gateway.networking.k8s.io/policy: direct
+  name: tlspolicies.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: TLSPolicy
+    listKind: TLSPolicyList
+    plural: tlspolicies
+    singular: tlspolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: TLSPolicy ready.
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TLSPolicy is the Schema for the tlspolicies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TLSPolicySpec defines the desired state of TLSPolicy
+            properties:
+              commonName:
+                description: 'CommonName is a common name to be used on the Certificate.
+                  The CommonName should have a length of 64 characters or fewer to
+                  avoid generating invalid CSRs. This value is ignored by TLS clients
+                  when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
+                type: string
+              duration:
+                description: The requested 'duration' (i.e. lifetime) of the Certificate.
+                  This option may be ignored/overridden by some issuer types. If unset
+                  this defaults to 90 days. Certificate will be renewed either 2/3
+                  through its duration or `renewBefore` period before its expiry,
+                  whichever is later. Minimum accepted duration is 1 hour. Value must
+                  be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for this certificate.
+                  If the `kind` field is not set, or set to `Issuer`, an Issuer resource
+                  with the given name in the same namespace as the Certificate will
+                  be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer
+                  with the provided name will be used. The `name` field in this stanza
+                  is required at all times.
+                properties:
+                  group:
+                    description: Group of the resource being referred to.
+                    type: string
+                  kind:
+                    description: Kind of the resource being referred to.
+                    type: string
+                  name:
+                    description: Name of the resource being referred to.
+                    type: string
+                required:
+                - name
+                type: object
+              privateKey:
+                description: Options to control private keys used for the Certificate.
+                properties:
+                  algorithm:
+                    description: Algorithm is the private key algorithm of the corresponding
+                      private key for this certificate. If provided, allowed values
+                      are either `RSA`,`Ed25519` or `ECDSA` If `algorithm` is specified
+                      and `size` is not provided, key size of 256 will be used for
+                      `ECDSA` key algorithm and key size of 2048 will be used for
+                      `RSA` key algorithm. key size is ignored when using the `Ed25519`
+                      key algorithm.
+                    enum:
+                    - RSA
+                    - ECDSA
+                    - Ed25519
+                    type: string
+                  encoding:
+                    description: The private key cryptography standards (PKCS) encoding
+                      for this certificate's private key to be encoded in. If provided,
+                      allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and
+                      PKCS#8, respectively. Defaults to `PKCS1` if not specified.
+                    enum:
+                    - PKCS1
+                    - PKCS8
+                    type: string
+                  rotationPolicy:
+                    description: RotationPolicy controls how private keys should be
+                      regenerated when a re-issuance is being processed. If set to
+                      Never, a private key will only be generated if one does not
+                      already exist in the target `spec.secretName`. If one does exists
+                      but it does not have the correct algorithm or size, a warning
+                      will be raised to await user intervention. If set to Always,
+                      a private key matching the specified requirements will be generated
+                      whenever a re-issuance occurs. Default is 'Never' for backward
+                      compatibility.
+                    type: string
+                  size:
+                    description: Size is the key bit size of the corresponding private
+                      key for this certificate. If `algorithm` is set to `RSA`, valid
+                      values are `2048`, `4096` or `8192`, and will default to `2048`
+                      if not specified. If `algorithm` is set to `ECDSA`, valid values
+                      are `256`, `384` or `521`, and will default to `256` if not
+                      specified. If `algorithm` is set to `Ed25519`, Size is ignored.
+                      No other values are allowed.
+                    type: integer
+                type: object
+              renewBefore:
+                description: How long before the currently issued certificate's expiry
+                  cert-manager should renew the certificate. The default is 2/3 of
+                  the issued certificate's duration. Minimum accepted value is 5 minutes.
+                  Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration
+                type: string
+              revisionHistoryLimit:
+                description: RevisionHistoryLimit is the maximum number of CertificateRequest
+                  revisions that are maintained in the Certificate's history. Each
+                  revision represents a single `CertificateRequest` created by this
+                  Certificate, either when it was created, renewed, or Spec was changed.
+                  Revisions will be removed by oldest first if the number of revisions
+                  exceeds this number. If set, revisionHistoryLimit must be a value
+                  of `1` or greater. If unset (`nil`), revisions will not be garbage
+                  collected. Default value is `nil`.
+                format: int32
+                type: integer
+              targetRef:
+                description: PolicyTargetReference identifies an API object to apply
+                  policy to. This should be used as part of Policy resources that
+                  can target Gateway API resources. For more information on how this
+                  policy attachment model works, and a sample Policy resource, refer
+                  to the policy attachment documentation for Gateway API.
+                properties:
+                  group:
+                    description: Group is the group of the target resource.
+                    maxLength: 253
+                    pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is kind of the target resource.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the target resource.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the referent. When
+                      unspecified, the local namespace is inferred. Even when policy
+                      targets a resource in a different namespace, it MUST only apply
+                      to traffic originating from the same namespace as the policy.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                type: object
+              usages:
+                description: Usages is the set of x509 usages that are requested for
+                  the certificate. Defaults to `digital signature` and `key encipherment`
+                  if not specified.
+                items:
+                  description: 'KeyUsage specifies valid usage contexts for keys.
+                    See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3 https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                    Valid KeyUsage values are as follows: "signing", "digital signature",
+                    "content commitment", "key encipherment", "key agreement", "data
+                    encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                    only", "any", "server auth", "client auth", "code signing", "email
+                    protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                    user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                    sgc"'
+                  enum:
+                  - signing
+                  - digital signature
+                  - content commitment
+                  - key encipherment
+                  - key agreement
+                  - data encipherment
+                  - cert sign
+                  - crl sign
+                  - encipher only
+                  - decipher only
+                  - any
+                  - server auth
+                  - client auth
+                  - code signing
+                  - email protection
+                  - s/mime
+                  - ipsec end system
+                  - ipsec tunnel
+                  - ipsec user
+                  - timestamping
+                  - ocsp signing
+                  - microsoft sgc
+                  - netscape sgc
+                  type: string
+                type: array
+            required:
+            - issuerRef
+            - targetRef
+            type: object
+          status:
+            description: TLSPolicyStatus defines the observed state of TLSPolicy
+            properties:
+              conditions:
+                description: "conditions are any conditions associated with the policy
+                  \n If configuring the policy fails, the \"Failed\" condition will
+                  be set with a reason and message describing the cause of the failure."
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    \n type FooStatus struct{ // Represents the observations of a
+                    foo's current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the most recently observed generation
+                  of the TLSPolicy.  When the TLSPolicy is updated, the controller
+                  updates the corresponding configuration. If an update fails, that
+                  failure is recorded in the status condition
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -49,3 +49,4 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- ../policy-controller

--- a/config/metallb/kustomization.yaml
+++ b/config/metallb/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+- github.com/metallb/metallb/config/native?ref=v0.13.7

--- a/config/policy-controller/delete-ns.yaml
+++ b/config/policy-controller/delete-ns.yaml
@@ -1,0 +1,7 @@
+---
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+

--- a/config/policy-controller/kustomization.yaml
+++ b/config/policy-controller/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+- github.com/Kuadrant/multicluster-gateway-controller/config/policy-controller/default?ref=main
+
+patchesStrategicMerge:
+  - delete-ns.yaml
+
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --ocm-hub=false
+  target:
+    kind: Deployment

--- a/examples/metal-lb.yaml
+++ b/examples/metal-lb.yaml
@@ -1,0 +1,14 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.31.200.0/24
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: empty
+  namespace: metallb-system


### PR DESCRIPTION
Draft PR adding the new policy controller to the deployment and CSV for kuadrant operator

This PR adds in the policy controller via kustomize it also add metal lb as an option

**Verification**
`make local-cluster-setup`
Build a new bundle and catalog and install it in to the cluster

expect to see a new `kuadrant-operator-policy-controller` in the `kuadrant-system` namespace
validate that the DNSPolicy and TLSPolicy CRDS are present in the cluster

**Extra Validation**

Before doing this you will need an AWS credential that gives access to route53 a domain (talk to craig as he can set you up with this)

deploy metallb to a local cluster
`make install-metallb`
`k create -f config/metallb/metal-lb.yaml`

create a new gateway isito gateway

```
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: prod-web
spec:
  gatewayClassName: istio
  listeners:
  - allowedRoutes:
      namespaces:
        from: All
    name: specific
    hostname: 'REPLACEME'
    port: 443
    protocol: HTTPS
    tls:
      mode: Terminate
      certificateRefs:
      - kind: Secret
        name: REPLACEME
  ```

Setup TLS

create an issuer

```
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: glbc-ca
spec:
  selfSigned: {}

```

create a TLSPolicy

```
apiVersion: kuadrant.io/v1alpha1 
kind: TLSPolicy 
metadata: 
  name: prod-web
spec: 
  targetRef: 
    name: prod-web 
    group: gateway.networking.k8s.io 
    kind: Gateway    
  issuerRef: 
    group: cert-manager.io
    kind: ClusterIssuer
    name: glbc-ca
```

Observe the gateway is now configured and has an address and tls secrets

```
get gateway
NAME       CLASS   ADDRESS        PROGRAMMED   AGE
prod-web   istio   172.31.200.0   True         7m56s
```

Setup DNS
setup a dnsprovider 
https://docs.kuadrant.io/multicluster-gateway-controller/docs/dnspolicy/dns-provider/
setup a managedzone
https://docs.kuadrant.io/multicluster-gateway-controller/docs/dnspolicy/managed-zone/

create a dnspolicy

```
apiVersion: kuadrant.io/v1alpha1
kind: DNSPolicy
metadata:
  name: prod-web
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: prod-web
  routingStrategy: simple  
```

setup a httproute and backend

```
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: echo2
spec:
  parentRefs:
  - kind: Gateway
    name: prod-web
  hostnames:
  - specific.cb.hcpapps.net
  rules:
  - backendRefs:
    - name: echo
      port: 8080
---
apiVersion: v1
kind: Service
metadata:
  name: echo
spec:
  ports:
    - name: http-port
      port: 8080
      targetPort: http-port
      protocol: TCP
  selector:
    app: echo     
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: echo
spec:
  replicas: 1
  selector:
    matchLabels:
      app: echo
  template:
    metadata:
      labels:
        app: echo
    spec:
      containers:
        - name: echo
          image: docker.io/jmalloc/echo-server
          ports:
            - name: http-port
              containerPort: 8080
              protocol: TCP 

```

should be able to dig your domain or curl it if you can resolve the IP

example `dig specific.cb.hcpapps.net`

clean up

```
k delete dnspolicy prod-web
k delete tlspolicy prod-web
```