### PR TITLE
Use istioctl for local install and skip sail tests on PR

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,6 +48,11 @@ jobs:
     strategy:
       matrix:
         istio-type: [ sail, istioctl ]
+        pr-event:
+          - ${{ github.event_name == 'pull_request' }}
+        exclude:
+          - istio-type: sail
+            pr-event: true
     runs-on: ubuntu-latest
     env:
       KIND_CLUSTER_NAME: kuadrant-test

--- a/make/istio.mk
+++ b/make/istio.mk
@@ -6,7 +6,7 @@
 ISTIO_INSTALL_DIR = config/dependencies/istio
 ISTIO_NAMESPACE = istio-system
 ## installs project sail vs istioctl install
-ISTIO_INSTALL_SAIL ?= true
+ISTIO_INSTALL_SAIL ?= false
 ifeq (true,$(ISTIO_INSTALL_SAIL))
 INSTALL_COMMAND=sail-install
 else


### PR DESCRIPTION
- Reverted the default install type for `make local-setup` to use `istioctl` instead of project sail
- Disabled the sail integration tests from PRs but still runs nightly
- Updated quickstart to depend on `ISTIO_INSTALL_SAIL` where default is to install without sail (false)

You can test the quickstart changes in this PR like this:

```bash
curl "https://raw.githubusercontent.com/adam-cattermole/kuadrant-operator/make-istioctl-default/hack/quickstart-setup.sh" | bash
```

TODO:
- [x] Check docs + quickstart


Related #382 