### PR TITLE
feat: accepted policy status condition

### DIFF
--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -277,6 +277,10 @@ func (ap *AuthPolicy) GetRulesHostnames() (ruleHosts []string) {
 	return
 }
 
+func (ap *AuthPolicy) Kind() string {
+	return ap.TypeMeta.Kind
+}
+
 //+kubebuilder:object:root=true
 
 // AuthPolicyList contains a list of AuthPolicy

--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -197,6 +197,8 @@ func (s *AuthPolicyStatus) Equals(other *AuthPolicyStatus, logger logr.Logger) b
 	return true
 }
 
+var _ common.KuadrantPolicy = &AuthPolicy{}
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=direct"

--- a/api/v1beta2/ratelimitpolicy_types.go
+++ b/api/v1beta2/ratelimitpolicy_types.go
@@ -240,6 +240,10 @@ func (r *RateLimitPolicy) GetRulesHostnames() (ruleHosts []string) {
 	return
 }
 
+func (r *RateLimitPolicy) Kind() string {
+	return r.TypeMeta.Kind
+}
+
 func init() {
 	SchemeBuilder.Register(&RateLimitPolicy{}, &RateLimitPolicyList{})
 }

--- a/api/v1beta2/ratelimitpolicy_types.go
+++ b/api/v1beta2/ratelimitpolicy_types.go
@@ -163,6 +163,8 @@ func (s *RateLimitPolicyStatus) Equals(other *RateLimitPolicyStatus, logger logr
 	return true
 }
 
+var _ common.KuadrantPolicy = &RateLimitPolicy{}
+
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=direct"

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -186,8 +186,8 @@ func (r *AuthPolicyReconciler) deleteResources(ctx context.Context, ap *api.Auth
 }
 
 // Ensures only one RLP targets the network resource
-func (r *AuthPolicyReconciler) reconcileNetworkResourceDirectBackReference(ctx context.Context, ap *api.AuthPolicy, targetNetworkObject client.Object) error {
-	return r.ReconcileTargetBackReference(ctx, client.ObjectKeyFromObject(ap), targetNetworkObject, common.AuthPolicyBackRefAnnotation)
+func (r *AuthPolicyReconciler) reconcileNetworkResourceDirectBackReference(ctx context.Context, ap common.KuadrantPolicy, targetNetworkObject client.Object) error {
+	return r.ReconcileTargetBackReference(ctx, ap, targetNetworkObject, common.AuthPolicyBackRefAnnotation)
 }
 
 func (r *AuthPolicyReconciler) deleteNetworkResourceDirectBackReference(ctx context.Context, targetNetworkObject client.Object) error {

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -159,7 +159,7 @@ func (r *AuthPolicyReconciler) reconcileResources(ctx context.Context, ap *api.A
 		return err
 	}
 
-	// set annotation of policies afftecting the gateway - should be the last step, only when all the reconciliation steps succeed
+	// set annotation of policies affecting the gateway - should be the last step, only when all the reconciliation steps succeed
 	return r.ReconcileGatewayPolicyReferences(ctx, ap, gatewayDiffObj)
 }
 
@@ -181,7 +181,7 @@ func (r *AuthPolicyReconciler) deleteResources(ctx context.Context, ap *api.Auth
 		}
 	}
 
-	// update annotation of policies afftecting the gateway
+	// update annotation of policies affecting the gateway
 	return r.ReconcileGatewayPolicyReferences(ctx, ap, gatewayDiffObj)
 }
 

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -133,11 +133,11 @@ func (r *AuthPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl.Requ
 func (r *AuthPolicyReconciler) reconcileResources(ctx context.Context, ap *api.AuthPolicy, targetNetworkObject client.Object) error {
 	// validate
 	if err := ap.Validate(); err != nil {
-		return err
+		return common.ErrInvalid{Kind: ap.Kind(), Err: err}
 	}
 
 	if err := common.ValidateHierarchicalRules(ap, targetNetworkObject); err != nil {
-		return err
+		return common.ErrInvalid{Kind: ap.Kind(), Err: err}
 	}
 
 	// reconcile based on gateway diffs

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -67,7 +67,7 @@ func (r *AuthPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl.Requ
 				if delResErr == nil {
 					delResErr = err
 				}
-				return r.reconcileStatus(ctx, ap, delResErr)
+				return r.reconcileStatus(ctx, ap, common.ErrTargetNotFound{Kind: ap.Kind(), TargetRef: ap.GetTargetRef(), Err: delResErr})
 			}
 			return ctrl.Result{}, err
 		}

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -67,7 +67,7 @@ func (r *AuthPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl.Requ
 				if delResErr == nil {
 					delResErr = err
 				}
-				return r.reconcileStatus(ctx, ap, common.ErrTargetNotFound{Kind: ap.Kind(), TargetRef: ap.GetTargetRef(), Err: delResErr})
+				return r.reconcileStatus(ctx, ap, common.NewErrTargetNotFound(ap.Kind(), ap.GetTargetRef(), delResErr))
 			}
 			return ctrl.Result{}, err
 		}
@@ -133,11 +133,11 @@ func (r *AuthPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl.Requ
 func (r *AuthPolicyReconciler) reconcileResources(ctx context.Context, ap *api.AuthPolicy, targetNetworkObject client.Object) error {
 	// validate
 	if err := ap.Validate(); err != nil {
-		return common.ErrInvalid{Kind: ap.Kind(), Err: err}
+		return common.NewErrInvalid(ap.Kind(), err)
 	}
 
 	if err := common.ValidateHierarchicalRules(ap, targetNetworkObject); err != nil {
-		return common.ErrInvalid{Kind: ap.Kind(), Err: err}
+		return common.NewErrInvalid(ap.Kind(), err)
 	}
 
 	// reconcile based on gateway diffs

--- a/controllers/authpolicy_controller_test.go
+++ b/controllers/authpolicy_controller_test.go
@@ -83,7 +83,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// check istio authorizationpolicy
 			iapKey := types.NamespacedName{Name: istioAuthorizationPolicyName(testGatewayName, policy.Spec.TargetRef), Namespace: testNamespace}
@@ -160,7 +160,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(policy), 60*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(policy), 60*time.Second, 5*time.Second).Should(BeTrue())
 
 			// check authorino authconfig hosts
 			authConfigKey := types.NamespacedName{Name: authConfigName(client.ObjectKeyFromObject(policy)), Namespace: testNamespace}
@@ -196,7 +196,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// check istio authorizationpolicy
 			iapKey := types.NamespacedName{Name: istioAuthorizationPolicyName(testGatewayName, policy.Spec.TargetRef), Namespace: testNamespace}
@@ -256,7 +256,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(routePolicy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(routePolicy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// create second (policyless) httproute
 			otherRoute := testBuildBasicHttpRoute("policyless-route", testGatewayName, testNamespace, []string{"*.other"})
@@ -295,7 +295,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(gwPolicy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(gwPolicy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// check istio authorizationpolicy
 			iapKey := types.NamespacedName{Name: istioAuthorizationPolicyName(testGatewayName, gwPolicy.Spec.TargetRef), Namespace: testNamespace}
@@ -356,7 +356,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(routePolicy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(routePolicy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// attach policy to the gatewaay
 			gwPolicy := &api.AuthPolicy{
@@ -386,7 +386,7 @@ var _ = Describe("AuthPolicy controller", func() {
 				if err != nil {
 					return false
 				}
-				condition := meta.FindStatusCondition(existingPolicy.Status.Conditions, APAvailableConditionType)
+				condition := meta.FindStatusCondition(existingPolicy.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted))
 				return condition != nil && condition.Reason == "AuthSchemeNotReady"
 			}, 30*time.Second, 5*time.Second).Should(BeTrue())
 
@@ -443,7 +443,7 @@ var _ = Describe("AuthPolicy controller", func() {
 				if err != nil {
 					return false
 				}
-				condition := meta.FindStatusCondition(existingPolicy.Status.Conditions, APAvailableConditionType)
+				condition := meta.FindStatusCondition(existingPolicy.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted))
 				return condition != nil && condition.Reason == "ReconciliationError" && strings.Contains(condition.Message, "cannot match any route rules, check for invalid route selectors in the policy")
 			}, 30*time.Second, 5*time.Second).Should(BeTrue())
 
@@ -502,7 +502,7 @@ var _ = Describe("AuthPolicy controller", func() {
 				if err != nil {
 					return false
 				}
-				condition := meta.FindStatusCondition(existingPolicy.Status.Conditions, APAvailableConditionType)
+				condition := meta.FindStatusCondition(existingPolicy.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted))
 				return condition != nil && condition.Reason == "ReconciliationError" && strings.Contains(condition.Message, "cannot match any route rules, check for invalid route selectors in the policy")
 			}, 30*time.Second, 5*time.Second).Should(BeTrue())
 
@@ -549,7 +549,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// delete policy
 			err = k8sClient.Delete(context.Background(), policy)
@@ -802,7 +802,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// check authorino authconfig
 			authConfigKey := types.NamespacedName{Name: authConfigName(client.ObjectKeyFromObject(policy)), Namespace: testNamespace}
@@ -849,7 +849,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// check istio authorizationpolicy
 			iapKey := types.NamespacedName{Name: istioAuthorizationPolicyName(testGatewayName, policy.Spec.TargetRef), Namespace: testNamespace}
@@ -957,7 +957,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// check istio authorizationpolicy
 			iapKey := types.NamespacedName{Name: istioAuthorizationPolicyName(testGatewayName, policy.Spec.TargetRef), Namespace: testNamespace}
@@ -1066,7 +1066,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// check istio authorizationpolicy
 			iapKey := types.NamespacedName{Name: istioAuthorizationPolicyName(testGatewayName, policy.Spec.TargetRef), Namespace: testNamespace}
@@ -1202,7 +1202,7 @@ var _ = Describe("AuthPolicy controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// check policy status
-			Eventually(testPolicyIsReady(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testPolicyIsAccepted(policy), 30*time.Second, 5*time.Second).Should(BeTrue())
 
 			// check authorino authconfig
 			authConfigKey := types.NamespacedName{Name: authConfigName(client.ObjectKeyFromObject(policy)), Namespace: testNamespace}
@@ -1598,10 +1598,10 @@ func testBasicAuthScheme() api.AuthSchemeSpec {
 	}
 }
 
-func testPolicyIsReady(policy *api.AuthPolicy) func() bool {
+func testPolicyIsAccepted(policy *api.AuthPolicy) func() bool {
 	return func() bool {
 		existingPolicy := &api.AuthPolicy{}
 		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(policy), existingPolicy)
-		return err == nil && meta.IsStatusConditionTrue(existingPolicy.Status.Conditions, "Available")
+		return err == nil && meta.IsStatusConditionTrue(existingPolicy.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted))
 	}
 }

--- a/controllers/authpolicy_status.go
+++ b/controllers/authpolicy_status.go
@@ -89,13 +89,13 @@ func (r *AuthPolicyReconciler) calculateStatus(ap *api.AuthPolicy, specErr error
 	return newStatus
 }
 
-func (r *AuthPolicyReconciler) availableCondition(targetNetworkObjectectKind string, specErr error, authConfigReady bool) *metav1.Condition {
+func (r *AuthPolicyReconciler) availableCondition(targetNetworkObjectKind string, specErr error, authConfigReady bool) *metav1.Condition {
 	// Condition if there is no issue
 	cond := &metav1.Condition{
 		Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
 		Status:  metav1.ConditionTrue,
 		Reason:  string(gatewayapiv1alpha2.PolicyReasonAccepted),
-		Message: fmt.Sprintf("AuthPolicy has been accepted. %s is protected", targetNetworkObjectectKind),
+		Message: fmt.Sprintf("AuthPolicy has been accepted. %s is protected", targetNetworkObjectKind),
 	}
 
 	if specErr != nil {
@@ -106,6 +106,9 @@ func (r *AuthPolicyReconciler) availableCondition(targetNetworkObjectectKind str
 		// TargetNotFound
 		case errors.As(specErr, &common.ErrTargetNotFound{}):
 			cond.Reason = string(gatewayapiv1alpha2.PolicyReasonTargetNotFound)
+		// Invalid
+		case errors.As(specErr, &common.ErrInvalid{}):
+			cond.Reason = string(gatewayapiv1alpha2.PolicyReasonInvalid)
 		default:
 			cond.Reason = "ReconciliationError"
 		}

--- a/controllers/authpolicy_status.go
+++ b/controllers/authpolicy_status.go
@@ -6,14 +6,15 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
-	authorinoapi "github.com/kuadrant/authorino/api/v1beta2"
-	api "github.com/kuadrant/kuadrant-operator/api/v1beta2"
-	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	authorinoapi "github.com/kuadrant/authorino/api/v1beta2"
+	api "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
 )
 
 // reconcileStatus makes sure status block of AuthPolicy is up-to-date.

--- a/controllers/limitador_cluster_envoyfilter_controller_test.go
+++ b/controllers/limitador_cluster_envoyfilter_controller_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Limitador Cluster EnvoyFilter controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			// Check RLP status is available
 			rlpKey := client.ObjectKey{Name: rlpName, Namespace: testNamespace}
-			Eventually(testRLPIsAvailable(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(testRLPIsAccepted(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
 
 			// Check envoy filter
 			Eventually(func() bool {

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -86,6 +86,7 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 	// fetch the target network object
 	targetNetworkObject, err := r.FetchValidTargetRef(ctx, rlp.GetTargetRef(), rlp.Namespace)
 	if err != nil {
+		// TODO - Target not found status
 		if !markedForDeletion {
 			if apierrors.IsNotFound(err) {
 				logger.V(1).Info("Network object not found. Cleaning up")
@@ -151,6 +152,7 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 
 func (r *RateLimitPolicyReconciler) reconcileResources(ctx context.Context, rlp *kuadrantv1beta2.RateLimitPolicy, targetNetworkObject client.Object) error {
 	// validate
+	// TODO - Validation Error
 	err := rlp.Validate()
 	if err != nil {
 		return err

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -151,7 +151,6 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 
 func (r *RateLimitPolicyReconciler) reconcileResources(ctx context.Context, rlp *kuadrantv1beta2.RateLimitPolicy, targetNetworkObject client.Object) error {
 	// validate
-	// TODO - Validation Error
 	err := rlp.Validate()
 	if err != nil {
 		return common.ErrInvalid{Kind: rlp.Kind(), Err: err}
@@ -181,7 +180,7 @@ func (r *RateLimitPolicyReconciler) reconcileResources(ctx context.Context, rlp 
 		return err
 	}
 
-	// set annotation of policies afftecting the gateway - should be the last step, only when all the reconciliation steps succeed
+	// set annotation of policies affecting the gateway - should be the last step, only when all the reconciliation steps succeed
 	return r.ReconcileGatewayPolicyReferences(ctx, rlp, gatewayDiffObj)
 }
 

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -93,7 +93,7 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 				if delResErr == nil {
 					delResErr = err
 				}
-				return r.reconcileStatus(ctx, rlp, common.ErrTargetNotFound{Kind: rlp.Kind(), TargetRef: rlp.GetTargetRef()})
+				return r.reconcileStatus(ctx, rlp, common.ErrTargetNotFound{Kind: rlp.Kind(), TargetRef: rlp.GetTargetRef(), Err: delResErr})
 			}
 			return ctrl.Result{}, err
 		}

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -86,7 +86,6 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 	// fetch the target network object
 	targetNetworkObject, err := r.FetchValidTargetRef(ctx, rlp.GetTargetRef(), rlp.Namespace)
 	if err != nil {
-		// TODO - Target not found status
 		if !markedForDeletion {
 			if apierrors.IsNotFound(err) {
 				logger.V(1).Info("Network object not found. Cleaning up")
@@ -94,7 +93,7 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 				if delResErr == nil {
 					delResErr = err
 				}
-				return r.reconcileStatus(ctx, rlp, delResErr)
+				return r.reconcileStatus(ctx, rlp, common.ErrTargetNotFound{Kind: rlp.Kind, TargetRef: rlp.GetTargetRef()})
 			}
 			return ctrl.Result{}, err
 		}

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -93,7 +93,7 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 				if delResErr == nil {
 					delResErr = err
 				}
-				return r.reconcileStatus(ctx, rlp, common.ErrTargetNotFound{Kind: rlp.Kind, TargetRef: rlp.GetTargetRef()})
+				return r.reconcileStatus(ctx, rlp, common.ErrTargetNotFound{Kind: rlp.Kind(), TargetRef: rlp.GetTargetRef()})
 			}
 			return ctrl.Result{}, err
 		}
@@ -154,12 +154,12 @@ func (r *RateLimitPolicyReconciler) reconcileResources(ctx context.Context, rlp 
 	// TODO - Validation Error
 	err := rlp.Validate()
 	if err != nil {
-		return common.ErrInvalid{Kind: rlp.Kind, Err: err}
+		return common.ErrInvalid{Kind: rlp.Kind(), Err: err}
 	}
 
 	err = common.ValidateHierarchicalRules(rlp, targetNetworkObject)
 	if err != nil {
-		return common.ErrInvalid{Kind: rlp.Kind, Err: err}
+		return common.ErrInvalid{Kind: rlp.Kind(), Err: err}
 	}
 
 	// reconcile based on gateway diffs
@@ -213,7 +213,7 @@ func (r *RateLimitPolicyReconciler) deleteResources(ctx context.Context, rlp *ku
 
 // Ensures only one RLP targets the network resource
 func (r *RateLimitPolicyReconciler) reconcileNetworkResourceDirectBackReference(ctx context.Context, policy common.KuadrantPolicy, targetNetworkObject client.Object) error {
-	return r.ReconcileTargetBackReference(ctx, client.ObjectKeyFromObject(policy), targetNetworkObject, common.RateLimitPolicyBackRefAnnotation)
+	return r.ReconcileTargetBackReference(ctx, policy, targetNetworkObject, common.RateLimitPolicyBackRefAnnotation)
 }
 
 func (r *RateLimitPolicyReconciler) deleteNetworkResourceDirectBackReference(ctx context.Context, targetNetworkObject client.Object) error {

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -154,12 +154,12 @@ func (r *RateLimitPolicyReconciler) reconcileResources(ctx context.Context, rlp 
 	// TODO - Validation Error
 	err := rlp.Validate()
 	if err != nil {
-		return err
+		return common.ErrInvalid{Kind: rlp.Kind, Err: err}
 	}
 
 	err = common.ValidateHierarchicalRules(rlp, targetNetworkObject)
 	if err != nil {
-		return err
+		return common.ErrInvalid{Kind: rlp.Kind, Err: err}
 	}
 
 	// reconcile based on gateway diffs

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -93,7 +93,7 @@ func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl
 				if delResErr == nil {
 					delResErr = err
 				}
-				return r.reconcileStatus(ctx, rlp, common.ErrTargetNotFound{Kind: rlp.Kind(), TargetRef: rlp.GetTargetRef(), Err: delResErr})
+				return r.reconcileStatus(ctx, rlp, common.NewErrTargetNotFound(rlp.Kind(), rlp.GetTargetRef(), delResErr))
 			}
 			return ctrl.Result{}, err
 		}
@@ -153,12 +153,12 @@ func (r *RateLimitPolicyReconciler) reconcileResources(ctx context.Context, rlp 
 	// validate
 	err := rlp.Validate()
 	if err != nil {
-		return common.ErrInvalid{Kind: rlp.Kind(), Err: err}
+		return common.NewErrInvalid(rlp.Kind(), err)
 	}
 
 	err = common.ValidateHierarchicalRules(rlp, targetNetworkObject)
 	if err != nil {
-		return common.ErrInvalid{Kind: rlp.Kind(), Err: err}
+		return common.NewErrInvalid(rlp.Kind(), err)
 	}
 
 	// reconcile based on gateway diffs

--- a/controllers/ratelimitpolicy_controller_test.go
+++ b/controllers/ratelimitpolicy_controller_test.go
@@ -116,7 +116,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 
 			// Check RLP status is available
 			rlpKey := client.ObjectKeyFromObject(rlp)
-			Eventually(testRLPIsAvailable(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(testRLPIsAccepted(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
 
 			// Check HTTPRoute direct back reference
 			routeKey := client.ObjectKey{Name: routeName, Namespace: testNamespace}
@@ -310,7 +310,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 
 			// Check RLP status is available
 			rlpKey := client.ObjectKeyFromObject(rlp)
-			Eventually(testRLPIsAvailable(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(testRLPIsAccepted(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
 
 			// Check wasm plugin
 			wasmPluginKey := client.ObjectKey{Name: rlptools.WASMPluginName(gateway), Namespace: testNamespace}
@@ -457,7 +457,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 
 			// Check RLP status is available
 			rlpKey := client.ObjectKey{Name: rlpName, Namespace: testNamespace}
-			Eventually(testRLPIsAvailable(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(testRLPIsAccepted(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
 
 			// Check Gateway direct back reference
 			gwKey := client.ObjectKeyFromObject(gateway)
@@ -575,7 +575,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 
 			// Check RLP status is available
 			rlpKey := client.ObjectKey{Name: rlpName, Namespace: testNamespace}
-			Eventually(testRLPIsAvailable(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(testRLPIsAccepted(rlpKey), time.Minute, 5*time.Second).Should(BeTrue())
 
 			// Check Gateway direct back reference
 			gwKey := client.ObjectKeyFromObject(gateway)
@@ -755,14 +755,14 @@ var _ = Describe("RateLimitPolicy CEL Validations", func() {
 	})
 })
 
-func testRLPIsAvailable(rlpKey client.ObjectKey) func() bool {
+func testRLPIsAccepted(rlpKey client.ObjectKey) func() bool {
 	return func() bool {
 		existingRLP := &kuadrantv1beta2.RateLimitPolicy{}
 		err := k8sClient.Get(context.Background(), rlpKey, existingRLP)
 		if err != nil {
 			return false
 		}
-		if !meta.IsStatusConditionTrue(existingRLP.Status.Conditions, "Available") {
+		if !meta.IsStatusConditionTrue(existingRLP.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted)) {
 			return false
 		}
 

--- a/controllers/ratelimitpolicy_status.go
+++ b/controllers/ratelimitpolicy_status.go
@@ -68,7 +68,6 @@ func (r *RateLimitPolicyReconciler) calculateStatus(_ context.Context, rlp *kuad
 	return newStatus
 }
 
-// TODO - Accepted Condition
 func (r *RateLimitPolicyReconciler) acceptedCondition(specErr error) *metav1.Condition {
 	// Accepted
 	cond := &metav1.Condition{
@@ -89,12 +88,13 @@ func (r *RateLimitPolicyReconciler) acceptedCondition(specErr error) *metav1.Con
 		// Invalid
 		case errors.As(specErr, &common.ErrInvalid{}):
 			cond.Reason = string(gatewayapiv1alpha2.PolicyReasonInvalid)
+		// Conflicted
+		case errors.As(specErr, &common.ErrConflict{}):
+			cond.Reason = string(gatewayapiv1alpha2.PolicyReasonConflicted)
 		default:
 			cond.Reason = "ReconciliationError"
 		}
 	}
-
-	// TODO - Conflicted Reason
 
 	return cond
 }

--- a/controllers/ratelimitpolicy_status.go
+++ b/controllers/ratelimitpolicy_status.go
@@ -82,16 +82,18 @@ func (r *RateLimitPolicyReconciler) acceptedCondition(specErr error) *metav1.Con
 		cond.Status = metav1.ConditionFalse
 		cond.Message = specErr.Error()
 
-		// TargetNotFound
 		switch {
+		// TargetNotFound
 		case errors.As(specErr, &common.ErrTargetNotFound{}):
 			cond.Reason = string(gatewayapiv1alpha2.PolicyReasonTargetNotFound)
+		// Invalid
+		case errors.As(specErr, &common.ErrInvalid{}):
+			cond.Reason = string(gatewayapiv1alpha2.PolicyReasonInvalid)
 		default:
 			cond.Reason = "ReconciliationError"
 		}
 	}
 
-	// TODO - Invalid Reason
 	// TODO - Conflicted Reason
 
 	return cond

--- a/controllers/ratelimitpolicy_status.go
+++ b/controllers/ratelimitpolicy_status.go
@@ -6,12 +6,13 @@ import (
 	"slices"
 
 	"github.com/go-logr/logr"
-	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
-	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
 )
 
 func (r *RateLimitPolicyReconciler) reconcileStatus(ctx context.Context, rlp *kuadrantv1beta2.RateLimitPolicy, specErr error) (ctrl.Result, error) {

--- a/pkg/common/apimachinery_status_conditions.go
+++ b/pkg/common/apimachinery_status_conditions.go
@@ -19,6 +19,15 @@ func (e ErrTargetNotFound) Error() string {
 	return fmt.Sprintf("%s target %s was not found", e.Kind, e.TargetRef.Name)
 }
 
+type ErrInvalid struct {
+	Kind string
+	Err  error
+}
+
+func (e ErrInvalid) Error() string {
+	return fmt.Sprintf("%s target is invalid: %s", e.Kind, e.Err.Error())
+}
+
 // ConditionMarshal marshals the set of conditions as a JSON array, sorted by condition type.
 func ConditionMarshal(conditions []metav1.Condition) ([]byte, error) {
 	condCopy := slices.Clone(conditions)

--- a/pkg/common/apimachinery_status_conditions.go
+++ b/pkg/common/apimachinery_status_conditions.go
@@ -2,10 +2,13 @@ package common
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"slices"
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 // ConditionMarshal marshals the set of conditions as a JSON array, sorted by condition type.
@@ -15,4 +18,36 @@ func ConditionMarshal(conditions []metav1.Condition) ([]byte, error) {
 		return condCopy[a].Type < condCopy[b].Type
 	})
 	return json.Marshal(condCopy)
+}
+
+// AcceptedCondition returns an accepted conditions with common reasons for a kuadrant policy
+func AcceptedCondition(policy KuadrantPolicy, err error) *metav1.Condition {
+	// Accepted
+	cond := &metav1.Condition{
+		Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayapiv1alpha2.PolicyReasonAccepted),
+		Message: fmt.Sprintf("%s has been accepted", policy.Kind()),
+	}
+
+	if err != nil {
+		cond.Status = metav1.ConditionFalse
+		cond.Message = err.Error()
+
+		switch {
+		// TargetNotFound
+		case errors.As(err, &ErrTargetNotFound{}):
+			cond.Reason = string(gatewayapiv1alpha2.PolicyReasonTargetNotFound)
+		// Invalid
+		case errors.As(err, &ErrInvalid{}):
+			cond.Reason = string(gatewayapiv1alpha2.PolicyReasonInvalid)
+		// Conflicted
+		case errors.As(err, &ErrConflict{}):
+			cond.Reason = string(gatewayapiv1alpha2.PolicyReasonConflicted)
+		default:
+			cond.Reason = "ReconciliationError"
+		}
+	}
+
+	return cond
 }

--- a/pkg/common/apimachinery_status_conditions.go
+++ b/pkg/common/apimachinery_status_conditions.go
@@ -2,11 +2,22 @@ package common
 
 import (
 	"encoding/json"
+	"fmt"
 	"slices"
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
+
+type ErrTargetNotFound struct {
+	Kind      string
+	TargetRef gatewayapiv1alpha2.PolicyTargetReference
+}
+
+func (e ErrTargetNotFound) Error() string {
+	return fmt.Sprintf("%s target %s was not found", e.Kind, e.TargetRef.Name)
+}
 
 // ConditionMarshal marshals the set of conditions as a JSON array, sorted by condition type.
 func ConditionMarshal(conditions []metav1.Condition) ([]byte, error) {

--- a/pkg/common/apimachinery_status_conditions.go
+++ b/pkg/common/apimachinery_status_conditions.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"encoding/json"
-	"fmt"
 	"slices"
 	"sort"
 

--- a/pkg/common/apimachinery_status_conditions.go
+++ b/pkg/common/apimachinery_status_conditions.go
@@ -7,26 +7,7 @@ import (
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
-
-type ErrTargetNotFound struct {
-	Kind      string
-	TargetRef gatewayapiv1alpha2.PolicyTargetReference
-}
-
-func (e ErrTargetNotFound) Error() string {
-	return fmt.Sprintf("%s target %s was not found", e.Kind, e.TargetRef.Name)
-}
-
-type ErrInvalid struct {
-	Kind string
-	Err  error
-}
-
-func (e ErrInvalid) Error() string {
-	return fmt.Sprintf("%s target is invalid: %s", e.Kind, e.Err.Error())
-}
 
 // ConditionMarshal marshals the set of conditions as a JSON array, sorted by condition type.
 func ConditionMarshal(conditions []metav1.Condition) ([]byte, error) {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -43,6 +43,7 @@ type KuadrantPolicy interface {
 	GetTargetRef() gatewayapiv1alpha2.PolicyTargetReference
 	GetWrappedNamespace() gatewayapiv1.Namespace
 	GetRulesHostnames() []string
+	Kind() string
 }
 
 type KuadrantPolicyList interface {

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"fmt"
+
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+type ErrTargetNotFound struct {
+	Kind      string
+	TargetRef gatewayapiv1alpha2.PolicyTargetReference
+}
+
+func (e ErrTargetNotFound) Error() string {
+	return fmt.Sprintf("%s target %s was not found", e.Kind, e.TargetRef.Name)
+}
+
+type ErrInvalid struct {
+	Kind string
+	Err  error
+}
+
+func (e ErrInvalid) Error() string {
+	return fmt.Sprintf("%s target is invalid: %s", e.Kind, e.Err.Error())
+}
+
+type ErrConflict struct {
+	Kind          string
+	NameNamespace string
+	Err           error
+}
+
+func (e ErrConflict) Error() string {
+	return fmt.Sprintf("%s is conflicted by %s: %s", e.Kind, e.NameNamespace, e.Err.Error())
+}

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -3,16 +3,22 @@ package common
 import (
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 type ErrTargetNotFound struct {
 	Kind      string
 	TargetRef gatewayapiv1alpha2.PolicyTargetReference
+	Err       error
 }
 
 func (e ErrTargetNotFound) Error() string {
-	return fmt.Sprintf("%s target %s was not found", e.Kind, e.TargetRef.Name)
+	if apierrors.IsNotFound(e.Err) {
+		return fmt.Sprintf("%s target %s was not found", e.Kind, e.TargetRef.Name)
+	}
+
+	return fmt.Sprintf("%s target %s was not found: %s", e.Kind, e.TargetRef.Name, e.Err.Error())
 }
 
 type ErrInvalid struct {

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -21,6 +21,14 @@ func (e ErrTargetNotFound) Error() string {
 	return fmt.Sprintf("%s target %s was not found: %s", e.Kind, e.TargetRef.Name, e.Err.Error())
 }
 
+func NewErrTargetNotFound(kind string, targetRef gatewayapiv1alpha2.PolicyTargetReference, err error) ErrTargetNotFound {
+	return ErrTargetNotFound{
+		Kind:      kind,
+		TargetRef: targetRef,
+		Err:       err,
+	}
+}
+
 type ErrInvalid struct {
 	Kind string
 	Err  error
@@ -28,6 +36,13 @@ type ErrInvalid struct {
 
 func (e ErrInvalid) Error() string {
 	return fmt.Sprintf("%s target is invalid: %s", e.Kind, e.Err.Error())
+}
+
+func NewErrInvalid(kind string, err error) ErrInvalid {
+	return ErrInvalid{
+		Kind: kind,
+		Err:  err,
+	}
 }
 
 type ErrConflict struct {
@@ -38,4 +53,12 @@ type ErrConflict struct {
 
 func (e ErrConflict) Error() string {
 	return fmt.Sprintf("%s is conflicted by %s: %s", e.Kind, e.NameNamespace, e.Err.Error())
+}
+
+func NewErrConflict(kind string, nameNamespace string, err error) ErrConflict {
+	return ErrConflict{
+		Kind:          kind,
+		NameNamespace: nameNamespace,
+		Err:           err,
+	}
 }

--- a/pkg/common/gatewayapi_utils_test.go
+++ b/pkg/common/gatewayapi_utils_test.go
@@ -1320,6 +1320,10 @@ func (p *FakePolicy) GetRulesHostnames() []string {
 	return p.Hosts
 }
 
+func (p *FakePolicy) Kind() string {
+	return "FakePolicy"
+}
+
 func TestValidateHierarchicalRules(t *testing.T) {
 	hostname := gatewayapiv1.Hostname("*.example.com")
 	gateway := &gatewayapiv1.Gateway{

--- a/pkg/common/gatewayapi_utils_test.go
+++ b/pkg/common/gatewayapi_utils_test.go
@@ -1302,28 +1302,6 @@ func TestGetKuadrantNamespaceFromPolicyTargetRef(t *testing.T) {
 	}
 }
 
-type FakePolicy struct {
-	client.Object
-	Hosts     []string
-	targetRef gatewayapiv1alpha2.PolicyTargetReference
-}
-
-func (p *FakePolicy) GetTargetRef() gatewayapiv1alpha2.PolicyTargetReference {
-	return p.targetRef
-}
-
-func (p *FakePolicy) GetWrappedNamespace() gatewayapiv1.Namespace {
-	return gatewayapiv1.Namespace(p.GetNamespace())
-}
-
-func (p *FakePolicy) GetRulesHostnames() []string {
-	return p.Hosts
-}
-
-func (p *FakePolicy) Kind() string {
-	return "FakePolicy"
-}
-
 func TestValidateHierarchicalRules(t *testing.T) {
 	hostname := gatewayapiv1.Hostname("*.example.com")
 	gateway := &gatewayapiv1.Gateway{

--- a/pkg/common/test_utils.go
+++ b/pkg/common/test_utils.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+type FakePolicy struct {
+	client.Object
+	Hosts     []string
+	targetRef gatewayapiv1alpha2.PolicyTargetReference
+}
+
+func (p *FakePolicy) GetTargetRef() gatewayapiv1alpha2.PolicyTargetReference {
+	return p.targetRef
+}
+
+func (p *FakePolicy) GetWrappedNamespace() gatewayapiv1.Namespace {
+	return gatewayapiv1.Namespace(p.GetNamespace())
+}
+
+func (p *FakePolicy) GetRulesHostnames() []string {
+	return p.Hosts
+}
+
+func (p *FakePolicy) Kind() string {
+	return "FakePolicy"
+}

--- a/pkg/reconcilers/targetref_reconciler.go
+++ b/pkg/reconcilers/targetref_reconciler.go
@@ -154,9 +154,10 @@ func (r *TargetRefReconciler) TargetedGatewayKeys(_ context.Context, targetNetwo
 }
 
 // ReconcileTargetBackReference adds policy key in annotations of the target object
-func (r *TargetRefReconciler) ReconcileTargetBackReference(ctx context.Context, policyKey client.ObjectKey, targetNetworkObject client.Object, annotationName string) error {
+func (r *TargetRefReconciler) ReconcileTargetBackReference(ctx context.Context, policy common.KuadrantPolicy, targetNetworkObject client.Object, annotationName string) error {
 	logger, _ := logr.FromContext(ctx)
 
+	policyKey := client.ObjectKeyFromObject(policy)
 	targetNetworkObjectKey := client.ObjectKeyFromObject(targetNetworkObject)
 	targetNetworkObjectKind := targetNetworkObject.GetObjectKind().GroupVersionKind()
 
@@ -165,7 +166,7 @@ func (r *TargetRefReconciler) ReconcileTargetBackReference(ctx context.Context, 
 
 	if val, ok := objAnnotations[annotationName]; ok {
 		if val != policyKey.String() {
-			return fmt.Errorf("the %s target %s is already referenced by policy %s", targetNetworkObjectKind, targetNetworkObjectKey, policyKey.String())
+			return common.ErrConflict{Kind: policy.Kind(), NameNamespace: val, Err: fmt.Errorf("the %s target %s is already referenced by policy %s", targetNetworkObjectKind, targetNetworkObjectKey, val)}
 		}
 	} else {
 		objAnnotations[annotationName] = policyKey.String()

--- a/pkg/reconcilers/targetref_reconciler.go
+++ b/pkg/reconcilers/targetref_reconciler.go
@@ -166,7 +166,7 @@ func (r *TargetRefReconciler) ReconcileTargetBackReference(ctx context.Context, 
 
 	if val, ok := objAnnotations[annotationName]; ok {
 		if val != policyKey.String() {
-			return common.ErrConflict{Kind: policy.Kind(), NameNamespace: val, Err: fmt.Errorf("the %s target %s is already referenced by policy %s", targetNetworkObjectKind, targetNetworkObjectKey, val)}
+			return common.NewErrConflict(policy.Kind(), val, fmt.Errorf("the %s target %s is already referenced by policy %s", targetNetworkObjectKind, targetNetworkObjectKey, val))
 		}
 	} else {
 		objAnnotations[annotationName] = policyKey.String()

--- a/pkg/reconcilers/targetref_reconciler_test.go
+++ b/pkg/reconcilers/targetref_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -302,6 +303,7 @@ func TestReconcileTargetBackReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	policy := &v1beta2.RateLimitPolicy{ObjectMeta: metav1.ObjectMeta{Name: "someName", Namespace: "someNamespace"}}
 	policyKey := client.ObjectKey{Name: "someName", Namespace: "someNamespace"}
 
 	existingRoute := &gatewayapiv1.HTTPRoute{
@@ -354,7 +356,7 @@ func TestReconcileTargetBackReference(t *testing.T) {
 		BaseReconciler: baseReconciler,
 	}
 
-	err = targetRefReconciler.ReconcileTargetBackReference(ctx, policyKey, existingRoute, annotationName)
+	err = targetRefReconciler.ReconcileTargetBackReference(ctx, policy, existingRoute, annotationName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -378,7 +380,7 @@ func TestReconcileTargetBackReference(t *testing.T) {
 		t.Fatal("expected annotation not found")
 	}
 
-	if val != policyKey.String() {
+	if val != client.ObjectKeyFromObject(policy).String() {
 		t.Fatalf("annotation value (%s) does not match expected (%s)", val, policyKey.String())
 	}
 }

--- a/pkg/reconcilers/targetref_reconciler_test.go
+++ b/pkg/reconcilers/targetref_reconciler_test.go
@@ -304,7 +304,6 @@ func TestReconcileTargetBackReference(t *testing.T) {
 	}
 
 	policy := &v1beta2.RateLimitPolicy{ObjectMeta: metav1.ObjectMeta{Name: "someName", Namespace: "someNamespace"}}
-	policyKey := client.ObjectKey{Name: "someName", Namespace: "someNamespace"}
 
 	existingRoute := &gatewayapiv1.HTTPRoute{
 		TypeMeta: metav1.TypeMeta{
@@ -381,7 +380,7 @@ func TestReconcileTargetBackReference(t *testing.T) {
 	}
 
 	if val != client.ObjectKeyFromObject(policy).String() {
-		t.Fatalf("annotation value (%s) does not match expected (%s)", val, policyKey.String())
+		t.Fatalf("annotation value (%s) does not match expected (%s)", val, client.ObjectKeyFromObject(policy).String())
 	}
 }
 


### PR DESCRIPTION
# Description
Part of https://github.com/Kuadrant/architecture/issues/38

Implements the `Accepted` Status Condition to `RateLimitPolicy` and `AuthPolicy`

# Verfication

Functionality is generally already tested with the integration tests added.

To verify manually instead:

## Setup
* Checkout this branch
* Deploy using `make local-setup`
* Create HTTPRoute
```sh
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - method: GET
      path:
        type: PathPrefix
        value: "/toys"
    backendRefs:
    - name: toystore
      port: 80
EOF
```

## AuthPolicy
* Create AuthPolicies
```sh
kubectl apply -f - <<EOF
# Accepted
---
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: auth0
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
---
# Conflict
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: auth1
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
---
# target not found
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: auth2
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway-not-found
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
---
# invalid
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: auth3
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
    namespace: istio-system
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
EOF
```
* Verify accepted condition status is as expected 
```sh
kubectl get authpolicies -n default -o yaml | yq '.items[].status'
```

<details><summary>Sample Output</summary>

```yaml
conditions:
  - lastTransitionTime: "2023-12-14T17:25:00Z"
    message: AuthPolicy has been accepted
    reason: Accepted
    status: "True"
    type: Accepted
observedGeneration: 2
conditions:
  - lastTransitionTime: "2023-12-14T17:25:00Z"
    message: 'AuthPolicy is conflicted by default/auth0: the gateway.networking.k8s.io/v1, Kind=HTTPRoute target default/toystore is already referenced by policy default/auth0'
    reason: Conflicted
    status: "False"
    type: Accepted
observedGeneration: 2
conditions:
  - lastTransitionTime: "2023-12-14T17:25:00Z"
    message: AuthPolicy target istio-ingressgateway-not-found was not found
    reason: TargetNotFound
    status: "False"
    type: Accepted
observedGeneration: 1
conditions:
  - lastTransitionTime: "2023-12-14T17:25:00Z"
    message: 'AuthPolicy target is invalid: invalid targetRef.Namespace istio-system. Currently only supporting references to the same namespace'
    reason: Invalid
    status: "False"
    type: Accepted
observedGeneration: 2

```

</details>


## RateLimitPolicy
* Create RateLimitPolicies 
```sh
kubectl apply -f - <<EOF
---
# Accepted
apiVersion: kuadrant.io/v1beta2                                                                                                                          
kind: RateLimitPolicy
metadata:                
  name: rlp0
spec:   
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:   
    "create-toy":
      rates:
      - limit: 5
        duration: 10
        unit: second
---
# Conflict
apiVersion: kuadrant.io/v1beta2                                                                                                                          
kind: RateLimitPolicy
metadata:                
  name: rlp1
spec:   
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:   
    "create-toy":
      rates:
      - limit: 5
        duration: 10
        unit: second
---
# Target not found
apiVersion: kuadrant.io/v1beta2                                                                                                                          
kind: RateLimitPolicy
metadata:                
  name: rlp2
spec:   
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway-not-found
  limits:   
    "create-toy":
      rates:
      - limit: 5
        duration: 10
        unit: second
---
# invalid
apiVersion: kuadrant.io/v1beta2                                                                                                                          
kind: RateLimitPolicy
metadata:                
  name: rlp3
spec:   
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
    namespace: istio-system
  limits:   
    "create-toy":
      rates:
      - limit: 5
        duration: 10
        unit: second
EOF
```
* Verifiy RateLimitPolicy accepted condition is as expected
```sh
 kubectl get ratelimitpolicies -n default -o yaml | yq '.items[].status'
```
<details><summary>Sample Output</summary>

```yaml
conditions:
  - lastTransitionTime: "2023-12-14T17:38:13Z"
    message: RateLimitPolicy has been accepted
    reason: Accepted
    status: "True"
    type: Accepted
observedGeneration: 1
conditions:
  - lastTransitionTime: "2023-12-14T17:38:13Z"
    message: 'RateLimitPolicy is conflicted by default/rlp0: the gateway.networking.k8s.io/v1, Kind=HTTPRoute target default/toystore is already referenced by policy default/rlp0'
    reason: Conflicted
    status: "False"
    type: Accepted
observedGeneration: 4
conditions:
  - lastTransitionTime: "2023-12-14T17:38:39Z"
    message: RateLimitPolicy target istio-ingressgateway-not-found was not found
    reason: TargetNotFound
    status: "False"
    type: Accepted
observedGeneration: 1
conditions:
  - lastTransitionTime: "2023-12-14T17:38:39Z"
    message: 'RateLimitPolicy target is invalid: invalid targetRef.Namespace istio-system. Currently only supporting references to the same namespace'
    reason: Invalid
    status: "False"
    type: Accepted

```
</details>