### PR TITLE
Enable gateway api alpha APIs

### DIFF
--- a/config/dependencies/istio/istio-operator.yaml
+++ b/config/dependencies/istio/istio-operator.yaml
@@ -21,6 +21,9 @@ spec:
     pilot:
       enabled: true
       k8s:
+        env:
+        - name: PILOT_ENABLE_ALPHA_GATEWAY_API
+          value: "true"
         resources:
           requests:
             cpu: "0"

--- a/config/dependencies/istio/sail/istio.yaml
+++ b/config/dependencies/istio/sail/istio.yaml
@@ -8,6 +8,8 @@ spec:
   # Disable autoscaling to reduce dev resources
   values:
     pilot:
+      env:
+        PILOT_ENABLE_ALPHA_GATEWAY_API: "true"
       autoscaleEnabled: false
   rawValues:
     gateways:


### PR DESCRIPTION
### What

Enable Gateway API alpha APIs for the development environment. It is mandatory for testing current alpha APIs like GRPCRoute API. 

### Verification steps

**Istio operator**
```
make local-setup
```
When finished, check the discovery controller has `PILOT_ENABLE_ALPHA_GATEWAY_API` env var set to true
```bash
kubectl get deployment istiod -n istio-system -o jsonpath='{.spec.template.spec.containers[?(@.name=="discovery")].env[?(@.name=="PILOT_ENABLE_ALPHA_GATEWAY_API")]}' | yq e -P
```
Should return
```
name: PILOT_ENABLE_ALPHA_GATEWAY_API
value: "true"
```

**Sail operator**
```
ISTIO_INSTALL_SAIL=true make local-setup
```
When finished, check the discovery controller has `PILOT_ENABLE_ALPHA_GATEWAY_API` env var set to true
```bash
kubectl get deployment istiod -n istio-system -o jsonpath='{.spec.template.spec.containers[?(@.name=="discovery")].env[?(@.name=="PILOT_ENABLE_ALPHA_GATEWAY_API")]}' | yq e -P
```
Should return
```
name: PILOT_ENABLE_ALPHA_GATEWAY_API
value: "true"
```