### PR TITLE
gh actions: issues workflow: disable job on forked PR's OR it's an issue

### DIFF
--- a/.github/workflows/issues-workflow.yaml
+++ b/.github/workflows/issues-workflow.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
+    if: github.event.pull_request.head.repo.full_name == github.repository  # Only run jobs if the feature branch is in your repo (not in a fork)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0

--- a/.github/workflows/issues-workflow.yaml
+++ b/.github/workflows/issues-workflow.yaml
@@ -11,7 +11,10 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
-    if: github.event.pull_request.head.repo.full_name == github.repository  # Only run jobs if the feature branch is in your repo (not in a fork)
+    # Only run jobs if the feature branch is in your repo (not in a fork)
+    # OR
+    # it is an issue
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event.issue.number != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0


### PR DESCRIPTION
When the feature branch is in the `Kuadrant/kuadrant-operator` repo the github action context looks like this:
```  
 "github.repository"  -> Kuadrant/kuadrant-operator
 "github.event.pull_request.head.repo.full_name" -> Kuadrant/kuadrant-operator
```

when the feature brnach is in another repo (forked one) and opens PR in this repo, the context looks like this:
```
"github.repository" -> Kuadrant/kuadrant-operator
"github.event.pull_request.head.repo.full_name" -> ilargitxiki/kuadrant-operator
```

When we want to disable job on PR's coming from forked repos to prevent it from failing (because there is no access to secrets), that is the cleanest way so far.

```yaml
jobs:
  job_id:
    if: github.event.pull_request.head.repo.full_name == github.repository
```

Issues workflow will also be run when an issue is being opened. 

> **Note**: for some unknown reason, when issues are opened, not matter internal or external collaborator, the `ADD_ISSUES_TOKEN` secret is available and the issue is being added to the project

Tested:
* External user creates issue :heavy_check_mark: 
* Internal collaborator creates issue :heavy_check_mark: 
* PR created by internal collaborator :heavy_check_mark: 
* PR from forked repo :negative_squared_cross_mark:  (not being run, and the workflow succeeds)