### PR TITLE
Missing space in quickstart script

### DIFF
--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -26,7 +26,7 @@ if [ -z $MGC_REF ]; then
   MGC_REF=${MGC_REF:="main"}
 fi
 
-if [ -z $ISTIO_INSTALL_SAIL]; then
+if [ -z $ISTIO_INSTALL_SAIL ]; then
   ISTIO_INSTALL_SAIL=${ISTIO_INSTALL_SAIL:=false}
 fi
 


### PR DESCRIPTION
Had not seen this error before but when curling the script I get an error from the missing whitespace:

```sh
export KUADRANT_REF=v0.6.1
curl "https://raw.githubusercontent.com/kuadrant/kuadrant-operator/${KUADRANT_REF}/hack/quickstart-setup.sh" | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5620  100  5620    0     0  53047      0 --:--:-- --:--:-- --:--:-- 53523
bash: line 29: [: missing `]'
```

Fortunately does not affect the logic or running of the quickstart script as the check later is an if else on `ISTIO_INSTALL_SAIL=true`