### PR TITLE
Pin version of sail to nightly 18-01-2024

### DIFF
--- a/config/dependencies/istio/sail/deployment_patch.yaml
+++ b/config/dependencies/istio/sail/deployment_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istio-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        # nightly build from commit b7f5286be0bc25cb257bc439e7c18acb99dce26f
+        image: quay.io/maistra-dev/istio-operator:3.0-nightly-2024-01-18

--- a/config/dependencies/istio/sail/kustomization.yaml
+++ b/config/dependencies/istio/sail/kustomization.yaml
@@ -1,4 +1,10 @@
 ---
 namespace: istio-system
 resources:
-- github.com/maistra/istio-operator/config/default?ref=maistra-3.0
+- github.com/maistra/istio-operator/config/default?ref=b7f5286be0bc25cb257bc439e7c18acb99dce26f
+# commit sha from prior to removal of kustomize manifests
+patches:
+- path: deployment_patch.yaml
+  target:
+    kind: Deployment
+    name: istio-operator


### PR DESCRIPTION
I have pinned the version of the sail operator to the commit prior to the kustomize manifests being removed: https://github.com/maistra/istio-operator/config/default?ref=b7f5286be0bc25cb257bc439e7c18acb99dce26f.

Test install locally:
```
ISTIO_INSTALL_SAIL=true make local-setup
```
Check deployment is using correct image:
```
kubectl get deployment istio-operator -n istio-system -o yaml | yq '.spec.template.spec.containers | filter(.name == "manager") | .[0].image'
# quay.io/maistra-dev/istio-operator:3.0-nightly-2024-01-18
```

Resolves #382