### PR TITLE
feat: auth policy enforced condition

### DIFF
--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -202,7 +202,8 @@ var _ common.KuadrantPolicy = &AuthPolicy{}
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=direct"
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`,description="AuthPolicy Status",priority=2
+// +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=`.status.conditions[?(@.type=="Accepted")].status`,description="AuthPolicy Accepted",priority=2
+// +kubebuilder:printcolumn:name="Enforced",type=string,JSONPath=`.status.conditions[?(@.type=="Enforced")].status`,description="AuthPolicy Enforced",priority=2
 // +kubebuilder:printcolumn:name="TargetRefKind",type="string",JSONPath=".spec.targetRef.kind",description="Type of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="TargetRefName",type="string",JSONPath=".spec.targetRef.name",description="Name of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1beta2/ratelimitpolicy_types.go
+++ b/api/v1beta2/ratelimitpolicy_types.go
@@ -168,7 +168,8 @@ var _ common.KuadrantPolicy = &RateLimitPolicy{}
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=direct"
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`,description="RateLimitPolicy Status",priority=2
+// +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=`.status.conditions[?(@.type=="Accepted")].status`,description="RateLimitPolicy Accepted",priority=2
+// +kubebuilder:printcolumn:name="Enforced",type=string,JSONPath=`.status.conditions[?(@.type=="Enforced")].status`,description="RateLimitPolicy Enforced",priority=2
 // +kubebuilder:printcolumn:name="TargetRefKind",type="string",JSONPath=".spec.targetRef.kind",description="Type of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="TargetRefName",type="string",JSONPath=".spec.targetRef.name",description="Name of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -131,7 +131,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-01-23T14:59:43Z"
+    createdAt: "2024-02-06T11:59:47Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/manifests/kuadrant.io_authpolicies.yaml
+++ b/bundle/manifests/kuadrant.io_authpolicies.yaml
@@ -18,9 +18,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: AuthPolicy Status
-      jsonPath: .status.conditions[0].reason
-      name: Status
+    - description: AuthPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: AuthPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
       priority: 2
       type: string
     - description: Type of the referenced Gateway API resource

--- a/bundle/manifests/kuadrant.io_ratelimitpolicies.yaml
+++ b/bundle/manifests/kuadrant.io_ratelimitpolicies.yaml
@@ -18,9 +18,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: RateLimitPolicy Status
-      jsonPath: .status.conditions[0].reason
-      name: Status
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
       priority: 2
       type: string
     - description: Type of the referenced Gateway API resource

--- a/config/crd/bases/kuadrant.io_authpolicies.yaml
+++ b/config/crd/bases/kuadrant.io_authpolicies.yaml
@@ -17,9 +17,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: AuthPolicy Status
-      jsonPath: .status.conditions[0].reason
-      name: Status
+    - description: AuthPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: AuthPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
       priority: 2
       type: string
     - description: Type of the referenced Gateway API resource

--- a/config/crd/bases/kuadrant.io_ratelimitpolicies.yaml
+++ b/config/crd/bases/kuadrant.io_ratelimitpolicies.yaml
@@ -17,9 +17,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: RateLimitPolicy Status
-      jsonPath: .status.conditions[0].reason
-      name: Status
+    - description: RateLimitPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: RateLimitPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
       priority: 2
       type: string
     - description: Type of the referenced Gateway API resource

--- a/controllers/authpolicy_authconfig.go
+++ b/controllers/authpolicy_authconfig.go
@@ -92,6 +92,7 @@ func (r *AuthPolicyReconciler) desiredAuthConfig(ctx context.Context, ap *api.Au
 		if len(rules) == 0 {
 			logger.V(1).Info("no httproutes attached to the targeted gateway, skipping authorino authconfig for the gateway authpolicy")
 			common.TagObjectToDelete(authConfig)
+			r.setOverriddenPolicy(ap)
 			return authConfig, nil
 		}
 		route = &gatewayapiv1.HTTPRoute{
@@ -101,6 +102,9 @@ func (r *AuthPolicyReconciler) desiredAuthConfig(ctx context.Context, ap *api.Au
 			},
 		}
 	}
+
+	// AuthPolicy is not overridden if code execution flow reaches here
+	r.removeOverriddenPolicy(ap)
 
 	// hosts
 	authConfig.Spec.Hosts = hosts

--- a/controllers/authpolicy_authconfig.go
+++ b/controllers/authpolicy_authconfig.go
@@ -92,7 +92,7 @@ func (r *AuthPolicyReconciler) desiredAuthConfig(ctx context.Context, ap *api.Au
 		if len(rules) == 0 {
 			logger.V(1).Info("no httproutes attached to the targeted gateway, skipping authorino authconfig for the gateway authpolicy")
 			common.TagObjectToDelete(authConfig)
-			r.setOverriddenPolicy(ap)
+			r.OverriddenPolicyMap.SetOverriddenPolicy(ap)
 			return authConfig, nil
 		}
 		route = &gatewayapiv1.HTTPRoute{
@@ -103,8 +103,8 @@ func (r *AuthPolicyReconciler) desiredAuthConfig(ctx context.Context, ap *api.Au
 		}
 	}
 
-	// AuthPolicy is not overridden if code execution flow reaches here
-	r.removeOverriddenPolicy(ap)
+	// AuthPolicy is not overridden if we still need to create an AuthConfig for it
+	r.OverriddenPolicyMap.RemoveOverriddenPolicy(ap)
 
 	// hosts
 	authConfig.Spec.Hosts = hosts

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -24,8 +23,8 @@ const authPolicyFinalizer = "authpolicy.kuadrant.io/finalizer"
 // AuthPolicyReconciler reconciles a AuthPolicy object
 type AuthPolicyReconciler struct {
 	reconcilers.TargetRefReconciler
-	// OverriddenPolicies tracks the overridden policies to report their status.
-	OverriddenPolicies map[types.UID]bool
+	// OverriddenPolicyMap tracks the overridden policies to report their status.
+	OverriddenPolicyMap *common.OverriddenPolicyMap
 }
 
 //+kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -67,7 +67,7 @@ func (r *AuthPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl.Requ
 				if delResErr == nil {
 					delResErr = err
 				}
-				return r.reconcileStatus(ctx, ap, common.NewErrTargetNotFound(ap.Kind(), ap.GetTargetRef(), delResErr))
+				return r.reconcileStatus(ctx, ap, targetNetworkObject, common.NewErrTargetNotFound(ap.Kind(), ap.GetTargetRef(), delResErr))
 			}
 			return ctrl.Result{}, err
 		}
@@ -103,7 +103,7 @@ func (r *AuthPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl.Requ
 	specErr := r.reconcileResources(ctx, ap, targetNetworkObject)
 
 	// reconcile authpolicy status
-	statusResult, statusErr := r.reconcileStatus(ctx, ap, specErr)
+	statusResult, statusErr := r.reconcileStatus(ctx, ap, targetNetworkObject, specErr)
 
 	if specErr != nil {
 		return ctrl.Result{}, specErr

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -23,6 +24,8 @@ const authPolicyFinalizer = "authpolicy.kuadrant.io/finalizer"
 // AuthPolicyReconciler reconciles a AuthPolicy object
 type AuthPolicyReconciler struct {
 	reconcilers.TargetRefReconciler
+	// OverriddenPolicies tracks the overridden policies to report their status.
+	OverriddenPolicies map[types.UID]bool
 }
 
 //+kubebuilder:rbac:groups=kuadrant.io,resources=authpolicies,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/authpolicy_controller_test.go
+++ b/controllers/authpolicy_controller_test.go
@@ -1246,6 +1246,15 @@ var _ = Describe("AuthPolicy controller", func() {
 				err := k8sClient.Get(context.Background(), authConfigKey, &authorinoapi.AuthConfig{})
 				return apierrors.IsNotFound(err)
 			}, 30*time.Second, 5*time.Second).Should(BeTrue())
+
+			// GW Policy should go back to being enforced when a HTTPRoute with no AP attached becomes available
+			route2 := testBuildBasicHttpRoute("route2", testGatewayName, testNamespace, []string{"*.carstore.com"})
+
+			err = k8sClient.Create(context.Background(), route2)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(isAuthPolicyAccepted(gwPolicy), 30*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(isAuthPolicyEnforced(gwPolicy), 30*time.Second, 5*time.Second).Should(BeTrue())
 		})
 	})
 })

--- a/controllers/authpolicy_status.go
+++ b/controllers/authpolicy_status.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -11,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	v1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	authorinoapi "github.com/kuadrant/authorino/api/v1beta2"
@@ -19,32 +22,15 @@ import (
 )
 
 // reconcileStatus makes sure status block of AuthPolicy is up-to-date.
-func (r *AuthPolicyReconciler) reconcileStatus(ctx context.Context, ap *api.AuthPolicy, specErr error) (ctrl.Result, error) {
+func (r *AuthPolicyReconciler) reconcileStatus(ctx context.Context, ap *api.AuthPolicy, targetNetworkObject client.Object, specErr error) (ctrl.Result, error) {
 	logger, _ := logr.FromContext(ctx)
 	logger.V(1).Info("Reconciling AuthPolicy status", "spec error", specErr)
 
-	// fetch the AuthConfig and check if it's ready.
-	isAuthConfigReady := true
-	if specErr == nil { // skip fetching authconfig if we already have a reconciliation error.
-		apKey := client.ObjectKeyFromObject(ap)
-		authConfigKey := client.ObjectKey{
-			Namespace: ap.Namespace,
-			Name:      authConfigName(apKey),
-		}
-		authConfig := &authorinoapi.AuthConfig{}
-		if err := r.GetResource(ctx, authConfigKey, authConfig); err != nil && !apierrors.IsNotFound(err) {
-			return ctrl.Result{}, err
-		}
-
-		isAuthConfigReady = authConfig.Status.Ready()
-	}
-
-	newStatus := r.calculateStatus(ap, specErr, isAuthConfigReady)
+	newStatus := r.calculateStatus(ctx, ap, targetNetworkObject, specErr)
 
 	equalStatus := ap.Status.Equals(newStatus, logger)
 	logger.V(1).Info("Status", "status is different", !equalStatus)
 	logger.V(1).Info("Status", "generation is different", ap.Generation != ap.Status.ObservedGeneration)
-	logger.V(1).Info("Status", "AuthConfig is ready", isAuthConfigReady)
 	if equalStatus && ap.Generation == ap.Status.ObservedGeneration {
 		logger.V(1).Info("Status up-to-date. No changes required.")
 		return ctrl.Result{}, nil
@@ -72,7 +58,7 @@ func (r *AuthPolicyReconciler) reconcileStatus(ctx context.Context, ap *api.Auth
 	return ctrl.Result{}, nil
 }
 
-func (r *AuthPolicyReconciler) calculateStatus(ap *api.AuthPolicy, specErr error, authConfigReady bool) *api.AuthPolicyStatus {
+func (r *AuthPolicyReconciler) calculateStatus(ctx context.Context, ap *api.AuthPolicy, targetNetworkObject client.Object, specErr error) *api.AuthPolicyStatus {
 	newStatus := &api.AuthPolicyStatus{
 		Conditions:         slices.Clone(ap.Status.Conditions),
 		ObservedGeneration: ap.Status.ObservedGeneration,
@@ -86,27 +72,69 @@ func (r *AuthPolicyReconciler) calculateStatus(ap *api.AuthPolicy, specErr error
 		return newStatus
 	}
 
-	enforcedCond := r.enforcedCondition(ap, authConfigReady)
+	enforcedCond := r.enforcedCondition(ctx, ap, targetNetworkObject)
 	meta.SetStatusCondition(&newStatus.Conditions, *enforcedCond)
 
 	return newStatus
 }
 
 func (r *AuthPolicyReconciler) acceptedCondition(policy common.KuadrantPolicy, specErr error) *metav1.Condition {
-	cond := common.AcceptedCondition(policy, specErr)
-
-	return cond
+	return common.AcceptedCondition(policy, specErr)
 }
 
-func (r *AuthPolicyReconciler) enforcedCondition(policy common.KuadrantPolicy, authConfigReady bool) *metav1.Condition {
-	var err common.PolicyError
-	if !authConfigReady {
-		err = common.NewErrUnknown(policy.Kind(), fmt.Errorf("AuthScheme is not ready yet"))
+// enforcedCondition checks if the provided AuthPolicy is enforced based on the status of the associated AuthConfig and Gateway.
+func (r *AuthPolicyReconciler) enforcedCondition(ctx context.Context, policy *api.AuthPolicy, targetNetworkObject client.Object) *metav1.Condition {
+	logger, _ := logr.FromContext(ctx)
+	authConfigReady, gwPolicyOverridden, err := r.checkAuthConfigAndGateway(ctx, policy)
+	if err != nil {
+		logger.Error(err, "Failed to check AuthConfig and Gateway")
+		return common.EnforcedCondition(policy, common.NewErrUnknown(policy.Kind(), err))
 	}
 
-	// TODO: Implement 'Overridden' Reason if AuthPolicy supports Inherited Policy Attachment
+	if !authConfigReady {
+		logger.V(1).Info("AuthConfig is not ready")
+		return common.EnforcedCondition(policy, common.NewErrUnknown(policy.Kind(), errors.New("AuthScheme is not ready yet")))
+	}
 
-	cond := common.EnforcedCondition(policy, err)
+	if gwPolicyOverridden {
+		logger.V(1).Info("Gateway Policy is overridden")
+		return r.handleGatewayPolicyOverride(logger, policy, targetNetworkObject)
+	}
 
-	return cond
+	logger.V(1).Info("AuthPolicy is enforced")
+	return common.EnforcedCondition(policy, nil)
+}
+
+// checkAuthConfigAndGateway checks if the AuthConfig is ready and if the Gateway Policy is overridden.
+func (r *AuthPolicyReconciler) checkAuthConfigAndGateway(ctx context.Context, policy *api.AuthPolicy) (bool, bool, error) {
+	apKey := client.ObjectKeyFromObject(policy)
+	authConfigKey := client.ObjectKey{
+		Namespace: policy.Namespace,
+		Name:      authConfigName(apKey),
+	}
+	authConfig := &authorinoapi.AuthConfig{}
+	err := r.GetResource(ctx, authConfigKey, authConfig)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, false, fmt.Errorf("failed to get AuthConfig: %w", err)
+		}
+		return true, common.IsTargetRefGateway(policy.GetTargetRef()), nil
+	}
+	return authConfig.Status.Ready(), false, nil
+}
+
+// handleGatewayPolicyOverride handles the case where the Gateway Policy is overridden.
+func (r *AuthPolicyReconciler) handleGatewayPolicyOverride(logger logr.Logger, policy *api.AuthPolicy, targetNetworkObject client.Object) *metav1.Condition {
+	obj := targetNetworkObject.(*v1.Gateway)
+	gatewayWrapper := common.GatewayWrapper{Gateway: obj, PolicyRefsConfig: &common.KuadrantAuthPolicyRefsConfig{}}
+	refs := gatewayWrapper.PolicyRefs()
+	filteredRef := common.Filter(refs, func(key client.ObjectKey) bool {
+		return key != client.ObjectKeyFromObject(policy)
+	})
+	jsonData, err := json.Marshal(filteredRef)
+	if err != nil {
+		logger.Error(err, "Failed to marshal filtered references")
+		return common.EnforcedCondition(policy, common.NewErrUnknown(policy.Kind(), err))
+	}
+	return common.EnforcedCondition(policy, common.NewErrOverridden(policy.Kind(), string(jsonData)))
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -25,6 +25,7 @@ import (
 
 	authorinoopapi "github.com/kuadrant/authorino-operator/api/v1beta1"
 	authorinoapi "github.com/kuadrant/authorino/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -131,6 +132,7 @@ var _ = BeforeSuite(func() {
 		TargetRefReconciler: reconcilers.TargetRefReconciler{
 			BaseReconciler: authPolicyBaseReconciler,
 		},
+		OverriddenPolicyMap: common.NewOverriddenPolicyMap(),
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	"k8s.io/utils/env"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -171,6 +172,7 @@ func main() {
 		TargetRefReconciler: reconcilers.TargetRefReconciler{
 			BaseReconciler: authPolicyBaseReconciler,
 		},
+		OverriddenPolicyMap: common.NewOverriddenPolicyMap(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AuthPolicy")
 		os.Exit(1)

--- a/pkg/common/apimachinery_status_conditions.go
+++ b/pkg/common/apimachinery_status_conditions.go
@@ -14,8 +14,9 @@ import (
 const (
 	PolicyConditionEnforced gatewayapiv1alpha2.PolicyConditionType = "Enforced"
 
-	PolicyReasonEnforced gatewayapiv1alpha2.PolicyConditionReason = "Enforced"
-	PolicyReasonUnknown  gatewayapiv1alpha2.PolicyConditionReason = "Unknown"
+	PolicyReasonEnforced   gatewayapiv1alpha2.PolicyConditionReason = "Enforced"
+	PolicyReasonOverridden gatewayapiv1alpha2.PolicyConditionReason = "Overridden"
+	PolicyReasonUnknown    gatewayapiv1alpha2.PolicyConditionReason = "Unknown"
 )
 
 // ConditionMarshal marshals the set of conditions as a JSON array, sorted by condition type.

--- a/pkg/common/apimachinery_status_conditions.go
+++ b/pkg/common/apimachinery_status_conditions.go
@@ -11,6 +11,13 @@ import (
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
+const (
+	PolicyConditionEnforced gatewayapiv1alpha2.PolicyConditionType = "Enforced"
+
+	PolicyReasonEnforced gatewayapiv1alpha2.PolicyConditionReason = "Enforced"
+	PolicyReasonUnknown  gatewayapiv1alpha2.PolicyConditionReason = "Unknown"
+)
+
 // ConditionMarshal marshals the set of conditions as a JSON array, sorted by condition type.
 func ConditionMarshal(conditions []metav1.Condition) ([]byte, error) {
 	condCopy := slices.Clone(conditions)
@@ -33,14 +40,35 @@ func AcceptedCondition(policy KuadrantPolicy, err error) *metav1.Condition {
 		return cond
 	}
 
+	// Wrap error into a PolicyError if it is not this type
+	var policyErr PolicyError
+	if !errors.As(err, &policyErr) {
+		policyErr = NewErrUnknown(policy.Kind(), err)
+	}
+
+	cond.Status = metav1.ConditionFalse
+	cond.Message = policyErr.Error()
+	cond.Reason = string(policyErr.Reason())
+
+	return cond
+}
+
+// EnforcedCondition returns an enforced conditions with common reasons for a kuadrant policy
+func EnforcedCondition(policy KuadrantPolicy, err PolicyError) *metav1.Condition {
+	// Enforced
+	cond := &metav1.Condition{
+		Type:    string(PolicyConditionEnforced),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(PolicyReasonEnforced),
+		Message: fmt.Sprintf("%s has been successfully enforced", policy.Kind()),
+	}
+	if err == nil {
+		return cond
+	}
+
 	cond.Status = metav1.ConditionFalse
 	cond.Message = err.Error()
-	cond.Reason = "ReconciliationError"
-
-	var policyErr PolicyError
-	if errors.As(err, &policyErr) {
-		cond.Reason = string(policyErr.Reason())
-	}
+	cond.Reason = string(err.Reason())
 
 	return cond
 }

--- a/pkg/common/apimachinery_status_conditions_test.go
+++ b/pkg/common/apimachinery_status_conditions_test.go
@@ -3,13 +3,13 @@
 package common
 
 import (
-	"fmt"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
 
 	goCmp "github.com/google/go-cmp/cmp"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -149,7 +149,7 @@ func TestAcceptedCondition(t *testing.T) {
 					Group: "gateway.networking.k8s.io",
 					Kind:  "HTTPRoute",
 					Name:  "my-target-ref",
-				}, errors.NewNotFound(schema.GroupResource{}, "my-target-ref")),
+				}, apiErrors.NewNotFound(schema.GroupResource{}, "my-target-ref")),
 			},
 			want: &metav1.Condition{
 				Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
@@ -166,7 +166,7 @@ func TestAcceptedCondition(t *testing.T) {
 					Group: "gateway.networking.k8s.io",
 					Kind:  "HTTPRoute",
 					Name:  "my-target-ref",
-				}, fmt.Errorf("deletion err")),
+				}, errors.New("deletion err")),
 			},
 			want: &metav1.Condition{
 				Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
@@ -179,7 +179,7 @@ func TestAcceptedCondition(t *testing.T) {
 			name: "invalid reason",
 			args: args{
 				policy: &FakePolicy{},
-				err:    NewErrInvalid("FakePolicy", fmt.Errorf("invalid err")),
+				err:    NewErrInvalid("FakePolicy", errors.New("invalid err")),
 			},
 			want: &metav1.Condition{
 				Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
@@ -192,7 +192,7 @@ func TestAcceptedCondition(t *testing.T) {
 			name: "conflicted reason",
 			args: args{
 				policy: &FakePolicy{},
-				err:    NewErrConflict("FakePolicy", "testNs/policy1", fmt.Errorf("conflict err")),
+				err:    NewErrConflict("FakePolicy", "testNs/policy1", errors.New("conflict err")),
 			},
 			want: &metav1.Condition{
 				Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
@@ -205,7 +205,7 @@ func TestAcceptedCondition(t *testing.T) {
 			name: "unknown error reason",
 			args: args{
 				policy: &FakePolicy{},
-				err:    fmt.Errorf("reconcile err"),
+				err:    errors.New("reconcile err"),
 			},
 			want: &metav1.Condition{
 				Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
@@ -248,16 +248,29 @@ func TestEnforcedCondition(t *testing.T) {
 			},
 		},
 		{
-			name: "enforced false",
+			name: "enforced false - unknown",
 			args: args{
 				policy: &FakePolicy{},
-				err:    NewErrUnknown(policy.Kind(), fmt.Errorf("unknown err")),
+				err:    NewErrUnknown(policy.Kind(), errors.New("unknown err")),
 			},
 			want: &metav1.Condition{
 				Type:    string(PolicyConditionEnforced),
 				Status:  metav1.ConditionFalse,
 				Reason:  string(PolicyReasonUnknown),
 				Message: "FakePolicy has encountered some issues: unknown err",
+			},
+		},
+		{
+			name: "enforced false - overridden",
+			args: args{
+				policy: &FakePolicy{},
+				err:    NewErrOverridden(policy.Kind(), "ns1/policy1"),
+			},
+			want: &metav1.Condition{
+				Type:    string(PolicyConditionEnforced),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(PolicyReasonOverridden),
+				Message: "FakePolicy is overridden by ns1/policy1",
 			},
 		},
 	}

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -85,3 +85,25 @@ func NewErrConflict(kind string, nameNamespace string, err error) ErrConflict {
 		Err:           err,
 	}
 }
+
+var _ PolicyError = ErrUnknown{}
+
+type ErrUnknown struct {
+	Kind string
+	Err  error
+}
+
+func (e ErrUnknown) Error() string {
+	return fmt.Sprintf("%s has encountered some issues: %s", e.Kind, e.Err.Error())
+}
+
+func (e ErrUnknown) Reason() gatewayapiv1alpha2.PolicyConditionReason {
+	return PolicyReasonUnknown
+}
+
+func NewErrUnknown(kind string, err error) ErrUnknown {
+	return ErrUnknown{
+		Kind: kind,
+		Err:  err,
+	}
+}

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -107,3 +107,25 @@ func NewErrUnknown(kind string, err error) ErrUnknown {
 		Err:  err,
 	}
 }
+
+var _ PolicyError = ErrOverridden{}
+
+type ErrOverridden struct {
+	Kind               string
+	OverridingPolicies string
+}
+
+func (e ErrOverridden) Error() string {
+	return fmt.Sprintf("%s is overridden by %s", e.Kind, e.OverridingPolicies)
+}
+
+func (e ErrOverridden) Reason() gatewayapiv1alpha2.PolicyConditionReason {
+	return PolicyReasonOverridden
+}
+
+func NewErrOverridden(kind, overridingPolicies string) ErrOverridden {
+	return ErrOverridden{
+		Kind:               kind,
+		OverridingPolicies: overridingPolicies,
+	}
+}


### PR DESCRIPTION
# Description
Part of https://github.com/Kuadrant/kuadrant-operator/issues/290 https://github.com/Kuadrant/architecture/issues/38
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/349

Add `Enforced` condition type to AuthPolicy. 

# Verification
Functionality is generally already tested with the integration tests added.

To verify manually instead:

## Setup
* Checkout this branch
* Deploy using `make local-setup`
* Create HTTPRoute
```sh
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - method: GET
      path:
        type: PathPrefix
        value: "/toys"
    backendRefs:
    - name: toystore
      port: 80
EOF
```
* Create AuthPolicy
```sh
kubectl apply -f - <<EOF
---
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: auth0
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authorization:
      deny-all:
        opa:
          rego: "allow = false"
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
EOF
```
* Verify status:
  * `Accepted`  - `True`
  * `Enforced` - `False`
```sh
kubectl get authpolicy -A -o wide
kubectl get authpolicy auth0 -o yaml | yq '.status'
``` 
![image](https://github.com/Kuadrant/kuadrant-operator/assets/24636860/6425eab4-5074-4003-9dbe-6cb6a476fd05)
* Deploy Kuadrant CR
```
kubectl apply -f - <<EOF
---                      
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
spec: {}
EOF
```
* Verify status:
  * `Accepted`  - `True`
  * `Enforced` - `True`
```sh
kubectl get authpolicy -A -o wide
kubectl get authpolicy auth0 -o yaml | yq '.status'
``` 
![image](https://github.com/Kuadrant/kuadrant-operator/assets/24636860/19b946db-5b6c-4e48-a8f2-59502bb16ca7)

