### PR TITLE
Update quickstart to correctly deploy from KUADRANT_REF

### DIFF
--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -36,7 +36,6 @@ source /dev/stdin <<< "$(curl -s https://raw.githubusercontent.com/${KUADRANT_OR
 
 YQ_BIN=$(dockerBinCmd "yq")
 
-KUADRANT_IMAGE="quay.io/${KUADRANT_ORG}/kuadrant-operator:latest"
 KUADRANT_REPO="github.com/${KUADRANT_ORG}/kuadrant-operator.git"
 MGC_REPO="github.com/${KUADRANT_ORG}/multicluster-gateway-controller.git"
 KUADRANT_REPO_RAW="https://raw.githubusercontent.com/${KUADRANT_ORG}/kuadrant-operator/${KUADRANT_REF}"
@@ -51,7 +50,7 @@ set -e pipefail
 
 if [[ "${KUADRANT_REF}" != "main" ]]; then
   echo "setting KUADRANT_REPO to use branch ${KUADRANT_REF}"
-  KUADRANT_IMAGE="quay.io/${KUADRANT_ORG}/kuadrant-operator:${KUADRANT_REF}"
+  KUADRANT_DEPLOY_KUSTOMIZATION=${KUADRANT_DEPLOY_KUSTOMIZATION}?ref=${KUADRANT_REF}
   KUADRANT_GATEWAY_API_KUSTOMIZATION=${KUADRANT_GATEWAY_API_KUSTOMIZATION}?ref=${KUADRANT_REF}
   KUADRANT_ISTIO_KUSTOMIZATION=${KUADRANT_ISTIO_KUSTOMIZATION}?ref=${KUADRANT_REF}
   KUADRANT_CERT_MANAGER_KUSTOMIZATION=${KUADRANT_CERT_MANAGER_KUSTOMIZATION}?ref=${KUADRANT_REF}
@@ -117,7 +116,6 @@ kubectl apply -n metallb-system -f - <<< "$(curl -s ${KUADRANT_REPO_RAW}/utils/d
 # Install kuadrant
 echo "Installing Kuadrant in ${KUADRANT_CLUSTER_NAME}"
 ${KUSTOMIZE_BIN} build ${KUADRANT_DEPLOY_KUSTOMIZATION} | kubectl apply -f -
-kubectl -n ${KUADRANT_NAMESPACE} patch deployment kuadrant-operator-controller-manager --type='merge' -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","image":"'"${KUADRANT_IMAGE}"'"}]}}}}'
 
 # Configure managedzone
 if [ ! -z "$DNS_PROVIDER" ]; then


### PR DESCRIPTION
There was a line missing to set the deploy kustomization to the one for `KUADRANT_REF` so main was being used (also the deployment patching was unnecessary so removed). I've cherry-picked the commit to a test release branch to verify this:

```sh
export KUADRANT_REF=release-v0.6.0-hotfix
export KUADRANT_ORG=adam-cattermole
curl "https://raw.githubusercontent.com/${KUADRANT_ORG}/kuadrant-operator/${KUADRANT_REF}/hack/quickstart-setup.sh" | bash
```

Can see that the deployment images are now pinned (apart from authorino-operator):
```sh
kubectl get deployments -n kuadrant-system -o yaml | yq '.items.[].spec.template.spec.containers[].image'
quay.io/kuadrant/authorino:latest
quay.io/kuadrant/authorino-operator:latest
quay.io/kuadrant/authorino:v0.16.0
quay.io/kuadrant/kuadrant-operator:v0.6.0
quay.io/kuadrant/policy-controller:release-0.3
quay.io/kuadrant/limitador:v1.3.0
quay.io/kuadrant/limitador-operator:v0.7.0
```

Authorino operator has a separate issue, where the tagged version of the code is pointing to latest in the manifests https://github.com/Kuadrant/authorino-operator/blob/v0.10.0/config/manager/kustomization.yaml#L14-L16.