### PR TITLE
Gateway `kuadrant.io/namespace` annotation owned by a single controller

### DIFF
--- a/controllers/gateway_kuadrant_controller.go
+++ b/controllers/gateway_kuadrant_controller.go
@@ -112,7 +112,8 @@ func (r *GatewayKuadrantReconciler) reconcileGatewayWithKuadrantMetadata(ctx con
 
 	val, ok := gw.GetAnnotations()[kuadrant.KuadrantNamespaceAnnotation]
 	if !ok || val != kuadrantList.Items[0].Namespace {
-		// either the does not exist or is different, hence update
+		// Either the annotation does not exist or
+		// the namespace differs from the available Kuadrant CR, hence the gateway is updated.
 		annotations := gw.GetAnnotations()
 		if annotations == nil {
 			annotations = map[string]string{}

--- a/controllers/gateway_kuadrant_controller_test.go
+++ b/controllers/gateway_kuadrant_controller_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -21,101 +20,134 @@ import (
 var _ = Describe("Kuadrant Gateway controller", func() {
 	var (
 		testNamespace string
-		gwName        = "toystore-gw"
+		gwAName       = "gw-a"
+		gwBName       = "gw-b"
 	)
 
 	beforeEachCallback := func() {
 		CreateNamespace(&testNamespace)
 
-		ApplyKuadrantCR(testNamespace)
 	}
 
 	BeforeEach(beforeEachCallback)
 	AfterEach(DeleteNamespaceCallback(&testNamespace))
 
-	Context("Gateway created after Kuadrant instance", func() {
-		It("gateway should have required annotation", func() {
-			gateway := testBuildBasicGateway(gwName, testNamespace)
-			err := k8sClient.Create(context.Background(), gateway)
-			Expect(err).ToNot(HaveOccurred())
+	Context("two gateways created after Kuadrant instance", func() {
+		It("gateways should have required annotation", func() {
+			ApplyKuadrantCR(testNamespace)
 
+			gwA := testBuildBasicGateway(gwAName, testNamespace)
+			err := k8sClient.Create(context.Background(), gwA)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(testGatewayIsReady(gwA), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			gwB := testBuildBasicGateway(gwBName, testNamespace)
+			err = k8sClient.Create(context.Background(), gwB)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(testGatewayIsReady(gwB), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			// Check gwA is annotated with kuadrant annotation
+			Eventually(testIsGatewayKuadrantManaged(gwA, testNamespace), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			// Check gwB is annotated with kuadrant annotation
+			Eventually(testIsGatewayKuadrantManaged(gwB, testNamespace), 15*time.Second, 5*time.Second).Should(BeTrue())
+		})
+	})
+
+	Context("two gateways created before Kuadrant instance", func() {
+		It("gateways should have required annotation", func() {
+			gwA := testBuildBasicGateway(gwAName, testNamespace)
+			err := k8sClient.Create(context.Background(), gwA)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(testGatewayIsReady(gwA), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			gwB := testBuildBasicGateway(gwBName, testNamespace)
+			err = k8sClient.Create(context.Background(), gwB)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(testGatewayIsReady(gwB), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			ApplyKuadrantCR(testNamespace)
+
+			// Check gwA is annotated with kuadrant annotation
+			Eventually(testIsGatewayKuadrantManaged(gwA, testNamespace), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			// Check gwB is annotated with kuadrant annotation
+			Eventually(testIsGatewayKuadrantManaged(gwB, testNamespace), 15*time.Second, 5*time.Second).Should(BeTrue())
+		})
+	})
+
+	Context("when Kuadrant instance is deleted", func() {
+		It("gateways should not have kuadrant annotation", func() {
+			kuadrantName := "sample"
+			ApplyKuadrantCRWithName(testNamespace, kuadrantName)
+
+			gwA := testBuildBasicGateway(gwAName, testNamespace)
+			err := k8sClient.Create(context.Background(), gwA)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(testGatewayIsReady(gwA), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			gwB := testBuildBasicGateway(gwBName, testNamespace)
+			err = k8sClient.Create(context.Background(), gwB)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(testGatewayIsReady(gwB), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			// Check gwA is annotated with kuadrant annotation
+			Eventually(testIsGatewayKuadrantManaged(gwA, testNamespace), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			// Check gwB is annotated with kuadrant annotation
+			Eventually(testIsGatewayKuadrantManaged(gwB, testNamespace), 15*time.Second, 5*time.Second).Should(BeTrue())
+
+			kObj := &kuadrantv1beta1.Kuadrant{ObjectMeta: metav1.ObjectMeta{Name: kuadrantName, Namespace: testNamespace}}
+			err = testClient().Delete(context.Background(), kObj)
+
+			// Check gwA is not annotated with kuadrant annotation
 			Eventually(func() bool {
 				existingGateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(gateway), existingGateway)
+				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(gwA), existingGateway)
 				if err != nil {
-					logf.Log.V(1).Info("[WARN] Getting gateway failed", "error", err)
+					logf.Log.Info("[WARN] Getting gateway failed", "error", err)
 					return false
 				}
-
-				if meta.IsStatusConditionFalse(existingGateway.Status.Conditions, string(gatewayapiv1.GatewayConditionProgrammed)) {
-					logf.Log.V(1).Info("[WARN] Gateway not ready")
-					return false
-				}
-
-				return true
+				_, isSet := existingGateway.GetAnnotations()[kuadrant.KuadrantNamespaceAnnotation]
+				return !isSet
 			}, 15*time.Second, 5*time.Second).Should(BeTrue())
 
-			// Check gateway is annotated with kuadrant annotation
+			// Check gwB is not annotated with kuadrant annotation
 			Eventually(func() bool {
 				existingGateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(gateway), existingGateway)
+				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(gwB), existingGateway)
 				if err != nil {
-					logf.Log.V(1).Info("[WARN] Getting gateway failed", "error", err)
+					logf.Log.Info("[WARN] Getting gateway failed", "error", err)
 					return false
 				}
-				return kuadrant.IsKuadrantManaged(existingGateway)
+				_, isSet := existingGateway.GetAnnotations()[kuadrant.KuadrantNamespaceAnnotation]
+				return !isSet
 			}, 15*time.Second, 5*time.Second).Should(BeTrue())
 		})
 	})
 
 	Context("Two kuadrant instances", func() {
-		var secondNamespace string
+		var (
+			secondNamespace string
+			kuadrantAName   string = "kuadrant-a"
+			kuadrantBName   string = "kuadrant-b"
+		)
 
 		BeforeEach(func() {
-			CreateNamespace(&secondNamespace)
-			newKuadrantName := "second"
-			newKuadrant := &kuadrantv1beta1.Kuadrant{
-				TypeMeta:   metav1.TypeMeta{APIVersion: "v1beta1", Kind: "Kuadrant"},
-				ObjectMeta: metav1.ObjectMeta{Name: newKuadrantName, Namespace: secondNamespace},
-			}
-			err := testClient().Create(context.Background(), newKuadrant)
-			Expect(err).ToNot(HaveOccurred())
+			ApplyKuadrantCRWithName(testNamespace, kuadrantAName)
 
-			Eventually(func() bool {
-				kuadrant := &kuadrantv1beta1.Kuadrant{}
-				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: newKuadrantName, Namespace: secondNamespace}, kuadrant)
-				if err != nil {
-					return false
-				}
-				if !meta.IsStatusConditionTrue(kuadrant.Status.Conditions, "Ready") {
-					return false
-				}
-				return true
-			}, time.Minute, 5*time.Second).Should(BeTrue())
+			CreateNamespace(&secondNamespace)
+			ApplyKuadrantCRWithName(secondNamespace, kuadrantBName)
 		})
 
 		AfterEach(DeleteNamespaceCallback(&secondNamespace))
 
 		It("new gateway should not be annotated", func() {
-			gateway := testBuildBasicGateway(gwName, testNamespace)
+			gateway := testBuildBasicGateway("gw-a", testNamespace)
 			err := k8sClient.Create(context.Background(), gateway)
 			Expect(err).ToNot(HaveOccurred())
 
-			Eventually(func() bool {
-				existingGateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(gateway), existingGateway)
-				if err != nil {
-					logf.Log.V(1).Info("[WARN] Getting gateway failed", "error", err)
-					return false
-				}
-
-				if meta.IsStatusConditionFalse(existingGateway.Status.Conditions, string(gatewayapiv1.GatewayConditionProgrammed)) {
-					logf.Log.V(1).Info("[WARN] Gateway not ready")
-					return false
-				}
-
-				return true
-			}, 15*time.Second, 5*time.Second).Should(BeTrue())
+			Eventually(testGatewayIsReady(gateway), 15*time.Second, 5*time.Second).Should(BeTrue())
 
 			// Check gateway is not annotated with kuadrant annotation
 			Eventually(func() bool {
@@ -125,8 +157,22 @@ var _ = Describe("Kuadrant Gateway controller", func() {
 					logf.Log.V(1).Info("[WARN] Getting gateway failed", "error", err)
 					return false
 				}
-				return !kuadrant.IsKuadrantManaged(existingGateway)
+				_, isSet := existingGateway.GetAnnotations()[kuadrant.KuadrantNamespaceAnnotation]
+				return !isSet
 			}, 15*time.Second, 5*time.Second).Should(BeTrue())
 		})
 	})
 })
+
+func testIsGatewayKuadrantManaged(gw *gatewayapiv1.Gateway, ns string) func() bool {
+	return func() bool {
+		existingGateway := &gatewayapiv1.Gateway{}
+		err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(gw), existingGateway)
+		if err != nil {
+			logf.Log.Info("[WARN] Getting gateway failed", "error", err)
+			return false
+		}
+		val, isSet := existingGateway.GetAnnotations()[kuadrant.KuadrantNamespaceAnnotation]
+		return isSet && val == ns
+	}
+}

--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -59,11 +58,26 @@ const (
 )
 
 func ApplyKuadrantCR(namespace string) {
-	err := ApplyResources(filepath.Join("..", "examples", "toystore", "kuadrant.yaml"), k8sClient, namespace)
+	ApplyKuadrantCRWithName(namespace, "kuadrant-sample")
+}
+
+func ApplyKuadrantCRWithName(namespace, name string) {
+	kuadrantCR := &kuadrantv1beta1.Kuadrant{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Kuadrant",
+			APIVersion: kuadrantv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	err := k8sClient.Create(context.Background(), kuadrantCR)
 	Expect(err).ToNot(HaveOccurred())
+
 	Eventually(func() bool {
 		kuadrant := &kuadrantv1beta1.Kuadrant{}
-		err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "kuadrant-sample", Namespace: namespace}, kuadrant)
+		err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, kuadrant)
 		if err != nil {
 			return false
 		}

--- a/pkg/library/mappers/kuadrant_to_gateway.go
+++ b/pkg/library/mappers/kuadrant_to_gateway.go
@@ -1,0 +1,41 @@
+package mappers
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
+)
+
+func NewKuadrantToGatewayEventMapper(o ...MapperOption) *KuadrantToGatewayEventMapper {
+	return &KuadrantToGatewayEventMapper{opts: Apply(o...)}
+}
+
+type KuadrantToGatewayEventMapper struct {
+	opts MapperOptions
+}
+
+func (k *KuadrantToGatewayEventMapper) Map(ctx context.Context, obj client.Object) []reconcile.Request {
+	logger := k.opts.Logger.WithValues("object", client.ObjectKeyFromObject(obj))
+
+	_, ok := obj.(*kuadrantv1beta1.Kuadrant)
+	if !ok {
+		logger.Error(fmt.Errorf("%T is not a kuadrant instance", obj), "cannot map")
+		return []reconcile.Request{}
+	}
+
+	gwList := &gatewayapiv1.GatewayList{}
+	if err := k.opts.Client.List(ctx, gwList); err != nil {
+		logger.Error(err, "failed to list gateways")
+		return []reconcile.Request{}
+	}
+
+	return utils.Map(gwList.Items, func(gw gatewayapiv1.Gateway) reconcile.Request {
+		return reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&gw)}
+	})
+}


### PR DESCRIPTION
### What 

The assignment of a gateway to a kuadrant instance is done using the `kuadrant.io/namespace` annotation. The owner of that annotation was a shared ownership between `gateway_kuadrant_controller` and `kuadrant_controller`. This PR moves the full ownership to `gateway_kuadrant_controller`. 

### Verification steps
* Setup the environment:   
                         
```sh                    
make local-setup         
```        

Checking the annotations of the  `istio-ingressgateway`  gateway
```sh
❯ k get gateways istio-ingressgateway -n istio-system -o jsonpath='{.metadata.annotations}' | yq e 'keys' -P
```
It does not have any kuadrant namespace annotation

```yaml
- gateway.istio.io/controller-version
- kubectl.kubernetes.io/last-applied-configuration
```

Request an instance of Kuadrant:                       
```sh
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```        
The istio  `istio-ingressgateway`  gateway, should be annotated with the kuadrant annotation
```sh
❯ k get gateways istio-ingressgateway -n istio-system -o jsonpath='{.metadata.annotations}' | yq e 'keys' -P
```
```yaml
- gateway.istio.io/controller-version
- kuadrant.io/namespace
- kubectl.kubernetes.io/last-applied-configuration
```

Create a new gateway

```bash
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: second
spec:
  gatewayClassName: istio
  listeners:
    - allowedRoutes:
        namespaces:
          from: All
      hostname: '*.example.com'
      name: api
      port: 80
      protocol: HTTP
EOF
```

Note that the gateway initial spec does not have the kuadrant annotation. The kuadrant controller will add it. 

The new gateway  `second`  gateway, should be annotated with the kuadrant annotation
```sh
❯ k get gateways second -n kuadrant-system -o jsonpath='{.metadata.annotations}' | yq e 'keys' -P
```

```yaml
- gateway.istio.io/controller-version
- kuadrant.io/namespace
- kubectl.kubernetes.io/last-applied-configuration
```

Now, let's delete the kuadrant CR
```bash
kubectl delete kuadrant kuadrant -n kuadrant-system 
```

The istio  `istio-ingressgateway`  gateway, must not have the annotation with the kuadrant namespace
```sh
❯ k get gateways istio-ingressgateway -n istio-system -o jsonpath='{.metadata.annotations}' | yq e 'keys' -P
```
```yaml
- gateway.istio.io/controller-version
- kubectl.kubernetes.io/last-applied-configuration
```
The new gateway  `second`, must not have the annotation with the kuadrant namespace
```sh
❯ k get gateways second -n kuadrant-system -o jsonpath='{.metadata.annotations}' | yq e 'keys' -P
```
```yaml
- gateway.istio.io/controller-version
- kubectl.kubernetes.io/last-applied-configuration
```
