### PR TITLE
Ensure shas retrieved by workflow are ordered by date

### DIFF
--- a/.github/workflows/update-stored-dependencies-version.yaml
+++ b/.github/workflows/update-stored-dependencies-version.yaml
@@ -28,14 +28,14 @@ jobs:
     steps:
       - name: Fetch dependencies images list
         id: fetch
-        uses: fjogeleit/http-request-action@master
+        uses: fjogeleit/http-request-action@v1
         with:
           method: 'GET'
           url: ${{env.IMG_REPO_URL}}${{ matrix.repository }}?includeTags=true
       - name: Parse the list to get the last SHA
         id: extract-sha-var
         run: |
-          echo "sha=$(echo '${{ steps.fetch.outputs.response }}' | jq -c -r '.tags | keys_unsorted | .[] | select(.|test("[0-9a-f]{5,40}"))' | jq -Rn '[inputs]' | jq -c -r '.[0]')" >> $GITHUB_OUTPUT
+          echo "sha=$(echo '${{ steps.fetch.outputs.response }}' | jq -c -r '.tags | to_entries | sort_by(.value.last_modified | strptime("%a, %d %b %Y %H:%M:%S -0000"))[].key | select(.|test("[0-9a-f]{5,40}"))' | jq -Rn '[inputs]' | jq -c -r '.[-1]')" >> $GITHUB_OUTPUT
           echo "var=$(echo ${{ matrix.repository }} | sed -E 's/-/_/g;s/[a-z]/\U&/g')_SHA" >> $GITHUB_OUTPUT
       - name: Update stored variable
         id: update


### PR DESCRIPTION
The http-request-action@master is deprecated in favour of main/v1.

The response from this action does not seem to be ordered correctly (at least for the policy-controller), when curling locally the order of the tags is by date, but the action seems to be consistently returning the tags in the incorrect order:

```json
"tags": {
    "2451921": {
        "name": "2451921",
        "size": 29951865,
        "last_modified": "Thu, 30 Nov 2023 16:44:16 -0000",
        "manifest_digest": "sha256:e2ea6a7340dd61e55dbef4f89fefc860f64b1b444f03a1ffd02058abaa667323"
    },
    "3019274": {
        "name": "3019274",
        "size": 28848877,
        "last_modified": "Mon, 13 Nov 2023 12:17:30 -0000",
        "manifest_digest": "sha256:861bd416069c8659c0d69e24f6b1ad6945b8c45a75a4efcef9f503f6cffeeac0"
    },
    "4390036": {
        "name": "4390036",
        "size": 29951865,
        "last_modified": "Thu, 30 Nov 2023 09:43:09 -0000",
        "manifest_digest": "sha256:f1fd29370141a33ac95c15e57cedbd9a93cb7ca2bae0aa9557e7dde01fc43ef1"
    },
    "5012370": {
        "name": "5012370",
        "size": 27952337,
        "last_modified": "Tue, 07 Nov 2023 09:31:24 -0000",
        "manifest_digest": "sha256:af33a04cb979273a4c835bb6bc793a2ea294a9828cced59dcbcaf940843ac465"
    },
    "5927261": {
        "name": "5927261",
        "size": 29951865,
        "last_modified": "Tue, 28 Nov 2023 11:42:59 -0000",
        "manifest_digest": "sha256:7bcba161ce28b6d7ff0e1c1ccb0acc13690815c56a6091232d71818d429771fb"
    },
    "9925934": {
        "name": "9925934",
        "size": 30035957,
        "last_modified": "Tue, 09 Jan 2024 12:00:24 -0000",
        "manifest_digest": "sha256:2df4aa4d851b1d6dcd0edafae54ac87d7c9b6bfc4cb9942f1b80561b4cf4bf86"
    },
    "main": {
        "name": "main",
        "size": 30036549,
        "last_modified": "Fri, 12 Jan 2024 15:44:43 -0000",
        "manifest_digest": "sha256:3d46a9c47beb89b1e1056b43c843150c473513023fa2af163efe5cf85c7e480e"
    },

...
```

Our nightly is therefore trying to use the [policy-controller commit sha 2451921](https://github.com/Kuadrant/kuadrant-operator/actions/runs/7495999651/job/20432344806#step:4:3) - this commit was before the kustomization file was added and will fail due to short commit sha https://github.com/Kuadrant/multicluster-gateway-controller/pull/761.

This PR sorts by the `last_modified` date and takes the last matching sha entry instead of using the default ordering taking the first matching sha entry. Once merged nightly builds should function again.