### PR TITLE
Remove the -v and --fail-fast from the ginkgo test command 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,8 +310,6 @@ test-integration: clean-cov generate fmt vet ginkgo ## Run Integration tests.
 		--output-dir $(PROJECT_PATH)/coverage/integration \
 		--coverprofile cover.out \
 		-tags integration \
-		--fail-fast \
-		-v \
 		$(INTEGRATION_TEST_SUITE_PATHS)
 
 ifdef TEST_NAME


### PR DESCRIPTION
# Reasoning

The verbose flag `-v` will print the logs of the test while they are running, even if the test passes. A recent test run contained over 700,000 lines of logs. This is enough to cause web browser issue when watching the logs live and afterwards GitHub force you to download the logs to view them. By remove the verbose flag only the logs of failing tests are printed. This happens after the test has failed, vastly reducing the number of logs produced. 

Removing the fail fast flag `--fail-fast` will mean the test suite will continue to run even after a fail test has triggered. As the integration tests take the best part of an hour to run, we don't want to be running it multiple times in a cycle of fix broken test, find next broken test. If there were multiple test suites I could see the advantage of doing this along with the `--keep-going` flags, as of today there are not multiple test suites.

