### PR TITLE
 Updated HTTPRoute for ToysStore with new label.

### DIFF
--- a/doc/user-guides/secure-protect-connect.md
+++ b/doc/user-guides/secure-protect-connect.md
@@ -117,6 +117,9 @@ apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
   name: toystore
+  labels:
+    deployment: toystore
+    service: toystore
 spec:
   parentRefs:
   - name: api-gateway


### PR DESCRIPTION
- Added a "deployment" label to the HTTPRoute resource so it can be tied to istio metrics

i.e. the `destination_workload ` and `destination_service_name ` labels on the `istio_requests_total` metric