### PR TITLE
GH-641 enforced condition on dnspolicy

### DIFF
--- a/controllers/authpolicy_status.go
+++ b/controllers/authpolicy_status.go
@@ -101,16 +101,16 @@ func (r *AuthPolicyReconciler) enforcedCondition(ctx context.Context, policy *ap
 	authConfigReady, err := r.isAuthConfigReady(ctx, policy)
 	if err != nil {
 		logger.Error(err, "Failed to check AuthConfig and Gateway")
-		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(policy.Kind(), err))
+		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(policy.Kind(), err), false)
 	}
 
 	if !authConfigReady {
 		logger.V(1).Info("AuthConfig is not ready")
-		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(policy.Kind(), errors.New("AuthScheme is not ready yet")))
+		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(policy.Kind(), errors.New("AuthScheme is not ready yet")), false)
 	}
 
 	logger.V(1).Info("AuthPolicy is enforced")
-	return kuadrant.EnforcedCondition(policy, nil)
+	return kuadrant.EnforcedCondition(policy, nil, true)
 }
 
 // isAuthConfigReady checks if the AuthConfig is ready.
@@ -142,7 +142,7 @@ func (r *AuthPolicyReconciler) handleGatewayPolicyOverride(logger logr.Logger, p
 	jsonData, err := json.Marshal(filteredRef)
 	if err != nil {
 		logger.Error(err, "Failed to marshal filtered references")
-		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(policy.Kind(), err))
+		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(policy.Kind(), err), false)
 	}
-	return kuadrant.EnforcedCondition(policy, kuadrant.NewErrOverridden(policy.Kind(), string(jsonData)))
+	return kuadrant.EnforcedCondition(policy, kuadrant.NewErrOverridden(policy.Kind(), string(jsonData)), false)
 }

--- a/controllers/dnspolicy_controller_test.go
+++ b/controllers/dnspolicy_controller_test.go
@@ -349,6 +349,18 @@ var _ = Describe("DNSPolicy controller", func() {
 					})),
 				)
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
+
+			// ensure there are no policies with not accepted condition
+			// in this case the "enforced" on the policy should be false
+			Eventually(func(g Gomega) {
+				dnsRecord := &kuadrantdnsv1alpha1.DNSRecord{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: recordName, Namespace: testNamespace}, dnsRecord)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(dnsRecord.Status.Conditions).ToNot(ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(string(gatewayapiv1alpha2.PolicyConditionAccepted)),
+					"Status": Equal(metav1.ConditionFalse),
+				})))
+			}, TestTimeoutMedium, time.Second).Should(Succeed())
 		})
 
 		It("should set gateway back reference", func() {

--- a/pkg/library/kuadrant/apimachinery_status_conditions.go
+++ b/pkg/library/kuadrant/apimachinery_status_conditions.go
@@ -92,13 +92,17 @@ func AcceptedCondition(p Policy, err error) *metav1.Condition {
 }
 
 // EnforcedCondition returns an enforced conditions with common reasons for a kuadrant policy
-func EnforcedCondition(policy Policy, err PolicyError) *metav1.Condition {
+func EnforcedCondition(policy Policy, err PolicyError, allSubresourcesReady bool) *metav1.Condition {
 	// Enforced
+	message := fmt.Sprintf("%s has been successfully enforced", policy.Kind())
+	if !allSubresourcesReady {
+		message = fmt.Sprintf("%s has been partially enforced", policy.Kind())
+	}
 	cond := &metav1.Condition{
 		Type:    string(PolicyConditionEnforced),
 		Status:  metav1.ConditionTrue,
 		Reason:  string(PolicyReasonEnforced),
-		Message: fmt.Sprintf("%s has been successfully enforced", policy.Kind()),
+		Message: message,
 	}
 	if err == nil {
 		return cond

--- a/pkg/library/kuadrant/apimachinery_status_conditions_test.go
+++ b/pkg/library/kuadrant/apimachinery_status_conditions_test.go
@@ -277,7 +277,7 @@ func TestEnforcedCondition(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := EnforcedCondition(tt.args.policy, tt.args.err); !reflect.DeepEqual(got, tt.want) {
+			if got := EnforcedCondition(tt.args.policy, tt.args.err, true); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("EnforcedCondition() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
## What 
Following recent changes with the auth policy and introducing DNS Policy to the `enforced` condition. 
Also closes #454 
## How 
The policy is used to create DNS Records and records are left with the controller owner annotation that mentions the policy. Listing DNS records and finding the one controlled by the policy should be sufficient to indicate that the policy was enforced, also including a tinny change to the test suite to reflect new logic. 
## Verification 
Integration suite passing should be sufficient. One could go through the "typical installation" and observe policy getting `enforced` status. 