### PR TITLE
remove kind port mappings

### DIFF
--- a/utils/kind-cluster.yaml
+++ b/utils/kind-cluster.yaml
@@ -4,14 +4,3 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
   image: kindest/node:v1.27.3
-  extraPortMappings:
-    - containerPort: 30950
-      hostPort: 9080
-    - containerPort: 30951
-      hostPort: 9443
-    - containerPort: 80
-      hostPort: 9081
-      protocol: TCP
-    - containerPort: 443
-      hostPort: 9444
-      protocol: TCP


### PR DESCRIPTION
### What

Port mappings defined for kind cluster are no longer needed. Hence, removed.

After adding metallb and LoadBalancer service types for the gateways, the gateways get an IP that is not the same as the IP address of the control plane docker container. Thus, port mapping does not work. 