### PR TITLE
Dry-run resource update before comparing changes

### DIFF
--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -126,6 +126,11 @@ func (b *BaseReconciler) ReconcileResource(ctx context.Context, obj, desired cli
 		return b.DeleteResource(ctx, desired)
 	}
 
+	desired.SetResourceVersion(obj.GetResourceVersion())
+	if err := b.Client().Update(ctx, desired, client.DryRunAll); err != nil {
+		return err
+	}
+
 	update, err := mutateFn(obj, desired)
 	if err != nil {
 		return err


### PR DESCRIPTION
Ensure defaults and all resource mutation are considered before comparing existing vs desired state of resources when reconciling updates, by dry-running the updates before

Closes #354 