### PR TITLE
extend the message for no records present whil updating enforced condition

### DIFF
--- a/controllers/dnspolicy_controller_test.go
+++ b/controllers/dnspolicy_controller_test.go
@@ -247,7 +247,7 @@ var _ = Describe("DNSPolicy controller", func() {
 							"Type":    Equal(string(kuadrant.PolicyConditionEnforced)),
 							"Status":  Equal(metav1.ConditionFalse),
 							"Reason":  Equal(PolicyReasonUnknown),
-							"Message": Equal("DNSPolicy has encountered some issues: policy is not enforced on any dns record"),
+							"Message": Equal("DNSPolicy has encountered some issues: policy is not enforced on any dns record: no routes attached for listeners"),
 						})),
 				)
 			}, TestTimeoutMedium, time.Second).Should(Succeed())

--- a/controllers/dnspolicy_status.go
+++ b/controllers/dnspolicy_status.go
@@ -112,5 +112,5 @@ func (r *DNSPolicyReconciler) enforcedCondition(ctx context.Context, dnsPolicy *
 		return kuadrant.EnforcedCondition(dnsPolicy, nil, true)
 	}
 	// there are no controlled DNS records present
-	return kuadrant.EnforcedCondition(dnsPolicy, kuadrant.NewErrUnknown(dnsPolicy.Kind(), errors.New("policy is not enforced on any dns record")), false)
+	return kuadrant.EnforcedCondition(dnsPolicy, kuadrant.NewErrUnknown(dnsPolicy.Kind(), errors.New("policy is not enforced on any dns record: no routes attached for listeners")), false)
 }


### PR DESCRIPTION
providing more detailed message for one of the cases when `enforced` = `false` 