### PR TITLE
fix kuadrant CR finalizer

### DIFF
--- a/controllers/kuadrant_controller.go
+++ b/controllers/kuadrant_controller.go
@@ -338,10 +338,13 @@ func (r *KuadrantReconciler) getIstioConfigObjects(ctx context.Context, logger l
 
 	istioConfigMap := &corev1.ConfigMap{}
 	if err := r.GetResource(ctx, client.ObjectKey{Name: controlPlaneConfigMapName(), Namespace: controlPlaneProviderNamespace()}, istioConfigMap); err != nil {
-		logger.V(1).Info("failed to get istio configMap", "key", istKey, "err", err)
-		return configsToUpdate, err
+		if !apierrors.IsNotFound(err) {
+			logger.V(1).Info("failed to get istio configMap", "key", istKey, "err", err)
+			return configsToUpdate, err
+		}
+	} else {
+		configsToUpdate = append(configsToUpdate, istio.NewConfigMapWrapper(istioConfigMap))
 	}
-	configsToUpdate = append(configsToUpdate, istio.NewConfigMapWrapper(istioConfigMap))
 	return configsToUpdate, nil
 }
 


### PR DESCRIPTION
### What

Fix Kuadrant CR cleaning up resources

When Kuadrant CR was deleted, the clean up process failed and the finalizer was never removed. The issue is specifically when the istio config map was not found, error was raised and the finalizer was never removed. 

Fixes #363

The whole  auth provider registration in istio/maistra code deserves a refactor. More :bomb: may arise 

### Verification Steps

* Setup the environment:   
                         
```sh                    
make local-setup         
```        
Request an instance of Kuadrant:

```sh
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```

Delete Istio

```
kubectl delete namespace istio-system
```

```
kubectl delete namespace istio-operator
```

Delete Kuadrant CR

```
kubectl delete kuadrant kuadrant -n kuadrant-system
```
The delete command should not be stuck and finish successfully.
