### PR TITLE
Integration tests for configuration reconcile

### DIFF
--- a/controllers/kuadrant_controller_test.go
+++ b/controllers/kuadrant_controller_test.go
@@ -6,13 +6,14 @@ import (
 	"reflect"
 	"time"
 
-	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
-	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	"github.com/kuadrant/limitador-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
 )
 
 var _ = Describe("Kuadrant controller", func() {

--- a/controllers/kuadrant_controller_test.go
+++ b/controllers/kuadrant_controller_test.go
@@ -4,18 +4,19 @@ package controllers
 
 import (
 	"context"
+	"reflect"
+	"time"
+
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	"github.com/kuadrant/limitador-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"time"
 )
 
-var _ = FDescribe("Kuadrant controller", func() {
+var _ = Describe("Kuadrant controller", func() {
 	var (
 		testNamespace string
 		kuadrant      = "kuadrant-sample"

--- a/controllers/kuadrant_controller_test.go
+++ b/controllers/kuadrant_controller_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package controllers
+
+import (
+	"context"
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
+	"github.com/kuadrant/limitador-operator/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+var _ = FDescribe("Kuadrant controller", func() {
+	var (
+		testNamespace string
+		kuadrant      = "kuadrant-sample"
+	)
+	Context("Reconcile limitador resources", func() {
+		BeforeEach(func() {
+			CreateNamespace(&testNamespace)
+			ApplyKuadrantCR(testNamespace)
+		})
+
+		AfterEach(DeleteNamespaceCallback(&testNamespace))
+		It("Copy configuration from Kuadrant CR to Limitador CR", func() {
+			kObj := &kuadrantv1beta1.Kuadrant{}
+			lObj := &v1alpha1.Limitador{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: kuadrant, Namespace: testNamespace}, kObj)
+				return err == nil
+			}, time.Minute, 5*time.Second).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
+				return err == nil
+			}, time.Minute, 5*time.Second).Should(BeTrue())
+			var tmp *int
+			Expect(lObj.Spec.Replicas).Should(Equal(tmp))
+
+			kObj.Spec.Limitador = &kuadrantv1beta1.LimitadorSpec{Replicas: ptr.To(1)}
+			err := k8sClient.Update(context.Background(), kObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
+				if err != nil {
+					return false
+				}
+				if reflect.DeepEqual(lObj.Spec.Replicas, ptr.To(1)) {
+					return false
+				}
+				return true
+			}, time.Minute, 5*time.Second).Should(BeTrue())
+		})
+
+		It("Kuadrant CR configuration overrides Limitador CR configuration", func() {
+			kObj := &kuadrantv1beta1.Kuadrant{}
+			lObj := &v1alpha1.Limitador{}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
+				return err == nil
+			}, time.Minute, 5*time.Second).Should(BeTrue())
+			lObj.Spec.Replicas = ptr.To(1)
+			err := k8sClient.Update(context.Background(), lObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: kuadrant, Namespace: testNamespace}, kObj)
+				return err == nil
+			}, time.Minute, 5*time.Second).Should(BeTrue())
+
+			kObj.Spec.Limitador = &kuadrantv1beta1.LimitadorSpec{Replicas: ptr.To(2)}
+			err = k8sClient.Update(context.Background(), kObj)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
+				if err != nil {
+					return false
+				}
+				if reflect.DeepEqual(lObj.Spec.Replicas, ptr.To(2)) {
+					return false
+				}
+				return true
+			}, time.Minute, 5*time.Second).Should(BeTrue())
+		})
+	})
+})

--- a/controllers/kuadrant_controller_test.go
+++ b/controllers/kuadrant_controller_test.go
@@ -21,6 +21,7 @@ var _ = Describe("Kuadrant controller", func() {
 		testNamespace string
 	)
 	const (
+		testTimeOut      = SpecTimeout(2 * time.Minute)
 		afterEachTimeOut = NodeTimeout(3 * time.Minute)
 		kuadrant         = "kuadrant-sample"
 	)
@@ -63,7 +64,7 @@ var _ = Describe("Kuadrant controller", func() {
 				}
 				return true
 			}).WithContext(ctx).Should(BeTrue())
-		})
+		}, testTimeOut)
 
 		It("Kuadrant CR configuration overrides Limitador CR configuration", func(ctx SpecContext) {
 			kObj := &kuadrantv1beta1.Kuadrant{}
@@ -96,6 +97,6 @@ var _ = Describe("Kuadrant controller", func() {
 				}
 				return true
 			}).WithContext(ctx).Should(BeTrue())
-		})
+		}, testTimeOut)
 	})
 })

--- a/controllers/kuadrant_controller_test.go
+++ b/controllers/kuadrant_controller_test.go
@@ -3,7 +3,6 @@
 package controllers
 
 import (
-	"context"
 	"reflect"
 	"time"
 
@@ -38,23 +37,23 @@ var _ = Describe("Kuadrant controller", func() {
 			lObj := &v1alpha1.Limitador{}
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: kuadrant, Namespace: testNamespace}, kObj)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: kuadrant, Namespace: testNamespace}, kObj)
 				return err == nil
 			}).WithContext(ctx).Should(BeTrue())
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
 				return err == nil
 			}).WithContext(ctx).Should(BeTrue())
 			var tmp *int
 			Expect(lObj.Spec.Replicas).Should(Equal(tmp))
 
 			kObj.Spec.Limitador = &kuadrantv1beta1.LimitadorSpec{Replicas: ptr.To(1)}
-			err := k8sClient.Update(context.Background(), kObj)
+			err := k8sClient.Update(ctx, kObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
 				if err != nil {
 					return false
 				}
@@ -70,24 +69,24 @@ var _ = Describe("Kuadrant controller", func() {
 			lObj := &v1alpha1.Limitador{}
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
 				return err == nil
 			}).WithContext(ctx).Should(BeTrue())
 			lObj.Spec.Replicas = ptr.To(1)
-			err := k8sClient.Update(context.Background(), lObj)
+			err := k8sClient.Update(ctx, lObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: kuadrant, Namespace: testNamespace}, kObj)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: kuadrant, Namespace: testNamespace}, kObj)
 				return err == nil
 			}).WithContext(ctx).Should(BeTrue())
 
 			kObj.Spec.Limitador = &kuadrantv1beta1.LimitadorSpec{Replicas: ptr.To(2)}
-			err = k8sClient.Update(context.Background(), kObj)
+			err = k8sClient.Update(ctx, kObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: common.LimitadorName, Namespace: testNamespace}, lObj)
 				if err != nil {
 					return false
 				}


### PR DESCRIPTION
Part of: https://github.com/Kuadrant/kuadrant-operator/issues/305

Add integration test for testing the reconcile of limitador configuration in the kuadrant CR into the limitador CR.