### PR TITLE
Disable fail-fast for nightly integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,6 +53,7 @@ jobs:
         exclude:
           - istio-type: sail
             pr-event: true
+      fail-fast: false
     runs-on: ubuntu-latest
     env:
       KIND_CLUSTER_NAME: kuadrant-test


### PR DESCRIPTION
When the nightly integration tests run if one of the sail operator / istioctl fails the other test in the matrix is cancelled due to `fail-fast: true`. Setting to false so we run both integration tests no matter the outcome of the first to complete.

See latest nightly here where the integration test for sail cancelled the integration test for istioctl:
https://github.com/Kuadrant/kuadrant-operator/actions/runs/7634245121