### PR TITLE
Add mandatory Gateway API label to the policy CRDs

### DIFF
--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -199,7 +199,7 @@ func (s *AuthPolicyStatus) Equals(other *AuthPolicyStatus, logger logr.Logger) b
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=inherited"
+// +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=direct"
 type AuthPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta2/ratelimitpolicy_types.go
+++ b/api/v1beta2/ratelimitpolicy_types.go
@@ -160,10 +160,10 @@ func (s *RateLimitPolicyStatus) Equals(other *RateLimitPolicyStatus, logger logr
 	return true
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-
 // RateLimitPolicy is the Schema for the ratelimitpolicies API
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=inherited"
 type RateLimitPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1beta2/ratelimitpolicy_types.go
+++ b/api/v1beta2/ratelimitpolicy_types.go
@@ -163,7 +163,7 @@ func (s *RateLimitPolicyStatus) Equals(other *RateLimitPolicyStatus, logger logr
 // RateLimitPolicy is the Schema for the ratelimitpolicies API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=inherited"
+// +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=direct"
 type RateLimitPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2023-11-02T12:36:24Z"
+    createdAt: "2023-11-13T13:12:01Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2023-11-13T13:12:01Z"
+    createdAt: "2023-11-14T13:20:04Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/manifests/kuadrant.io_authpolicies.yaml
+++ b/bundle/manifests/kuadrant.io_authpolicies.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: kuadrant
-    gateway.networking.k8s.io/policy: inherited
+    gateway.networking.k8s.io/policy: direct
   name: authpolicies.kuadrant.io
 spec:
   group: kuadrant.io

--- a/bundle/manifests/kuadrant.io_ratelimitpolicies.yaml
+++ b/bundle/manifests/kuadrant.io_ratelimitpolicies.yaml
@@ -6,7 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: kuadrant
-    gateway.networking.k8s.io/policy: inherited
+    gateway.networking.k8s.io/policy: direct
   name: ratelimitpolicies.kuadrant.io
 spec:
   group: kuadrant.io

--- a/bundle/manifests/kuadrant.io_ratelimitpolicies.yaml
+++ b/bundle/manifests/kuadrant.io_ratelimitpolicies.yaml
@@ -6,6 +6,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: kuadrant
+    gateway.networking.k8s.io/policy: inherited
   name: ratelimitpolicies.kuadrant.io
 spec:
   group: kuadrant.io

--- a/config/crd/bases/kuadrant.io_authpolicies.yaml
+++ b/config/crd/bases/kuadrant.io_authpolicies.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
   labels:
-    gateway.networking.k8s.io/policy: inherited
+    gateway.networking.k8s.io/policy: direct
   name: authpolicies.kuadrant.io
 spec:
   group: kuadrant.io

--- a/config/crd/bases/kuadrant.io_ratelimitpolicies.yaml
+++ b/config/crd/bases/kuadrant.io_ratelimitpolicies.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
+  labels:
+    gateway.networking.k8s.io/policy: inherited
   name: ratelimitpolicies.kuadrant.io
 spec:
   group: kuadrant.io

--- a/config/crd/bases/kuadrant.io_ratelimitpolicies.yaml
+++ b/config/crd/bases/kuadrant.io_ratelimitpolicies.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.13.0
   labels:
-    gateway.networking.k8s.io/policy: inherited
+    gateway.networking.k8s.io/policy: direct
   name: ratelimitpolicies.kuadrant.io
 spec:
   group: kuadrant.io


### PR DESCRIPTION
- [x] Add mandatory Gateway API `gateway.networking.k8s.io/policy` label to the RateLimitPolicy CRD
- [x] Fixes mandatory Gateway API `gateway.networking.k8s.io/policy` label in the AuthPolicy CRD

Ref.: https://github.com/youngnick/gateway-api/blob/main/geps/gep-713.md#standard-label-on-crd-objects

Closes #245.