### PR TITLE
Adding packages other than `controllers` to the code coverage report from the integration tests

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -27,18 +27,6 @@ ignore:
   - api/external/**  #  ignoring external vendor code
   - "**/*.deepcopy.go"  # ignore controller-gen generated code
 
-flag_management:
-  individual_flags:
-    - name: unit
-      paths:
-        - pkg/**
-        - api/**
-      carryforward: true
-    - name: integration
-      paths:
-        - controllers/**
-      carryforward: true
-
 component_management:
   individual_components:
     - component_id: api-v1beta1

--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -45,6 +45,10 @@ component_management:
       name: api/v1beta1 (u)
       paths:
         - api/v1beta1
+    - component_id: api-v1beta2
+      name: api/v1beta2 (u)
+      paths:
+        - api/v1beta2
     - component_id: common
       name: pkg/common (u)
       paths:
@@ -69,4 +73,3 @@ component_management:
       name: controllers (i)
       paths:
         - controllers
-

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,7 +53,6 @@ jobs:
         exclude:
           - istio-type: sail
             pr-event: true
-      fail-fast: false
     runs-on: ubuntu-latest
     env:
       KIND_CLUSTER_NAME: kuadrant-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           make test-unit
       - name: Upload unit-test coverage reports to CodeCov # more at https://github.com/codecov/codecov-action
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit
@@ -92,7 +92,7 @@ jobs:
         run: |
           make test-integration
       - name: Upload integration-test coverage reports to CodeCov # more at https://github.com/codecov/codecov-action
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ ENVTEST_K8S_VERSION = 1.22
 # Directories containing unit & integration test packages
 UNIT_DIRS := ./pkg/... ./api/... ./controllers/...
 INTEGRATION_DIRS := ./controllers...
+INTEGRATION_COVER_PKGS := ./pkg/...,./controllers/...,./api/...
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -289,7 +290,7 @@ test: test-unit test-integration ## Run all tests
 
 test-integration: clean-cov generate fmt vet envtest ## Run Integration tests.
 	mkdir -p coverage/integration
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) $(ARCH_PARAM) use $(ENVTEST_K8S_VERSION) -p path)" USE_EXISTING_CLUSTER=true go test $(INTEGRATION_DIRS) -coverprofile $(PROJECT_PATH)/coverage/integration/cover.out -tags integration -ginkgo.v -ginkgo.progress -v -timeout 0
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) $(ARCH_PARAM) use $(ENVTEST_K8S_VERSION) -p path)" go test $(INTEGRATION_DIRS) -coverpkg=$(INTEGRATION_COVER_PKGS) -coverprofile $(PROJECT_PATH)/coverage/integration/cover.out -tags integration -ginkgo.v -ginkgo.progress -v -timeout 0
 
 ifdef TEST_NAME
 test-unit: TEST_PATTERN := --run $(TEST_NAME)
@@ -415,7 +416,7 @@ install-metallb: kustomize yq ## Installs the metallb load balancer allowing use
 	./utils/docker-network-ipaddresspool.sh kind $(YQ) | kubectl apply -n metallb-system -f -
 
 .PHONY: uninstall-metallb
-uninstall-metallb: $(KUSTOMIZE) 
+uninstall-metallb: $(KUSTOMIZE)
 	$(KUSTOMIZE) build config/metallb | kubectl delete -f -
 
 .PHONY: install-olm

--- a/controllers/ratelimitpolicy_controller_test.go
+++ b/controllers/ratelimitpolicy_controller_test.go
@@ -752,36 +752,3 @@ var _ = Describe("RateLimitPolicy CEL Validations", func() {
 		})
 	})
 })
-
-func testRLPIsAccepted(rlpKey client.ObjectKey) func() bool {
-	return func() bool {
-		existingRLP := &kuadrantv1beta2.RateLimitPolicy{}
-		err := k8sClient.Get(context.Background(), rlpKey, existingRLP)
-		if err != nil {
-			return false
-		}
-		if !meta.IsStatusConditionTrue(existingRLP.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted)) {
-			return false
-		}
-
-		return true
-	}
-}
-
-func testWasmPluginIsAvailable(key client.ObjectKey) func() bool {
-	return func() bool {
-		wp := &istioclientgoextensionv1alpha1.WasmPlugin{}
-		err := k8sClient.Get(context.Background(), key, wp)
-		if err != nil {
-			return false
-		}
-
-		// Unfortunately, WasmPlugin does not have status yet
-		// Leaving this here for future use
-		//if !meta.IsStatusConditionTrue(wp.Status.Conditions, "Available") {
-		//	return false
-		//}
-
-		return true
-	}
-}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -72,6 +72,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
+		UseExistingCluster:    &[]bool{true}[0],
 	}
 
 	cfg, err := testEnv.Start()


### PR DESCRIPTION
### What

Adding packages other than `controllers` to the code coverage report from the integration tests has increased ~14% the full code coverage :tada: 

Makes sense. Integration tests also run code other than in the `controllers` package that was not covered with the unit tests

Additionally:

* Integration tests report code coverage for all golang packages (not just `./controllers/...`)
* Upgraded GH Action `codecov/codecov-action@v4`
* Integration test setting to use existing cluster defined at the suite test
* Use the Ginkgo CLI as it is the recommended and supported tool for running Ginkgo suites
* Since this repo has not been using controller-runtime’s [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest) environment to run e2e tests, remove unused kubebuilder assets.

