### PR TITLE
limitador cluster envoy filter leverages DAG

### DIFF
--- a/api/v1beta2/ratelimitpolicy_types.go
+++ b/api/v1beta2/ratelimitpolicy_types.go
@@ -55,7 +55,6 @@ const (
 	ExcludeOperator    WhenConditionOperator = "excl"
 	MatchesOperator    WhenConditionOperator = "matches"
 
-	RateLimitPolicyBackReferenceAnnotationName   = "kuadrant.io/ratelimitpolicies"
 	RateLimitPolicyDirectReferenceAnnotationName = "kuadrant.io/ratelimitpolicy"
 )
 
@@ -170,7 +169,6 @@ func (s *RateLimitPolicyStatus) Equals(other *RateLimitPolicyStatus, logger logr
 }
 
 var _ kuadrant.Policy = &RateLimitPolicy{}
-var _ kuadrant.Referrer = &RateLimitPolicy{}
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
@@ -254,10 +252,6 @@ func (r *RateLimitPolicy) GetRulesHostnames() (ruleHosts []string) {
 
 func (r *RateLimitPolicy) Kind() string {
 	return r.TypeMeta.Kind
-}
-
-func (r *RateLimitPolicy) BackReferenceAnnotationName() string {
-	return RateLimitPolicyBackReferenceAnnotationName
 }
 
 func (r *RateLimitPolicy) DirectReferenceAnnotationName() string {

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ import (
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	"github.com/kuadrant/kuadrant-operator/controllers"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/fieldindexers"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/reconcilers"
 	"github.com/kuadrant/kuadrant-operator/pkg/log"
@@ -129,6 +130,14 @@ func main() {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if err := fieldindexers.HTTPRouteIndexByGateway(
+		mgr,
+		log.Log.WithName("kuadrant").WithName("indexer").WithName("routeIndexByGateway"),
+	); err != nil {
+		setupLog.Error(err, "unable to add indexer")
 		os.Exit(1)
 	}
 

--- a/pkg/library/fieldindexers/httproute_parents.go
+++ b/pkg/library/fieldindexers/httproute_parents.go
@@ -1,0 +1,44 @@
+package fieldindexers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
+)
+
+const (
+	HTTPRouteGatewayParentField = ".metadata.parentRefs.gateway"
+)
+
+// HTTPRouteByGatewayIndexer declares an index key that we can later use with the client as a pseudo-field name,
+// allowing to query all the routes parented by a given gateway
+// to prevent creating the same index field multiple times, the function is declared private to be
+// called only by this controller
+func HTTPRouteIndexByGateway(mgr ctrl.Manager, baseLogger logr.Logger) error {
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayapiv1.HTTPRoute{}, HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
+		// grab the route object, extract the parents
+		route, assertionOk := rawObj.(*gatewayapiv1.HTTPRoute)
+		if !assertionOk {
+			baseLogger.V(1).Error(fmt.Errorf("%T is not a *gatewayapiv1.HTTPRoute", rawObj), "cannot map")
+			return nil
+		}
+
+		logger := baseLogger.WithValues("route", client.ObjectKeyFromObject(route).String())
+
+		return utils.Map(kuadrantgatewayapi.GetRouteAcceptedGatewayParentKeys(route), func(key client.ObjectKey) string {
+			logger.V(1).Info("new gateway added", "key", key.String())
+			return key.String()
+		})
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/rlptools/topology_index.go
+++ b/pkg/rlptools/topology_index.go
@@ -1,0 +1,62 @@
+package rlptools
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/fieldindexers"
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
+)
+
+func TopologyIndexesFromGateway(ctx context.Context, cl client.Client, gw *gatewayapiv1.Gateway) (*kuadrantgatewayapi.TopologyIndexes, error) {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	routeList := &gatewayapiv1.HTTPRouteList{}
+	// Get all the routes having the gateway as parent
+	err = cl.List(
+		ctx,
+		routeList,
+		client.MatchingFields{
+			fieldindexers.HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gw).String(),
+		})
+	logger.V(1).Info("topologyIndexesFromGateway: list httproutes from gateway",
+		"gateway", client.ObjectKeyFromObject(gw),
+		"#HTTPRoutes", len(routeList.Items),
+		"err", err)
+	if err != nil {
+		return nil, err
+	}
+
+	rlpList := &kuadrantv1beta2.RateLimitPolicyList{}
+	// Get all the rate limit policies
+	err = cl.List(ctx, rlpList)
+	logger.V(1).Info("topologyIndexesFromGateway: list rate limit policies",
+		"#RLPS", len(rlpList.Items),
+		"err", err)
+	if err != nil {
+		return nil, err
+	}
+
+	policies := utils.Map(rlpList.Items, func(p kuadrantv1beta2.RateLimitPolicy) kuadrantgatewayapi.Policy { return &p })
+
+	t, err := kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithGateways([]*gatewayapiv1.Gateway{gw}),
+		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To)),
+		kuadrantgatewayapi.WithPolicies(policies),
+		kuadrantgatewayapi.WithLogger(logger),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return kuadrantgatewayapi.NewTopologyIndexes(t), nil
+}


### PR DESCRIPTION
### What

Limitador cluster envoy filter controller reading from DAG Gateway API topology and RateLimitPolicies

Kuadrant rate limiting controllers no longer depends on *back references* annotation: `kuadrant.io/ratelimitpolicies`. Instead, controllers rely on the DAG Gateway API topopology to read cluster state. Kuadrant envoy filter controller is also based on this approach. 

Fix reconciliation event blind spots due to race conditions or timing issues. The reconciled resource reflects latest updates from the cluster (Gateways, Routes and policies).

Built on top of #527, so that must be merged first (not a hard requirement, though)