### PR TITLE
codecov disabled for forks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,7 +35,11 @@ jobs:
       - name: Run make test
         run: |
           make test-unit
-      - name: Upload unit-test coverage reports to CodeCov # more at https://github.com/codecov/codecov-action
+      - name: Upload unit-test coverage reports to CodeCov
+        # more at https://github.com/codecov/codecov-action
+        # Only run if the feature branch is in your repo (not in a fork)
+        # as Tokenless uploading is rate limited for public repos
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -90,7 +94,11 @@ jobs:
       - name: Run integration tests
         run: |
           make test-integration
-      - name: Upload integration-test coverage reports to CodeCov # more at https://github.com/codecov/codecov-action
+      - name: Upload integration-test coverage reports to CodeCov
+        # more at https://github.com/codecov/codecov-action
+        # Only run if the feature branch is in your repo (not in a fork)
+        # as Tokenless uploading is rate limited for public repos
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### What

On Codecov GitHub Action v4 Tokenless uploading is unsupported. However, PRs made from forks to the upstream public repos will support tokenless (e.g. contributors to OS projects do not need the upstream repo's Codecov token) [doc](https://github.com/codecov/codecov-action?tab=readme-ov-file#v4-release)

However, even if allowed for public repos, it is being rate limited. When rate limited, the report is not being uploaded and therefore the PR's codecov check fails. 

This PR disables codecov reporting for forks.  When the report is not uploaded, the codecov check is not run, hence does not fail. 

The following is a PR for testing purposes from a fork https://github.com/Kuadrant/kuadrant-operator/pull/488, Note that the codecov check is not in the list of checks. Codecov also shows that no report has been uploaded for the #488 PR
![Screenshot 2024-03-13 at 18-08-38 Code coverage done right](https://github.com/Kuadrant/kuadrant-operator/assets/881529/135aa75d-18dd-471f-9547-361a28dc497b)

