### PR TITLE
Fix generic function without instantiation

### DIFF
--- a/controllers/rate_limiting_wasmplugin_controller.go
+++ b/controllers/rate_limiting_wasmplugin_controller.go
@@ -221,7 +221,7 @@ func (r *RateLimitingWASMPluginReconciler) topologyIndexesFromGateway(ctx contex
 
 	t, err := kuadrantgatewayapi.NewTopology(
 		kuadrantgatewayapi.WithGateways([]*gatewayapiv1.Gateway{gw}),
-		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To)),
+		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(policies),
 		kuadrantgatewayapi.WithLogger(logger),
 	)


### PR DESCRIPTION
Avoid invalid linting errors flagged on some IDEs.

See https://github.com/Kuadrant/kuadrant-operator/pull/447#discussion_r1514856791