### PR TITLE
Update istio to 1.20

### DIFF
--- a/controllers/authpolicy_authconfig.go
+++ b/controllers/authpolicy_authconfig.go
@@ -29,6 +29,11 @@ func (r *AuthPolicyReconciler) reconcileAuthConfigs(ctx context.Context, ap *api
 		return err
 	}
 
+	err = r.SetOwnerReference(ap, authConfig)
+	if err != nil {
+		return err
+	}
+
 	err = r.ReconcileResource(ctx, &authorinoapi.AuthConfig{}, authConfig, alwaysUpdateAuthConfig)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		logger.Error(err, "ReconcileResource failed to create/update AuthConfig resource")

--- a/controllers/authpolicy_authconfig.go
+++ b/controllers/authpolicy_authconfig.go
@@ -42,32 +42,6 @@ func (r *AuthPolicyReconciler) reconcileAuthConfigs(ctx context.Context, ap *api
 	return nil
 }
 
-func (r *AuthPolicyReconciler) deleteAuthConfigs(ctx context.Context, ap *api.AuthPolicy) error {
-	logger, err := logr.FromContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	logger.Info("Removing Authorino's AuthConfigs")
-
-	authConfig := &authorinoapi.AuthConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      authConfigName(client.ObjectKeyFromObject(ap)),
-			Namespace: ap.Namespace,
-		},
-	}
-
-	if err := r.DeleteResource(ctx, authConfig); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		logger.Error(err, "failed to delete Authorino's AuthConfig")
-		return err
-	}
-
-	return nil
-}
-
 func (r *AuthPolicyReconciler) desiredAuthConfig(ctx context.Context, ap *api.AuthPolicy, targetNetworkObject client.Object) (*authorinoapi.AuthConfig, error) {
 	logger, _ := logr.FromContext(ctx)
 	logger = logger.WithName("desiredAuthConfig")

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	authorinoapi "github.com/kuadrant/authorino/api/v1beta2"
 	api "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
@@ -226,6 +227,7 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&api.AuthPolicy{}).
+		Owns(&authorinoapi.AuthConfig{}).
 		Watches(
 			&gatewayapiv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(httpRouteEventMapper.MapToAuthPolicy),

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -174,10 +174,6 @@ func (r *AuthPolicyReconciler) deleteResources(ctx context.Context, ap *api.Auth
 		return err
 	}
 
-	if err := r.deleteAuthConfigs(ctx, ap); err != nil {
-		return err
-	}
-
 	// remove direct back ref
 	if targetNetworkObject != nil {
 		if err := r.deleteNetworkResourceDirectBackReference(ctx, targetNetworkObject); err != nil {

--- a/doc/user-guides/gateway-rl-for-cluster-operators.md
+++ b/doc/user-guides/gateway-rl-for-cluster-operators.md
@@ -188,13 +188,13 @@ kubectl port-forward -n istio-system service/internal-istio 9082:80 2>&1 >/dev/n
 Up to 5 successful (`200 OK`) requests every 10 seconds through the `external` ingress gateway (`*.io`), then `429 Too Many Requests`:
 
 ```sh
-while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H 'Host: api.toystore.io' http://localhost:9081 | egrep --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.io' http://localhost:9081 | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
 Unlimited successful (`200 OK`) through the `internal` ingress gateway (`*.local`):
 
 ```sh
-while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H 'Host: api.toystore.local' http://localhost:9082 | egrep --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.local' http://localhost:9082 | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
 ## Cleanup

--- a/doc/user-guides/simple-rl-for-app-developers.md
+++ b/doc/user-guides/simple-rl-for-app-developers.md
@@ -141,13 +141,13 @@ Verify the rate limiting works by sending requests in a loop.
 Up to 5 successful (`200 OK`) requests every 10 seconds to `POST /toys`, then `429 Too Many Requests`:
 
 ```sh
-while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H 'Host: api.toystore.com' http://localhost:9080/toys -X POST | egrep --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://localhost:9080/toys -X POST | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
 Unlimited successful (`200 OK`) to `GET /toys`:
 
 ```sh
-while :; do curl --write-out '%{http_code}' --silent --output /dev/null -H 'Host: api.toystore.com' http://localhost:9080/toys | egrep --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://localhost:9080/toys | egrep --color "\b(429)\b|$"; sleep 1; done
 ```
 
 ## Cleanup

--- a/make/istio.mk
+++ b/make/istio.mk
@@ -8,7 +8,7 @@ ISTIO_NAMESPACE = istio-system
 
 # istioctl tool
 ISTIOCTL=$(shell pwd)/bin/istioctl
-ISTIOVERSION = 1.17.2
+ISTIOVERSION = 1.20.0
 $(ISTIOCTL):
 	mkdir -p $(shell pwd)/bin
 	$(eval TMP := $(shell mktemp -d))


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/297

This PR bumps the istio version in our Makefile targets in order to setup Kuadrant for local development. It's also an effort to check if our user guides and general usage is not broken due their new version. As a bonus, it fixes some user guides.

## User guides tried

- [x] [Simple Rate Limiting for Application Developers](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/simple-rl-for-app-developers.md) 👍🏼 
- [x] [Authenticated Rate Limiting for Application Developers](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/authenticated-rl-for-app-developers.md) 👍🏼 
- [x] [Gateway Rate Limiting for Cluster Operators](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/gateway-rl-for-cluster-operators.md) 👍🏼 
- [x] [Authenticated Rate Limiting with JWTs and Kubernetes RBAC](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md)  ~The ACCESS_TOKEN retrieved from Keycloak is null~ Fixed by https://github.com/Kuadrant/kuadrant-operator/pull/311 👍🏼 