### PR TITLE
Change scheduled build naming

### DIFF
--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -1,4 +1,4 @@
-name: Schedule build with latest image SHA versions
+name: Schedule nightly build with latest image SHA versions
 
 on:
   schedule:
@@ -11,7 +11,7 @@ jobs:
     secrets: inherit
     with:
       kuadrantOperatorVersion: ${{ github.sha }}
-      kuadrantOperatorTag: ${{ github.sha }}
+      kuadrantOperatorTag: nightly-$(date +'%d-%m-%Y')
       authorinoOperatorVersion: ${{ vars.AUTHORINO_OPERATOR_SHA }}
       limitadorOperatorVersion: ${{ vars.LIMITADOR_OPERATOR_SHA }}
       policyControllerVersion: ${{ vars.POLICY_CONTROLLER_SHA }}


### PR DESCRIPTION
# Summary

This PR aims to solve these two issues:

- Since the scheduled build actions effectively became `nightly` builds, update the naming to make it more apparent in both tags and Action name
- If the kuadrant-operator did not change between builds, but components did, the tag would stay the same but the contents would change
   - This will cause more tags in the quay (literally for each day) 

I still need to do a bit of testing to make sure the change is correct but the idea stands and I would like to know your opinion
