### PR TITLE
fix authconfig reconciliation

### DIFF
--- a/controllers/authpolicy_authconfig.go
+++ b/controllers/authpolicy_authconfig.go
@@ -172,6 +172,11 @@ func authorinoSpecsFromConfigs[T, U any](configs map[string]U, extractAuthorinoS
 		authorinoConfig := extractAuthorinoSpec(config)
 		specs[name] = authorinoConfig
 	}
+
+	if len(specs) == 0 {
+		return nil
+	}
+
 	return specs
 }
 


### PR DESCRIPTION
### What

After https://github.com/Kuadrant/kuadrant-operator/pull/303, the authpolicy controller watched for changes of the authconfig objects owned by the authpolicy. 

When the desired authconfig is being generated and compared with the existing object, [here](https://github.com/Kuadrant/kuadrant-operator/blob/77ee696c0b312406ec4dcea273d18936d4a30db7/controllers/authpolicy_authconfig.go#L504), the comparison always gives "update needed" when some fields are empty maps. This is because the serialization omits empty maps, but the desired object has a map with 0 entries, which is not nil. 

```
spec:   v1beta2.AuthConfigSpec{
  	... // 4 identical fields
  	Metadata:      nil,
  	Authorization: {"deny-all": {AuthorizationMethodSpec: {Opa: &{Rego: "allow = false"}}}},
  	Response: &v1beta2.ResponseSpec{
  		Unauthenticated: nil,
  		Unauthorized:    &{Headers: {"content-type": {Value: {Raw: `"application/json"`}}}, Body: &{Value: {Raw: `"{\n  \"error\": \"Forbidden\",\n  \"message\": \"Access denied `...}}},
  		Success: v1beta2.WrappedSuccessResponseSpec{
- 			Headers:         nil,
+ 			Headers:         map[string]v1beta2.HeaderSuccessResponseSpec{},
- 			DynamicMetadata: nil,
+ 			DynamicMetadata: map[string]v1beta2.SuccessResponseSpec{},
  		},
  	},
  	Callbacks: nil,
  }
```

The consequence is that the authpolicy controller is endlessly reconciling an object and also failing to update it with the following error log
```
{"level":"error","ts":"2023-11-27T14:17:03Z","logger":"kuadrant-operator.authpolicy","msg":"ReconcileResource failed to create/update AuthConfig resource","AuthPolicy":{"name":"gw-auth","namespace":"istio-system"},"error":"Operation cannot be fulfilled on authconfigs.authorino.kuadrant.io \"ap-istio-system-gw-auth\": the object has been modified; please apply your changes to the latest version and try again","stacktrace":"github.com/kuadrant/kuadrant-operator/controllers.(*AuthPolicyReconciler).reconcileAuthConfigs\n\t/workspace/controllers/authpolicy_authconfig.go:39\ngithub.com/kuadrant/kuadrant-operator/controllers.(*AuthPolicyReconciler).reconcileResources\n\t/workspace/controllers/authpolicy_controller.go:153\ngithub.com/kuadrant/kuadrant-operator/controllers.(*AuthPolicyReconciler).Reconcile\n\t/workspace/controllers/authpolicy_controller.go:103\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:119\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227"}
{"level":"error","ts":"2023-11-27T14:17:03Z","logger":"kuadrant-operator","msg":"Reconciler error","controller":"authpolicy","controllerGroup":"kuadrant.io","controllerKind":"AuthPolicy","AuthPolicy":{"name":"gw-auth","namespace":"istio-system"},"namespace":"istio-system","name":"gw-auth","reconcileID":"9d8f5a06-b9ae-4806-8cdd-41b553a8e8a3","error":"Operation cannot be fulfilled on authconfigs.authorino.kuadrant.io \"ap-istio-system-gw-auth\": the object has been modified; please apply your changes to the latest version and try again","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:266\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.16.3/pkg/internal/controller/controller.go:227"}
```