### PR TITLE
fix istioctl deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,7 @@ local-cluster-setup: ## Sets up Kind cluster with GatewayAPI manifests and istio
 	$(MAKE) kind-create-cluster
 	$(MAKE) namespace
 	$(MAKE) gateway-api-install
+	$(MAKE) install-metallb
 	$(MAKE) istio-install
 	$(MAKE) install-cert-manager
 	$(MAKE) deploy-gateway
@@ -320,6 +321,7 @@ local-env-setup: ## Deploys all services and manifests required by kuadrant to r
 test-env-setup: ## Deploys all services and manifests required by kuadrant to run on CI.
 	$(MAKE) namespace
 	$(MAKE) gateway-api-install
+	$(MAKE) install-metallb
 	$(MAKE) istio-install
 	$(MAKE) install-cert-manager
 	$(MAKE) deploy-gateway

--- a/Makefile
+++ b/Makefile
@@ -285,9 +285,13 @@ local-deploy: ## Deploy Kuadrant Operator in the cluster pointed by KUBECONFIG
 	@echo
 	@echo "Now you can export the kuadrant gateway by doing:"
 	@echo "kubectl port-forward -n istio-system service/istio-ingressgateway-istio 9080:80 &"
-	@echo "after that, you can curl -H \"Host: myhost.com\" localhost:9080"
-	@echo "-- Linux only -- Ingress gateway is exported using nodePort service in port 9080"
-	@echo "curl -H \"Host: myhost.com\" localhost:9080"
+	@echo "export GATEWAY_URL=localhost:9080"
+	@echo "after that, you can curl -H \"Host: myhost.com\" \$$GATEWAY_URL"
+	@echo "-- Linux only -- Ingress gateway is exported using loadbalancer service in port 80"
+	@echo "export INGRESS_HOST=\$$(kubectl get gtw istio-ingressgateway -n istio-system -o jsonpath='{.status.addresses[0].value}')"
+	@echo "export INGRESS_PORT=\$$(kubectl get gtw istio-ingressgateway -n istio-system -o jsonpath='{.spec.listeners[?(@.name==\"http\")].port}')"
+	@echo "export GATEWAY_URL=\$$INGRESS_HOST:\$$INGRESS_PORT"
+	@echo "curl -H \"Host: myhost.com\" \$$GATEWAY_URL"
 	@echo
 
 .PHONY: local-setup

--- a/config/dependencies/istio/istio-operator.yaml
+++ b/config/dependencies/istio/istio-operator.yaml
@@ -16,29 +16,8 @@ spec:
       - enabled: false
         name: istio-egressgateway
     ingressGateways:
-      - enabled: true
+      - enabled: false
         name: istio-ingressgateway
-        k8s:
-          service:
-            type: NodePort
-            ports:
-              - name: status-port
-                port: 15021
-                protocol: TCP
-                targetPort: 15021
-              - name: http2
-                port: 80
-                protocol: TCP
-                targetPort: 8080
-                nodePort: 30950
-              - name: https
-                port: 443
-                protocol: TCP
-                targetPort: 8443
-                nodePort: 30951
-          resources:
-            requests:
-              cpu: "0"
     pilot:
       enabled: true
       k8s:
@@ -48,9 +27,5 @@ spec:
   values:
     pilot:
       autoscaleEnabled: false
-    gateways:
-      istio-ingressgateway:
-        type: ClusterIP
-        autoscaleEnabled: false
     global:
       istioNamespace: istio-system

--- a/doc/user-guides/authenticated-rl-for-app-developers.md
+++ b/doc/user-guides/authenticated-rl-for-app-developers.md
@@ -101,6 +101,17 @@ curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy -i
 # HTTP/1.1 200 OK
 ```
 
+> **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service and accessing over localhost:
+>
+> ```sh
+> kubectl port-forward -n istio-system service/istio-ingressgateway-istio 9080:80 2>&1 >/dev/null &
+> export GATEWAY_URL=localhost:9080
+> ```
+> ```sh
+> curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy -i
+> # HTTP/1.1 200 OK
+> ```
+
 ### ③ Enforce authentication on requests to the Toy Store API
 
 Create a Kuadrant `AuthPolicy` to configure the authentication:

--- a/doc/user-guides/authenticated-rl-for-app-developers.md
+++ b/doc/user-guides/authenticated-rl-for-app-developers.md
@@ -101,14 +101,6 @@ curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy -i
 # HTTP/1.1 200 OK
 ```
 
-> **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service and accessing over localhost:
->
-> ```sh
-> kubectl port-forward -n istio-system service/istio-ingressgateway 9080:80 2>&1 >/dev/null &
-> curl -H 'Host: api.toystore.com' http://localhost:9080/toy -i
-> # HTTP/1.1 200 OK
-> ```
-
 ### ③ Enforce authentication on requests to the Toy Store API
 
 Create a Kuadrant `AuthPolicy` to configure the authentication:

--- a/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
+++ b/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
@@ -97,14 +97,6 @@ curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy -i
 
 It should return `200 OK`.
 
-> **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service and accessing over localhost:
->
-> ```sh
-> kubectl port-forward -n istio-system service/istio-ingressgateway 9080:80 2>&1 >/dev/null &
-> curl -H 'Host: api.toystore.com' http://localhost:9080/toy -i
-> # HTTP/1.1 200 OK
-> ```
-
 ### ③ Deploy Keycloak
 
 Create the namesapce:

--- a/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
+++ b/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
@@ -97,6 +97,17 @@ curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy -i
 
 It should return `200 OK`.
 
+> **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service and accessing over localhost:
+>
+> ```sh
+> kubectl port-forward -n istio-system service/istio-ingressgateway-istio 9080:80 2>&1 >/dev/null &
+> export GATEWAY_URL=localhost:9080
+> ```
+> ```sh
+> curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy -i
+> # HTTP/1.1 200 OK
+> ```
+
 ### ③ Deploy Keycloak
 
 Create the namesapce:

--- a/doc/user-guides/simple-rl-for-app-developers.md
+++ b/doc/user-guides/simple-rl-for-app-developers.md
@@ -102,6 +102,17 @@ curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -i
 # HTTP/1.1 200 OK
 ```
 
+> **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service and accessing over localhost:
+>
+> ```sh
+> kubectl port-forward -n istio-system service/istio-ingressgateway-istio 9080:80 2>&1 >/dev/null &
+> export GATEWAY_URL=localhost:9080
+> ```
+> ```sh
+> curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -i
+> # HTTP/1.1 200 OK
+> ```
+
 ### ③ Enforce rate limiting on requests to the Toy Store API
 
 Create a Kuadrant `RateLimitPolicy` to configure rate limiting:

--- a/doc/user-guides/simple-rl-for-app-developers.md
+++ b/doc/user-guides/simple-rl-for-app-developers.md
@@ -102,12 +102,6 @@ curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -i
 # HTTP/1.1 200 OK
 ```
 
-> **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service:
->
-> ```sh
-> kubectl port-forward -n istio-system service/istio-ingressgateway 9080:80 2>&1 >/dev/null &
-> ```
-
 ### ③ Enforce rate limiting on requests to the Toy Store API
 
 Create a Kuadrant `RateLimitPolicy` to configure rate limiting:

--- a/make/istio.mk
+++ b/make/istio.mk
@@ -41,7 +41,6 @@ istioctl-verify-install: istioctl ## Verify istio installation.
 
 .PHONY: sail-install
 sail-install: kustomize
-	$(MAKE) install-metallb
 	$(KUSTOMIZE) build $(ISTIO_INSTALL_DIR)/sail | kubectl apply -f -
 	kubectl -n istio-system wait --for=condition=Available deployment istio-operator --timeout=300s
 	kubectl apply -f $(ISTIO_INSTALL_DIR)/sail/istio.yaml
@@ -50,7 +49,6 @@ sail-install: kustomize
 sail-uninstall: kustomize
 	kubectl delete -f $(ISTIO_INSTALL_DIR)/sail/istio.yaml
 	$(KUSTOMIZE) build $(ISTIO_INSTALL_DIR)/sail | kubectl delete -f -
-	$(MAKE) uninstall-metallb
 
 .PHONY: istio-install
 istio-install:


### PR DESCRIPTION
When running with `ISTIO_INSTALL_SAIL=false make local-setup` two ingress gateways are present, one with type NodePort, the other created for the GWAPI Gateway as a LoadBalancer service (which never gets accepted as there is no load balancer provisioner).

We need to install metallb for istioctl installs as well as remove the old gateway.