### PR TITLE
Maintenance/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,7 @@ EOF
 
 * Deploy the service/API to be protected ("Upstream")
 * Expose the service/API using the kubernetes Gateway API, ie
-<<<<<<< HEAD
   [HTTPRoute](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute) object.
-=======
-  [HTTPRoute](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.HTTPRoute) object.
->>>>>>> 689f000 (Update Readme)
 * Write and apply the Kuadrant's [RateLimitPolicy](doc/rate-limiting.md) and/or
   [AuthPolicy](doc/auth.md) custom resources targeting the HTTPRoute resource
   to have your API protected.
@@ -137,11 +133,7 @@ EOF
 #### If you are a *Cluster Operator*
 
 * (Optionally) deploy istio ingress gateway using the
-<<<<<<< HEAD
   [Gateway](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Gateway) resource.
-=======
-  [Gateway](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.Gateway) resource.
->>>>>>> 689f000 (Update Readme)
 * Write and apply the Kuadrant's [RateLimitPolicy](doc/rate-limiting.md) and/or
   [AuthPolicy](doc/auth.md) custom resources targeting the Gateway resource
   to have your gateway traffic protected.

--- a/README.md
+++ b/README.md
@@ -7,27 +7,6 @@
 
 The Operator to install and manage the lifecycle of the [Kuadrant](https://github.com/Kuadrant/) components deployments.
 
-<!--ts-->
-- [Overview](#overview)
-- [Architecture](#architecture)
-  - [Kuadrant components](#kuadrant-components)
-  - [Provided APIs](#provided-apis)
-- [Getting started](#getting-started)
-  - [Pre-requisites](#pre-requisites)
-  - [Installing Kuadrant](#installing-kuadrant)
-    - [1. Install the Kuadrant Operator](#1-install-the-kuadrant-operator)
-    - [2. Request a Kuadrant instance](#2-request-a-kuadrant-instance)
-  - [Protect your service](#protect-your-service)
-    - [If you are an *API Provider*](#if-you-are-an-api-provider)
-    - [If you are a *Cluster Operator*](#if-you-are-a-cluster-operator)
-- [User guides](#user-guides)
-- [Kuadrant Rate Limiting](#kuadrant-rate-limiting)
-- [Documentation](#documentation)
-- [Contributing](#contributing)
-- [Licensing](#licensing)
-
-<!--te-->
-
 ## Overview
 
 Kuadrant is a re-architecture of API Management using Cloud Native concepts and separating the components to be less coupled,
@@ -75,7 +54,7 @@ Additionally, Kuadrant provides the following CRDs
 |--------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|-------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | [Kuadrant CRD](https://github.com/Kuadrant/kuadrant-operator/blob/main/api/v1beta1/kuadrant_types.go)        | [Kuadrant Operator](https://github.com/Kuadrant/kuadrant-operator)   | Represents an instance of kuadrant  | [Kuadrant CR](https://github.com/Kuadrant/kuadrant-operator/blob/main/config/samples/kuadrant_v1beta1_kuadrant.yaml)              |
 | [Limitador CRD](https://github.com/Kuadrant/limitador-operator/blob/main/api/v1alpha1/limitador_types.go)    | [Limitador Operator](https://github.com/Kuadrant/limitador-operator) | Represents an instance of Limitador | [Limitador CR](https://github.com/Kuadrant/limitador-operator/blob/main/config/samples/limitador_v1alpha1_limitador.yaml)         |
-| [Authorino CRD](https://github.com/Kuadrant/authorino-operator#the-authorino-custom-resource-definition-crd) | [Authorino Operator](https://github.com/Kuadrant/authorino-operator) | Represents an instance of Authorino | [Authorino CR](https://github.com/Kuadrant/authorino-operator/blob/main/config/samples/authorino-operator_v1beta1_authorino.yaml) |
+| [Authorino CRD](https://docs.kuadrant.io/authorino-operator/#the-authorino-custom-resource-definition-crd) | [Authorino Operator](https://github.com/Kuadrant/authorino-operator) | Represents an instance of Authorino | [Authorino CR](https://github.com/Kuadrant/authorino-operator/blob/main/config/samples/authorino-operator_v1beta1_authorino.yaml) |
 
 <img alt="Kuadrant Architecture" src="doc/images/kuadrant-architecture.svg" />
 
@@ -146,7 +125,11 @@ EOF
 
 * Deploy the service/API to be protected ("Upstream")
 * Expose the service/API using the kubernetes Gateway API, ie
+<<<<<<< HEAD
   [HTTPRoute](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute) object.
+=======
+  [HTTPRoute](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.HTTPRoute) object.
+>>>>>>> 689f000 (Update Readme)
 * Write and apply the Kuadrant's [RateLimitPolicy](doc/rate-limiting.md) and/or
   [AuthPolicy](doc/auth.md) custom resources targeting the HTTPRoute resource
   to have your API protected.
@@ -154,7 +137,11 @@ EOF
 #### If you are a *Cluster Operator*
 
 * (Optionally) deploy istio ingress gateway using the
+<<<<<<< HEAD
   [Gateway](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Gateway) resource.
+=======
+  [Gateway](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.Gateway) resource.
+>>>>>>> 689f000 (Update Readme)
 * Write and apply the Kuadrant's [RateLimitPolicy](doc/rate-limiting.md) and/or
   [AuthPolicy](doc/auth.md) custom resources targeting the Gateway resource
   to have your gateway traffic protected.

--- a/doc/development.md
+++ b/doc/development.md
@@ -1,26 +1,5 @@
 # Development Guide
 
-<!--ts-->
-   * [Technology stack required for development](#technology-stack-required-for-development)
-   * [Build](#build)
-   * [Run locally](#run-locally)
-   * [Deploy the operator in a deployment object](#deploy-the-operator-in-a-deployment-object)
-   * [Deploy kuadrant operator using OLM](#deploy-kuadrant-operator-using-olm)
-   * [Build custom OLM catalog](#build-custom-olm-catalog)
-      * [Build kuadrant operator bundle image](#build-kuadrant-operator-bundle-image)
-      * [Build custom catalog](#build-custom-catalog)
-   * [Cleaning up](#cleaning-up)
-   * [Run tests](#run-tests)
-      * [Unit tests](#unittests)
-      * [Integration tests](#integration-tests)
-      * [All tests](#all-tests)
-      * [Lint tests](#lint-tests)
-   * [(Un)Install Kuadrant CRDs](#uninstall-kuadrant-crds)
-
-<!-- Created by https://github.com/ekalinin/github-markdown-toc -->
-
-<!--te-->
-
 ## Technology stack required for development
 
 * [operator-sdk] version v1.28.1

--- a/doc/user-guides/authenticated-rl-for-app-developers.md
+++ b/doc/user-guides/authenticated-rl-for-app-developers.md
@@ -2,14 +2,11 @@
 
 This user guide walks you through an example of how to configure authenticated rate limiting for an application using Kuadrant.
 
-<br/>
-
 Authenticated rate limiting rate limits the traffic directed to an application based on attributes of the client user, who is authenticated by some authentication method. A few examples of authenticated rate limiting use cases are:
+
 - User A can send up to 50rps ("requests per second"), while User B can send up to 100rps.
 - Each user can send up to 20rpm ("request per minute").
 - Admin users (members of the 'admin' group) can send up to 100rps, while regular users (non-admins) can send up to 20rpm and no more than 5rps.
-
-<br/>
 
 In this guide, we will rate limit a sample REST API called **Toy Store**. In reality, this API is just an echo service that echoes back to the user whatever attributes it gets in the request. The API exposes an endpoint at `GET http://api.toystore.com/toy`, to mimic an operation of reading toy records.
 
@@ -19,8 +16,6 @@ We will define 2 users of the API, which can send requests to the API at differe
 |---------|----------------------------------------|
 | alice   | 5rp10s ("5 requests every 10 seconds") |
 | bob     | 2rp10s ("2 requests every 10 seconds") |
-
-<br/>
 
 ## Run the steps ① → ④
 
@@ -224,8 +219,6 @@ EOF
 ```
 
 > **Note:** It may take a couple of minutes for the RateLimitPolicy to be applied depending on your cluster.
-
-<br/>
 
 Verify the rate limiting works by sending requests as Alice and Bob.
 

--- a/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
+++ b/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
@@ -1,12 +1,11 @@
 # Authenticated Rate Limiting with JWTs and Kubernetes RBAC
 
 This user guide walks you through an example of how to use Kuadrant to protect an application with policies to enforce:
+
 - authentication based OpenId Connect (OIDC) ID tokens (signed JWTs), issued by a Keycloak server;
 - alternative authentication method by Kubernetes Service Account tokens;
 - authorization delegated to Kubernetes RBAC system;
 - rate limiting by user ID.
-
-<br/>
 
 In this example, we will protect a sample REST API called **Toy Store**. In reality, this API is just an echo service that echoes back to the user whatever attributes it gets in the request.
 
@@ -266,14 +265,14 @@ subjects:
 EOF
 ```
 
-<details>
+<details markdown="1">
   <summary><i>Q:</i> Can I use <code>Roles</code> and <code>RoleBindings</code> instead of <code>ClusterRoles</code> and <code>ClusterRoleBindings</code>?</summary>
 
   Yes, you can.
 
   The example above is for non-resource URL Kubernetes roles. For using `Roles` and `RoleBindings` instead of
   `ClusterRoles` and `ClusterRoleBindings`, thus more flexible resource-based permissions to protect the API,
-  see the spec for [Kubernetes SubjectAccessReview authorization](https://github.com/Kuadrant/authorino/blob/v0.5.0/docs/features.md#kubernetes-subjectaccessreview-authorizationkubernetes)
+  see the spec for [Kubernetes SubjectAccessReview authorization](https://docs.kuadrant.io/authorino/docs/features/#kubernetes-subjectaccessreview-authorizationkubernetessubjectaccessreview)
   in the Authorino docs.
 </details>
 


### PR DESCRIPTION
- Update docs for better rendering of dos.kaudrant.io
- fix broken links

# Verification 
- Edited markdown pages should render correctly in
  -  Github
  - Docs.kuadrant,io
- All links should work in both locations

To help with rendering these changes on the docs site, https://github.com/Kuadrant/docs.kuadrant.io/pull/41 can be used to run these changes locally