### PR TITLE
update dns policy to have immutable strategy field

### DIFF
--- a/api/v1alpha1/dnspolicy_types.go
+++ b/api/v1alpha1/dnspolicy_types.go
@@ -57,6 +57,7 @@ type DNSPolicySpec struct {
 
 	// +required
 	// +kubebuilder:validation:Enum=simple;loadbalanced
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="RoutingStrategy is immutable"
 	// +kubebuilder:default=loadbalanced
 	RoutingStrategy RoutingStrategy `json:"routingStrategy"`
 }

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-03-12T12:20:22Z"
+    createdAt: "2024-03-20T12:29:04Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -186,6 +186,9 @@ spec:
                 - simple
                 - loadbalanced
                 type: string
+                x-kubernetes-validations:
+                - message: RoutingStrategy is immutable
+                  rule: self == oldSelf
               targetRef:
                 description: |-
                   PolicyTargetReference identifies an API object to apply a direct or

--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -185,6 +185,9 @@ spec:
                 - simple
                 - loadbalanced
                 type: string
+                x-kubernetes-validations:
+                - message: RoutingStrategy is immutable
+                  rule: self == oldSelf
               targetRef:
                 description: |-
                   PolicyTargetReference identifies an API object to apply a direct or

--- a/controllers/dnspolicy_controller_test.go
+++ b/controllers/dnspolicy_controller_test.go
@@ -111,6 +111,17 @@ var _ = Describe("DNSPolicy controller", func() {
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
 		})
 
+		It("should not allow changing routing strategy", func() {
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsPolicy), dnsPolicy)
+				g.Expect(err).NotTo(HaveOccurred())
+				dnsPolicy.Spec.RoutingStrategy = v1alpha1.LoadBalancedRoutingStrategy
+				err = k8sClient.Update(ctx, dnsPolicy)
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err).To(MatchError(ContainSubstring("RoutingStrategy is immutable")))
+			}, TestTimeoutMedium, time.Second).Should(Succeed())
+		})
+
 		It("should not have any health check records created", func() {
 			// create a health check with the labels for the dnspolicy and the gateway name and namespace that would be expected in a valid target scenario
 			// this one should get deleted if the gateway is invalid policy ref

--- a/doc/reference/dnspolicy.md
+++ b/doc/reference/dnspolicy.md
@@ -24,7 +24,7 @@
 | `targetRef`       | [Gateway API PolicyTargetReference](https://gateway-api.sigs.k8s.io/geps/gep-713/?h=policytargetreference#policy-targetref-api)    |      Yes       | Reference to a Kuberentes resource that the policy attaches to |
 | `healthCheck`     | [HealthCheckSpec](#healthcheckspec)                                                                                                         |       No       | HealthCheck spec                                               |
 | `loadBalancing`   | [LoadBalancingSpec](#loadbalancingspec)                                                                                                     |       No       | LoadBancking Spec                                              |
-| `routingStrategy` | String                                                                                                                                      |      Yes       | Routing Strategy to use, one of "simple" or "loadbalacned"     |
+| `routingStrategy` | String (immutable)                                                                                                                                     |      Yes       | **Immutable!** Routing Strategy to use, one of "simple" or "loadbalacned"     |
 
 ## HealthCheckSpec
 


### PR DESCRIPTION
**What**


Makes the routingStrategy immutable. This make migrating between strategies more predictable and sane and also supports the distributd dns work