### PR TITLE
Allow the coverage to drop by 3%

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -12,11 +12,11 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1%
+        threshold: 3%
     patch:
       default:
         target: auto
-        threshold: 1%
+        threshold: 3%
 
 # Layout of the PR comment produced by Codecov bot
 comment:


### PR DESCRIPTION
having 1% lead to too many codecov status check errors