### PR TITLE
Enhance docker network ipaddresspool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,11 +408,11 @@ undeploy-policy-controller: ## Undeploy policy-controller from the K8s cluster s
 	$(KUSTOMIZE) build config/policy-controller | kubectl delete -f -
 
 .PHONY: install-metallb
-install-metallb: $(KUSTOMIZE) ## Installs the metallb load balancer allowing use of an LoadBalancer type with a gateway
+install-metallb: $(KUSTOMIZE) $(YQ) ## Installs the metallb load balancer allowing use of an LoadBalancer type with a gateway
 	$(KUSTOMIZE) build config/metallb | kubectl apply -f -
 	kubectl -n metallb-system wait --for=condition=Available deployments controller --timeout=300s
 	kubectl -n metallb-system wait --for=condition=ready pod --selector=app=metallb --timeout=60s
-	./utils/docker-network-ipaddresspool.sh kind | kubectl apply -n metallb-system -f -
+	./utils/docker-network-ipaddresspool.sh kind $(YQ) | kubectl apply -n metallb-system -f -
 
 .PHONY: uninstall-metallb
 uninstall-metallb: $(KUSTOMIZE) 

--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ undeploy-policy-controller: ## Undeploy policy-controller from the K8s cluster s
 	$(KUSTOMIZE) build config/policy-controller | kubectl delete -f -
 
 .PHONY: install-metallb
-install-metallb: $(KUSTOMIZE) $(YQ) ## Installs the metallb load balancer allowing use of an LoadBalancer type with a gateway
+install-metallb: kustomize yq ## Installs the metallb load balancer allowing use of an LoadBalancer type with a gateway
 	$(KUSTOMIZE) build config/metallb | kubectl apply -f -
 	kubectl -n metallb-system wait --for=condition=Available deployments controller --timeout=300s
 	kubectl -n metallb-system wait --for=condition=ready pod --selector=app=metallb --timeout=60s

--- a/utils/docker-network-ipaddresspool.sh
+++ b/utils/docker-network-ipaddresspool.sh
@@ -16,7 +16,8 @@ yq=$2
 SUBNET=$(docker network inspect $networkName --format '{{json .IPAM.Config }}' | \
     ${yq} '.[] | select( .Subnet | test("^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}/\d+$")) | .Subnet')
 
-echo "---
+cat <<EOF | ADDRESS=$SUBNET ${yq} '(select(.kind == "IPAddressPool") | .spec.addresses[0]) = env(ADDRESS)'
+---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
@@ -29,5 +30,4 @@ kind: L2Advertisement
 metadata:
   name: empty
   namespace: metallb-system
-" | \
-ADDRESS=$SUBNET ${yq} '(select(.kind == "IPAddressPool") | .spec.addresses[0]) = env(ADDRESS)'
+EOF

--- a/utils/docker-network-ipaddresspool.sh
+++ b/utils/docker-network-ipaddresspool.sh
@@ -29,5 +29,4 @@ apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
   name: empty
-  namespace: metallb-system
 EOF


### PR DESCRIPTION
### What

[metallb](https://metallb.org) is configured with the network address, or subnet, of the docker network defined by kind. 

`docker network inspect kind` looks like

```json
[
    {
        "Name": "kind",
        "Id": "c9a255dd3206276365f3f00c6d87d921f9eb43d6e9fa8193180615c4b48a4b9f",
        "Created": "2024-02-08T19:18:10.314623672+01:00",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv6": true,
        "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "172.18.0.0/16",
                    "Gateway": "172.18.0.1"
                },
                {
                    "Subnet": "fc00:f853:ccd:e793::/64",
                    "Gateway": "fc00:f853:ccd:e793::1"
                }
            ]
        },
        "Internal": false,
        "Attachable": false,
        "Ingress": false,
        "ConfigFrom": {
            "Network": ""
        },
        "ConfigOnly": false,
        "Containers": {},
        "Options": {
            "com.docker.network.bridge.enable_ip_masquerade": "true",
            "com.docker.network.driver.mtu": "1500"
        },
        "Labels": {}
    }
]
```

Currently, the script `utils/docker-network-ipaddresspool.sh` was parsing only the first item of the `IPAM.Config` list. When IPv6 is also there, the order of the items is not assured. So it can also be

```json
"IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "fc00:f853:ccd:e793::/64"
                },
                {
                    "Subnet": "172.18.0.0/16",
                    "Gateway": "172.18.0.1"
                }
            ]
        },
``` 
This PR enhances the script to read only IPv4 subnets.


