### PR TITLE
docker-network-ipaddresspool.sh: dedicated IP address range

### DIFF
--- a/utils/docker-network-ipaddresspool.sh
+++ b/utils/docker-network-ipaddresspool.sh
@@ -20,7 +20,11 @@ if [[ -z "$SUBNET" ]]; then
    exit 1
 fi
 
-cat <<EOF | ADDRESS=$SUBNET ${YQ} '(select(.kind == "IPAddressPool") | .spec.addresses[0]) = env(ADDRESS)'
+# shellcheck disable=SC2206
+subnetParts=(${SUBNET//./ })
+cidr="${subnetParts[0]}.${subnetParts[1]}.200.0/24"
+
+cat <<EOF | ADDRESS=$cidr ${YQ} '(select(.kind == "IPAddressPool") | .spec.addresses[0]) = env(ADDRESS)'
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool


### PR DESCRIPTION
Turns out that using the entire `kind` subnet address space leads to conflicts.

The kind network is exposed to the host using the `X.Y.0.1`. Metallb will assign `X.Y.0.0` to the first service of LB type. Then it will assign `X.Y.0.1` to the second service of LB type. This second service will not be reachable as the IP conflicts with the host IP inside `kind`network. 

The fix is to derive an IP address range that lives in the kind network from the `X.Y.0.0/16` subnet. The PR https://github.com/Kuadrant/kuadrant-operator/pull/418 removed this derivation  and this PR is bringing that back in place. 

