### PR TITLE
Remove --ocm-hub flag and update bundle

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -131,7 +131,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2023-12-12T12:34:15Z"
+    createdAt: "2024-01-23T14:59:43Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator
@@ -518,14 +518,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - cluster.open-cluster-management.io
-          resources:
-          - managedclusters
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups:
           - gateway.networking.k8s.io
           resources:
           - gateways
@@ -758,7 +750,6 @@ spec:
               containers:
               - args:
                 - --leader-elect
-                - --ocm-hub=false
                 command:
                 - /policy_controller
                 image: quay.io/kuadrant/policy-controller:main

--- a/config/dependencies/policy-controller/kustomization.template.yaml
+++ b/config/dependencies/policy-controller/kustomization.template.yaml
@@ -3,11 +3,3 @@ resources:
 
 patchesStrategicMerge:
 - delete-ns.yaml
-
-patches:
-- patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --ocm-hub=false
-  target:
-    kind: Deployment

--- a/config/dependencies/policy-controller/kustomization.yaml
+++ b/config/dependencies/policy-controller/kustomization.yaml
@@ -3,11 +3,3 @@ resources:
 
 patchesStrategicMerge:
 - delete-ns.yaml
-
-patches:
-- patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --ocm-hub=false
-  target:
-    kind: Deployment


### PR DESCRIPTION
Policy controller pod was failing to start due to additional `--ocm-hub` flag which was removed (see https://github.com/Kuadrant/multicluster-gateway-controller/pull/711).

Manifests also needed updating from `make bundle`