### PR TITLE
Fix local setup for podman users

### DIFF
--- a/utils/docker-network-ipaddresspool.sh
+++ b/utils/docker-network-ipaddresspool.sh
@@ -17,9 +17,11 @@ SUBNET=""
 
 # Try podman version of cmd first. docker alias may be used for podman, so network
 # command will be different
+set +e
 if command -v podman &> /dev/null; then
   SUBNET=`podman network inspect -f '{{range .Subnets}}{{if eq (len .Subnet.IP) 4}}{{.Subnet}}{{end}}{{end}}' $networkName`
 fi
+set -e
 
 # Fallback to docker version of cmd
 if [[ -z "$SUBNET" ]]; then


### PR DESCRIPTION
To verify, when using podman only:

```
make local-cluster-setup
```

prior to this change, you may see an error like this:

```
./utils/docker-network-ipaddresspool.sh kind /Users/davidmartin/work/kuadrant-operator/bin/yq | kubectl apply -n metallb-system -f -
Error: template: inspect:1:23: executing "inspect" at <.IPAM.Config>: can't evaluate field IPAM in type interface {}
error: no objects passed to apply
make[1]: *** [install-metallb] Error 1
make: *** [local-cluster-setup] Error 2
```