### PR TITLE
AuthPolicy Atomic Overrides

### DIFF
--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -24,19 +24,19 @@ type AuthSchemeSpec struct {
 	// Authentication configs.
 	// At least one config MUST evaluate to a valid identity object for the auth request to be successful.
 	// +optional
-	// +kubebuilder:validation:MaxProperties=14
+	// +kubebuilder:validation:MaxProperties=10
 	Authentication map[string]AuthenticationSpec `json:"authentication,omitempty"`
 
 	// Metadata sources.
 	// Authorino fetches auth metadata as JSON from sources specified in this config.
 	// +optional
-	// +kubebuilder:validation:MaxProperties=14
+	// +kubebuilder:validation:MaxProperties=10
 	Metadata map[string]MetadataSpec `json:"metadata,omitempty"`
 
 	// Authorization policies.
 	// All policies MUST evaluate to "allowed = true" for the auth request be successful.
 	// +optional
-	// +kubebuilder:validation:MaxProperties=14
+	// +kubebuilder:validation:MaxProperties=10
 	Authorization map[string]AuthorizationSpec `json:"authorization,omitempty"`
 
 	// Response items.
@@ -47,7 +47,7 @@ type AuthSchemeSpec struct {
 	// Callback functions.
 	// Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
 	// +optional
-	// +kubebuilder:validation:MaxProperties=14
+	// +kubebuilder:validation:MaxProperties=10
 	Callbacks map[string]CallbackSpec `json:"callbacks,omitempty"`
 }
 
@@ -104,13 +104,13 @@ type ResponseSpec struct {
 type WrappedSuccessResponseSpec struct {
 	// Custom success response items wrapped as HTTP headers.
 	// For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
-	// +kubebuilder:validation:MaxProperties=14
+	// +kubebuilder:validation:MaxProperties=10
 	Headers map[string]HeaderSuccessResponseSpec `json:"headers,omitempty"`
 
 	// Custom success response items wrapped as HTTP headers.
 	// For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
 	// See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
-	// +kubebuilder:validation:MaxProperties=14
+	// +kubebuilder:validation:MaxProperties=10
 	DynamicMetadata map[string]SuccessResponseSpec `json:"dynamicMetadata,omitempty"`
 }
 
@@ -144,8 +144,18 @@ type CallbackSpec struct {
 // +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.defaults) || !has(self.defaults.rules) || !has(self.defaults.rules.response) || !has(self.defaults.rules.response.success) || !has(self.defaults.rules.response.success.headers) || !self.defaults.rules.response.success.headers.exists(x, has(self.defaults.rules.response.success.headers[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
 // +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.defaults) || !has(self.defaults.rules) || !has(self.defaults.rules.response) || !has(self.defaults.rules.response.success) || !has(self.defaults.rules.response.success.dynamicMetadata) || !self.defaults.rules.response.success.dynamicMetadata.exists(x, has(self.defaults.rules.response.success.dynamicMetadata[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
 // +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.defaults) || !has(self.defaults.rules) || !has(self.defaults.rules.callbacks) || !self.defaults.rules.callbacks.exists(x, has(self.defaults.rules.callbacks[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// RouteSelectors - explicit overrides validation
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.routeSelectors)",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules) || !has(self.overrides.rules.authentication) || !self.overrides.rules.authentication.exists(x, has(self.overrides.rules.authentication[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules) || !has(self.overrides.rules.metadata) || !self.overrides.rules.metadata.exists(x, has(self.overrides.rules.metadata[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules) || !has(self.overrides.rules.authorization) || !self.overrides.rules.authorization.exists(x, has(self.overrides.rules.authorization[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules) || !has(self.overrides.rules.response) || !has(self.overrides.rules.response.success) || !has(self.overrides.rules.response.success.headers) || !self.overrides.rules.response.success.headers.exists(x, has(self.overrides.rules.response.success.headers[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules) || !has(self.overrides.rules.response) || !has(self.overrides.rules.response.success) || !has(self.overrides.rules.response.success.dynamicMetadata) || !self.overrides.rules.response.success.dynamicMetadata.exists(x, has(self.overrides.rules.response.success.dynamicMetadata[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
+// +kubebuilder:validation:XValidation:rule="self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules) || !has(self.overrides.rules.callbacks) || !self.overrides.rules.callbacks.exists(x, has(self.overrides.rules.callbacks[x].routeSelectors))",message="route selectors not supported when targeting a Gateway"
 // Mutual Exclusivity Validation
 // +kubebuilder:validation:XValidation:rule="!(has(self.defaults) && (has(self.routeSelectors) || has(self.patterns) || has(self.when) || has(self.rules)))",message="Implicit and explicit defaults are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!(has(self.overrides) && (has(self.routeSelectors) || has(self.patterns) || has(self.when) || has(self.rules)))",message="Implicit defaults and explicit overrides are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!(has(self.overrides) && has(self.defaults))",message="Explicit overrides and explicit defaults are mutually exclusive"
 type AuthPolicySpec struct {
 	// TargetRef identifies an API object to apply policy to.
 	// +kubebuilder:validation:XValidation:rule="self.group == 'gateway.networking.k8s.io'",message="Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'"
@@ -156,6 +166,11 @@ type AuthPolicySpec struct {
 	// Defaults are mutually exclusive with implicit defaults defined by AuthPolicyCommonSpec.
 	// +optional
 	Defaults *AuthPolicyCommonSpec `json:"defaults,omitempty"`
+
+	// Overrides define explicit override values for this policy.
+	// Overrides are mutually exclusive with explicit and implicit defaults defined by AuthPolicyCommonSpec.
+	// +optional
+	Overrides *AuthPolicyCommonSpec `json:"overrides,omitempty"`
 
 	// AuthPolicyCommonSpec defines implicit default values for this policy and for policies inheriting this policy.
 	// AuthPolicyCommonSpec is mutually exclusive with explicit defaults defined by Defaults.

--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -262,6 +262,10 @@ type AuthPolicy struct {
 	Status AuthPolicyStatus `json:"status,omitempty"`
 }
 
+func (ap *AuthPolicy) IsAtomicOverride() bool {
+	return ap.Spec.Overrides != nil
+}
+
 func (ap *AuthPolicy) TargetKey() client.ObjectKey {
 	ns := ap.Namespace
 	if ap.Spec.TargetRef.Namespace != nil {
@@ -348,6 +352,10 @@ func (ap *AuthPolicy) DirectReferenceAnnotationName() string {
 func (ap *AuthPolicySpec) CommonSpec() *AuthPolicyCommonSpec {
 	if ap.Defaults != nil {
 		return ap.Defaults
+	}
+
+	if ap.Overrides != nil {
+		return ap.Overrides
 	}
 
 	return &ap.AuthPolicyCommonSpec

--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -156,6 +156,7 @@ type CallbackSpec struct {
 // +kubebuilder:validation:XValidation:rule="!(has(self.defaults) && (has(self.routeSelectors) || has(self.patterns) || has(self.when) || has(self.rules)))",message="Implicit and explicit defaults are mutually exclusive"
 // +kubebuilder:validation:XValidation:rule="!(has(self.overrides) && (has(self.routeSelectors) || has(self.patterns) || has(self.when) || has(self.rules)))",message="Implicit defaults and explicit overrides are mutually exclusive"
 // +kubebuilder:validation:XValidation:rule="!(has(self.overrides) && has(self.defaults))",message="Explicit overrides and explicit defaults are mutually exclusive"
+// +kubebuilder:validation:XValidation:rule="!(has(self.overrides) && self.targetRef.kind == 'HTTPRoute')",message="Overrides are not allowed for policies targeting a HTTPRoute resource"
 type AuthPolicySpec struct {
 	// TargetRef identifies an API object to apply policy to.
 	// +kubebuilder:validation:XValidation:rule="self.group == 'gateway.networking.k8s.io'",message="Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'"

--- a/api/v1beta2/zz_generated.deepcopy.go
+++ b/api/v1beta2/zz_generated.deepcopy.go
@@ -145,6 +145,11 @@ func (in *AuthPolicySpec) DeepCopyInto(out *AuthPolicySpec) {
 		*out = new(AuthPolicyCommonSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Overrides != nil {
+		in, out := &in.Overrides, &out.Overrides
+		*out = new(AuthPolicyCommonSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	in.AuthPolicyCommonSpec.DeepCopyInto(&out.AuthPolicyCommonSpec)
 }
 

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-03-25T09:38:12Z"
+    createdAt: "2024-04-10T13:13:33Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-04-10T13:13:33Z"
+    createdAt: "2024-04-15T13:13:02Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/manifests/kuadrant.io_authpolicies.yaml
+++ b/bundle/manifests/kuadrant.io_authpolicies.yaml
@@ -68,6 +68,7 @@ spec:
             description: |-
               RouteSelectors - implicit default validation
               RouteSelectors - explicit default validation
+              RouteSelectors - explicit overrides validation
               Mutual Exclusivity Validation
             properties:
               defaults:
@@ -1067,7 +1068,7 @@ spec:
                         description: |-
                           Authentication configs.
                           At least one config MUST evaluate to a valid identity object for the auth request to be successful.
-                        maxProperties: 14
+                        maxProperties: 10
                         type: object
                       authorization:
                         additionalProperties:
@@ -1954,7 +1955,7 @@ spec:
                         description: |-
                           Authorization policies.
                           All policies MUST evaluate to "allowed = true" for the auth request be successful.
-                        maxProperties: 14
+                        maxProperties: 10
                         type: object
                       callbacks:
                         additionalProperties:
@@ -2541,7 +2542,7 @@ spec:
                         description: |-
                           Callback functions.
                           Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
-                        maxProperties: 14
+                        maxProperties: 10
                         type: object
                       metadata:
                         additionalProperties:
@@ -3165,7 +3166,7 @@ spec:
                         description: |-
                           Metadata sources.
                           Authorino fetches auth metadata as JSON from sources specified in this config.
-                        maxProperties: 14
+                        maxProperties: 10
                         type: object
                       response:
                         description: |-
@@ -3689,7 +3690,7 @@ spec:
                                   Custom success response items wrapped as HTTP headers.
                                   For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
                                   See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
-                                maxProperties: 14
+                                maxProperties: 10
                                 type: object
                               headers:
                                 additionalProperties:
@@ -4202,7 +4203,4309 @@ spec:
                                 description: |-
                                   Custom success response items wrapped as HTTP headers.
                                   For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
-                                maxProperties: 14
+                                maxProperties: 10
+                                type: object
+                            type: object
+                          unauthenticated:
+                            description: |-
+                              Customizations on the denial status attributes when the request is unauthenticated.
+                              For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                              Default: 401 Unauthorized
+                            properties:
+                              body:
+                                description: HTTP response body to override the default
+                                  denial body.
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              code:
+                                description: HTTP status code to override the default
+                                  denial status code.
+                                format: int64
+                                maximum: 599
+                                minimum: 300
+                                type: integer
+                              headers:
+                                additionalProperties:
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                description: HTTP response headers to override the
+                                  default denial headers.
+                                type: object
+                              message:
+                                description: HTTP message to override the default
+                                  denial message.
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          unauthorized:
+                            description: |-
+                              Customizations on the denial status attributes when the request is unauthorized.
+                              For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                              Default: 403 Forbidden
+                            properties:
+                              body:
+                                description: HTTP response body to override the default
+                                  denial body.
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              code:
+                                description: HTTP status code to override the default
+                                  denial status code.
+                                format: int64
+                                maximum: 599
+                                minimum: 300
+                                type: integer
+                              headers:
+                                additionalProperties:
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                description: HTTP response headers to override the
+                                  default denial headers.
+                                type: object
+                              message:
+                                description: HTTP message to override the default
+                                  denial message.
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  when:
+                    description: |-
+                      Overall conditions for the AuthPolicy to be enforced.
+                      If omitted, the AuthPolicy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the AuthPolicy to be enforced; otherwise, the authorization service skips the AuthPolicy and returns to the auth request with status OK.
+                    items:
+                      properties:
+                        all:
+                          description: A list of pattern expressions to be evaluated
+                            as a logical AND.
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                        any:
+                          description: A list of pattern expressions to be evaluated
+                            as a logical OR.
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                        operator:
+                          description: |-
+                            The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                            Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                          enum:
+                          - eq
+                          - neq
+                          - incl
+                          - excl
+                          - matches
+                          type: string
+                        patternRef:
+                          description: Reference to a named set of pattern expressions
+                          type: string
+                        selector:
+                          description: |-
+                            Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                            Authorino custom JSON path modifiers are also supported.
+                          type: string
+                        value:
+                          description: |-
+                            The value of reference for the comparison with the content fetched from the authorization JSON.
+                            If used with the "matches" operator, the value must compile to a valid Golang regex.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              overrides:
+                description: |-
+                  Overrides define explicit override values for this policy.
+                  Overrides are mutually exclusive with explicit and implicit defaults defined by AuthPolicyCommonSpec.
+                properties:
+                  patterns:
+                    additionalProperties:
+                      items:
+                        properties:
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                    description: Named sets of patterns that can be referred in `when`
+                      conditions and in pattern-matching authorization policy rules.
+                    type: object
+                  routeSelectors:
+                    description: |-
+                      Top-level route selectors.
+                      If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the external authorization service.
+                      At least one selected HTTPRoute rule must match to trigger the AuthPolicy.
+                      If no route selectors are specified, the AuthPolicy will be enforced at all requests to the protected routes.
+                    items:
+                      description: |-
+                        RouteSelector defines semantics for matching an HTTP request based on conditions
+                        https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                      properties:
+                        hostnames:
+                          description: |-
+                            Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                            https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                          items:
+                            description: |-
+                              Hostname is the fully qualified domain name of a network host. This matches
+                              the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                               1. IPs are not allowed.
+                               2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                  label must appear by itself as the first label.
+
+
+                              Hostname can be "precise" which is a domain name without the terminating
+                              dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                              domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                              Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                              alphanumeric characters or '-', and must start and end with an alphanumeric
+                              character. No other punctuation is allowed.
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          type: array
+                        matches:
+                          description: |-
+                            Matches define conditions used for matching the rule against incoming HTTP requests.
+                            https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                          items:
+                            description: "HTTPRouteMatch defines the predicate used
+                              to match requests to a given\naction. Multiple match
+                              types are ANDed together, i.e. the match will\nevaluate
+                              to true only if all conditions are satisfied.\n\n\nFor
+                              example, the match below will match a HTTP request only
+                              if its path\nstarts with `/foo` AND it contains the
+                              `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                              \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                              \ value \"v1\"\n\n\n```"
+                            properties:
+                              headers:
+                                description: |-
+                                  Headers specifies HTTP request header matchers. Multiple match values are
+                                  ANDed together, meaning, a request must match all the specified headers
+                                  to select the route.
+                                items:
+                                  description: |-
+                                    HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                    headers.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header names, only the first
+                                        entry with an equivalent name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+
+
+                                        When a header is repeated in an HTTP request, it is
+                                        implementation-specific behavior as to how this is represented.
+                                        Generally, proxies should follow the guidance from the RFC:
+                                        https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                        processing a repeated header, with special handling for "Set-Cookie".
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    type:
+                                      default: Exact
+                                      description: |-
+                                        Type specifies how to match against the value of the header.
+
+
+                                        Support: Core (Exact)
+
+
+                                        Support: Implementation-specific (RegularExpression)
+
+
+                                        Since RegularExpression HeaderMatchType has implementation-specific
+                                        conformance, implementations can support POSIX, PCRE or any other dialects
+                                        of regular expressions. Please read the implementation's documentation to
+                                        determine the supported dialect.
+                                      enum:
+                                      - Exact
+                                      - RegularExpression
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              method:
+                                description: |-
+                                  Method specifies HTTP method matcher.
+                                  When specified, this route will be matched only if the request has the
+                                  specified method.
+
+
+                                  Support: Extended
+                                enum:
+                                - GET
+                                - HEAD
+                                - POST
+                                - PUT
+                                - DELETE
+                                - CONNECT
+                                - OPTIONS
+                                - TRACE
+                                - PATCH
+                                type: string
+                              path:
+                                default:
+                                  type: PathPrefix
+                                  value: /
+                                description: |-
+                                  Path specifies a HTTP request path matcher. If this field is not
+                                  specified, a default prefix match on the "/" path is provided.
+                                properties:
+                                  type:
+                                    default: PathPrefix
+                                    description: |-
+                                      Type specifies how to match against the path Value.
+
+
+                                      Support: Core (Exact, PathPrefix)
+
+
+                                      Support: Implementation-specific (RegularExpression)
+                                    enum:
+                                    - Exact
+                                    - PathPrefix
+                                    - RegularExpression
+                                    type: string
+                                  value:
+                                    default: /
+                                    description: Value of the HTTP path to match against.
+                                    maxLength: 1024
+                                    type: string
+                                type: object
+                                x-kubernetes-validations:
+                                - message: value must be an absolute path and start
+                                    with '/' when type one of ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? self.value.startsWith(''/'') : true'
+                                - message: must not contain '//' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''//'') : true'
+                                - message: must not contain '/./' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''/./'') : true'
+                                - message: must not contain '/../' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''/../'') : true'
+                                - message: must not contain '%2f' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''%2f'') : true'
+                                - message: must not contain '%2F' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''%2F'') : true'
+                                - message: must not contain '#' when type one of ['Exact',
+                                    'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''#'') : true'
+                                - message: must not end with '/..' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.endsWith(''/..'') : true'
+                                - message: must not end with '/.' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.endsWith(''/.'') : true'
+                                - message: type must be one of ['Exact', 'PathPrefix',
+                                    'RegularExpression']
+                                  rule: self.type in ['Exact','PathPrefix'] || self.type
+                                    == 'RegularExpression'
+                                - message: must only contain valid characters (matching
+                                    ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                    for types ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                    : true'
+                              queryParams:
+                                description: |-
+                                  QueryParams specifies HTTP query parameter matchers. Multiple match
+                                  values are ANDed together, meaning, a request must match all the
+                                  specified query parameters to select the route.
+
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                    query parameters.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP query param to be matched. This must be an
+                                        exact string match. (See
+                                        https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                        If multiple entries specify equivalent query param names, only the first
+                                        entry with an equivalent name MUST be considered for a match. Subsequent
+                                        entries with an equivalent query param name MUST be ignored.
+
+
+                                        If a query param is repeated in an HTTP request, the behavior is
+                                        purposely left undefined, since different data planes have different
+                                        capabilities. However, it is *recommended* that implementations should
+                                        match against the first value of the param if the data plane supports it,
+                                        as this behavior is expected in other load balancing contexts outside of
+                                        the Gateway API.
+
+
+                                        Users SHOULD NOT route traffic based on repeated query params to guard
+                                        themselves against potential differences in the implementations.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    type:
+                                      default: Exact
+                                      description: |-
+                                        Type specifies how to match against the value of the query parameter.
+
+
+                                        Support: Extended (Exact)
+
+
+                                        Support: Implementation-specific (RegularExpression)
+
+
+                                        Since RegularExpression QueryParamMatchType has Implementation-specific
+                                        conformance, implementations can support POSIX, PCRE or any other
+                                        dialects of regular expressions. Please read the implementation's
+                                        documentation to determine the supported dialect.
+                                      enum:
+                                      - Exact
+                                      - RegularExpression
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP query
+                                        param to be matched.
+                                      maxLength: 1024
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          maxItems: 8
+                          type: array
+                      type: object
+                    maxItems: 15
+                    type: array
+                  rules:
+                    description: |-
+                      The auth rules of the policy.
+                      See Authorino's AuthConfig CRD for more details.
+                    properties:
+                      authentication:
+                        additionalProperties:
+                          properties:
+                            anonymous:
+                              description: Anonymous access.
+                              type: object
+                            apiKey:
+                              description: Authentication based on API keys stored
+                                in Kubernetes secrets.
+                              properties:
+                                allNamespaces:
+                                  default: false
+                                  description: |-
+                                    Whether Authorino should look for API key secrets in all namespaces or only in the same namespace as the AuthConfig.
+                                    Enabling this option in namespaced Authorino instances has no effect.
+                                  type: boolean
+                                selector:
+                                  description: Label selector used by Authorino to
+                                    match secrets from the cluster storing valid credentials
+                                    to authenticate to this service
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - selector
+                              type: object
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            credentials:
+                              description: |-
+                                Defines where credentials are required to be passed in the request for authentication based on this config.
+                                If omitted, it defaults to credentials passed in the HTTP Authorization header and the "Bearer" prefix prepended to the secret credential value.
+                              properties:
+                                authorizationHeader:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                  type: object
+                                cookie:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                customHeader:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryString:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            defaults:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: |-
+                                Set default property values (claims) for the resolved identity object, that are set before appending the object to
+                                the authorization JSON. If the property is already present in the resolved identity object, the default value is ignored.
+                                It requires the resolved identity object to always be a JSON object.
+                                Do not use this option with identity objects of other JSON types (array, string, etc).
+                              type: object
+                            jwt:
+                              description: Authentication based on JWT tokens.
+                              properties:
+                                issuerUrl:
+                                  description: |-
+                                    URL of the issuer of the JWT.
+                                    If `jwksUrl` is omitted, Authorino will append the path to the OpenID Connect Well-Known Discovery endpoint
+                                    (i.e. "/.well-known/openid-configuration") to this URL, to discover the OIDC configuration where to obtain
+                                    the "jkws_uri" claim from.
+                                    The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    Decides how long to wait before refreshing the JWKS (in seconds).
+                                    If omitted, Authorino will never refresh the JWKS.
+                                  type: integer
+                              type: object
+                            kubernetesTokenReview:
+                              description: Authentication by Kubernetes token review.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino.
+                                    If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            oauth2Introspection:
+                              description: Authentication by OAuth2 token introspection.
+                              properties:
+                                credentialsRef:
+                                  description: Reference to a Kubernetes secret in
+                                    the same namespace, that stores client credentials
+                                    to the OAuth2 server.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                endpoint:
+                                  description: The full URL of the token introspection
+                                    endpoint.
+                                  type: string
+                                tokenTypeHint:
+                                  description: |-
+                                    The token type hint for the token introspection.
+                                    If omitted, it defaults to "access_token".
+                                  type: string
+                              required:
+                              - credentialsRef
+                              - endpoint
+                              type: object
+                            overrides:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: |-
+                                Overrides the resolved identity object by setting the additional properties (claims) specified in this config,
+                                before appending the object to the authorization JSON.
+                                It requires the resolved identity object to always be a JSON object.
+                                Do not use this option with identity objects of other JSON types (array, string, etc).
+                              type: object
+                            plain:
+                              description: |-
+                                Identity object extracted from the context.
+                                Use this method when authentication is performed beforehand by a proxy and the resulting object passed to Authorino as JSON in the auth request.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                              required:
+                              - selector
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            routeSelectors:
+                              description: |-
+                                Top-level route selectors.
+                                If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                              items:
+                                description: |-
+                                  RouteSelector defines semantics for matching an HTTP request based on conditions
+                                  https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                properties:
+                                  hostnames:
+                                    description: |-
+                                      Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: |-
+                                        Hostname is the fully qualified domain name of a network host. This matches
+                                        the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                         1. IPs are not allowed.
+                                         2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                            label must appear by itself as the first label.
+
+
+                                        Hostname can be "precise" which is a domain name without the terminating
+                                        dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                        domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                        Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                        alphanumeric characters or '-', and must start and end with an alphanumeric
+                                        character. No other punctuation is allowed.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    type: array
+                                  matches:
+                                    description: |-
+                                      Matches define conditions used for matching the rule against incoming HTTP requests.
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: "HTTPRouteMatch defines the predicate
+                                        used to match requests to a given\naction.
+                                        Multiple match types are ANDed together, i.e.
+                                        the match will\nevaluate to true only if all
+                                        conditions are satisfied.\n\n\nFor example,
+                                        the match below will match a HTTP request
+                                        only if its path\nstarts with `/foo` AND it
+                                        contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                                        \ value \"v1\"\n\n\n```"
+                                      properties:
+                                        headers:
+                                          description: |-
+                                            Headers specifies HTTP request header matchers. Multiple match values are
+                                            ANDed together, meaning, a request must match all the specified headers
+                                            to select the route.
+                                          items:
+                                            description: |-
+                                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                              headers.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                  If multiple entries specify equivalent header names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent header name MUST be ignored. Due to the
+                                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                                  equivalent.
+
+
+                                                  When a header is repeated in an HTTP request, it is
+                                                  implementation-specific behavior as to how this is represented.
+                                                  Generally, proxies should follow the guidance from the RFC:
+                                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                  processing a repeated header, with special handling for "Set-Cookie".
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the header.
+
+
+                                                  Support: Core (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression HeaderMatchType has implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other dialects
+                                                  of regular expressions. Please read the implementation's documentation to
+                                                  determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP Header to be matched.
+                                                maxLength: 4096
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        method:
+                                          description: |-
+                                            Method specifies HTTP method matcher.
+                                            When specified, this route will be matched only if the request has the
+                                            specified method.
+
+
+                                            Support: Extended
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                        path:
+                                          default:
+                                            type: PathPrefix
+                                            value: /
+                                          description: |-
+                                            Path specifies a HTTP request path matcher. If this field is not
+                                            specified, a default prefix match on the "/" path is provided.
+                                          properties:
+                                            type:
+                                              default: PathPrefix
+                                              description: |-
+                                                Type specifies how to match against the path Value.
+
+
+                                                Support: Core (Exact, PathPrefix)
+
+
+                                                Support: Implementation-specific (RegularExpression)
+                                              enum:
+                                              - Exact
+                                              - PathPrefix
+                                              - RegularExpression
+                                              type: string
+                                            value:
+                                              default: /
+                                              description: Value of the HTTP path
+                                                to match against.
+                                              maxLength: 1024
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: value must be an absolute path
+                                              and start with '/' when type one of
+                                              ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.startsWith(''/'') : true'
+                                          - message: must not contain '//' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''//'') : true'
+                                          - message: must not contain '/./' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/./'') : true'
+                                          - message: must not contain '/../' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/../'') : true'
+                                          - message: must not contain '%2f' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2f'') : true'
+                                          - message: must not contain '%2F' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2F'') : true'
+                                          - message: must not contain '#' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''#'') : true'
+                                          - message: must not end with '/..' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/..'') : true'
+                                          - message: must not end with '/.' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/.'') : true'
+                                          - message: type must be one of ['Exact',
+                                              'PathPrefix', 'RegularExpression']
+                                            rule: self.type in ['Exact','PathPrefix']
+                                              || self.type == 'RegularExpression'
+                                          - message: must only contain valid characters
+                                              (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                              for types ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                              : true'
+                                        queryParams:
+                                          description: |-
+                                            QueryParams specifies HTTP query parameter matchers. Multiple match
+                                            values are ANDed together, meaning, a request must match all the
+                                            specified query parameters to select the route.
+
+
+                                            Support: Extended
+                                          items:
+                                            description: |-
+                                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                              query parameters.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP query param to be matched. This must be an
+                                                  exact string match. (See
+                                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                  If multiple entries specify equivalent query param names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent query param name MUST be ignored.
+
+
+                                                  If a query param is repeated in an HTTP request, the behavior is
+                                                  purposely left undefined, since different data planes have different
+                                                  capabilities. However, it is *recommended* that implementations should
+                                                  match against the first value of the param if the data plane supports it,
+                                                  as this behavior is expected in other load balancing contexts outside of
+                                                  the Gateway API.
+
+
+                                                  Users SHOULD NOT route traffic based on repeated query params to guard
+                                                  themselves against potential differences in the implementations.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the query parameter.
+
+
+                                                  Support: Extended (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other
+                                                  dialects of regular expressions. Please read the implementation's
+                                                  documentation to determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP query param to be matched.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                    maxItems: 8
+                                    type: array
+                                type: object
+                              maxItems: 8
+                              type: array
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            x509:
+                              description: |-
+                                Authentication based on client X.509 certificates.
+                                The certificates presented by the clients must be signed by a trusted CA whose certificates are stored in Kubernetes secrets.
+                              properties:
+                                allNamespaces:
+                                  default: false
+                                  description: |-
+                                    Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
+                                    Enabling this option in namespaced Authorino instances has no effect.
+                                  type: boolean
+                                selector:
+                                  description: |-
+                                    Label selector used by Authorino to match secrets from the cluster storing trusted CA certificates to validate
+                                    clients trying to authenticate to this service
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - selector
+                              type: object
+                          type: object
+                        description: |-
+                          Authentication configs.
+                          At least one config MUST evaluate to a valid identity object for the auth request to be successful.
+                        maxProperties: 10
+                        type: object
+                      authorization:
+                        additionalProperties:
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            kubernetesSubjectAccessReview:
+                              description: Authorization by Kubernetes SubjectAccessReview
+                              properties:
+                                groups:
+                                  description: Groups the user must be a member of
+                                    or, if `user` is omitted, the groups to check
+                                    for authorization in the Kubernetes RBAC.
+                                  items:
+                                    type: string
+                                  type: array
+                                resourceAttributes:
+                                  description: |-
+                                    Use resourceAttributes to check permissions on Kubernetes resources.
+                                    If omitted, it performs a non-resource SubjectAccessReview, with verb and path inferred from the request.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        API group of the resource.
+                                        Use '*' for all API groups.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    name:
+                                      description: |-
+                                        Resource name
+                                        Omit it to check for authorization on all resources of the specified kind.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    namespace:
+                                      description: Namespace where the user must have
+                                        permissions on the resource.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    resource:
+                                      description: |-
+                                        Resource kind
+                                        Use '*' for all resource kinds.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    subresource:
+                                      description: Subresource kind
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    verb:
+                                      description: |-
+                                        Verb to check for authorization on the resource.
+                                        Use '*' for all verbs.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                user:
+                                  description: |-
+                                    User to check for authorization in the Kubernetes RBAC.
+                                    Omit it to check for group authorization only.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            opa:
+                              description: Open Policy Agent (OPA) Rego policy.
+                              properties:
+                                allValues:
+                                  default: false
+                                  description: |-
+                                    Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
+                                    Otherwise, only the default `allow` rule will be exposed.
+                                    Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
+                                  type: boolean
+                                externalPolicy:
+                                  description: |-
+                                    Settings for fetching the OPA policy from an external registry.
+                                    Use it alternatively to 'rego'.
+                                    For the configurations of the HTTP request, the following options are not implemented: 'method', 'body', 'bodyParameters',
+                                    'contentType', 'headers', 'oauth2'. Use it only with: 'url', 'sharedSecret', 'credentials'.
+                                  properties:
+                                    body:
+                                      description: |-
+                                        Raw body of the HTTP request.
+                                        Supersedes 'bodyParameters'; use either one or the other.
+                                        Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    bodyParameters:
+                                      additionalProperties:
+                                        properties:
+                                          selector:
+                                            description: |-
+                                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                            type: string
+                                          value:
+                                            description: Static value
+                                            x-kubernetes-preserve-unknown-fields: true
+                                        type: object
+                                      description: |-
+                                        Custom parameters to encode in the body of the HTTP request.
+                                        Superseded by 'body'; use either one or the other.
+                                        Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                      type: object
+                                    contentType:
+                                      default: application/x-www-form-urlencoded
+                                      description: |-
+                                        Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                        Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                                      enum:
+                                      - application/x-www-form-urlencoded
+                                      - application/json
+                                      type: string
+                                    credentials:
+                                      description: |-
+                                        Defines where client credentials will be passed in the request to the service.
+                                        If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                                      properties:
+                                        authorizationHeader:
+                                          properties:
+                                            prefix:
+                                              type: string
+                                          type: object
+                                        cookie:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        customHeader:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        queryString:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                      type: object
+                                    headers:
+                                      additionalProperties:
+                                        properties:
+                                          selector:
+                                            description: |-
+                                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                            type: string
+                                          value:
+                                            description: Static value
+                                            x-kubernetes-preserve-unknown-fields: true
+                                        type: object
+                                      description: Custom headers in the HTTP request.
+                                      type: object
+                                    method:
+                                      default: GET
+                                      description: |-
+                                        HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                        When the request method is POST, the authorization JSON is passed in the body of the request.
+                                      enum:
+                                      - GET
+                                      - POST
+                                      - PUT
+                                      - PATCH
+                                      - DELETE
+                                      - HEAD
+                                      - OPTIONS
+                                      - CONNECT
+                                      - TRACE
+                                      type: string
+                                    oauth2:
+                                      description: Authentication with the HTTP service
+                                        by OAuth2 Client Credentials grant.
+                                      properties:
+                                        cache:
+                                          default: true
+                                          description: |-
+                                            Caches and reuses the token until expired.
+                                            Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                          type: boolean
+                                        clientId:
+                                          description: OAuth2 Client ID.
+                                          type: string
+                                        clientSecretRef:
+                                          description: Reference to a Kuberentes Secret
+                                            key that stores that OAuth2 Client Secret.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: The name of the secret
+                                                in the Authorino's namespace to select
+                                                from.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        extraParams:
+                                          additionalProperties:
+                                            type: string
+                                          description: Optional extra parameters for
+                                            the requests to the token URL.
+                                          type: object
+                                        scopes:
+                                          description: Optional scopes for the client
+                                            credentials grant, if supported by he
+                                            OAuth2 server.
+                                          items:
+                                            type: string
+                                          type: array
+                                        tokenUrl:
+                                          description: Token endpoint URL of the OAuth2
+                                            resource server.
+                                          type: string
+                                      required:
+                                      - clientId
+                                      - clientSecretRef
+                                      - tokenUrl
+                                      type: object
+                                    sharedSecretRef:
+                                      description: |-
+                                        Reference to a Secret key whose value will be passed by Authorino in the request.
+                                        The HTTP service can use the shared secret to authenticate the origin of the request.
+                                        Ignored if used together with oauth2.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: The name of the secret in the
+                                            Authorino's namespace to select from.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                    ttl:
+                                      description: Duration (in seconds) of the external
+                                        data in the cache before pulled again from
+                                        the source.
+                                      type: integer
+                                    url:
+                                      description: |-
+                                        Endpoint URL of the HTTP service.
+                                        The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                        E.g. https://ext-auth-server.io/metadata?p={request.path}
+                                      type: string
+                                  required:
+                                  - url
+                                  type: object
+                                rego:
+                                  description: |-
+                                    Authorization policy as a Rego language document.
+                                    The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
+                                    The Rego document must NOT include the "package" declaration in line 1.
+                                  type: string
+                              type: object
+                            patternMatching:
+                              description: Pattern-matching authorization rules.
+                              properties:
+                                patterns:
+                                  items:
+                                    properties:
+                                      all:
+                                        description: A list of pattern expressions
+                                          to be evaluated as a logical AND.
+                                        items:
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        type: array
+                                      any:
+                                        description: A list of pattern expressions
+                                          to be evaluated as a logical OR.
+                                        items:
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        type: array
+                                      operator:
+                                        description: |-
+                                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                        enum:
+                                        - eq
+                                        - neq
+                                        - incl
+                                        - excl
+                                        - matches
+                                        type: string
+                                      patternRef:
+                                        description: Reference to a named set of pattern
+                                          expressions
+                                        type: string
+                                      selector:
+                                        description: |-
+                                          Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          Authorino custom JSON path modifiers are also supported.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          The value of reference for the comparison with the content fetched from the authorization JSON.
+                                          If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                        type: string
+                                    type: object
+                                  type: array
+                              required:
+                              - patterns
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            routeSelectors:
+                              description: |-
+                                Top-level route selectors.
+                                If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                              items:
+                                description: |-
+                                  RouteSelector defines semantics for matching an HTTP request based on conditions
+                                  https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                properties:
+                                  hostnames:
+                                    description: |-
+                                      Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: |-
+                                        Hostname is the fully qualified domain name of a network host. This matches
+                                        the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                         1. IPs are not allowed.
+                                         2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                            label must appear by itself as the first label.
+
+
+                                        Hostname can be "precise" which is a domain name without the terminating
+                                        dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                        domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                        Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                        alphanumeric characters or '-', and must start and end with an alphanumeric
+                                        character. No other punctuation is allowed.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    type: array
+                                  matches:
+                                    description: |-
+                                      Matches define conditions used for matching the rule against incoming HTTP requests.
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: "HTTPRouteMatch defines the predicate
+                                        used to match requests to a given\naction.
+                                        Multiple match types are ANDed together, i.e.
+                                        the match will\nevaluate to true only if all
+                                        conditions are satisfied.\n\n\nFor example,
+                                        the match below will match a HTTP request
+                                        only if its path\nstarts with `/foo` AND it
+                                        contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                                        \ value \"v1\"\n\n\n```"
+                                      properties:
+                                        headers:
+                                          description: |-
+                                            Headers specifies HTTP request header matchers. Multiple match values are
+                                            ANDed together, meaning, a request must match all the specified headers
+                                            to select the route.
+                                          items:
+                                            description: |-
+                                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                              headers.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                  If multiple entries specify equivalent header names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent header name MUST be ignored. Due to the
+                                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                                  equivalent.
+
+
+                                                  When a header is repeated in an HTTP request, it is
+                                                  implementation-specific behavior as to how this is represented.
+                                                  Generally, proxies should follow the guidance from the RFC:
+                                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                  processing a repeated header, with special handling for "Set-Cookie".
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the header.
+
+
+                                                  Support: Core (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression HeaderMatchType has implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other dialects
+                                                  of regular expressions. Please read the implementation's documentation to
+                                                  determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP Header to be matched.
+                                                maxLength: 4096
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        method:
+                                          description: |-
+                                            Method specifies HTTP method matcher.
+                                            When specified, this route will be matched only if the request has the
+                                            specified method.
+
+
+                                            Support: Extended
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                        path:
+                                          default:
+                                            type: PathPrefix
+                                            value: /
+                                          description: |-
+                                            Path specifies a HTTP request path matcher. If this field is not
+                                            specified, a default prefix match on the "/" path is provided.
+                                          properties:
+                                            type:
+                                              default: PathPrefix
+                                              description: |-
+                                                Type specifies how to match against the path Value.
+
+
+                                                Support: Core (Exact, PathPrefix)
+
+
+                                                Support: Implementation-specific (RegularExpression)
+                                              enum:
+                                              - Exact
+                                              - PathPrefix
+                                              - RegularExpression
+                                              type: string
+                                            value:
+                                              default: /
+                                              description: Value of the HTTP path
+                                                to match against.
+                                              maxLength: 1024
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: value must be an absolute path
+                                              and start with '/' when type one of
+                                              ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.startsWith(''/'') : true'
+                                          - message: must not contain '//' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''//'') : true'
+                                          - message: must not contain '/./' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/./'') : true'
+                                          - message: must not contain '/../' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/../'') : true'
+                                          - message: must not contain '%2f' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2f'') : true'
+                                          - message: must not contain '%2F' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2F'') : true'
+                                          - message: must not contain '#' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''#'') : true'
+                                          - message: must not end with '/..' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/..'') : true'
+                                          - message: must not end with '/.' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/.'') : true'
+                                          - message: type must be one of ['Exact',
+                                              'PathPrefix', 'RegularExpression']
+                                            rule: self.type in ['Exact','PathPrefix']
+                                              || self.type == 'RegularExpression'
+                                          - message: must only contain valid characters
+                                              (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                              for types ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                              : true'
+                                        queryParams:
+                                          description: |-
+                                            QueryParams specifies HTTP query parameter matchers. Multiple match
+                                            values are ANDed together, meaning, a request must match all the
+                                            specified query parameters to select the route.
+
+
+                                            Support: Extended
+                                          items:
+                                            description: |-
+                                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                              query parameters.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP query param to be matched. This must be an
+                                                  exact string match. (See
+                                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                  If multiple entries specify equivalent query param names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent query param name MUST be ignored.
+
+
+                                                  If a query param is repeated in an HTTP request, the behavior is
+                                                  purposely left undefined, since different data planes have different
+                                                  capabilities. However, it is *recommended* that implementations should
+                                                  match against the first value of the param if the data plane supports it,
+                                                  as this behavior is expected in other load balancing contexts outside of
+                                                  the Gateway API.
+
+
+                                                  Users SHOULD NOT route traffic based on repeated query params to guard
+                                                  themselves against potential differences in the implementations.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the query parameter.
+
+
+                                                  Support: Extended (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other
+                                                  dialects of regular expressions. Please read the implementation's
+                                                  documentation to determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP query param to be matched.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                    maxItems: 8
+                                    type: array
+                                type: object
+                              maxItems: 8
+                              type: array
+                            spicedb:
+                              description: Authorization decision delegated to external
+                                Authzed/SpiceDB server.
+                              properties:
+                                endpoint:
+                                  description: Hostname and port number to the GRPC
+                                    interface of the SpiceDB server (e.g. spicedb:50051).
+                                  type: string
+                                insecure:
+                                  description: Insecure HTTP connection (i.e. disables
+                                    TLS verification)
+                                  type: boolean
+                                permission:
+                                  description: The name of the permission (or relation)
+                                    on which to execute the check.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                resource:
+                                  description: The resource on which to check the
+                                    permission or relation.
+                                  properties:
+                                    kind:
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    name:
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                sharedSecretRef:
+                                  description: Reference to a Secret key whose value
+                                    will be used by Authorino to authenticate with
+                                    the Authzed service.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                subject:
+                                  description: The subject that will be checked for
+                                    the permission or relation.
+                                  properties:
+                                    kind:
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    name:
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                              required:
+                              - endpoint
+                              type: object
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        description: |-
+                          Authorization policies.
+                          All policies MUST evaluate to "allowed = true" for the auth request be successful.
+                        maxProperties: 10
+                        type: object
+                      callbacks:
+                        additionalProperties:
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            http:
+                              description: Settings of the external HTTP request
+                              properties:
+                                body:
+                                  description: |-
+                                    Raw body of the HTTP request.
+                                    Supersedes 'bodyParameters'; use either one or the other.
+                                    Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                bodyParameters:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: |-
+                                    Custom parameters to encode in the body of the HTTP request.
+                                    Superseded by 'body'; use either one or the other.
+                                    Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                  type: object
+                                contentType:
+                                  default: application/x-www-form-urlencoded
+                                  description: |-
+                                    Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                    Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                                  enum:
+                                  - application/x-www-form-urlencoded
+                                  - application/json
+                                  type: string
+                                credentials:
+                                  description: |-
+                                    Defines where client credentials will be passed in the request to the service.
+                                    If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                                  properties:
+                                    authorizationHeader:
+                                      properties:
+                                        prefix:
+                                          type: string
+                                      type: object
+                                    cookie:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    customHeader:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    queryString:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                  type: object
+                                headers:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Custom headers in the HTTP request.
+                                  type: object
+                                method:
+                                  default: GET
+                                  description: |-
+                                    HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                    When the request method is POST, the authorization JSON is passed in the body of the request.
+                                  enum:
+                                  - GET
+                                  - POST
+                                  - PUT
+                                  - PATCH
+                                  - DELETE
+                                  - HEAD
+                                  - OPTIONS
+                                  - CONNECT
+                                  - TRACE
+                                  type: string
+                                oauth2:
+                                  description: Authentication with the HTTP service
+                                    by OAuth2 Client Credentials grant.
+                                  properties:
+                                    cache:
+                                      default: true
+                                      description: |-
+                                        Caches and reuses the token until expired.
+                                        Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                      type: boolean
+                                    clientId:
+                                      description: OAuth2 Client ID.
+                                      type: string
+                                    clientSecretRef:
+                                      description: Reference to a Kuberentes Secret
+                                        key that stores that OAuth2 Client Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: The name of the secret in the
+                                            Authorino's namespace to select from.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                    extraParams:
+                                      additionalProperties:
+                                        type: string
+                                      description: Optional extra parameters for the
+                                        requests to the token URL.
+                                      type: object
+                                    scopes:
+                                      description: Optional scopes for the client
+                                        credentials grant, if supported by he OAuth2
+                                        server.
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      description: Token endpoint URL of the OAuth2
+                                        resource server.
+                                      type: string
+                                  required:
+                                  - clientId
+                                  - clientSecretRef
+                                  - tokenUrl
+                                  type: object
+                                sharedSecretRef:
+                                  description: |-
+                                    Reference to a Secret key whose value will be passed by Authorino in the request.
+                                    The HTTP service can use the shared secret to authenticate the origin of the request.
+                                    Ignored if used together with oauth2.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                url:
+                                  description: |-
+                                    Endpoint URL of the HTTP service.
+                                    The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                    by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                    E.g. https://ext-auth-server.io/metadata?p={request.path}
+                                  type: string
+                              required:
+                              - url
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            routeSelectors:
+                              description: |-
+                                Top-level route selectors.
+                                If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                              items:
+                                description: |-
+                                  RouteSelector defines semantics for matching an HTTP request based on conditions
+                                  https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                properties:
+                                  hostnames:
+                                    description: |-
+                                      Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: |-
+                                        Hostname is the fully qualified domain name of a network host. This matches
+                                        the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                         1. IPs are not allowed.
+                                         2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                            label must appear by itself as the first label.
+
+
+                                        Hostname can be "precise" which is a domain name without the terminating
+                                        dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                        domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                        Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                        alphanumeric characters or '-', and must start and end with an alphanumeric
+                                        character. No other punctuation is allowed.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    type: array
+                                  matches:
+                                    description: |-
+                                      Matches define conditions used for matching the rule against incoming HTTP requests.
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: "HTTPRouteMatch defines the predicate
+                                        used to match requests to a given\naction.
+                                        Multiple match types are ANDed together, i.e.
+                                        the match will\nevaluate to true only if all
+                                        conditions are satisfied.\n\n\nFor example,
+                                        the match below will match a HTTP request
+                                        only if its path\nstarts with `/foo` AND it
+                                        contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                                        \ value \"v1\"\n\n\n```"
+                                      properties:
+                                        headers:
+                                          description: |-
+                                            Headers specifies HTTP request header matchers. Multiple match values are
+                                            ANDed together, meaning, a request must match all the specified headers
+                                            to select the route.
+                                          items:
+                                            description: |-
+                                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                              headers.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                  If multiple entries specify equivalent header names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent header name MUST be ignored. Due to the
+                                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                                  equivalent.
+
+
+                                                  When a header is repeated in an HTTP request, it is
+                                                  implementation-specific behavior as to how this is represented.
+                                                  Generally, proxies should follow the guidance from the RFC:
+                                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                  processing a repeated header, with special handling for "Set-Cookie".
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the header.
+
+
+                                                  Support: Core (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression HeaderMatchType has implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other dialects
+                                                  of regular expressions. Please read the implementation's documentation to
+                                                  determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP Header to be matched.
+                                                maxLength: 4096
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        method:
+                                          description: |-
+                                            Method specifies HTTP method matcher.
+                                            When specified, this route will be matched only if the request has the
+                                            specified method.
+
+
+                                            Support: Extended
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                        path:
+                                          default:
+                                            type: PathPrefix
+                                            value: /
+                                          description: |-
+                                            Path specifies a HTTP request path matcher. If this field is not
+                                            specified, a default prefix match on the "/" path is provided.
+                                          properties:
+                                            type:
+                                              default: PathPrefix
+                                              description: |-
+                                                Type specifies how to match against the path Value.
+
+
+                                                Support: Core (Exact, PathPrefix)
+
+
+                                                Support: Implementation-specific (RegularExpression)
+                                              enum:
+                                              - Exact
+                                              - PathPrefix
+                                              - RegularExpression
+                                              type: string
+                                            value:
+                                              default: /
+                                              description: Value of the HTTP path
+                                                to match against.
+                                              maxLength: 1024
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: value must be an absolute path
+                                              and start with '/' when type one of
+                                              ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.startsWith(''/'') : true'
+                                          - message: must not contain '//' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''//'') : true'
+                                          - message: must not contain '/./' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/./'') : true'
+                                          - message: must not contain '/../' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/../'') : true'
+                                          - message: must not contain '%2f' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2f'') : true'
+                                          - message: must not contain '%2F' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2F'') : true'
+                                          - message: must not contain '#' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''#'') : true'
+                                          - message: must not end with '/..' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/..'') : true'
+                                          - message: must not end with '/.' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/.'') : true'
+                                          - message: type must be one of ['Exact',
+                                              'PathPrefix', 'RegularExpression']
+                                            rule: self.type in ['Exact','PathPrefix']
+                                              || self.type == 'RegularExpression'
+                                          - message: must only contain valid characters
+                                              (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                              for types ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                              : true'
+                                        queryParams:
+                                          description: |-
+                                            QueryParams specifies HTTP query parameter matchers. Multiple match
+                                            values are ANDed together, meaning, a request must match all the
+                                            specified query parameters to select the route.
+
+
+                                            Support: Extended
+                                          items:
+                                            description: |-
+                                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                              query parameters.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP query param to be matched. This must be an
+                                                  exact string match. (See
+                                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                  If multiple entries specify equivalent query param names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent query param name MUST be ignored.
+
+
+                                                  If a query param is repeated in an HTTP request, the behavior is
+                                                  purposely left undefined, since different data planes have different
+                                                  capabilities. However, it is *recommended* that implementations should
+                                                  match against the first value of the param if the data plane supports it,
+                                                  as this behavior is expected in other load balancing contexts outside of
+                                                  the Gateway API.
+
+
+                                                  Users SHOULD NOT route traffic based on repeated query params to guard
+                                                  themselves against potential differences in the implementations.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the query parameter.
+
+
+                                                  Support: Extended (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other
+                                                  dialects of regular expressions. Please read the implementation's
+                                                  documentation to determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP query param to be matched.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                    maxItems: 8
+                                    type: array
+                                type: object
+                              maxItems: 8
+                              type: array
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                          required:
+                          - http
+                          type: object
+                        description: |-
+                          Callback functions.
+                          Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
+                        maxProperties: 10
+                        type: object
+                      metadata:
+                        additionalProperties:
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            http:
+                              description: External source of auth metadata via HTTP
+                                request
+                              properties:
+                                body:
+                                  description: |-
+                                    Raw body of the HTTP request.
+                                    Supersedes 'bodyParameters'; use either one or the other.
+                                    Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                bodyParameters:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: |-
+                                    Custom parameters to encode in the body of the HTTP request.
+                                    Superseded by 'body'; use either one or the other.
+                                    Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                  type: object
+                                contentType:
+                                  default: application/x-www-form-urlencoded
+                                  description: |-
+                                    Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                    Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                                  enum:
+                                  - application/x-www-form-urlencoded
+                                  - application/json
+                                  type: string
+                                credentials:
+                                  description: |-
+                                    Defines where client credentials will be passed in the request to the service.
+                                    If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                                  properties:
+                                    authorizationHeader:
+                                      properties:
+                                        prefix:
+                                          type: string
+                                      type: object
+                                    cookie:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    customHeader:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    queryString:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                  type: object
+                                headers:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Custom headers in the HTTP request.
+                                  type: object
+                                method:
+                                  default: GET
+                                  description: |-
+                                    HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                    When the request method is POST, the authorization JSON is passed in the body of the request.
+                                  enum:
+                                  - GET
+                                  - POST
+                                  - PUT
+                                  - PATCH
+                                  - DELETE
+                                  - HEAD
+                                  - OPTIONS
+                                  - CONNECT
+                                  - TRACE
+                                  type: string
+                                oauth2:
+                                  description: Authentication with the HTTP service
+                                    by OAuth2 Client Credentials grant.
+                                  properties:
+                                    cache:
+                                      default: true
+                                      description: |-
+                                        Caches and reuses the token until expired.
+                                        Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                      type: boolean
+                                    clientId:
+                                      description: OAuth2 Client ID.
+                                      type: string
+                                    clientSecretRef:
+                                      description: Reference to a Kuberentes Secret
+                                        key that stores that OAuth2 Client Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: The name of the secret in the
+                                            Authorino's namespace to select from.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                    extraParams:
+                                      additionalProperties:
+                                        type: string
+                                      description: Optional extra parameters for the
+                                        requests to the token URL.
+                                      type: object
+                                    scopes:
+                                      description: Optional scopes for the client
+                                        credentials grant, if supported by he OAuth2
+                                        server.
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      description: Token endpoint URL of the OAuth2
+                                        resource server.
+                                      type: string
+                                  required:
+                                  - clientId
+                                  - clientSecretRef
+                                  - tokenUrl
+                                  type: object
+                                sharedSecretRef:
+                                  description: |-
+                                    Reference to a Secret key whose value will be passed by Authorino in the request.
+                                    The HTTP service can use the shared secret to authenticate the origin of the request.
+                                    Ignored if used together with oauth2.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                url:
+                                  description: |-
+                                    Endpoint URL of the HTTP service.
+                                    The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                    by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                    E.g. https://ext-auth-server.io/metadata?p={request.path}
+                                  type: string
+                              required:
+                              - url
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            routeSelectors:
+                              description: |-
+                                Top-level route selectors.
+                                If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                              items:
+                                description: |-
+                                  RouteSelector defines semantics for matching an HTTP request based on conditions
+                                  https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                properties:
+                                  hostnames:
+                                    description: |-
+                                      Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: |-
+                                        Hostname is the fully qualified domain name of a network host. This matches
+                                        the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                         1. IPs are not allowed.
+                                         2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                            label must appear by itself as the first label.
+
+
+                                        Hostname can be "precise" which is a domain name without the terminating
+                                        dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                        domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                        Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                        alphanumeric characters or '-', and must start and end with an alphanumeric
+                                        character. No other punctuation is allowed.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    type: array
+                                  matches:
+                                    description: |-
+                                      Matches define conditions used for matching the rule against incoming HTTP requests.
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: "HTTPRouteMatch defines the predicate
+                                        used to match requests to a given\naction.
+                                        Multiple match types are ANDed together, i.e.
+                                        the match will\nevaluate to true only if all
+                                        conditions are satisfied.\n\n\nFor example,
+                                        the match below will match a HTTP request
+                                        only if its path\nstarts with `/foo` AND it
+                                        contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                                        \ value \"v1\"\n\n\n```"
+                                      properties:
+                                        headers:
+                                          description: |-
+                                            Headers specifies HTTP request header matchers. Multiple match values are
+                                            ANDed together, meaning, a request must match all the specified headers
+                                            to select the route.
+                                          items:
+                                            description: |-
+                                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                              headers.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                  If multiple entries specify equivalent header names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent header name MUST be ignored. Due to the
+                                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                                  equivalent.
+
+
+                                                  When a header is repeated in an HTTP request, it is
+                                                  implementation-specific behavior as to how this is represented.
+                                                  Generally, proxies should follow the guidance from the RFC:
+                                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                  processing a repeated header, with special handling for "Set-Cookie".
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the header.
+
+
+                                                  Support: Core (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression HeaderMatchType has implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other dialects
+                                                  of regular expressions. Please read the implementation's documentation to
+                                                  determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP Header to be matched.
+                                                maxLength: 4096
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        method:
+                                          description: |-
+                                            Method specifies HTTP method matcher.
+                                            When specified, this route will be matched only if the request has the
+                                            specified method.
+
+
+                                            Support: Extended
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                        path:
+                                          default:
+                                            type: PathPrefix
+                                            value: /
+                                          description: |-
+                                            Path specifies a HTTP request path matcher. If this field is not
+                                            specified, a default prefix match on the "/" path is provided.
+                                          properties:
+                                            type:
+                                              default: PathPrefix
+                                              description: |-
+                                                Type specifies how to match against the path Value.
+
+
+                                                Support: Core (Exact, PathPrefix)
+
+
+                                                Support: Implementation-specific (RegularExpression)
+                                              enum:
+                                              - Exact
+                                              - PathPrefix
+                                              - RegularExpression
+                                              type: string
+                                            value:
+                                              default: /
+                                              description: Value of the HTTP path
+                                                to match against.
+                                              maxLength: 1024
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: value must be an absolute path
+                                              and start with '/' when type one of
+                                              ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.startsWith(''/'') : true'
+                                          - message: must not contain '//' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''//'') : true'
+                                          - message: must not contain '/./' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/./'') : true'
+                                          - message: must not contain '/../' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/../'') : true'
+                                          - message: must not contain '%2f' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2f'') : true'
+                                          - message: must not contain '%2F' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2F'') : true'
+                                          - message: must not contain '#' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''#'') : true'
+                                          - message: must not end with '/..' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/..'') : true'
+                                          - message: must not end with '/.' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/.'') : true'
+                                          - message: type must be one of ['Exact',
+                                              'PathPrefix', 'RegularExpression']
+                                            rule: self.type in ['Exact','PathPrefix']
+                                              || self.type == 'RegularExpression'
+                                          - message: must only contain valid characters
+                                              (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                              for types ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                              : true'
+                                        queryParams:
+                                          description: |-
+                                            QueryParams specifies HTTP query parameter matchers. Multiple match
+                                            values are ANDed together, meaning, a request must match all the
+                                            specified query parameters to select the route.
+
+
+                                            Support: Extended
+                                          items:
+                                            description: |-
+                                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                              query parameters.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP query param to be matched. This must be an
+                                                  exact string match. (See
+                                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                  If multiple entries specify equivalent query param names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent query param name MUST be ignored.
+
+
+                                                  If a query param is repeated in an HTTP request, the behavior is
+                                                  purposely left undefined, since different data planes have different
+                                                  capabilities. However, it is *recommended* that implementations should
+                                                  match against the first value of the param if the data plane supports it,
+                                                  as this behavior is expected in other load balancing contexts outside of
+                                                  the Gateway API.
+
+
+                                                  Users SHOULD NOT route traffic based on repeated query params to guard
+                                                  themselves against potential differences in the implementations.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the query parameter.
+
+
+                                                  Support: Extended (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other
+                                                  dialects of regular expressions. Please read the implementation's
+                                                  documentation to determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP query param to be matched.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                    maxItems: 8
+                                    type: array
+                                type: object
+                              maxItems: 8
+                              type: array
+                            uma:
+                              description: User-Managed Access (UMA) source of resource
+                                data.
+                              properties:
+                                credentialsRef:
+                                  description: Reference to a Kubernetes secret in
+                                    the same namespace, that stores client credentials
+                                    to the resource registration API of the UMA server.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                endpoint:
+                                  description: |-
+                                    The endpoint of the UMA server.
+                                    The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
+                                  type: string
+                              required:
+                              - credentialsRef
+                              - endpoint
+                              type: object
+                            userInfo:
+                              description: OpendID Connect UserInfo linked to an OIDC
+                                authentication config specified in this same AuthConfig.
+                              properties:
+                                identitySource:
+                                  description: The name of an OIDC-enabled JWT authentication
+                                    config whose OpenID Connect configuration discovered
+                                    includes the OIDC "userinfo_endpoint" claim.
+                                  type: string
+                              required:
+                              - identitySource
+                              type: object
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        description: |-
+                          Metadata sources.
+                          Authorino fetches auth metadata as JSON from sources specified in this config.
+                        maxProperties: 10
+                        type: object
+                      response:
+                        description: |-
+                          Response items.
+                          Authorino builds custom responses to the client of the auth request.
+                        properties:
+                          success:
+                            description: |-
+                              Response items to be included in the auth response when the request is authenticated and authorized.
+                              For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata and/or inject data in the request.
+                            properties:
+                              dynamicMetadata:
+                                additionalProperties:
+                                  properties:
+                                    cache:
+                                      description: |-
+                                        Caching options for the resolved object returned when applying this config.
+                                        Omit it to avoid caching objects for this config.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            Key used to store the entry in the cache.
+                                            The resolved key must be unique within the scope of this particular config.
+                                          properties:
+                                            selector:
+                                              description: |-
+                                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                              type: string
+                                            value:
+                                              description: Static value
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        ttl:
+                                          default: 60
+                                          description: Duration (in seconds) of the
+                                            external data in the cache before pulled
+                                            again from the source.
+                                          type: integer
+                                      required:
+                                      - key
+                                      type: object
+                                    json:
+                                      description: |-
+                                        JSON object
+                                        Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                                      properties:
+                                        properties:
+                                          additionalProperties:
+                                            properties:
+                                              selector:
+                                                description: |-
+                                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                                type: string
+                                              value:
+                                                description: Static value
+                                                x-kubernetes-preserve-unknown-fields: true
+                                            type: object
+                                          type: object
+                                      required:
+                                      - properties
+                                      type: object
+                                    key:
+                                      description: |-
+                                        The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                        If omitted, it will be set to the name of the response config.
+                                      type: string
+                                    metrics:
+                                      default: false
+                                      description: Whether this config should generate
+                                        individual observability metrics
+                                      type: boolean
+                                    plain:
+                                      description: Plain text content
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    priority:
+                                      default: 0
+                                      description: |-
+                                        Priority group of the config.
+                                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                                      type: integer
+                                    routeSelectors:
+                                      description: |-
+                                        Top-level route selectors.
+                                        If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                        At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                        If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                                      items:
+                                        description: |-
+                                          RouteSelector defines semantics for matching an HTTP request based on conditions
+                                          https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                        properties:
+                                          hostnames:
+                                            description: |-
+                                              Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                              https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                            items:
+                                              description: |-
+                                                Hostname is the fully qualified domain name of a network host. This matches
+                                                the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                                 1. IPs are not allowed.
+                                                 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                                    label must appear by itself as the first label.
+
+
+                                                Hostname can be "precise" which is a domain name without the terminating
+                                                dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                                domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                                Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                                alphanumeric characters or '-', and must start and end with an alphanumeric
+                                                character. No other punctuation is allowed.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            type: array
+                                          matches:
+                                            description: |-
+                                              Matches define conditions used for matching the rule against incoming HTTP requests.
+                                              https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                            items:
+                                              description: "HTTPRouteMatch defines
+                                                the predicate used to match requests
+                                                to a given\naction. Multiple match
+                                                types are ANDed together, i.e. the
+                                                match will\nevaluate to true only
+                                                if all conditions are satisfied.\n\n\nFor
+                                                example, the match below will match
+                                                a HTTP request only if its path\nstarts
+                                                with `/foo` AND it contains the `version:
+                                                v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                                \ value: \"/foo\"\n\theaders:\n\t-
+                                                name: \"version\"\n\t  value \"v1\"\n\n\n```"
+                                              properties:
+                                                headers:
+                                                  description: |-
+                                                    Headers specifies HTTP request header matchers. Multiple match values are
+                                                    ANDed together, meaning, a request must match all the specified headers
+                                                    to select the route.
+                                                  items:
+                                                    description: |-
+                                                      HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                                      headers.
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                          case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                          If multiple entries specify equivalent header names, only the first
+                                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                                          entries with an equivalent header name MUST be ignored. Due to the
+                                                          case-insensitivity of header names, "foo" and "Foo" are considered
+                                                          equivalent.
+
+
+                                                          When a header is repeated in an HTTP request, it is
+                                                          implementation-specific behavior as to how this is represented.
+                                                          Generally, proxies should follow the guidance from the RFC:
+                                                          https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                          processing a repeated header, with special handling for "Set-Cookie".
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      type:
+                                                        default: Exact
+                                                        description: |-
+                                                          Type specifies how to match against the value of the header.
+
+
+                                                          Support: Core (Exact)
+
+
+                                                          Support: Implementation-specific (RegularExpression)
+
+
+                                                          Since RegularExpression HeaderMatchType has implementation-specific
+                                                          conformance, implementations can support POSIX, PCRE or any other dialects
+                                                          of regular expressions. Please read the implementation's documentation to
+                                                          determine the supported dialect.
+                                                        enum:
+                                                        - Exact
+                                                        - RegularExpression
+                                                        type: string
+                                                      value:
+                                                        description: Value is the
+                                                          value of HTTP Header to
+                                                          be matched.
+                                                        maxLength: 4096
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  maxItems: 16
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
+                                                method:
+                                                  description: |-
+                                                    Method specifies HTTP method matcher.
+                                                    When specified, this route will be matched only if the request has the
+                                                    specified method.
+
+
+                                                    Support: Extended
+                                                  enum:
+                                                  - GET
+                                                  - HEAD
+                                                  - POST
+                                                  - PUT
+                                                  - DELETE
+                                                  - CONNECT
+                                                  - OPTIONS
+                                                  - TRACE
+                                                  - PATCH
+                                                  type: string
+                                                path:
+                                                  default:
+                                                    type: PathPrefix
+                                                    value: /
+                                                  description: |-
+                                                    Path specifies a HTTP request path matcher. If this field is not
+                                                    specified, a default prefix match on the "/" path is provided.
+                                                  properties:
+                                                    type:
+                                                      default: PathPrefix
+                                                      description: |-
+                                                        Type specifies how to match against the path Value.
+
+
+                                                        Support: Core (Exact, PathPrefix)
+
+
+                                                        Support: Implementation-specific (RegularExpression)
+                                                      enum:
+                                                      - Exact
+                                                      - PathPrefix
+                                                      - RegularExpression
+                                                      type: string
+                                                    value:
+                                                      default: /
+                                                      description: Value of the HTTP
+                                                        path to match against.
+                                                      maxLength: 1024
+                                                      type: string
+                                                  type: object
+                                                  x-kubernetes-validations:
+                                                  - message: value must be an absolute
+                                                      path and start with '/' when
+                                                      type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? self.value.startsWith(''/'')
+                                                      : true'
+                                                  - message: must not contain '//'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''//'')
+                                                      : true'
+                                                  - message: must not contain '/./'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''/./'')
+                                                      : true'
+                                                  - message: must not contain '/../'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''/../'')
+                                                      : true'
+                                                  - message: must not contain '%2f'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''%2f'')
+                                                      : true'
+                                                  - message: must not contain '%2F'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''%2F'')
+                                                      : true'
+                                                  - message: must not contain '#'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''#'')
+                                                      : true'
+                                                  - message: must not end with '/..'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.endsWith(''/..'')
+                                                      : true'
+                                                  - message: must not end with '/.'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.endsWith(''/.'')
+                                                      : true'
+                                                  - message: type must be one of ['Exact',
+                                                      'PathPrefix', 'RegularExpression']
+                                                    rule: self.type in ['Exact','PathPrefix']
+                                                      || self.type == 'RegularExpression'
+                                                  - message: must only contain valid
+                                                      characters (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                                      for types ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                                      : true'
+                                                queryParams:
+                                                  description: |-
+                                                    QueryParams specifies HTTP query parameter matchers. Multiple match
+                                                    values are ANDed together, meaning, a request must match all the
+                                                    specified query parameters to select the route.
+
+
+                                                    Support: Extended
+                                                  items:
+                                                    description: |-
+                                                      HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                                      query parameters.
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          Name is the name of the HTTP query param to be matched. This must be an
+                                                          exact string match. (See
+                                                          https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                          If multiple entries specify equivalent query param names, only the first
+                                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                                          entries with an equivalent query param name MUST be ignored.
+
+
+                                                          If a query param is repeated in an HTTP request, the behavior is
+                                                          purposely left undefined, since different data planes have different
+                                                          capabilities. However, it is *recommended* that implementations should
+                                                          match against the first value of the param if the data plane supports it,
+                                                          as this behavior is expected in other load balancing contexts outside of
+                                                          the Gateway API.
+
+
+                                                          Users SHOULD NOT route traffic based on repeated query params to guard
+                                                          themselves against potential differences in the implementations.
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      type:
+                                                        default: Exact
+                                                        description: |-
+                                                          Type specifies how to match against the value of the query parameter.
+
+
+                                                          Support: Extended (Exact)
+
+
+                                                          Support: Implementation-specific (RegularExpression)
+
+
+                                                          Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                          conformance, implementations can support POSIX, PCRE or any other
+                                                          dialects of regular expressions. Please read the implementation's
+                                                          documentation to determine the supported dialect.
+                                                        enum:
+                                                        - Exact
+                                                        - RegularExpression
+                                                        type: string
+                                                      value:
+                                                        description: Value is the
+                                                          value of HTTP query param
+                                                          to be matched.
+                                                        maxLength: 1024
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  maxItems: 16
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
+                                              type: object
+                                            maxItems: 8
+                                            type: array
+                                        type: object
+                                      maxItems: 8
+                                      type: array
+                                    when:
+                                      description: |-
+                                        Conditions for Authorino to enforce this config.
+                                        If omitted, the config will be enforced for all requests.
+                                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                                      items:
+                                        properties:
+                                          all:
+                                            description: A list of pattern expressions
+                                              to be evaluated as a logical AND.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                          any:
+                                            description: A list of pattern expressions
+                                              to be evaluated as a logical OR.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                          operator:
+                                            description: |-
+                                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                            enum:
+                                            - eq
+                                            - neq
+                                            - incl
+                                            - excl
+                                            - matches
+                                            type: string
+                                          patternRef:
+                                            description: Reference to a named set
+                                              of pattern expressions
+                                            type: string
+                                          selector:
+                                            description: |-
+                                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                              Authorino custom JSON path modifiers are also supported.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                            type: string
+                                        type: object
+                                      type: array
+                                    wristband:
+                                      description: Authorino Festival Wristband token
+                                      properties:
+                                        customClaims:
+                                          additionalProperties:
+                                            properties:
+                                              selector:
+                                                description: |-
+                                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                                type: string
+                                              value:
+                                                description: Static value
+                                                x-kubernetes-preserve-unknown-fields: true
+                                            type: object
+                                          description: Any claims to be added to the
+                                            wristband token apart from the standard
+                                            JWT claims (iss, iat, exp) added by default.
+                                          type: object
+                                        issuer:
+                                          description: 'The endpoint to the Authorino
+                                            service that issues the wristband (format:
+                                            <scheme>://<host>:<port>/<realm>, where
+                                            <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                          type: string
+                                        signingKeyRefs:
+                                          description: |-
+                                            Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                            The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                          items:
+                                            properties:
+                                              algorithm:
+                                                description: Algorithm to sign the
+                                                  wristband token using the signing
+                                                  key provided
+                                                enum:
+                                                - ES256
+                                                - ES384
+                                                - ES512
+                                                - RS256
+                                                - RS384
+                                                - RS512
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the signing key.
+                                                  The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                                type: string
+                                            required:
+                                            - algorithm
+                                            - name
+                                            type: object
+                                          type: array
+                                        tokenDuration:
+                                          description: Time span of the wristband
+                                            token, in seconds.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - issuer
+                                      - signingKeyRefs
+                                      type: object
+                                  type: object
+                                description: |-
+                                  Custom success response items wrapped as HTTP headers.
+                                  For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
+                                  See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
+                                maxProperties: 10
+                                type: object
+                              headers:
+                                additionalProperties:
+                                  properties:
+                                    cache:
+                                      description: |-
+                                        Caching options for the resolved object returned when applying this config.
+                                        Omit it to avoid caching objects for this config.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            Key used to store the entry in the cache.
+                                            The resolved key must be unique within the scope of this particular config.
+                                          properties:
+                                            selector:
+                                              description: |-
+                                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                              type: string
+                                            value:
+                                              description: Static value
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        ttl:
+                                          default: 60
+                                          description: Duration (in seconds) of the
+                                            external data in the cache before pulled
+                                            again from the source.
+                                          type: integer
+                                      required:
+                                      - key
+                                      type: object
+                                    json:
+                                      description: |-
+                                        JSON object
+                                        Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                                      properties:
+                                        properties:
+                                          additionalProperties:
+                                            properties:
+                                              selector:
+                                                description: |-
+                                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                                type: string
+                                              value:
+                                                description: Static value
+                                                x-kubernetes-preserve-unknown-fields: true
+                                            type: object
+                                          type: object
+                                      required:
+                                      - properties
+                                      type: object
+                                    key:
+                                      description: |-
+                                        The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                        If omitted, it will be set to the name of the response config.
+                                      type: string
+                                    metrics:
+                                      default: false
+                                      description: Whether this config should generate
+                                        individual observability metrics
+                                      type: boolean
+                                    plain:
+                                      description: Plain text content
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    priority:
+                                      default: 0
+                                      description: |-
+                                        Priority group of the config.
+                                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                                      type: integer
+                                    routeSelectors:
+                                      description: |-
+                                        Top-level route selectors.
+                                        If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                        At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                        If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                                      items:
+                                        description: |-
+                                          RouteSelector defines semantics for matching an HTTP request based on conditions
+                                          https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                        properties:
+                                          hostnames:
+                                            description: |-
+                                              Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                              https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                            items:
+                                              description: |-
+                                                Hostname is the fully qualified domain name of a network host. This matches
+                                                the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                                 1. IPs are not allowed.
+                                                 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                                    label must appear by itself as the first label.
+
+
+                                                Hostname can be "precise" which is a domain name without the terminating
+                                                dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                                domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                                Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                                alphanumeric characters or '-', and must start and end with an alphanumeric
+                                                character. No other punctuation is allowed.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            type: array
+                                          matches:
+                                            description: |-
+                                              Matches define conditions used for matching the rule against incoming HTTP requests.
+                                              https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                            items:
+                                              description: "HTTPRouteMatch defines
+                                                the predicate used to match requests
+                                                to a given\naction. Multiple match
+                                                types are ANDed together, i.e. the
+                                                match will\nevaluate to true only
+                                                if all conditions are satisfied.\n\n\nFor
+                                                example, the match below will match
+                                                a HTTP request only if its path\nstarts
+                                                with `/foo` AND it contains the `version:
+                                                v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                                \ value: \"/foo\"\n\theaders:\n\t-
+                                                name: \"version\"\n\t  value \"v1\"\n\n\n```"
+                                              properties:
+                                                headers:
+                                                  description: |-
+                                                    Headers specifies HTTP request header matchers. Multiple match values are
+                                                    ANDed together, meaning, a request must match all the specified headers
+                                                    to select the route.
+                                                  items:
+                                                    description: |-
+                                                      HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                                      headers.
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                          case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                          If multiple entries specify equivalent header names, only the first
+                                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                                          entries with an equivalent header name MUST be ignored. Due to the
+                                                          case-insensitivity of header names, "foo" and "Foo" are considered
+                                                          equivalent.
+
+
+                                                          When a header is repeated in an HTTP request, it is
+                                                          implementation-specific behavior as to how this is represented.
+                                                          Generally, proxies should follow the guidance from the RFC:
+                                                          https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                          processing a repeated header, with special handling for "Set-Cookie".
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      type:
+                                                        default: Exact
+                                                        description: |-
+                                                          Type specifies how to match against the value of the header.
+
+
+                                                          Support: Core (Exact)
+
+
+                                                          Support: Implementation-specific (RegularExpression)
+
+
+                                                          Since RegularExpression HeaderMatchType has implementation-specific
+                                                          conformance, implementations can support POSIX, PCRE or any other dialects
+                                                          of regular expressions. Please read the implementation's documentation to
+                                                          determine the supported dialect.
+                                                        enum:
+                                                        - Exact
+                                                        - RegularExpression
+                                                        type: string
+                                                      value:
+                                                        description: Value is the
+                                                          value of HTTP Header to
+                                                          be matched.
+                                                        maxLength: 4096
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  maxItems: 16
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
+                                                method:
+                                                  description: |-
+                                                    Method specifies HTTP method matcher.
+                                                    When specified, this route will be matched only if the request has the
+                                                    specified method.
+
+
+                                                    Support: Extended
+                                                  enum:
+                                                  - GET
+                                                  - HEAD
+                                                  - POST
+                                                  - PUT
+                                                  - DELETE
+                                                  - CONNECT
+                                                  - OPTIONS
+                                                  - TRACE
+                                                  - PATCH
+                                                  type: string
+                                                path:
+                                                  default:
+                                                    type: PathPrefix
+                                                    value: /
+                                                  description: |-
+                                                    Path specifies a HTTP request path matcher. If this field is not
+                                                    specified, a default prefix match on the "/" path is provided.
+                                                  properties:
+                                                    type:
+                                                      default: PathPrefix
+                                                      description: |-
+                                                        Type specifies how to match against the path Value.
+
+
+                                                        Support: Core (Exact, PathPrefix)
+
+
+                                                        Support: Implementation-specific (RegularExpression)
+                                                      enum:
+                                                      - Exact
+                                                      - PathPrefix
+                                                      - RegularExpression
+                                                      type: string
+                                                    value:
+                                                      default: /
+                                                      description: Value of the HTTP
+                                                        path to match against.
+                                                      maxLength: 1024
+                                                      type: string
+                                                  type: object
+                                                  x-kubernetes-validations:
+                                                  - message: value must be an absolute
+                                                      path and start with '/' when
+                                                      type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? self.value.startsWith(''/'')
+                                                      : true'
+                                                  - message: must not contain '//'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''//'')
+                                                      : true'
+                                                  - message: must not contain '/./'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''/./'')
+                                                      : true'
+                                                  - message: must not contain '/../'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''/../'')
+                                                      : true'
+                                                  - message: must not contain '%2f'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''%2f'')
+                                                      : true'
+                                                  - message: must not contain '%2F'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''%2F'')
+                                                      : true'
+                                                  - message: must not contain '#'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''#'')
+                                                      : true'
+                                                  - message: must not end with '/..'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.endsWith(''/..'')
+                                                      : true'
+                                                  - message: must not end with '/.'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.endsWith(''/.'')
+                                                      : true'
+                                                  - message: type must be one of ['Exact',
+                                                      'PathPrefix', 'RegularExpression']
+                                                    rule: self.type in ['Exact','PathPrefix']
+                                                      || self.type == 'RegularExpression'
+                                                  - message: must only contain valid
+                                                      characters (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                                      for types ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                                      : true'
+                                                queryParams:
+                                                  description: |-
+                                                    QueryParams specifies HTTP query parameter matchers. Multiple match
+                                                    values are ANDed together, meaning, a request must match all the
+                                                    specified query parameters to select the route.
+
+
+                                                    Support: Extended
+                                                  items:
+                                                    description: |-
+                                                      HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                                      query parameters.
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          Name is the name of the HTTP query param to be matched. This must be an
+                                                          exact string match. (See
+                                                          https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                          If multiple entries specify equivalent query param names, only the first
+                                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                                          entries with an equivalent query param name MUST be ignored.
+
+
+                                                          If a query param is repeated in an HTTP request, the behavior is
+                                                          purposely left undefined, since different data planes have different
+                                                          capabilities. However, it is *recommended* that implementations should
+                                                          match against the first value of the param if the data plane supports it,
+                                                          as this behavior is expected in other load balancing contexts outside of
+                                                          the Gateway API.
+
+
+                                                          Users SHOULD NOT route traffic based on repeated query params to guard
+                                                          themselves against potential differences in the implementations.
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      type:
+                                                        default: Exact
+                                                        description: |-
+                                                          Type specifies how to match against the value of the query parameter.
+
+
+                                                          Support: Extended (Exact)
+
+
+                                                          Support: Implementation-specific (RegularExpression)
+
+
+                                                          Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                          conformance, implementations can support POSIX, PCRE or any other
+                                                          dialects of regular expressions. Please read the implementation's
+                                                          documentation to determine the supported dialect.
+                                                        enum:
+                                                        - Exact
+                                                        - RegularExpression
+                                                        type: string
+                                                      value:
+                                                        description: Value is the
+                                                          value of HTTP query param
+                                                          to be matched.
+                                                        maxLength: 1024
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  maxItems: 16
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
+                                              type: object
+                                            maxItems: 8
+                                            type: array
+                                        type: object
+                                      maxItems: 8
+                                      type: array
+                                    when:
+                                      description: |-
+                                        Conditions for Authorino to enforce this config.
+                                        If omitted, the config will be enforced for all requests.
+                                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                                      items:
+                                        properties:
+                                          all:
+                                            description: A list of pattern expressions
+                                              to be evaluated as a logical AND.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                          any:
+                                            description: A list of pattern expressions
+                                              to be evaluated as a logical OR.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                          operator:
+                                            description: |-
+                                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                            enum:
+                                            - eq
+                                            - neq
+                                            - incl
+                                            - excl
+                                            - matches
+                                            type: string
+                                          patternRef:
+                                            description: Reference to a named set
+                                              of pattern expressions
+                                            type: string
+                                          selector:
+                                            description: |-
+                                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                              Authorino custom JSON path modifiers are also supported.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                            type: string
+                                        type: object
+                                      type: array
+                                    wristband:
+                                      description: Authorino Festival Wristband token
+                                      properties:
+                                        customClaims:
+                                          additionalProperties:
+                                            properties:
+                                              selector:
+                                                description: |-
+                                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                                type: string
+                                              value:
+                                                description: Static value
+                                                x-kubernetes-preserve-unknown-fields: true
+                                            type: object
+                                          description: Any claims to be added to the
+                                            wristband token apart from the standard
+                                            JWT claims (iss, iat, exp) added by default.
+                                          type: object
+                                        issuer:
+                                          description: 'The endpoint to the Authorino
+                                            service that issues the wristband (format:
+                                            <scheme>://<host>:<port>/<realm>, where
+                                            <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                          type: string
+                                        signingKeyRefs:
+                                          description: |-
+                                            Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                            The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                          items:
+                                            properties:
+                                              algorithm:
+                                                description: Algorithm to sign the
+                                                  wristband token using the signing
+                                                  key provided
+                                                enum:
+                                                - ES256
+                                                - ES384
+                                                - ES512
+                                                - RS256
+                                                - RS384
+                                                - RS512
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the signing key.
+                                                  The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                                type: string
+                                            required:
+                                            - algorithm
+                                            - name
+                                            type: object
+                                          type: array
+                                        tokenDuration:
+                                          description: Time span of the wristband
+                                            token, in seconds.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - issuer
+                                      - signingKeyRefs
+                                      type: object
+                                  type: object
+                                description: |-
+                                  Custom success response items wrapped as HTTP headers.
+                                  For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
+                                maxProperties: 10
                                 type: object
                             type: object
                           unauthenticated:
@@ -5358,7 +9661,7 @@ spec:
                     description: |-
                       Authentication configs.
                       At least one config MUST evaluate to a valid identity object for the auth request to be successful.
-                    maxProperties: 14
+                    maxProperties: 10
                     type: object
                   authorization:
                     additionalProperties:
@@ -6241,7 +10544,7 @@ spec:
                     description: |-
                       Authorization policies.
                       All policies MUST evaluate to "allowed = true" for the auth request be successful.
-                    maxProperties: 14
+                    maxProperties: 10
                     type: object
                   callbacks:
                     additionalProperties:
@@ -6825,7 +11128,7 @@ spec:
                     description: |-
                       Callback functions.
                       Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
-                    maxProperties: 14
+                    maxProperties: 10
                     type: object
                   metadata:
                     additionalProperties:
@@ -7445,7 +11748,7 @@ spec:
                     description: |-
                       Metadata sources.
                       Authorino fetches auth metadata as JSON from sources specified in this config.
-                    maxProperties: 14
+                    maxProperties: 10
                     type: object
                   response:
                     description: |-
@@ -7965,7 +12268,7 @@ spec:
                               Custom success response items wrapped as HTTP headers.
                               For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
                               See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
-                            maxProperties: 14
+                            maxProperties: 10
                             type: object
                           headers:
                             additionalProperties:
@@ -8474,7 +12777,7 @@ spec:
                             description: |-
                               Custom success response items wrapped as HTTP headers.
                               For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
-                            maxProperties: 14
+                            maxProperties: 10
                             type: object
                         type: object
                       unauthenticated:
@@ -8737,9 +13040,42 @@ spec:
               rule: self.targetRef.kind != 'Gateway' || !has(self.defaults) || !has(self.defaults.rules)
                 || !has(self.defaults.rules.callbacks) || !self.defaults.rules.callbacks.exists(x,
                 has(self.defaults.rules.callbacks[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.routeSelectors)
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.authentication) || !self.overrides.rules.authentication.exists(x,
+                has(self.overrides.rules.authentication[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.metadata) || !self.overrides.rules.metadata.exists(x,
+                has(self.overrides.rules.metadata[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.authorization) || !self.overrides.rules.authorization.exists(x,
+                has(self.overrides.rules.authorization[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.response) || !has(self.overrides.rules.response.success)
+                || !has(self.overrides.rules.response.success.headers) || !self.overrides.rules.response.success.headers.exists(x,
+                has(self.overrides.rules.response.success.headers[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.response) || !has(self.overrides.rules.response.success)
+                || !has(self.overrides.rules.response.success.dynamicMetadata) ||
+                !self.overrides.rules.response.success.dynamicMetadata.exists(x, has(self.overrides.rules.response.success.dynamicMetadata[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.callbacks) || !self.overrides.rules.callbacks.exists(x,
+                has(self.overrides.rules.callbacks[x].routeSelectors))
             - message: Implicit and explicit defaults are mutually exclusive
               rule: '!(has(self.defaults) && (has(self.routeSelectors) || has(self.patterns)
                 || has(self.when) || has(self.rules)))'
+            - message: Implicit defaults and explicit overrides are mutually exclusive
+              rule: '!(has(self.overrides) && (has(self.routeSelectors) || has(self.patterns)
+                || has(self.when) || has(self.rules)))'
+            - message: Explicit overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.defaults))'
           status:
             properties:
               conditions:

--- a/bundle/manifests/kuadrant.io_authpolicies.yaml
+++ b/bundle/manifests/kuadrant.io_authpolicies.yaml
@@ -13076,6 +13076,9 @@ spec:
                 || has(self.when) || has(self.rules)))'
             - message: Explicit overrides and explicit defaults are mutually exclusive
               rule: '!(has(self.overrides) && has(self.defaults))'
+            - message: Overrides are not allowed for policies targeting a HTTPRoute
+                resource
+              rule: '!(has(self.overrides) && self.targetRef.kind == ''HTTPRoute'')'
           status:
             properties:
               conditions:

--- a/config/crd/bases/kuadrant.io_authpolicies.yaml
+++ b/config/crd/bases/kuadrant.io_authpolicies.yaml
@@ -67,6 +67,7 @@ spec:
             description: |-
               RouteSelectors - implicit default validation
               RouteSelectors - explicit default validation
+              RouteSelectors - explicit overrides validation
               Mutual Exclusivity Validation
             properties:
               defaults:
@@ -1066,7 +1067,7 @@ spec:
                         description: |-
                           Authentication configs.
                           At least one config MUST evaluate to a valid identity object for the auth request to be successful.
-                        maxProperties: 14
+                        maxProperties: 10
                         type: object
                       authorization:
                         additionalProperties:
@@ -1953,7 +1954,7 @@ spec:
                         description: |-
                           Authorization policies.
                           All policies MUST evaluate to "allowed = true" for the auth request be successful.
-                        maxProperties: 14
+                        maxProperties: 10
                         type: object
                       callbacks:
                         additionalProperties:
@@ -2540,7 +2541,7 @@ spec:
                         description: |-
                           Callback functions.
                           Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
-                        maxProperties: 14
+                        maxProperties: 10
                         type: object
                       metadata:
                         additionalProperties:
@@ -3164,7 +3165,7 @@ spec:
                         description: |-
                           Metadata sources.
                           Authorino fetches auth metadata as JSON from sources specified in this config.
-                        maxProperties: 14
+                        maxProperties: 10
                         type: object
                       response:
                         description: |-
@@ -3688,7 +3689,7 @@ spec:
                                   Custom success response items wrapped as HTTP headers.
                                   For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
                                   See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
-                                maxProperties: 14
+                                maxProperties: 10
                                 type: object
                               headers:
                                 additionalProperties:
@@ -4201,7 +4202,4309 @@ spec:
                                 description: |-
                                   Custom success response items wrapped as HTTP headers.
                                   For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
-                                maxProperties: 14
+                                maxProperties: 10
+                                type: object
+                            type: object
+                          unauthenticated:
+                            description: |-
+                              Customizations on the denial status attributes when the request is unauthenticated.
+                              For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                              Default: 401 Unauthorized
+                            properties:
+                              body:
+                                description: HTTP response body to override the default
+                                  denial body.
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              code:
+                                description: HTTP status code to override the default
+                                  denial status code.
+                                format: int64
+                                maximum: 599
+                                minimum: 300
+                                type: integer
+                              headers:
+                                additionalProperties:
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                description: HTTP response headers to override the
+                                  default denial headers.
+                                type: object
+                              message:
+                                description: HTTP message to override the default
+                                  denial message.
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                          unauthorized:
+                            description: |-
+                              Customizations on the denial status attributes when the request is unauthorized.
+                              For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.
+                              Default: 403 Forbidden
+                            properties:
+                              body:
+                                description: HTTP response body to override the default
+                                  denial body.
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              code:
+                                description: HTTP status code to override the default
+                                  denial status code.
+                                format: int64
+                                maximum: 599
+                                minimum: 300
+                                type: integer
+                              headers:
+                                additionalProperties:
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                description: HTTP response headers to override the
+                                  default denial headers.
+                                type: object
+                              message:
+                                description: HTTP message to override the default
+                                  denial message.
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  when:
+                    description: |-
+                      Overall conditions for the AuthPolicy to be enforced.
+                      If omitted, the AuthPolicy will be enforced at all requests to the protected routes.
+                      If present, all conditions must match for the AuthPolicy to be enforced; otherwise, the authorization service skips the AuthPolicy and returns to the auth request with status OK.
+                    items:
+                      properties:
+                        all:
+                          description: A list of pattern expressions to be evaluated
+                            as a logical AND.
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                        any:
+                          description: A list of pattern expressions to be evaluated
+                            as a logical OR.
+                          items:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type: array
+                        operator:
+                          description: |-
+                            The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                            Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                          enum:
+                          - eq
+                          - neq
+                          - incl
+                          - excl
+                          - matches
+                          type: string
+                        patternRef:
+                          description: Reference to a named set of pattern expressions
+                          type: string
+                        selector:
+                          description: |-
+                            Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                            Authorino custom JSON path modifiers are also supported.
+                          type: string
+                        value:
+                          description: |-
+                            The value of reference for the comparison with the content fetched from the authorization JSON.
+                            If used with the "matches" operator, the value must compile to a valid Golang regex.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              overrides:
+                description: |-
+                  Overrides define explicit override values for this policy.
+                  Overrides are mutually exclusive with explicit and implicit defaults defined by AuthPolicyCommonSpec.
+                properties:
+                  patterns:
+                    additionalProperties:
+                      items:
+                        properties:
+                          operator:
+                            description: |-
+                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                            enum:
+                            - eq
+                            - neq
+                            - incl
+                            - excl
+                            - matches
+                            type: string
+                          selector:
+                            description: |-
+                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                              Authorino custom JSON path modifiers are also supported.
+                            type: string
+                          value:
+                            description: |-
+                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                            type: string
+                        type: object
+                      type: array
+                    description: Named sets of patterns that can be referred in `when`
+                      conditions and in pattern-matching authorization policy rules.
+                    type: object
+                  routeSelectors:
+                    description: |-
+                      Top-level route selectors.
+                      If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the external authorization service.
+                      At least one selected HTTPRoute rule must match to trigger the AuthPolicy.
+                      If no route selectors are specified, the AuthPolicy will be enforced at all requests to the protected routes.
+                    items:
+                      description: |-
+                        RouteSelector defines semantics for matching an HTTP request based on conditions
+                        https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                      properties:
+                        hostnames:
+                          description: |-
+                            Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                            https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                          items:
+                            description: |-
+                              Hostname is the fully qualified domain name of a network host. This matches
+                              the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                               1. IPs are not allowed.
+                               2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                  label must appear by itself as the first label.
+
+
+                              Hostname can be "precise" which is a domain name without the terminating
+                              dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                              domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                              Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                              alphanumeric characters or '-', and must start and end with an alphanumeric
+                              character. No other punctuation is allowed.
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          type: array
+                        matches:
+                          description: |-
+                            Matches define conditions used for matching the rule against incoming HTTP requests.
+                            https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                          items:
+                            description: "HTTPRouteMatch defines the predicate used
+                              to match requests to a given\naction. Multiple match
+                              types are ANDed together, i.e. the match will\nevaluate
+                              to true only if all conditions are satisfied.\n\n\nFor
+                              example, the match below will match a HTTP request only
+                              if its path\nstarts with `/foo` AND it contains the
+                              `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                              \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                              \ value \"v1\"\n\n\n```"
+                            properties:
+                              headers:
+                                description: |-
+                                  Headers specifies HTTP request header matchers. Multiple match values are
+                                  ANDed together, meaning, a request must match all the specified headers
+                                  to select the route.
+                                items:
+                                  description: |-
+                                    HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                    headers.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                        case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                        If multiple entries specify equivalent header names, only the first
+                                        entry with an equivalent name MUST be considered for a match. Subsequent
+                                        entries with an equivalent header name MUST be ignored. Due to the
+                                        case-insensitivity of header names, "foo" and "Foo" are considered
+                                        equivalent.
+
+
+                                        When a header is repeated in an HTTP request, it is
+                                        implementation-specific behavior as to how this is represented.
+                                        Generally, proxies should follow the guidance from the RFC:
+                                        https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                        processing a repeated header, with special handling for "Set-Cookie".
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    type:
+                                      default: Exact
+                                      description: |-
+                                        Type specifies how to match against the value of the header.
+
+
+                                        Support: Core (Exact)
+
+
+                                        Support: Implementation-specific (RegularExpression)
+
+
+                                        Since RegularExpression HeaderMatchType has implementation-specific
+                                        conformance, implementations can support POSIX, PCRE or any other dialects
+                                        of regular expressions. Please read the implementation's documentation to
+                                        determine the supported dialect.
+                                      enum:
+                                      - Exact
+                                      - RegularExpression
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP Header
+                                        to be matched.
+                                      maxLength: 4096
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              method:
+                                description: |-
+                                  Method specifies HTTP method matcher.
+                                  When specified, this route will be matched only if the request has the
+                                  specified method.
+
+
+                                  Support: Extended
+                                enum:
+                                - GET
+                                - HEAD
+                                - POST
+                                - PUT
+                                - DELETE
+                                - CONNECT
+                                - OPTIONS
+                                - TRACE
+                                - PATCH
+                                type: string
+                              path:
+                                default:
+                                  type: PathPrefix
+                                  value: /
+                                description: |-
+                                  Path specifies a HTTP request path matcher. If this field is not
+                                  specified, a default prefix match on the "/" path is provided.
+                                properties:
+                                  type:
+                                    default: PathPrefix
+                                    description: |-
+                                      Type specifies how to match against the path Value.
+
+
+                                      Support: Core (Exact, PathPrefix)
+
+
+                                      Support: Implementation-specific (RegularExpression)
+                                    enum:
+                                    - Exact
+                                    - PathPrefix
+                                    - RegularExpression
+                                    type: string
+                                  value:
+                                    default: /
+                                    description: Value of the HTTP path to match against.
+                                    maxLength: 1024
+                                    type: string
+                                type: object
+                                x-kubernetes-validations:
+                                - message: value must be an absolute path and start
+                                    with '/' when type one of ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? self.value.startsWith(''/'') : true'
+                                - message: must not contain '//' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''//'') : true'
+                                - message: must not contain '/./' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''/./'') : true'
+                                - message: must not contain '/../' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''/../'') : true'
+                                - message: must not contain '%2f' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''%2f'') : true'
+                                - message: must not contain '%2F' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''%2F'') : true'
+                                - message: must not contain '#' when type one of ['Exact',
+                                    'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.contains(''#'') : true'
+                                - message: must not end with '/..' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.endsWith(''/..'') : true'
+                                - message: must not end with '/.' when type one of
+                                    ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? !self.value.endsWith(''/.'') : true'
+                                - message: type must be one of ['Exact', 'PathPrefix',
+                                    'RegularExpression']
+                                  rule: self.type in ['Exact','PathPrefix'] || self.type
+                                    == 'RegularExpression'
+                                - message: must only contain valid characters (matching
+                                    ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                    for types ['Exact', 'PathPrefix']
+                                  rule: '(self.type in [''Exact'',''PathPrefix''])
+                                    ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                    : true'
+                              queryParams:
+                                description: |-
+                                  QueryParams specifies HTTP query parameter matchers. Multiple match
+                                  values are ANDed together, meaning, a request must match all the
+                                  specified query parameters to select the route.
+
+
+                                  Support: Extended
+                                items:
+                                  description: |-
+                                    HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                    query parameters.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name is the name of the HTTP query param to be matched. This must be an
+                                        exact string match. (See
+                                        https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                        If multiple entries specify equivalent query param names, only the first
+                                        entry with an equivalent name MUST be considered for a match. Subsequent
+                                        entries with an equivalent query param name MUST be ignored.
+
+
+                                        If a query param is repeated in an HTTP request, the behavior is
+                                        purposely left undefined, since different data planes have different
+                                        capabilities. However, it is *recommended* that implementations should
+                                        match against the first value of the param if the data plane supports it,
+                                        as this behavior is expected in other load balancing contexts outside of
+                                        the Gateway API.
+
+
+                                        Users SHOULD NOT route traffic based on repeated query params to guard
+                                        themselves against potential differences in the implementations.
+                                      maxLength: 256
+                                      minLength: 1
+                                      pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                      type: string
+                                    type:
+                                      default: Exact
+                                      description: |-
+                                        Type specifies how to match against the value of the query parameter.
+
+
+                                        Support: Extended (Exact)
+
+
+                                        Support: Implementation-specific (RegularExpression)
+
+
+                                        Since RegularExpression QueryParamMatchType has Implementation-specific
+                                        conformance, implementations can support POSIX, PCRE or any other
+                                        dialects of regular expressions. Please read the implementation's
+                                        documentation to determine the supported dialect.
+                                      enum:
+                                      - Exact
+                                      - RegularExpression
+                                      type: string
+                                    value:
+                                      description: Value is the value of HTTP query
+                                        param to be matched.
+                                      maxLength: 1024
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                maxItems: 16
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                            type: object
+                          maxItems: 8
+                          type: array
+                      type: object
+                    maxItems: 15
+                    type: array
+                  rules:
+                    description: |-
+                      The auth rules of the policy.
+                      See Authorino's AuthConfig CRD for more details.
+                    properties:
+                      authentication:
+                        additionalProperties:
+                          properties:
+                            anonymous:
+                              description: Anonymous access.
+                              type: object
+                            apiKey:
+                              description: Authentication based on API keys stored
+                                in Kubernetes secrets.
+                              properties:
+                                allNamespaces:
+                                  default: false
+                                  description: |-
+                                    Whether Authorino should look for API key secrets in all namespaces or only in the same namespace as the AuthConfig.
+                                    Enabling this option in namespaced Authorino instances has no effect.
+                                  type: boolean
+                                selector:
+                                  description: Label selector used by Authorino to
+                                    match secrets from the cluster storing valid credentials
+                                    to authenticate to this service
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - selector
+                              type: object
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            credentials:
+                              description: |-
+                                Defines where credentials are required to be passed in the request for authentication based on this config.
+                                If omitted, it defaults to credentials passed in the HTTP Authorization header and the "Bearer" prefix prepended to the secret credential value.
+                              properties:
+                                authorizationHeader:
+                                  properties:
+                                    prefix:
+                                      type: string
+                                  type: object
+                                cookie:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                customHeader:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                queryString:
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                              type: object
+                            defaults:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: |-
+                                Set default property values (claims) for the resolved identity object, that are set before appending the object to
+                                the authorization JSON. If the property is already present in the resolved identity object, the default value is ignored.
+                                It requires the resolved identity object to always be a JSON object.
+                                Do not use this option with identity objects of other JSON types (array, string, etc).
+                              type: object
+                            jwt:
+                              description: Authentication based on JWT tokens.
+                              properties:
+                                issuerUrl:
+                                  description: |-
+                                    URL of the issuer of the JWT.
+                                    If `jwksUrl` is omitted, Authorino will append the path to the OpenID Connect Well-Known Discovery endpoint
+                                    (i.e. "/.well-known/openid-configuration") to this URL, to discover the OIDC configuration where to obtain
+                                    the "jkws_uri" claim from.
+                                    The value must coincide with the value of  the "iss" (issuer) claim of the discovered OpenID Connect configuration.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    Decides how long to wait before refreshing the JWKS (in seconds).
+                                    If omitted, Authorino will never refresh the JWKS.
+                                  type: integer
+                              type: object
+                            kubernetesTokenReview:
+                              description: Authentication by Kubernetes token review.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino.
+                                    If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            oauth2Introspection:
+                              description: Authentication by OAuth2 token introspection.
+                              properties:
+                                credentialsRef:
+                                  description: Reference to a Kubernetes secret in
+                                    the same namespace, that stores client credentials
+                                    to the OAuth2 server.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                endpoint:
+                                  description: The full URL of the token introspection
+                                    endpoint.
+                                  type: string
+                                tokenTypeHint:
+                                  description: |-
+                                    The token type hint for the token introspection.
+                                    If omitted, it defaults to "access_token".
+                                  type: string
+                              required:
+                              - credentialsRef
+                              - endpoint
+                              type: object
+                            overrides:
+                              additionalProperties:
+                                properties:
+                                  selector:
+                                    description: |-
+                                      Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                    type: string
+                                  value:
+                                    description: Static value
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                              description: |-
+                                Overrides the resolved identity object by setting the additional properties (claims) specified in this config,
+                                before appending the object to the authorization JSON.
+                                It requires the resolved identity object to always be a JSON object.
+                                Do not use this option with identity objects of other JSON types (array, string, etc).
+                              type: object
+                            plain:
+                              description: |-
+                                Identity object extracted from the context.
+                                Use this method when authentication is performed beforehand by a proxy and the resulting object passed to Authorino as JSON in the auth request.
+                              properties:
+                                selector:
+                                  description: |-
+                                    Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                    Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                    The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                  type: string
+                              required:
+                              - selector
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            routeSelectors:
+                              description: |-
+                                Top-level route selectors.
+                                If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                              items:
+                                description: |-
+                                  RouteSelector defines semantics for matching an HTTP request based on conditions
+                                  https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                properties:
+                                  hostnames:
+                                    description: |-
+                                      Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: |-
+                                        Hostname is the fully qualified domain name of a network host. This matches
+                                        the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                         1. IPs are not allowed.
+                                         2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                            label must appear by itself as the first label.
+
+
+                                        Hostname can be "precise" which is a domain name without the terminating
+                                        dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                        domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                        Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                        alphanumeric characters or '-', and must start and end with an alphanumeric
+                                        character. No other punctuation is allowed.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    type: array
+                                  matches:
+                                    description: |-
+                                      Matches define conditions used for matching the rule against incoming HTTP requests.
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: "HTTPRouteMatch defines the predicate
+                                        used to match requests to a given\naction.
+                                        Multiple match types are ANDed together, i.e.
+                                        the match will\nevaluate to true only if all
+                                        conditions are satisfied.\n\n\nFor example,
+                                        the match below will match a HTTP request
+                                        only if its path\nstarts with `/foo` AND it
+                                        contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                                        \ value \"v1\"\n\n\n```"
+                                      properties:
+                                        headers:
+                                          description: |-
+                                            Headers specifies HTTP request header matchers. Multiple match values are
+                                            ANDed together, meaning, a request must match all the specified headers
+                                            to select the route.
+                                          items:
+                                            description: |-
+                                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                              headers.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                  If multiple entries specify equivalent header names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent header name MUST be ignored. Due to the
+                                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                                  equivalent.
+
+
+                                                  When a header is repeated in an HTTP request, it is
+                                                  implementation-specific behavior as to how this is represented.
+                                                  Generally, proxies should follow the guidance from the RFC:
+                                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                  processing a repeated header, with special handling for "Set-Cookie".
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the header.
+
+
+                                                  Support: Core (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression HeaderMatchType has implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other dialects
+                                                  of regular expressions. Please read the implementation's documentation to
+                                                  determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP Header to be matched.
+                                                maxLength: 4096
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        method:
+                                          description: |-
+                                            Method specifies HTTP method matcher.
+                                            When specified, this route will be matched only if the request has the
+                                            specified method.
+
+
+                                            Support: Extended
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                        path:
+                                          default:
+                                            type: PathPrefix
+                                            value: /
+                                          description: |-
+                                            Path specifies a HTTP request path matcher. If this field is not
+                                            specified, a default prefix match on the "/" path is provided.
+                                          properties:
+                                            type:
+                                              default: PathPrefix
+                                              description: |-
+                                                Type specifies how to match against the path Value.
+
+
+                                                Support: Core (Exact, PathPrefix)
+
+
+                                                Support: Implementation-specific (RegularExpression)
+                                              enum:
+                                              - Exact
+                                              - PathPrefix
+                                              - RegularExpression
+                                              type: string
+                                            value:
+                                              default: /
+                                              description: Value of the HTTP path
+                                                to match against.
+                                              maxLength: 1024
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: value must be an absolute path
+                                              and start with '/' when type one of
+                                              ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.startsWith(''/'') : true'
+                                          - message: must not contain '//' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''//'') : true'
+                                          - message: must not contain '/./' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/./'') : true'
+                                          - message: must not contain '/../' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/../'') : true'
+                                          - message: must not contain '%2f' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2f'') : true'
+                                          - message: must not contain '%2F' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2F'') : true'
+                                          - message: must not contain '#' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''#'') : true'
+                                          - message: must not end with '/..' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/..'') : true'
+                                          - message: must not end with '/.' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/.'') : true'
+                                          - message: type must be one of ['Exact',
+                                              'PathPrefix', 'RegularExpression']
+                                            rule: self.type in ['Exact','PathPrefix']
+                                              || self.type == 'RegularExpression'
+                                          - message: must only contain valid characters
+                                              (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                              for types ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                              : true'
+                                        queryParams:
+                                          description: |-
+                                            QueryParams specifies HTTP query parameter matchers. Multiple match
+                                            values are ANDed together, meaning, a request must match all the
+                                            specified query parameters to select the route.
+
+
+                                            Support: Extended
+                                          items:
+                                            description: |-
+                                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                              query parameters.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP query param to be matched. This must be an
+                                                  exact string match. (See
+                                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                  If multiple entries specify equivalent query param names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent query param name MUST be ignored.
+
+
+                                                  If a query param is repeated in an HTTP request, the behavior is
+                                                  purposely left undefined, since different data planes have different
+                                                  capabilities. However, it is *recommended* that implementations should
+                                                  match against the first value of the param if the data plane supports it,
+                                                  as this behavior is expected in other load balancing contexts outside of
+                                                  the Gateway API.
+
+
+                                                  Users SHOULD NOT route traffic based on repeated query params to guard
+                                                  themselves against potential differences in the implementations.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the query parameter.
+
+
+                                                  Support: Extended (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other
+                                                  dialects of regular expressions. Please read the implementation's
+                                                  documentation to determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP query param to be matched.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                    maxItems: 8
+                                    type: array
+                                type: object
+                              maxItems: 8
+                              type: array
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                            x509:
+                              description: |-
+                                Authentication based on client X.509 certificates.
+                                The certificates presented by the clients must be signed by a trusted CA whose certificates are stored in Kubernetes secrets.
+                              properties:
+                                allNamespaces:
+                                  default: false
+                                  description: |-
+                                    Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.
+                                    Enabling this option in namespaced Authorino instances has no effect.
+                                  type: boolean
+                                selector:
+                                  description: |-
+                                    Label selector used by Authorino to match secrets from the cluster storing trusted CA certificates to validate
+                                    clients trying to authenticate to this service
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - selector
+                              type: object
+                          type: object
+                        description: |-
+                          Authentication configs.
+                          At least one config MUST evaluate to a valid identity object for the auth request to be successful.
+                        maxProperties: 10
+                        type: object
+                      authorization:
+                        additionalProperties:
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            kubernetesSubjectAccessReview:
+                              description: Authorization by Kubernetes SubjectAccessReview
+                              properties:
+                                groups:
+                                  description: Groups the user must be a member of
+                                    or, if `user` is omitted, the groups to check
+                                    for authorization in the Kubernetes RBAC.
+                                  items:
+                                    type: string
+                                  type: array
+                                resourceAttributes:
+                                  description: |-
+                                    Use resourceAttributes to check permissions on Kubernetes resources.
+                                    If omitted, it performs a non-resource SubjectAccessReview, with verb and path inferred from the request.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        API group of the resource.
+                                        Use '*' for all API groups.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    name:
+                                      description: |-
+                                        Resource name
+                                        Omit it to check for authorization on all resources of the specified kind.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    namespace:
+                                      description: Namespace where the user must have
+                                        permissions on the resource.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    resource:
+                                      description: |-
+                                        Resource kind
+                                        Use '*' for all resource kinds.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    subresource:
+                                      description: Subresource kind
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    verb:
+                                      description: |-
+                                        Verb to check for authorization on the resource.
+                                        Use '*' for all verbs.
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                user:
+                                  description: |-
+                                    User to check for authorization in the Kubernetes RBAC.
+                                    Omit it to check for group authorization only.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            opa:
+                              description: Open Policy Agent (OPA) Rego policy.
+                              properties:
+                                allValues:
+                                  default: false
+                                  description: |-
+                                    Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.
+                                    Otherwise, only the default `allow` rule will be exposed.
+                                    Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.
+                                  type: boolean
+                                externalPolicy:
+                                  description: |-
+                                    Settings for fetching the OPA policy from an external registry.
+                                    Use it alternatively to 'rego'.
+                                    For the configurations of the HTTP request, the following options are not implemented: 'method', 'body', 'bodyParameters',
+                                    'contentType', 'headers', 'oauth2'. Use it only with: 'url', 'sharedSecret', 'credentials'.
+                                  properties:
+                                    body:
+                                      description: |-
+                                        Raw body of the HTTP request.
+                                        Supersedes 'bodyParameters'; use either one or the other.
+                                        Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    bodyParameters:
+                                      additionalProperties:
+                                        properties:
+                                          selector:
+                                            description: |-
+                                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                            type: string
+                                          value:
+                                            description: Static value
+                                            x-kubernetes-preserve-unknown-fields: true
+                                        type: object
+                                      description: |-
+                                        Custom parameters to encode in the body of the HTTP request.
+                                        Superseded by 'body'; use either one or the other.
+                                        Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                      type: object
+                                    contentType:
+                                      default: application/x-www-form-urlencoded
+                                      description: |-
+                                        Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                        Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                                      enum:
+                                      - application/x-www-form-urlencoded
+                                      - application/json
+                                      type: string
+                                    credentials:
+                                      description: |-
+                                        Defines where client credentials will be passed in the request to the service.
+                                        If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                                      properties:
+                                        authorizationHeader:
+                                          properties:
+                                            prefix:
+                                              type: string
+                                          type: object
+                                        cookie:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        customHeader:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        queryString:
+                                          properties:
+                                            name:
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                      type: object
+                                    headers:
+                                      additionalProperties:
+                                        properties:
+                                          selector:
+                                            description: |-
+                                              Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                              The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                            type: string
+                                          value:
+                                            description: Static value
+                                            x-kubernetes-preserve-unknown-fields: true
+                                        type: object
+                                      description: Custom headers in the HTTP request.
+                                      type: object
+                                    method:
+                                      default: GET
+                                      description: |-
+                                        HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                        When the request method is POST, the authorization JSON is passed in the body of the request.
+                                      enum:
+                                      - GET
+                                      - POST
+                                      - PUT
+                                      - PATCH
+                                      - DELETE
+                                      - HEAD
+                                      - OPTIONS
+                                      - CONNECT
+                                      - TRACE
+                                      type: string
+                                    oauth2:
+                                      description: Authentication with the HTTP service
+                                        by OAuth2 Client Credentials grant.
+                                      properties:
+                                        cache:
+                                          default: true
+                                          description: |-
+                                            Caches and reuses the token until expired.
+                                            Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                          type: boolean
+                                        clientId:
+                                          description: OAuth2 Client ID.
+                                          type: string
+                                        clientSecretRef:
+                                          description: Reference to a Kuberentes Secret
+                                            key that stores that OAuth2 Client Secret.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              description: The name of the secret
+                                                in the Authorino's namespace to select
+                                                from.
+                                              type: string
+                                          required:
+                                          - key
+                                          - name
+                                          type: object
+                                        extraParams:
+                                          additionalProperties:
+                                            type: string
+                                          description: Optional extra parameters for
+                                            the requests to the token URL.
+                                          type: object
+                                        scopes:
+                                          description: Optional scopes for the client
+                                            credentials grant, if supported by he
+                                            OAuth2 server.
+                                          items:
+                                            type: string
+                                          type: array
+                                        tokenUrl:
+                                          description: Token endpoint URL of the OAuth2
+                                            resource server.
+                                          type: string
+                                      required:
+                                      - clientId
+                                      - clientSecretRef
+                                      - tokenUrl
+                                      type: object
+                                    sharedSecretRef:
+                                      description: |-
+                                        Reference to a Secret key whose value will be passed by Authorino in the request.
+                                        The HTTP service can use the shared secret to authenticate the origin of the request.
+                                        Ignored if used together with oauth2.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: The name of the secret in the
+                                            Authorino's namespace to select from.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                    ttl:
+                                      description: Duration (in seconds) of the external
+                                        data in the cache before pulled again from
+                                        the source.
+                                      type: integer
+                                    url:
+                                      description: |-
+                                        Endpoint URL of the HTTP service.
+                                        The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                        by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                        E.g. https://ext-auth-server.io/metadata?p={request.path}
+                                      type: string
+                                  required:
+                                  - url
+                                  type: object
+                                rego:
+                                  description: |-
+                                    Authorization policy as a Rego language document.
+                                    The Rego document must include the "allow" condition, set by Authorino to "false" by default (i.e. requests are unauthorized unless changed).
+                                    The Rego document must NOT include the "package" declaration in line 1.
+                                  type: string
+                              type: object
+                            patternMatching:
+                              description: Pattern-matching authorization rules.
+                              properties:
+                                patterns:
+                                  items:
+                                    properties:
+                                      all:
+                                        description: A list of pattern expressions
+                                          to be evaluated as a logical AND.
+                                        items:
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        type: array
+                                      any:
+                                        description: A list of pattern expressions
+                                          to be evaluated as a logical OR.
+                                        items:
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
+                                        type: array
+                                      operator:
+                                        description: |-
+                                          The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                          Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                        enum:
+                                        - eq
+                                        - neq
+                                        - incl
+                                        - excl
+                                        - matches
+                                        type: string
+                                      patternRef:
+                                        description: Reference to a named set of pattern
+                                          expressions
+                                        type: string
+                                      selector:
+                                        description: |-
+                                          Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          Authorino custom JSON path modifiers are also supported.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          The value of reference for the comparison with the content fetched from the authorization JSON.
+                                          If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                        type: string
+                                    type: object
+                                  type: array
+                              required:
+                              - patterns
+                              type: object
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            routeSelectors:
+                              description: |-
+                                Top-level route selectors.
+                                If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                              items:
+                                description: |-
+                                  RouteSelector defines semantics for matching an HTTP request based on conditions
+                                  https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                properties:
+                                  hostnames:
+                                    description: |-
+                                      Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: |-
+                                        Hostname is the fully qualified domain name of a network host. This matches
+                                        the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                         1. IPs are not allowed.
+                                         2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                            label must appear by itself as the first label.
+
+
+                                        Hostname can be "precise" which is a domain name without the terminating
+                                        dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                        domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                        Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                        alphanumeric characters or '-', and must start and end with an alphanumeric
+                                        character. No other punctuation is allowed.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    type: array
+                                  matches:
+                                    description: |-
+                                      Matches define conditions used for matching the rule against incoming HTTP requests.
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: "HTTPRouteMatch defines the predicate
+                                        used to match requests to a given\naction.
+                                        Multiple match types are ANDed together, i.e.
+                                        the match will\nevaluate to true only if all
+                                        conditions are satisfied.\n\n\nFor example,
+                                        the match below will match a HTTP request
+                                        only if its path\nstarts with `/foo` AND it
+                                        contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                                        \ value \"v1\"\n\n\n```"
+                                      properties:
+                                        headers:
+                                          description: |-
+                                            Headers specifies HTTP request header matchers. Multiple match values are
+                                            ANDed together, meaning, a request must match all the specified headers
+                                            to select the route.
+                                          items:
+                                            description: |-
+                                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                              headers.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                  If multiple entries specify equivalent header names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent header name MUST be ignored. Due to the
+                                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                                  equivalent.
+
+
+                                                  When a header is repeated in an HTTP request, it is
+                                                  implementation-specific behavior as to how this is represented.
+                                                  Generally, proxies should follow the guidance from the RFC:
+                                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                  processing a repeated header, with special handling for "Set-Cookie".
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the header.
+
+
+                                                  Support: Core (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression HeaderMatchType has implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other dialects
+                                                  of regular expressions. Please read the implementation's documentation to
+                                                  determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP Header to be matched.
+                                                maxLength: 4096
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        method:
+                                          description: |-
+                                            Method specifies HTTP method matcher.
+                                            When specified, this route will be matched only if the request has the
+                                            specified method.
+
+
+                                            Support: Extended
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                        path:
+                                          default:
+                                            type: PathPrefix
+                                            value: /
+                                          description: |-
+                                            Path specifies a HTTP request path matcher. If this field is not
+                                            specified, a default prefix match on the "/" path is provided.
+                                          properties:
+                                            type:
+                                              default: PathPrefix
+                                              description: |-
+                                                Type specifies how to match against the path Value.
+
+
+                                                Support: Core (Exact, PathPrefix)
+
+
+                                                Support: Implementation-specific (RegularExpression)
+                                              enum:
+                                              - Exact
+                                              - PathPrefix
+                                              - RegularExpression
+                                              type: string
+                                            value:
+                                              default: /
+                                              description: Value of the HTTP path
+                                                to match against.
+                                              maxLength: 1024
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: value must be an absolute path
+                                              and start with '/' when type one of
+                                              ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.startsWith(''/'') : true'
+                                          - message: must not contain '//' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''//'') : true'
+                                          - message: must not contain '/./' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/./'') : true'
+                                          - message: must not contain '/../' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/../'') : true'
+                                          - message: must not contain '%2f' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2f'') : true'
+                                          - message: must not contain '%2F' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2F'') : true'
+                                          - message: must not contain '#' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''#'') : true'
+                                          - message: must not end with '/..' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/..'') : true'
+                                          - message: must not end with '/.' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/.'') : true'
+                                          - message: type must be one of ['Exact',
+                                              'PathPrefix', 'RegularExpression']
+                                            rule: self.type in ['Exact','PathPrefix']
+                                              || self.type == 'RegularExpression'
+                                          - message: must only contain valid characters
+                                              (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                              for types ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                              : true'
+                                        queryParams:
+                                          description: |-
+                                            QueryParams specifies HTTP query parameter matchers. Multiple match
+                                            values are ANDed together, meaning, a request must match all the
+                                            specified query parameters to select the route.
+
+
+                                            Support: Extended
+                                          items:
+                                            description: |-
+                                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                              query parameters.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP query param to be matched. This must be an
+                                                  exact string match. (See
+                                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                  If multiple entries specify equivalent query param names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent query param name MUST be ignored.
+
+
+                                                  If a query param is repeated in an HTTP request, the behavior is
+                                                  purposely left undefined, since different data planes have different
+                                                  capabilities. However, it is *recommended* that implementations should
+                                                  match against the first value of the param if the data plane supports it,
+                                                  as this behavior is expected in other load balancing contexts outside of
+                                                  the Gateway API.
+
+
+                                                  Users SHOULD NOT route traffic based on repeated query params to guard
+                                                  themselves against potential differences in the implementations.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the query parameter.
+
+
+                                                  Support: Extended (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other
+                                                  dialects of regular expressions. Please read the implementation's
+                                                  documentation to determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP query param to be matched.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                    maxItems: 8
+                                    type: array
+                                type: object
+                              maxItems: 8
+                              type: array
+                            spicedb:
+                              description: Authorization decision delegated to external
+                                Authzed/SpiceDB server.
+                              properties:
+                                endpoint:
+                                  description: Hostname and port number to the GRPC
+                                    interface of the SpiceDB server (e.g. spicedb:50051).
+                                  type: string
+                                insecure:
+                                  description: Insecure HTTP connection (i.e. disables
+                                    TLS verification)
+                                  type: boolean
+                                permission:
+                                  description: The name of the permission (or relation)
+                                    on which to execute the check.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                resource:
+                                  description: The resource on which to check the
+                                    permission or relation.
+                                  properties:
+                                    kind:
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    name:
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                                sharedSecretRef:
+                                  description: Reference to a Secret key whose value
+                                    will be used by Authorino to authenticate with
+                                    the Authzed service.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                subject:
+                                  description: The subject that will be checked for
+                                    the permission or relation.
+                                  properties:
+                                    kind:
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    name:
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                  type: object
+                              required:
+                              - endpoint
+                              type: object
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        description: |-
+                          Authorization policies.
+                          All policies MUST evaluate to "allowed = true" for the auth request be successful.
+                        maxProperties: 10
+                        type: object
+                      callbacks:
+                        additionalProperties:
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            http:
+                              description: Settings of the external HTTP request
+                              properties:
+                                body:
+                                  description: |-
+                                    Raw body of the HTTP request.
+                                    Supersedes 'bodyParameters'; use either one or the other.
+                                    Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                bodyParameters:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: |-
+                                    Custom parameters to encode in the body of the HTTP request.
+                                    Superseded by 'body'; use either one or the other.
+                                    Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                  type: object
+                                contentType:
+                                  default: application/x-www-form-urlencoded
+                                  description: |-
+                                    Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                    Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                                  enum:
+                                  - application/x-www-form-urlencoded
+                                  - application/json
+                                  type: string
+                                credentials:
+                                  description: |-
+                                    Defines where client credentials will be passed in the request to the service.
+                                    If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                                  properties:
+                                    authorizationHeader:
+                                      properties:
+                                        prefix:
+                                          type: string
+                                      type: object
+                                    cookie:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    customHeader:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    queryString:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                  type: object
+                                headers:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Custom headers in the HTTP request.
+                                  type: object
+                                method:
+                                  default: GET
+                                  description: |-
+                                    HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                    When the request method is POST, the authorization JSON is passed in the body of the request.
+                                  enum:
+                                  - GET
+                                  - POST
+                                  - PUT
+                                  - PATCH
+                                  - DELETE
+                                  - HEAD
+                                  - OPTIONS
+                                  - CONNECT
+                                  - TRACE
+                                  type: string
+                                oauth2:
+                                  description: Authentication with the HTTP service
+                                    by OAuth2 Client Credentials grant.
+                                  properties:
+                                    cache:
+                                      default: true
+                                      description: |-
+                                        Caches and reuses the token until expired.
+                                        Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                      type: boolean
+                                    clientId:
+                                      description: OAuth2 Client ID.
+                                      type: string
+                                    clientSecretRef:
+                                      description: Reference to a Kuberentes Secret
+                                        key that stores that OAuth2 Client Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: The name of the secret in the
+                                            Authorino's namespace to select from.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                    extraParams:
+                                      additionalProperties:
+                                        type: string
+                                      description: Optional extra parameters for the
+                                        requests to the token URL.
+                                      type: object
+                                    scopes:
+                                      description: Optional scopes for the client
+                                        credentials grant, if supported by he OAuth2
+                                        server.
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      description: Token endpoint URL of the OAuth2
+                                        resource server.
+                                      type: string
+                                  required:
+                                  - clientId
+                                  - clientSecretRef
+                                  - tokenUrl
+                                  type: object
+                                sharedSecretRef:
+                                  description: |-
+                                    Reference to a Secret key whose value will be passed by Authorino in the request.
+                                    The HTTP service can use the shared secret to authenticate the origin of the request.
+                                    Ignored if used together with oauth2.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                url:
+                                  description: |-
+                                    Endpoint URL of the HTTP service.
+                                    The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                    by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                    E.g. https://ext-auth-server.io/metadata?p={request.path}
+                                  type: string
+                              required:
+                              - url
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            routeSelectors:
+                              description: |-
+                                Top-level route selectors.
+                                If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                              items:
+                                description: |-
+                                  RouteSelector defines semantics for matching an HTTP request based on conditions
+                                  https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                properties:
+                                  hostnames:
+                                    description: |-
+                                      Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: |-
+                                        Hostname is the fully qualified domain name of a network host. This matches
+                                        the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                         1. IPs are not allowed.
+                                         2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                            label must appear by itself as the first label.
+
+
+                                        Hostname can be "precise" which is a domain name without the terminating
+                                        dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                        domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                        Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                        alphanumeric characters or '-', and must start and end with an alphanumeric
+                                        character. No other punctuation is allowed.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    type: array
+                                  matches:
+                                    description: |-
+                                      Matches define conditions used for matching the rule against incoming HTTP requests.
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: "HTTPRouteMatch defines the predicate
+                                        used to match requests to a given\naction.
+                                        Multiple match types are ANDed together, i.e.
+                                        the match will\nevaluate to true only if all
+                                        conditions are satisfied.\n\n\nFor example,
+                                        the match below will match a HTTP request
+                                        only if its path\nstarts with `/foo` AND it
+                                        contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                                        \ value \"v1\"\n\n\n```"
+                                      properties:
+                                        headers:
+                                          description: |-
+                                            Headers specifies HTTP request header matchers. Multiple match values are
+                                            ANDed together, meaning, a request must match all the specified headers
+                                            to select the route.
+                                          items:
+                                            description: |-
+                                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                              headers.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                  If multiple entries specify equivalent header names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent header name MUST be ignored. Due to the
+                                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                                  equivalent.
+
+
+                                                  When a header is repeated in an HTTP request, it is
+                                                  implementation-specific behavior as to how this is represented.
+                                                  Generally, proxies should follow the guidance from the RFC:
+                                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                  processing a repeated header, with special handling for "Set-Cookie".
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the header.
+
+
+                                                  Support: Core (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression HeaderMatchType has implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other dialects
+                                                  of regular expressions. Please read the implementation's documentation to
+                                                  determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP Header to be matched.
+                                                maxLength: 4096
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        method:
+                                          description: |-
+                                            Method specifies HTTP method matcher.
+                                            When specified, this route will be matched only if the request has the
+                                            specified method.
+
+
+                                            Support: Extended
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                        path:
+                                          default:
+                                            type: PathPrefix
+                                            value: /
+                                          description: |-
+                                            Path specifies a HTTP request path matcher. If this field is not
+                                            specified, a default prefix match on the "/" path is provided.
+                                          properties:
+                                            type:
+                                              default: PathPrefix
+                                              description: |-
+                                                Type specifies how to match against the path Value.
+
+
+                                                Support: Core (Exact, PathPrefix)
+
+
+                                                Support: Implementation-specific (RegularExpression)
+                                              enum:
+                                              - Exact
+                                              - PathPrefix
+                                              - RegularExpression
+                                              type: string
+                                            value:
+                                              default: /
+                                              description: Value of the HTTP path
+                                                to match against.
+                                              maxLength: 1024
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: value must be an absolute path
+                                              and start with '/' when type one of
+                                              ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.startsWith(''/'') : true'
+                                          - message: must not contain '//' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''//'') : true'
+                                          - message: must not contain '/./' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/./'') : true'
+                                          - message: must not contain '/../' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/../'') : true'
+                                          - message: must not contain '%2f' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2f'') : true'
+                                          - message: must not contain '%2F' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2F'') : true'
+                                          - message: must not contain '#' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''#'') : true'
+                                          - message: must not end with '/..' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/..'') : true'
+                                          - message: must not end with '/.' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/.'') : true'
+                                          - message: type must be one of ['Exact',
+                                              'PathPrefix', 'RegularExpression']
+                                            rule: self.type in ['Exact','PathPrefix']
+                                              || self.type == 'RegularExpression'
+                                          - message: must only contain valid characters
+                                              (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                              for types ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                              : true'
+                                        queryParams:
+                                          description: |-
+                                            QueryParams specifies HTTP query parameter matchers. Multiple match
+                                            values are ANDed together, meaning, a request must match all the
+                                            specified query parameters to select the route.
+
+
+                                            Support: Extended
+                                          items:
+                                            description: |-
+                                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                              query parameters.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP query param to be matched. This must be an
+                                                  exact string match. (See
+                                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                  If multiple entries specify equivalent query param names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent query param name MUST be ignored.
+
+
+                                                  If a query param is repeated in an HTTP request, the behavior is
+                                                  purposely left undefined, since different data planes have different
+                                                  capabilities. However, it is *recommended* that implementations should
+                                                  match against the first value of the param if the data plane supports it,
+                                                  as this behavior is expected in other load balancing contexts outside of
+                                                  the Gateway API.
+
+
+                                                  Users SHOULD NOT route traffic based on repeated query params to guard
+                                                  themselves against potential differences in the implementations.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the query parameter.
+
+
+                                                  Support: Extended (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other
+                                                  dialects of regular expressions. Please read the implementation's
+                                                  documentation to determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP query param to be matched.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                    maxItems: 8
+                                    type: array
+                                type: object
+                              maxItems: 8
+                              type: array
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                          required:
+                          - http
+                          type: object
+                        description: |-
+                          Callback functions.
+                          Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
+                        maxProperties: 10
+                        type: object
+                      metadata:
+                        additionalProperties:
+                          properties:
+                            cache:
+                              description: |-
+                                Caching options for the resolved object returned when applying this config.
+                                Omit it to avoid caching objects for this config.
+                              properties:
+                                key:
+                                  description: |-
+                                    Key used to store the entry in the cache.
+                                    The resolved key must be unique within the scope of this particular config.
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                ttl:
+                                  default: 60
+                                  description: Duration (in seconds) of the external
+                                    data in the cache before pulled again from the
+                                    source.
+                                  type: integer
+                              required:
+                              - key
+                              type: object
+                            http:
+                              description: External source of auth metadata via HTTP
+                                request
+                              properties:
+                                body:
+                                  description: |-
+                                    Raw body of the HTTP request.
+                                    Supersedes 'bodyParameters'; use either one or the other.
+                                    Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                  properties:
+                                    selector:
+                                      description: |-
+                                        Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                        Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                        The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                      type: string
+                                    value:
+                                      description: Static value
+                                      x-kubernetes-preserve-unknown-fields: true
+                                  type: object
+                                bodyParameters:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: |-
+                                    Custom parameters to encode in the body of the HTTP request.
+                                    Superseded by 'body'; use either one or the other.
+                                    Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).
+                                  type: object
+                                contentType:
+                                  default: application/x-www-form-urlencoded
+                                  description: |-
+                                    Content-Type of the request body. Shapes how 'bodyParameters' are encoded.
+                                    Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.
+                                  enum:
+                                  - application/x-www-form-urlencoded
+                                  - application/json
+                                  type: string
+                                credentials:
+                                  description: |-
+                                    Defines where client credentials will be passed in the request to the service.
+                                    If omitted, it defaults to client credentials passed in the HTTP Authorization header and the "Bearer" prefix expected prepended to the secret value.
+                                  properties:
+                                    authorizationHeader:
+                                      properties:
+                                        prefix:
+                                          type: string
+                                      type: object
+                                    cookie:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    customHeader:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    queryString:
+                                      properties:
+                                        name:
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                  type: object
+                                headers:
+                                  additionalProperties:
+                                    properties:
+                                      selector:
+                                        description: |-
+                                          Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                          Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                          The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                        type: string
+                                      value:
+                                        description: Static value
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                  description: Custom headers in the HTTP request.
+                                  type: object
+                                method:
+                                  default: GET
+                                  description: |-
+                                    HTTP verb used in the request to the service. Accepted values: GET (default), POST.
+                                    When the request method is POST, the authorization JSON is passed in the body of the request.
+                                  enum:
+                                  - GET
+                                  - POST
+                                  - PUT
+                                  - PATCH
+                                  - DELETE
+                                  - HEAD
+                                  - OPTIONS
+                                  - CONNECT
+                                  - TRACE
+                                  type: string
+                                oauth2:
+                                  description: Authentication with the HTTP service
+                                    by OAuth2 Client Credentials grant.
+                                  properties:
+                                    cache:
+                                      default: true
+                                      description: |-
+                                        Caches and reuses the token until expired.
+                                        Set it to false to force fetch the token at every authorization request regardless of expiration.
+                                      type: boolean
+                                    clientId:
+                                      description: OAuth2 Client ID.
+                                      type: string
+                                    clientSecretRef:
+                                      description: Reference to a Kuberentes Secret
+                                        key that stores that OAuth2 Client Secret.
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: The name of the secret in the
+                                            Authorino's namespace to select from.
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                    extraParams:
+                                      additionalProperties:
+                                        type: string
+                                      description: Optional extra parameters for the
+                                        requests to the token URL.
+                                      type: object
+                                    scopes:
+                                      description: Optional scopes for the client
+                                        credentials grant, if supported by he OAuth2
+                                        server.
+                                      items:
+                                        type: string
+                                      type: array
+                                    tokenUrl:
+                                      description: Token endpoint URL of the OAuth2
+                                        resource server.
+                                      type: string
+                                  required:
+                                  - clientId
+                                  - clientSecretRef
+                                  - tokenUrl
+                                  type: object
+                                sharedSecretRef:
+                                  description: |-
+                                    Reference to a Secret key whose value will be passed by Authorino in the request.
+                                    The HTTP service can use the shared secret to authenticate the origin of the request.
+                                    Ignored if used together with oauth2.
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: The name of the secret in the Authorino's
+                                        namespace to select from.
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                                url:
+                                  description: |-
+                                    Endpoint URL of the HTTP service.
+                                    The value can include variable placeholders in the format "{selector}", where "selector" is any pattern supported
+                                    by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.
+                                    E.g. https://ext-auth-server.io/metadata?p={request.path}
+                                  type: string
+                              required:
+                              - url
+                              type: object
+                            metrics:
+                              default: false
+                              description: Whether this config should generate individual
+                                observability metrics
+                              type: boolean
+                            priority:
+                              default: 0
+                              description: |-
+                                Priority group of the config.
+                                All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                              type: integer
+                            routeSelectors:
+                              description: |-
+                                Top-level route selectors.
+                                If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                              items:
+                                description: |-
+                                  RouteSelector defines semantics for matching an HTTP request based on conditions
+                                  https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                properties:
+                                  hostnames:
+                                    description: |-
+                                      Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: |-
+                                        Hostname is the fully qualified domain name of a network host. This matches
+                                        the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                         1. IPs are not allowed.
+                                         2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                            label must appear by itself as the first label.
+
+
+                                        Hostname can be "precise" which is a domain name without the terminating
+                                        dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                        domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                        Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                        alphanumeric characters or '-', and must start and end with an alphanumeric
+                                        character. No other punctuation is allowed.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    type: array
+                                  matches:
+                                    description: |-
+                                      Matches define conditions used for matching the rule against incoming HTTP requests.
+                                      https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                    items:
+                                      description: "HTTPRouteMatch defines the predicate
+                                        used to match requests to a given\naction.
+                                        Multiple match types are ANDed together, i.e.
+                                        the match will\nevaluate to true only if all
+                                        conditions are satisfied.\n\n\nFor example,
+                                        the match below will match a HTTP request
+                                        only if its path\nstarts with `/foo` AND it
+                                        contains the `version: v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                        \ value: \"/foo\"\n\theaders:\n\t- name: \"version\"\n\t
+                                        \ value \"v1\"\n\n\n```"
+                                      properties:
+                                        headers:
+                                          description: |-
+                                            Headers specifies HTTP request header matchers. Multiple match values are
+                                            ANDed together, meaning, a request must match all the specified headers
+                                            to select the route.
+                                          items:
+                                            description: |-
+                                              HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                              headers.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                  case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                  If multiple entries specify equivalent header names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent header name MUST be ignored. Due to the
+                                                  case-insensitivity of header names, "foo" and "Foo" are considered
+                                                  equivalent.
+
+
+                                                  When a header is repeated in an HTTP request, it is
+                                                  implementation-specific behavior as to how this is represented.
+                                                  Generally, proxies should follow the guidance from the RFC:
+                                                  https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                  processing a repeated header, with special handling for "Set-Cookie".
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the header.
+
+
+                                                  Support: Core (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression HeaderMatchType has implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other dialects
+                                                  of regular expressions. Please read the implementation's documentation to
+                                                  determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP Header to be matched.
+                                                maxLength: 4096
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        method:
+                                          description: |-
+                                            Method specifies HTTP method matcher.
+                                            When specified, this route will be matched only if the request has the
+                                            specified method.
+
+
+                                            Support: Extended
+                                          enum:
+                                          - GET
+                                          - HEAD
+                                          - POST
+                                          - PUT
+                                          - DELETE
+                                          - CONNECT
+                                          - OPTIONS
+                                          - TRACE
+                                          - PATCH
+                                          type: string
+                                        path:
+                                          default:
+                                            type: PathPrefix
+                                            value: /
+                                          description: |-
+                                            Path specifies a HTTP request path matcher. If this field is not
+                                            specified, a default prefix match on the "/" path is provided.
+                                          properties:
+                                            type:
+                                              default: PathPrefix
+                                              description: |-
+                                                Type specifies how to match against the path Value.
+
+
+                                                Support: Core (Exact, PathPrefix)
+
+
+                                                Support: Implementation-specific (RegularExpression)
+                                              enum:
+                                              - Exact
+                                              - PathPrefix
+                                              - RegularExpression
+                                              type: string
+                                            value:
+                                              default: /
+                                              description: Value of the HTTP path
+                                                to match against.
+                                              maxLength: 1024
+                                              type: string
+                                          type: object
+                                          x-kubernetes-validations:
+                                          - message: value must be an absolute path
+                                              and start with '/' when type one of
+                                              ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.startsWith(''/'') : true'
+                                          - message: must not contain '//' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''//'') : true'
+                                          - message: must not contain '/./' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/./'') : true'
+                                          - message: must not contain '/../' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''/../'') : true'
+                                          - message: must not contain '%2f' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2f'') : true'
+                                          - message: must not contain '%2F' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''%2F'') : true'
+                                          - message: must not contain '#' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.contains(''#'') : true'
+                                          - message: must not end with '/..' when
+                                              type one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/..'') : true'
+                                          - message: must not end with '/.' when type
+                                              one of ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? !self.value.endsWith(''/.'') : true'
+                                          - message: type must be one of ['Exact',
+                                              'PathPrefix', 'RegularExpression']
+                                            rule: self.type in ['Exact','PathPrefix']
+                                              || self.type == 'RegularExpression'
+                                          - message: must only contain valid characters
+                                              (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                              for types ['Exact', 'PathPrefix']
+                                            rule: '(self.type in [''Exact'',''PathPrefix''])
+                                              ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                              : true'
+                                        queryParams:
+                                          description: |-
+                                            QueryParams specifies HTTP query parameter matchers. Multiple match
+                                            values are ANDed together, meaning, a request must match all the
+                                            specified query parameters to select the route.
+
+
+                                            Support: Extended
+                                          items:
+                                            description: |-
+                                              HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                              query parameters.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name is the name of the HTTP query param to be matched. This must be an
+                                                  exact string match. (See
+                                                  https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                  If multiple entries specify equivalent query param names, only the first
+                                                  entry with an equivalent name MUST be considered for a match. Subsequent
+                                                  entries with an equivalent query param name MUST be ignored.
+
+
+                                                  If a query param is repeated in an HTTP request, the behavior is
+                                                  purposely left undefined, since different data planes have different
+                                                  capabilities. However, it is *recommended* that implementations should
+                                                  match against the first value of the param if the data plane supports it,
+                                                  as this behavior is expected in other load balancing contexts outside of
+                                                  the Gateway API.
+
+
+                                                  Users SHOULD NOT route traffic based on repeated query params to guard
+                                                  themselves against potential differences in the implementations.
+                                                maxLength: 256
+                                                minLength: 1
+                                                pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                type: string
+                                              type:
+                                                default: Exact
+                                                description: |-
+                                                  Type specifies how to match against the value of the query parameter.
+
+
+                                                  Support: Extended (Exact)
+
+
+                                                  Support: Implementation-specific (RegularExpression)
+
+
+                                                  Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                  conformance, implementations can support POSIX, PCRE or any other
+                                                  dialects of regular expressions. Please read the implementation's
+                                                  documentation to determine the supported dialect.
+                                                enum:
+                                                - Exact
+                                                - RegularExpression
+                                                type: string
+                                              value:
+                                                description: Value is the value of
+                                                  HTTP query param to be matched.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          maxItems: 16
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                    maxItems: 8
+                                    type: array
+                                type: object
+                              maxItems: 8
+                              type: array
+                            uma:
+                              description: User-Managed Access (UMA) source of resource
+                                data.
+                              properties:
+                                credentialsRef:
+                                  description: Reference to a Kubernetes secret in
+                                    the same namespace, that stores client credentials
+                                    to the resource registration API of the UMA server.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                endpoint:
+                                  description: |-
+                                    The endpoint of the UMA server.
+                                    The value must coincide with the "issuer" claim of the UMA config discovered from the well-known uma configuration endpoint.
+                                  type: string
+                              required:
+                              - credentialsRef
+                              - endpoint
+                              type: object
+                            userInfo:
+                              description: OpendID Connect UserInfo linked to an OIDC
+                                authentication config specified in this same AuthConfig.
+                              properties:
+                                identitySource:
+                                  description: The name of an OIDC-enabled JWT authentication
+                                    config whose OpenID Connect configuration discovered
+                                    includes the OIDC "userinfo_endpoint" claim.
+                                  type: string
+                              required:
+                              - identitySource
+                              type: object
+                            when:
+                              description: |-
+                                Conditions for Authorino to enforce this config.
+                                If omitted, the config will be enforced for all requests.
+                                If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                              items:
+                                properties:
+                                  all:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical AND.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  any:
+                                    description: A list of pattern expressions to
+                                      be evaluated as a logical OR.
+                                    items:
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  operator:
+                                    description: |-
+                                      The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                      Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                    enum:
+                                    - eq
+                                    - neq
+                                    - incl
+                                    - excl
+                                    - matches
+                                    type: string
+                                  patternRef:
+                                    description: Reference to a named set of pattern
+                                      expressions
+                                    type: string
+                                  selector:
+                                    description: |-
+                                      Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                      Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                      Authorino custom JSON path modifiers are also supported.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      The value of reference for the comparison with the content fetched from the authorization JSON.
+                                      If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                    type: string
+                                type: object
+                              type: array
+                          type: object
+                        description: |-
+                          Metadata sources.
+                          Authorino fetches auth metadata as JSON from sources specified in this config.
+                        maxProperties: 10
+                        type: object
+                      response:
+                        description: |-
+                          Response items.
+                          Authorino builds custom responses to the client of the auth request.
+                        properties:
+                          success:
+                            description: |-
+                              Response items to be included in the auth response when the request is authenticated and authorized.
+                              For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata and/or inject data in the request.
+                            properties:
+                              dynamicMetadata:
+                                additionalProperties:
+                                  properties:
+                                    cache:
+                                      description: |-
+                                        Caching options for the resolved object returned when applying this config.
+                                        Omit it to avoid caching objects for this config.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            Key used to store the entry in the cache.
+                                            The resolved key must be unique within the scope of this particular config.
+                                          properties:
+                                            selector:
+                                              description: |-
+                                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                              type: string
+                                            value:
+                                              description: Static value
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        ttl:
+                                          default: 60
+                                          description: Duration (in seconds) of the
+                                            external data in the cache before pulled
+                                            again from the source.
+                                          type: integer
+                                      required:
+                                      - key
+                                      type: object
+                                    json:
+                                      description: |-
+                                        JSON object
+                                        Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                                      properties:
+                                        properties:
+                                          additionalProperties:
+                                            properties:
+                                              selector:
+                                                description: |-
+                                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                                type: string
+                                              value:
+                                                description: Static value
+                                                x-kubernetes-preserve-unknown-fields: true
+                                            type: object
+                                          type: object
+                                      required:
+                                      - properties
+                                      type: object
+                                    key:
+                                      description: |-
+                                        The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                        If omitted, it will be set to the name of the response config.
+                                      type: string
+                                    metrics:
+                                      default: false
+                                      description: Whether this config should generate
+                                        individual observability metrics
+                                      type: boolean
+                                    plain:
+                                      description: Plain text content
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    priority:
+                                      default: 0
+                                      description: |-
+                                        Priority group of the config.
+                                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                                      type: integer
+                                    routeSelectors:
+                                      description: |-
+                                        Top-level route selectors.
+                                        If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                        At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                        If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                                      items:
+                                        description: |-
+                                          RouteSelector defines semantics for matching an HTTP request based on conditions
+                                          https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                        properties:
+                                          hostnames:
+                                            description: |-
+                                              Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                              https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                            items:
+                                              description: |-
+                                                Hostname is the fully qualified domain name of a network host. This matches
+                                                the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                                 1. IPs are not allowed.
+                                                 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                                    label must appear by itself as the first label.
+
+
+                                                Hostname can be "precise" which is a domain name without the terminating
+                                                dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                                domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                                Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                                alphanumeric characters or '-', and must start and end with an alphanumeric
+                                                character. No other punctuation is allowed.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            type: array
+                                          matches:
+                                            description: |-
+                                              Matches define conditions used for matching the rule against incoming HTTP requests.
+                                              https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                            items:
+                                              description: "HTTPRouteMatch defines
+                                                the predicate used to match requests
+                                                to a given\naction. Multiple match
+                                                types are ANDed together, i.e. the
+                                                match will\nevaluate to true only
+                                                if all conditions are satisfied.\n\n\nFor
+                                                example, the match below will match
+                                                a HTTP request only if its path\nstarts
+                                                with `/foo` AND it contains the `version:
+                                                v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                                \ value: \"/foo\"\n\theaders:\n\t-
+                                                name: \"version\"\n\t  value \"v1\"\n\n\n```"
+                                              properties:
+                                                headers:
+                                                  description: |-
+                                                    Headers specifies HTTP request header matchers. Multiple match values are
+                                                    ANDed together, meaning, a request must match all the specified headers
+                                                    to select the route.
+                                                  items:
+                                                    description: |-
+                                                      HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                                      headers.
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                          case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                          If multiple entries specify equivalent header names, only the first
+                                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                                          entries with an equivalent header name MUST be ignored. Due to the
+                                                          case-insensitivity of header names, "foo" and "Foo" are considered
+                                                          equivalent.
+
+
+                                                          When a header is repeated in an HTTP request, it is
+                                                          implementation-specific behavior as to how this is represented.
+                                                          Generally, proxies should follow the guidance from the RFC:
+                                                          https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                          processing a repeated header, with special handling for "Set-Cookie".
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      type:
+                                                        default: Exact
+                                                        description: |-
+                                                          Type specifies how to match against the value of the header.
+
+
+                                                          Support: Core (Exact)
+
+
+                                                          Support: Implementation-specific (RegularExpression)
+
+
+                                                          Since RegularExpression HeaderMatchType has implementation-specific
+                                                          conformance, implementations can support POSIX, PCRE or any other dialects
+                                                          of regular expressions. Please read the implementation's documentation to
+                                                          determine the supported dialect.
+                                                        enum:
+                                                        - Exact
+                                                        - RegularExpression
+                                                        type: string
+                                                      value:
+                                                        description: Value is the
+                                                          value of HTTP Header to
+                                                          be matched.
+                                                        maxLength: 4096
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  maxItems: 16
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
+                                                method:
+                                                  description: |-
+                                                    Method specifies HTTP method matcher.
+                                                    When specified, this route will be matched only if the request has the
+                                                    specified method.
+
+
+                                                    Support: Extended
+                                                  enum:
+                                                  - GET
+                                                  - HEAD
+                                                  - POST
+                                                  - PUT
+                                                  - DELETE
+                                                  - CONNECT
+                                                  - OPTIONS
+                                                  - TRACE
+                                                  - PATCH
+                                                  type: string
+                                                path:
+                                                  default:
+                                                    type: PathPrefix
+                                                    value: /
+                                                  description: |-
+                                                    Path specifies a HTTP request path matcher. If this field is not
+                                                    specified, a default prefix match on the "/" path is provided.
+                                                  properties:
+                                                    type:
+                                                      default: PathPrefix
+                                                      description: |-
+                                                        Type specifies how to match against the path Value.
+
+
+                                                        Support: Core (Exact, PathPrefix)
+
+
+                                                        Support: Implementation-specific (RegularExpression)
+                                                      enum:
+                                                      - Exact
+                                                      - PathPrefix
+                                                      - RegularExpression
+                                                      type: string
+                                                    value:
+                                                      default: /
+                                                      description: Value of the HTTP
+                                                        path to match against.
+                                                      maxLength: 1024
+                                                      type: string
+                                                  type: object
+                                                  x-kubernetes-validations:
+                                                  - message: value must be an absolute
+                                                      path and start with '/' when
+                                                      type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? self.value.startsWith(''/'')
+                                                      : true'
+                                                  - message: must not contain '//'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''//'')
+                                                      : true'
+                                                  - message: must not contain '/./'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''/./'')
+                                                      : true'
+                                                  - message: must not contain '/../'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''/../'')
+                                                      : true'
+                                                  - message: must not contain '%2f'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''%2f'')
+                                                      : true'
+                                                  - message: must not contain '%2F'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''%2F'')
+                                                      : true'
+                                                  - message: must not contain '#'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''#'')
+                                                      : true'
+                                                  - message: must not end with '/..'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.endsWith(''/..'')
+                                                      : true'
+                                                  - message: must not end with '/.'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.endsWith(''/.'')
+                                                      : true'
+                                                  - message: type must be one of ['Exact',
+                                                      'PathPrefix', 'RegularExpression']
+                                                    rule: self.type in ['Exact','PathPrefix']
+                                                      || self.type == 'RegularExpression'
+                                                  - message: must only contain valid
+                                                      characters (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                                      for types ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                                      : true'
+                                                queryParams:
+                                                  description: |-
+                                                    QueryParams specifies HTTP query parameter matchers. Multiple match
+                                                    values are ANDed together, meaning, a request must match all the
+                                                    specified query parameters to select the route.
+
+
+                                                    Support: Extended
+                                                  items:
+                                                    description: |-
+                                                      HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                                      query parameters.
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          Name is the name of the HTTP query param to be matched. This must be an
+                                                          exact string match. (See
+                                                          https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                          If multiple entries specify equivalent query param names, only the first
+                                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                                          entries with an equivalent query param name MUST be ignored.
+
+
+                                                          If a query param is repeated in an HTTP request, the behavior is
+                                                          purposely left undefined, since different data planes have different
+                                                          capabilities. However, it is *recommended* that implementations should
+                                                          match against the first value of the param if the data plane supports it,
+                                                          as this behavior is expected in other load balancing contexts outside of
+                                                          the Gateway API.
+
+
+                                                          Users SHOULD NOT route traffic based on repeated query params to guard
+                                                          themselves against potential differences in the implementations.
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      type:
+                                                        default: Exact
+                                                        description: |-
+                                                          Type specifies how to match against the value of the query parameter.
+
+
+                                                          Support: Extended (Exact)
+
+
+                                                          Support: Implementation-specific (RegularExpression)
+
+
+                                                          Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                          conformance, implementations can support POSIX, PCRE or any other
+                                                          dialects of regular expressions. Please read the implementation's
+                                                          documentation to determine the supported dialect.
+                                                        enum:
+                                                        - Exact
+                                                        - RegularExpression
+                                                        type: string
+                                                      value:
+                                                        description: Value is the
+                                                          value of HTTP query param
+                                                          to be matched.
+                                                        maxLength: 1024
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  maxItems: 16
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
+                                              type: object
+                                            maxItems: 8
+                                            type: array
+                                        type: object
+                                      maxItems: 8
+                                      type: array
+                                    when:
+                                      description: |-
+                                        Conditions for Authorino to enforce this config.
+                                        If omitted, the config will be enforced for all requests.
+                                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                                      items:
+                                        properties:
+                                          all:
+                                            description: A list of pattern expressions
+                                              to be evaluated as a logical AND.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                          any:
+                                            description: A list of pattern expressions
+                                              to be evaluated as a logical OR.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                          operator:
+                                            description: |-
+                                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                            enum:
+                                            - eq
+                                            - neq
+                                            - incl
+                                            - excl
+                                            - matches
+                                            type: string
+                                          patternRef:
+                                            description: Reference to a named set
+                                              of pattern expressions
+                                            type: string
+                                          selector:
+                                            description: |-
+                                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                              Authorino custom JSON path modifiers are also supported.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                            type: string
+                                        type: object
+                                      type: array
+                                    wristband:
+                                      description: Authorino Festival Wristband token
+                                      properties:
+                                        customClaims:
+                                          additionalProperties:
+                                            properties:
+                                              selector:
+                                                description: |-
+                                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                                type: string
+                                              value:
+                                                description: Static value
+                                                x-kubernetes-preserve-unknown-fields: true
+                                            type: object
+                                          description: Any claims to be added to the
+                                            wristband token apart from the standard
+                                            JWT claims (iss, iat, exp) added by default.
+                                          type: object
+                                        issuer:
+                                          description: 'The endpoint to the Authorino
+                                            service that issues the wristband (format:
+                                            <scheme>://<host>:<port>/<realm>, where
+                                            <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                          type: string
+                                        signingKeyRefs:
+                                          description: |-
+                                            Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                            The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                          items:
+                                            properties:
+                                              algorithm:
+                                                description: Algorithm to sign the
+                                                  wristband token using the signing
+                                                  key provided
+                                                enum:
+                                                - ES256
+                                                - ES384
+                                                - ES512
+                                                - RS256
+                                                - RS384
+                                                - RS512
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the signing key.
+                                                  The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                                type: string
+                                            required:
+                                            - algorithm
+                                            - name
+                                            type: object
+                                          type: array
+                                        tokenDuration:
+                                          description: Time span of the wristband
+                                            token, in seconds.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - issuer
+                                      - signingKeyRefs
+                                      type: object
+                                  type: object
+                                description: |-
+                                  Custom success response items wrapped as HTTP headers.
+                                  For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
+                                  See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
+                                maxProperties: 10
+                                type: object
+                              headers:
+                                additionalProperties:
+                                  properties:
+                                    cache:
+                                      description: |-
+                                        Caching options for the resolved object returned when applying this config.
+                                        Omit it to avoid caching objects for this config.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            Key used to store the entry in the cache.
+                                            The resolved key must be unique within the scope of this particular config.
+                                          properties:
+                                            selector:
+                                              description: |-
+                                                Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                              type: string
+                                            value:
+                                              description: Static value
+                                              x-kubernetes-preserve-unknown-fields: true
+                                          type: object
+                                        ttl:
+                                          default: 60
+                                          description: Duration (in seconds) of the
+                                            external data in the cache before pulled
+                                            again from the source.
+                                          type: integer
+                                      required:
+                                      - key
+                                      type: object
+                                    json:
+                                      description: |-
+                                        JSON object
+                                        Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.
+                                      properties:
+                                        properties:
+                                          additionalProperties:
+                                            properties:
+                                              selector:
+                                                description: |-
+                                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                                type: string
+                                              value:
+                                                description: Static value
+                                                x-kubernetes-preserve-unknown-fields: true
+                                            type: object
+                                          type: object
+                                      required:
+                                      - properties
+                                      type: object
+                                    key:
+                                      description: |-
+                                        The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).
+                                        If omitted, it will be set to the name of the response config.
+                                      type: string
+                                    metrics:
+                                      default: false
+                                      description: Whether this config should generate
+                                        individual observability metrics
+                                      type: boolean
+                                    plain:
+                                      description: Plain text content
+                                      properties:
+                                        selector:
+                                          description: |-
+                                            Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                            Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                            The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                          type: string
+                                        value:
+                                          description: Static value
+                                          x-kubernetes-preserve-unknown-fields: true
+                                      type: object
+                                    priority:
+                                      default: 0
+                                      description: |-
+                                        Priority group of the config.
+                                        All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.
+                                      type: integer
+                                    routeSelectors:
+                                      description: |-
+                                        Top-level route selectors.
+                                        If present, the elements will be used to select HTTPRoute rules that, when activated, trigger the auth rule.
+                                        At least one selected HTTPRoute rule must match to trigger the auth rule.
+                                        If no route selectors are specified, the auth rule will be evaluated at all requests to the protected routes.
+                                      items:
+                                        description: |-
+                                          RouteSelector defines semantics for matching an HTTP request based on conditions
+                                          https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                        properties:
+                                          hostnames:
+                                            description: |-
+                                              Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process the request
+                                              https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                            items:
+                                              description: |-
+                                                Hostname is the fully qualified domain name of a network host. This matches
+                                                the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+
+                                                 1. IPs are not allowed.
+                                                 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                                                    label must appear by itself as the first label.
+
+
+                                                Hostname can be "precise" which is a domain name without the terminating
+                                                dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                                                domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+
+                                                Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                                                alphanumeric characters or '-', and must start and end with an alphanumeric
+                                                character. No other punctuation is allowed.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            type: array
+                                          matches:
+                                            description: |-
+                                              Matches define conditions used for matching the rule against incoming HTTP requests.
+                                              https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteSpec
+                                            items:
+                                              description: "HTTPRouteMatch defines
+                                                the predicate used to match requests
+                                                to a given\naction. Multiple match
+                                                types are ANDed together, i.e. the
+                                                match will\nevaluate to true only
+                                                if all conditions are satisfied.\n\n\nFor
+                                                example, the match below will match
+                                                a HTTP request only if its path\nstarts
+                                                with `/foo` AND it contains the `version:
+                                                v1` header:\n\n\n```\nmatch:\n\n\n\tpath:\n\t
+                                                \ value: \"/foo\"\n\theaders:\n\t-
+                                                name: \"version\"\n\t  value \"v1\"\n\n\n```"
+                                              properties:
+                                                headers:
+                                                  description: |-
+                                                    Headers specifies HTTP request header matchers. Multiple match values are
+                                                    ANDed together, meaning, a request must match all the specified headers
+                                                    to select the route.
+                                                  items:
+                                                    description: |-
+                                                      HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request
+                                                      headers.
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          Name is the name of the HTTP Header to be matched. Name matching MUST be
+                                                          case insensitive. (See https://tools.ietf.org/html/rfc7230#section-3.2).
+
+
+                                                          If multiple entries specify equivalent header names, only the first
+                                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                                          entries with an equivalent header name MUST be ignored. Due to the
+                                                          case-insensitivity of header names, "foo" and "Foo" are considered
+                                                          equivalent.
+
+
+                                                          When a header is repeated in an HTTP request, it is
+                                                          implementation-specific behavior as to how this is represented.
+                                                          Generally, proxies should follow the guidance from the RFC:
+                                                          https://www.rfc-editor.org/rfc/rfc7230.html#section-3.2.2 regarding
+                                                          processing a repeated header, with special handling for "Set-Cookie".
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      type:
+                                                        default: Exact
+                                                        description: |-
+                                                          Type specifies how to match against the value of the header.
+
+
+                                                          Support: Core (Exact)
+
+
+                                                          Support: Implementation-specific (RegularExpression)
+
+
+                                                          Since RegularExpression HeaderMatchType has implementation-specific
+                                                          conformance, implementations can support POSIX, PCRE or any other dialects
+                                                          of regular expressions. Please read the implementation's documentation to
+                                                          determine the supported dialect.
+                                                        enum:
+                                                        - Exact
+                                                        - RegularExpression
+                                                        type: string
+                                                      value:
+                                                        description: Value is the
+                                                          value of HTTP Header to
+                                                          be matched.
+                                                        maxLength: 4096
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  maxItems: 16
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
+                                                method:
+                                                  description: |-
+                                                    Method specifies HTTP method matcher.
+                                                    When specified, this route will be matched only if the request has the
+                                                    specified method.
+
+
+                                                    Support: Extended
+                                                  enum:
+                                                  - GET
+                                                  - HEAD
+                                                  - POST
+                                                  - PUT
+                                                  - DELETE
+                                                  - CONNECT
+                                                  - OPTIONS
+                                                  - TRACE
+                                                  - PATCH
+                                                  type: string
+                                                path:
+                                                  default:
+                                                    type: PathPrefix
+                                                    value: /
+                                                  description: |-
+                                                    Path specifies a HTTP request path matcher. If this field is not
+                                                    specified, a default prefix match on the "/" path is provided.
+                                                  properties:
+                                                    type:
+                                                      default: PathPrefix
+                                                      description: |-
+                                                        Type specifies how to match against the path Value.
+
+
+                                                        Support: Core (Exact, PathPrefix)
+
+
+                                                        Support: Implementation-specific (RegularExpression)
+                                                      enum:
+                                                      - Exact
+                                                      - PathPrefix
+                                                      - RegularExpression
+                                                      type: string
+                                                    value:
+                                                      default: /
+                                                      description: Value of the HTTP
+                                                        path to match against.
+                                                      maxLength: 1024
+                                                      type: string
+                                                  type: object
+                                                  x-kubernetes-validations:
+                                                  - message: value must be an absolute
+                                                      path and start with '/' when
+                                                      type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? self.value.startsWith(''/'')
+                                                      : true'
+                                                  - message: must not contain '//'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''//'')
+                                                      : true'
+                                                  - message: must not contain '/./'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''/./'')
+                                                      : true'
+                                                  - message: must not contain '/../'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''/../'')
+                                                      : true'
+                                                  - message: must not contain '%2f'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''%2f'')
+                                                      : true'
+                                                  - message: must not contain '%2F'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''%2F'')
+                                                      : true'
+                                                  - message: must not contain '#'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.contains(''#'')
+                                                      : true'
+                                                  - message: must not end with '/..'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.endsWith(''/..'')
+                                                      : true'
+                                                  - message: must not end with '/.'
+                                                      when type one of ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? !self.value.endsWith(''/.'')
+                                                      : true'
+                                                  - message: type must be one of ['Exact',
+                                                      'PathPrefix', 'RegularExpression']
+                                                    rule: self.type in ['Exact','PathPrefix']
+                                                      || self.type == 'RegularExpression'
+                                                  - message: must only contain valid
+                                                      characters (matching ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$)
+                                                      for types ['Exact', 'PathPrefix']
+                                                    rule: '(self.type in [''Exact'',''PathPrefix''])
+                                                      ? self.value.matches(r"""^(?:[-A-Za-z0-9/._~!$&''()*+,;=:@]|[%][0-9a-fA-F]{2})+$""")
+                                                      : true'
+                                                queryParams:
+                                                  description: |-
+                                                    QueryParams specifies HTTP query parameter matchers. Multiple match
+                                                    values are ANDed together, meaning, a request must match all the
+                                                    specified query parameters to select the route.
+
+
+                                                    Support: Extended
+                                                  items:
+                                                    description: |-
+                                                      HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP
+                                                      query parameters.
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          Name is the name of the HTTP query param to be matched. This must be an
+                                                          exact string match. (See
+                                                          https://tools.ietf.org/html/rfc7230#section-2.7.3).
+
+
+                                                          If multiple entries specify equivalent query param names, only the first
+                                                          entry with an equivalent name MUST be considered for a match. Subsequent
+                                                          entries with an equivalent query param name MUST be ignored.
+
+
+                                                          If a query param is repeated in an HTTP request, the behavior is
+                                                          purposely left undefined, since different data planes have different
+                                                          capabilities. However, it is *recommended* that implementations should
+                                                          match against the first value of the param if the data plane supports it,
+                                                          as this behavior is expected in other load balancing contexts outside of
+                                                          the Gateway API.
+
+
+                                                          Users SHOULD NOT route traffic based on repeated query params to guard
+                                                          themselves against potential differences in the implementations.
+                                                        maxLength: 256
+                                                        minLength: 1
+                                                        pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                                        type: string
+                                                      type:
+                                                        default: Exact
+                                                        description: |-
+                                                          Type specifies how to match against the value of the query parameter.
+
+
+                                                          Support: Extended (Exact)
+
+
+                                                          Support: Implementation-specific (RegularExpression)
+
+
+                                                          Since RegularExpression QueryParamMatchType has Implementation-specific
+                                                          conformance, implementations can support POSIX, PCRE or any other
+                                                          dialects of regular expressions. Please read the implementation's
+                                                          documentation to determine the supported dialect.
+                                                        enum:
+                                                        - Exact
+                                                        - RegularExpression
+                                                        type: string
+                                                      value:
+                                                        description: Value is the
+                                                          value of HTTP query param
+                                                          to be matched.
+                                                        maxLength: 1024
+                                                        minLength: 1
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  maxItems: 16
+                                                  type: array
+                                                  x-kubernetes-list-map-keys:
+                                                  - name
+                                                  x-kubernetes-list-type: map
+                                              type: object
+                                            maxItems: 8
+                                            type: array
+                                        type: object
+                                      maxItems: 8
+                                      type: array
+                                    when:
+                                      description: |-
+                                        Conditions for Authorino to enforce this config.
+                                        If omitted, the config will be enforced for all requests.
+                                        If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.
+                                      items:
+                                        properties:
+                                          all:
+                                            description: A list of pattern expressions
+                                              to be evaluated as a logical AND.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                          any:
+                                            description: A list of pattern expressions
+                                              to be evaluated as a logical OR.
+                                            items:
+                                              type: object
+                                              x-kubernetes-preserve-unknown-fields: true
+                                            type: array
+                                          operator:
+                                            description: |-
+                                              The binary operator to be applied to the content fetched from the authorization JSON, for comparison with "value".
+                                              Possible values are: "eq" (equal to), "neq" (not equal to), "incl" (includes; for arrays), "excl" (excludes; for arrays), "matches" (regex)
+                                            enum:
+                                            - eq
+                                            - neq
+                                            - incl
+                                            - excl
+                                            - matches
+                                            type: string
+                                          patternRef:
+                                            description: Reference to a named set
+                                              of pattern expressions
+                                            type: string
+                                          selector:
+                                            description: |-
+                                              Path selector to fetch content from the authorization JSON (e.g. 'request.method').
+                                              Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                              Authorino custom JSON path modifiers are also supported.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              The value of reference for the comparison with the content fetched from the authorization JSON.
+                                              If used with the "matches" operator, the value must compile to a valid Golang regex.
+                                            type: string
+                                        type: object
+                                      type: array
+                                    wristband:
+                                      description: Authorino Festival Wristband token
+                                      properties:
+                                        customClaims:
+                                          additionalProperties:
+                                            properties:
+                                              selector:
+                                                description: |-
+                                                  Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. "Hello, {auth.identity.name}!").
+                                                  Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.
+                                                  The following Authorino custom modifiers are supported: @extract:{sep:" ",pos:0}, @replace{old:"",new:""}, @case:upper|lower, @base64:encode|decode and @strip.
+                                                type: string
+                                              value:
+                                                description: Static value
+                                                x-kubernetes-preserve-unknown-fields: true
+                                            type: object
+                                          description: Any claims to be added to the
+                                            wristband token apart from the standard
+                                            JWT claims (iss, iat, exp) added by default.
+                                          type: object
+                                        issuer:
+                                          description: 'The endpoint to the Authorino
+                                            service that issues the wristband (format:
+                                            <scheme>://<host>:<port>/<realm>, where
+                                            <realm> = <namespace>/<authorino-auth-config-resource-name/wristband-config-name)'
+                                          type: string
+                                        signingKeyRefs:
+                                          description: |-
+                                            Reference by name to Kubernetes secrets and corresponding signing algorithms.
+                                            The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.
+                                          items:
+                                            properties:
+                                              algorithm:
+                                                description: Algorithm to sign the
+                                                  wristband token using the signing
+                                                  key provided
+                                                enum:
+                                                - ES256
+                                                - ES384
+                                                - ES512
+                                                - RS256
+                                                - RS384
+                                                - RS512
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the signing key.
+                                                  The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.
+                                                type: string
+                                            required:
+                                            - algorithm
+                                            - name
+                                            type: object
+                                          type: array
+                                        tokenDuration:
+                                          description: Time span of the wristband
+                                            token, in seconds.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - issuer
+                                      - signingKeyRefs
+                                      type: object
+                                  type: object
+                                description: |-
+                                  Custom success response items wrapped as HTTP headers.
+                                  For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
+                                maxProperties: 10
                                 type: object
                             type: object
                           unauthenticated:
@@ -5357,7 +9660,7 @@ spec:
                     description: |-
                       Authentication configs.
                       At least one config MUST evaluate to a valid identity object for the auth request to be successful.
-                    maxProperties: 14
+                    maxProperties: 10
                     type: object
                   authorization:
                     additionalProperties:
@@ -6240,7 +10543,7 @@ spec:
                     description: |-
                       Authorization policies.
                       All policies MUST evaluate to "allowed = true" for the auth request be successful.
-                    maxProperties: 14
+                    maxProperties: 10
                     type: object
                   callbacks:
                     additionalProperties:
@@ -6824,7 +11127,7 @@ spec:
                     description: |-
                       Callback functions.
                       Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.
-                    maxProperties: 14
+                    maxProperties: 10
                     type: object
                   metadata:
                     additionalProperties:
@@ -7444,7 +11747,7 @@ spec:
                     description: |-
                       Metadata sources.
                       Authorino fetches auth metadata as JSON from sources specified in this config.
-                    maxProperties: 14
+                    maxProperties: 10
                     type: object
                   response:
                     description: |-
@@ -7964,7 +12267,7 @@ spec:
                               Custom success response items wrapped as HTTP headers.
                               For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.
                               See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata
-                            maxProperties: 14
+                            maxProperties: 10
                             type: object
                           headers:
                             additionalProperties:
@@ -8473,7 +12776,7 @@ spec:
                             description: |-
                               Custom success response items wrapped as HTTP headers.
                               For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.
-                            maxProperties: 14
+                            maxProperties: 10
                             type: object
                         type: object
                       unauthenticated:
@@ -8736,9 +13039,42 @@ spec:
               rule: self.targetRef.kind != 'Gateway' || !has(self.defaults) || !has(self.defaults.rules)
                 || !has(self.defaults.rules.callbacks) || !self.defaults.rules.callbacks.exists(x,
                 has(self.defaults.rules.callbacks[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.routeSelectors)
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.authentication) || !self.overrides.rules.authentication.exists(x,
+                has(self.overrides.rules.authentication[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.metadata) || !self.overrides.rules.metadata.exists(x,
+                has(self.overrides.rules.metadata[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.authorization) || !self.overrides.rules.authorization.exists(x,
+                has(self.overrides.rules.authorization[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.response) || !has(self.overrides.rules.response.success)
+                || !has(self.overrides.rules.response.success.headers) || !self.overrides.rules.response.success.headers.exists(x,
+                has(self.overrides.rules.response.success.headers[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.response) || !has(self.overrides.rules.response.success)
+                || !has(self.overrides.rules.response.success.dynamicMetadata) ||
+                !self.overrides.rules.response.success.dynamicMetadata.exists(x, has(self.overrides.rules.response.success.dynamicMetadata[x].routeSelectors))
+            - message: route selectors not supported when targeting a Gateway
+              rule: self.targetRef.kind != 'Gateway' || !has(self.overrides) || !has(self.overrides.rules)
+                || !has(self.overrides.rules.callbacks) || !self.overrides.rules.callbacks.exists(x,
+                has(self.overrides.rules.callbacks[x].routeSelectors))
             - message: Implicit and explicit defaults are mutually exclusive
               rule: '!(has(self.defaults) && (has(self.routeSelectors) || has(self.patterns)
                 || has(self.when) || has(self.rules)))'
+            - message: Implicit defaults and explicit overrides are mutually exclusive
+              rule: '!(has(self.overrides) && (has(self.routeSelectors) || has(self.patterns)
+                || has(self.when) || has(self.rules)))'
+            - message: Explicit overrides and explicit defaults are mutually exclusive
+              rule: '!(has(self.overrides) && has(self.defaults))'
           status:
             properties:
               conditions:

--- a/config/crd/bases/kuadrant.io_authpolicies.yaml
+++ b/config/crd/bases/kuadrant.io_authpolicies.yaml
@@ -13075,6 +13075,9 @@ spec:
                 || has(self.when) || has(self.rules)))'
             - message: Explicit overrides and explicit defaults are mutually exclusive
               rule: '!(has(self.overrides) && has(self.defaults))'
+            - message: Overrides are not allowed for policies targeting a HTTPRoute
+                resource
+              rule: '!(has(self.overrides) && self.targetRef.kind == ''HTTPRoute'')'
           status:
             properties:
               conditions:

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -171,18 +171,9 @@ func (r *AuthPolicyReconciler) reconcileResources(ctx context.Context, ap *api.A
 	// this is due to not knowing if the Gateway AuthPolicy was updated to include or remove the overrides section.
 	switch obj := targetNetworkObject.(type) {
 	case *gatewayapiv1.Gateway:
-		gw := kuadrant.GatewayWrapper{Gateway: obj}
-		annotation, ok := gw.GetAnnotations()[ap.BackReferenceAnnotationName()]
-		if !ok {
-			break
-		}
-		policyKeys := &[]client.ObjectKey{}
+		gw := kuadrant.GatewayWrapper{Gateway: obj, Referrer: ap}
 		apKey := client.ObjectKeyFromObject(ap)
-		err = json.Unmarshal([]byte(annotation), policyKeys)
-		if err != nil {
-			return err
-		}
-		for _, policyKey := range *policyKeys {
+		for _, policyKey := range gw.PolicyRefs() {
 			if policyKey == apKey {
 				continue
 			}

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/go-logr/logr"
 	authorinoapi "github.com/kuadrant/authorino/api/v1beta2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/doc/reference/authpolicy.md
+++ b/doc/reference/authpolicy.md
@@ -20,7 +20,7 @@
 
 | **Field** | **Type**                              | **Required** | **Description**                                 |
 |-----------|---------------------------------------|:------------:|-------------------------------------------------|
-| `spec`    | [AuthPolicySpec](#authpolicyspec)     | Yes          | The specfication for AuthPolicy custom resource |
+| `spec`    | [AuthPolicySpec](#authpolicyspec)     | Yes          | The specification for AuthPolicy custom resource |
 | `status`  | [AuthPolicyStatus](#authpolicystatus) | No           | The status for the custom resource              |
 
 ## AuthPolicySpec
@@ -33,6 +33,7 @@
 | `patterns`       | Map<String: [NamedPattern](#namedpattern)>                                                                                                  | No           | Implicit default named patterns of lists of `selector`, `operator` and `value` tuples, to be reused in `when` conditions and pattern-matching authorization rules.                                                                                                                              |
 | `when`           | [][PatternExpressionOrRef](https://docs.kuadrant.io/authorino/docs/features/#common-feature-conditions-when)                                | No           | List of implicit default additional dynamic conditions (expressions) to activate the policy. Use it for filtering attributes that cannot be expressed in the targeted HTTPRoute's `spec.hostnames` and `spec.rules.matches` fields, or when targeting a Gateway.                                |
 | `defaults`       | [AuthPolicyCommonSpec](#authPolicyCommonSpec)                                                                                               | No           | Explicit default definitions. This field is mutually exclusive with any of the implicit default definitions: `spec.rules`, `spec.routeSelectors`, `spec.patterns`, `spec.when`                                                                                                                  |
+| `overrides`      | [AuthPolicyCommonSpec](#authPolicyCommonSpec)                                                                                               | No           | Atomic overrides definitions. This field is mutually exclusive with any of the implicit or explicit default definitions: `spec.rules`, `spec.routeSelectors`, `spec.patterns`, `spec.when`, `spec.default`                                                                                      |
 
 
 ## AuthPolicyCommonSpec

--- a/pkg/library/reconcilers/target_ref_reconciler.go
+++ b/pkg/library/reconcilers/target_ref_reconciler.go
@@ -249,7 +249,7 @@ func (r *TargetRefReconciler) ReconcileGatewayPolicyReferences(ctx context.Conte
 	for _, gw := range gwDiffObj.GatewaysMissingPolicyRef {
 		if gw.AddPolicy(client.ObjectKeyFromObject(policy)) {
 			err := r.Client.Update(ctx, gw.Gateway)
-			logger.V(1).Info("ReconcileGatewayPolicyReferences: update gateway", "gateway missinf policy ref", gw.Key(), "err", err)
+			logger.V(1).Info("ReconcileGatewayPolicyReferences: update gateway", "gateway missing policy ref", gw.Key(), "err", err)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# AuthPolicy Atomic Overrides
Closes: #464 

## Verification

### Base Setup
Create local cluster from this branch
```shell
make local-setup
```
    
Apply Kuadrant CR.
```shell
echo "  
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
  namespace: kuadrant-system
spec: {}
"
```

Install the toy store app
```shell
kubectl apply -f examples/toystore/toystore.yaml
```

Add HTTP Route
```shell
echo "
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - path:
        type: Exact
        value: "/toy"
      method: GET
    backendRefs:
    - name: toystore
      port: 80
" | kubectl apply -f -
```

Create secrets for Auth. The secrets are doubled to be created in two namespaces.
```shell
echo "
apiVersion: v1
kind: Secret
metadata:
  name: alice-key
  namespace: default
  labels:
    authorino.kuadrant.io/managed-by: authorino
    app: toystore
  annotations:
    secret.kuadrant.io/user-id: alice
stringData:
  api_key: IAMALICE
type: Opaque
---
apiVersion: v1
kind: Secret
metadata:
  name: alice-key
  namespace: istio-system
  labels:
    authorino.kuadrant.io/managed-by: authorino
    app: toystore
  annotations:
    secret.kuadrant.io/user-id: alice
stringData:
  api_key: IAMALICE
type: Opaque
" | kubectl apply -f -
```

Set up gateway url
```shell
export INGRESS_HOST=$(kubectl get gtw istio-ingressgateway -n istio-system -o jsonpath='{.status.addresses[0].value}')
export INGRESS_PORT=$(kubectl get gtw istio-ingressgateway -n istio-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
```

Set up a watch on AuthConfigs.
```shell
watch kubectl get authconfig -A
```

### Case 1
There is an existing AuthPolicy attached to a HTTPRoute and the system admin attaches a AuthPolicy to the Gateway with atonic overrides.

Create HTTPRoute AuthPolicy. Expect watch to contain one AuthConfig `ap-default-toystore`
```shell
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: toystore
  namespace: default
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: TOYSTORE
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f - 
```

Check auth is working. Note the name of the Authorization key, `TOYSTORE`. Expected result is `200`.
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: TOYSTORE IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Add the Gateway AuthPolicy that contains overrides. Expect AuthConfig to change to `ap-istio-system-gateway`
```shell    
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gateway
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  overrides:
    rules:
      authentication:
        "api-key-users":
          apiKey:
            selector:
              matchLabels:
                app: toystore
            allNamespaces: true
          credentials:
            authorizationHeader:
              prefix: APIKEY
      response:
        success:
          dynamicMetadata:
            "identity":
              json:
                properties:
                  "userid":
                    selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f -
```

Curl the endpoint again with Route Key. Expected `401`
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: TOYSTORE IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Curl endpoint with key defined in the Gateway AuthPolicy, `APIKEY`. Expected `200`.
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

This show the Gateway overrides are working.

### Case 2
In this case the Gateway AuthPolicy has being defined before any route AuthPolicies have being attached.

Set the cluster back to the configuration as per the [Base Setup](#base-setup).

Install the gateway AuthPolicy. Expected AuthConfig on watch: `ap-istio-system-gateway`
```shell    
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gateway
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  overrides:
    rules:
      authentication:
        "api-key-users":
          apiKey:
            selector:
              matchLabels:
                app: toystore
            allNamespaces: true
          credentials:
            authorizationHeader:
              prefix: APIKEY
      response:
        success:
          dynamicMetadata:
            "identity":
              json:
                properties:
                  "userid":
                    selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f -
```

Curl endpoint with key defined in the Gateway AuthPolicy, `APIKEY`. Expected `200`.
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Apply Auth Policy to route. Expected AuthConfig on watch: `ap-istio-system-gateway`
```shell
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: toystore
  namespace: default
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: TOYSTORE
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f - 
```
Curl the endpoint with Route Key. Expected `401`
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: TOYSTORE IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Curl endpoint with key defined in the Gateway AuthPolicy, `APIKEY`. Expected `200`.
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

This show the Gateway overrides are working for routes added after the initial overrides.

### Case 3
The cluster has exiting AuthPolicies attached to the routes and gateways. The system admin later defines the overrides on the gateway AuthPolicy.

Set the cluster back to the configuration as per the [Base Setup](#base-setup).

Create the Route and Gateway AuthPolices. Note that the Gateway AuthPolicy does not define any overrides. Expected AuthConfig in watch: `ap-default-toystore` 
```shell
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: toystore
  namespace: default
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: TOYSTORE
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
---
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gateway
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: APIKEY
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f - 
```
    
Curl the endpoint with Route Key. Expected `200`
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: TOYSTORE IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Curl endpoint with key defined in the Gateway AuthPolicy, `APIKEY`. Expected `401`.
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Update the Gateway AuthPolicy to have `overrides`. Expected AuthConfig on watch: `ap-istio-system-gateway`.
```shell    
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gateway
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  overrides:
    rules:
      authentication:
        "api-key-users":
          apiKey:
            selector:
              matchLabels:
                app: toystore
            allNamespaces: true
          credentials:
            authorizationHeader:
              prefix: APIKEY
      response:
        success:
          dynamicMetadata:
            "identity":
              json:
                properties:
                  "userid":
                    selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f -
```

Curl the endpoint with Route Key. Expected `401`
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: TOYSTORE IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Curl endpoint with key defined in the Gateway AuthPolicy, `APIKEY`. Expected `200`.
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

This proves that existing Gateway AuthPolicies can be updated to contain `overrides`.

### Case 4
The cluster in this case is configure to have `overrides` on the Gateway from the start. At a later time the system admin removes the `overrides` from the gateway AuthPolicy.

Set the cluster back to the configuration as per the [Base Setup](#base-setup).

Create the Route and Gateway AuthPolices. Note that the Gateway AuthPolicy does define overrides. Expected AuthConfig in watch: `ap-istio-system-gateway`
```shell
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: toystore
  namespace: default
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: TOYSTORE
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
---
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gateway
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  overrides:
      rules:
        authentication:
          "api-key-users":
            apiKey:
              selector:
                matchLabels:
                  app: toystore
              allNamespaces: true
            credentials:
              authorizationHeader:
                prefix: APIKEY
        response:
          success:
            dynamicMetadata:
              "identity":
                json:
                  properties:
                    "userid":
                      selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f - 
```

Curl the endpoint with Route Key. Expected `401`
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: TOYSTORE IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Curl endpoint with key defined in the Gateway AuthPolicy, `APIKEY`. Expected `200`.
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Update the Gateway AuthPolicy to remove the overrides. Expect AuthConfig in watch: `ap-default-toystore`
```shell
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gateway
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: APIKEY
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f - 
```

Curl the endpoint with Route Key. Expected `200`
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: TOYSTORE IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

Curl endpoint with key defined in the Gateway AuthPolicy, `APIKEY`. Expected `401`.
```shell
curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy
```

This proves AuthPolicies can be updated to remove `overrides`.````