### PR TITLE
Add alerts for TLS/DNS/Auth/RateLimit policies not targeting Gateways…

### DIFF
--- a/examples/alerts/prometheusrules_policies_missing.yaml
+++ b/examples/alerts/prometheusrules_policies_missing.yaml
@@ -1,0 +1,57 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: policies-missing
+  namespace: monitoring
+spec:
+  groups:
+  - name: policy-rules
+    rules:
+    - alert: GatewayWithoutDnsPolicy
+      expr: |
+        label_replace(gatewayapi_gateway_info, "gateway_name", "$1", "name", "(.*)") unless 
+        (label_replace(gatewayapi_gateway_info, "gateway_name", "$1", "name", "(.*)") 
+        * on(gateway_name) group_left 
+        label_replace(gatewayapi_dnspolicy_target_info{target_kind="Gateway"}, "gateway_name", "$1", "target_name", "(.*)"))
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "No DNSPolicy targeting Gateway '{{ $labels.gateway_name }}'"
+        description: "This alert fires if a gateway does not have an associated DNSPolicy."
+    - alert: GatewayWithoutTlsPolicy
+      expr: |
+        label_replace(gatewayapi_gateway_info, "gateway_name", "$1", "name", "(.*)") unless 
+        (label_replace(gatewayapi_gateway_info, "gateway_name", "$1", "name", "(.*)") 
+        * on(gateway_name) group_left 
+        label_replace(gatewayapi_tlspolicy_target_info{target_kind="Gateway"}, "gateway_name", "$1", "target_name", "(.*)"))
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "No TLSPolicy targeting Gateway '{{ $labels.gateway_name }}'"
+        description: "This alert fires if a gateway does not have an associated TLSPolicy."
+    - alert: HTTPRouteWithoutAuthPolicy
+      expr: |
+        label_replace(gatewayapi_httproute_created, "httproute_name", "$1", "name", "(.*)") unless 
+        (label_replace(gatewayapi_httproute_created, "httproute_name", "$1", "name", "(.*)") 
+        * on(httproute_name) group_left 
+        label_replace(gatewayapi_authpolicy_target_info{target_kind="HTTPRoute"}, "httproute_name", "$1", "target_name", "(.*)"))
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "No AuthPolicy targeting HTTPRoute '{{ $labels.httproute_name }}'"
+        description: "This alert fires if a HTTPRoute does not have an associated AuthPolicy."
+    - alert: HTTPRouteWithoutRateLimitPolicy
+      expr: |
+        label_replace(gatewayapi_httproute_created, "httproute_name", "$1", "name", "(.*)") unless 
+        (label_replace(gatewayapi_httproute_created, "httproute_name", "$1", "name", "(.*)") 
+        * on(httproute_name) group_left 
+        label_replace(gatewayapi_ratelimitpolicy_target_info{target_kind="HTTPRoute"}, "httproute_name", "$1", "target_name", "(.*)"))
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "No RateLimitPolicy targeting HTTPRoute '{{ $labels.httproute_name }}'"
+        description: "This alert fires if a HTTPRoute does not have an associated RateLimitPolicy."


### PR DESCRIPTION
… and HTTPRoutes

Closes #440

To verify:

- Bring up a local cluster as per https://docs.kuadrant.io/getting-started-single-cluster/, using the release-v0.6.2 branch by specifying `export KUADRANT_REF=release-v0.6.2`
- Bring up an observability stack using these commands from this PR branch
  - `./bin/kustomize build ./config/observability/| docker run --rm -i ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -`
  - `./bin/kustomize build ./config/observability/| docker run --rm -i ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -`
- Import the example PrometheusRules resource with the alerting rules
  - `kubectl apply -f ./examples/alerts/prometheusrules_policies_missing.yaml`
- Create example Gateways, HTTPRotues and policies to verify the alerts behave as expected. *It isn't important that the Gateways, HTTPRoutes & policies are actually working, just that they exist in etcd*
  - `kubectl apply -f https://gist.githubusercontent.com/david-martin/991d76255d90b51860f9ed8724f43983/raw/b1835fb5b58ab7e8f0a0f60be29f4dddc4908512/alerting_resources.yaml`
- Access the Prometheus Alerts tab by using port-forwarding and verify the following alerts are firing
  - `kubectl -n monitoring port-forward service/prometheus-k8s 9090:9090`
  - open http://127.0.0.1:9090 > Alerts tab
  - There should be a total of 8 Gateway/HTTPRoutes alerts firing. You can check the summary text for each, or run this query from the Graph tab and compare: `ALERTS{alertstate="firing",alertname=~"Gateway.*|HTTPRoute.*"}`

```promql
ALERTS{alertname="GatewayWithoutDnsPolicy", alertstate="firing", container="kube-rbac-proxy-main", customresource_group="gateway.networking.k8s.io", customresource_kind="Gateway", customresource_version="v1beta1", gateway_name="testgw3", gatewayclass_name="test", instance="10.244.0.31:8443", job="kube-state-metrics", name="testgw3", namespace="default", severity="warning"}
1
ALERTS{alertname="GatewayWithoutDnsPolicy", alertstate="firing", container="kube-rbac-proxy-main", customresource_group="gateway.networking.k8s.io", customresource_kind="Gateway", customresource_version="v1beta1", gateway_name="testgw4", gatewayclass_name="test", instance="10.244.0.31:8443", job="kube-state-metrics", name="testgw4", namespace="default", severity="warning"}
1
ALERTS{alertname="GatewayWithoutTlsPolicy", alertstate="firing", container="kube-rbac-proxy-main", customresource_group="gateway.networking.k8s.io", customresource_kind="Gateway", customresource_version="v1beta1", gateway_name="testgw1", gatewayclass_name="test", instance="10.244.0.31:8443", job="kube-state-metrics", name="testgw1", namespace="default", severity="warning"}
1
ALERTS{alertname="GatewayWithoutTlsPolicy", alertstate="firing", container="kube-rbac-proxy-main", customresource_group="gateway.networking.k8s.io", customresource_kind="Gateway", customresource_version="v1beta1", gateway_name="testgw4", gatewayclass_name="test", instance="10.244.0.31:8443", job="kube-state-metrics", name="testgw4", namespace="default", severity="warning"}
1
ALERTS{alertname="HTTPRouteWithoutAuthPolicy", alertstate="firing", container="kube-rbac-proxy-main", customresource_group="gateway.networking.k8s.io", customresource_kind="HTTPRoute", customresource_version="v1beta1", httproute_name="testhttproute1", instance="10.244.0.31:8443", job="kube-state-metrics", name="testhttproute1", namespace="default", severity="warning"}
1
ALERTS{alertname="HTTPRouteWithoutAuthPolicy", alertstate="firing", container="kube-rbac-proxy-main", customresource_group="gateway.networking.k8s.io", customresource_kind="HTTPRoute", customresource_version="v1beta1", httproute_name="testhttproute4", instance="10.244.0.31:8443", job="kube-state-metrics", name="testhttproute4", namespace="default", severity="warning"}
1
ALERTS{alertname="HTTPRouteWithoutRateLimitPolicy", alertstate="firing", container="kube-rbac-proxy-main", customresource_group="gateway.networking.k8s.io", customresource_kind="HTTPRoute", customresource_version="v1beta1", httproute_name="testhttproute3", instance="10.244.0.31:8443", job="kube-state-metrics", name="testhttproute3", namespace="default", severity="warning"}
1
ALERTS{alertname="HTTPRouteWithoutRateLimitPolicy", alertstate="firing", container="kube-rbac-proxy-main", customresource_group="gateway.networking.k8s.io", customresource_kind="HTTPRoute", customresource_version="v1beta1", httproute_name="testhttproute4", instance="10.244.0.31:8443", job="kube-state-metrics", name="testhttproute4", namespace="default", severity="warning"}

```