### PR TITLE
GH-545 restrict default geo to local

### DIFF
--- a/api/v1alpha1/dnspolicy_types.go
+++ b/api/v1alpha1/dnspolicy_types.go
@@ -348,31 +348,14 @@ func (p *DNSPolicy) WithHealthCheckFor(endpoint string, port *int, protocol stri
 
 //LoadBalancing
 
-func (p *DNSPolicy) WithLoadBalancingWeighted(lbWeighted LoadBalancingWeighted) *DNSPolicy {
-	if p.Spec.LoadBalancing == nil {
-		p.WithLoadBalancing(LoadBalancingSpec{})
-	}
-	p.Spec.LoadBalancing.Weighted = &lbWeighted
-	return p
-}
-
-func (p *DNSPolicy) WithLoadBalancingGeo(lbGeo LoadBalancingGeo) *DNSPolicy {
-	if p.Spec.LoadBalancing == nil {
-		p.Spec.LoadBalancing = &LoadBalancingSpec{}
-	}
-	p.Spec.LoadBalancing.Geo = &lbGeo
-	return p
-}
-
-func (p *DNSPolicy) WithLoadBalancingWeightedFor(defaultWeight Weight, custom []*CustomWeight) *DNSPolicy {
-	return p.WithLoadBalancingWeighted(LoadBalancingWeighted{
-		DefaultWeight: defaultWeight,
-		Custom:        custom,
-	})
-}
-
-func (p *DNSPolicy) WithLoadBalancingGeoFor(defaultGeo string) *DNSPolicy {
-	return p.WithLoadBalancingGeo(LoadBalancingGeo{
-		DefaultGeo: defaultGeo,
+func (p *DNSPolicy) WithLoadBalancingFor(defaultWeight Weight, custom []*CustomWeight, defaultGeo string) *DNSPolicy {
+	return p.WithLoadBalancing(LoadBalancingSpec{
+		Weighted: &LoadBalancingWeighted{
+			DefaultWeight: defaultWeight,
+			Custom:        custom,
+		},
+		Geo: &LoadBalancingGeo{
+			DefaultGeo: defaultGeo,
+		},
 	})
 }

--- a/controllers/dnspolicy_controller_single_cluster_test.go
+++ b/controllers/dnspolicy_controller_single_cluster_test.go
@@ -172,7 +172,8 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 		BeforeEach(func() {
 			dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithTargetGateway(TestGatewayName).
-				WithRoutingStrategy(v1alpha1.LoadBalancedRoutingStrategy)
+				WithRoutingStrategy(v1alpha1.LoadBalancedRoutingStrategy).
+				WithLoadBalancingFor(120, nil, "IE")
 			Expect(k8sClient.Create(ctx, dnsPolicy)).To(Succeed())
 		})
 
@@ -206,7 +207,7 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 									"RecordTTL":     Equal(externaldns.TTL(60)),
 								})),
 								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":          Equal("default." + "klb.test.example.com"),
+									"DNSName":          Equal("ie.klb.test.example.com"),
 									"Targets":          ConsistOf(clusterHash + "-" + gwHash + "." + "klb.test.example.com"),
 									"RecordType":       Equal("CNAME"),
 									"SetIdentifier":    Equal(clusterHash + "-" + gwHash + "." + "klb.test.example.com"),
@@ -215,7 +216,15 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 								})),
 								PointTo(MatchFields(IgnoreExtras, Fields{
 									"DNSName":          Equal("klb.test.example.com"),
-									"Targets":          ConsistOf("default." + "klb.test.example.com"),
+									"Targets":          ConsistOf("ie.klb.test.example.com"),
+									"RecordType":       Equal("CNAME"),
+									"SetIdentifier":    Equal("IE"),
+									"RecordTTL":        Equal(externaldns.TTL(300)),
+									"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "IE"}}),
+								})),
+								PointTo(MatchFields(IgnoreExtras, Fields{
+									"DNSName":          Equal("klb.test.example.com"),
+									"Targets":          ConsistOf("ie.klb.test.example.com"),
 									"RecordType":       Equal("CNAME"),
 									"SetIdentifier":    Equal("default"),
 									"RecordTTL":        Equal(externaldns.TTL(300)),
@@ -247,7 +256,7 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 									"RecordTTL":     Equal(externaldns.TTL(60)),
 								})),
 								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":          Equal("default." + "klb.example.com"),
+									"DNSName":          Equal("ie.klb.example.com"),
 									"Targets":          ConsistOf(clusterHash + "-" + gwHash + "." + "klb.example.com"),
 									"RecordType":       Equal("CNAME"),
 									"SetIdentifier":    Equal(clusterHash + "-" + gwHash + "." + "klb.example.com"),
@@ -256,11 +265,19 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 								})),
 								PointTo(MatchFields(IgnoreExtras, Fields{
 									"DNSName":          Equal("klb.example.com"),
-									"Targets":          ConsistOf("default." + "klb.example.com"),
+									"Targets":          ConsistOf("ie.klb.example.com"),
 									"RecordType":       Equal("CNAME"),
 									"SetIdentifier":    Equal("default"),
 									"RecordTTL":        Equal(externaldns.TTL(300)),
 									"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+								})),
+								PointTo(MatchFields(IgnoreExtras, Fields{
+									"DNSName":          Equal("klb.example.com"),
+									"Targets":          ConsistOf("ie.klb.example.com"),
+									"RecordType":       Equal("CNAME"),
+									"SetIdentifier":    Equal("IE"),
+									"RecordTTL":        Equal(externaldns.TTL(300)),
+									"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "IE"}}),
 								})),
 								PointTo(MatchFields(IgnoreExtras, Fields{
 									"DNSName":       Equal(TestHostWildcard),


### PR DESCRIPTION
Prevent creation of the default endpoint if we are using  the `LoadBalanced` strategy  and the `lb-attribute-geo-code` label on a gateway does not match the default geo in the policy spec 