### PR TITLE
Do/auth policy status

### DIFF
--- a/pkg/library/kuadrant/apimachinery_status_conditions.go
+++ b/pkg/library/kuadrant/apimachinery_status_conditions.go
@@ -11,8 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-
-	"github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 )
 
 const (
@@ -55,7 +53,7 @@ func (o *OverriddenPolicyMap) RemoveOverriddenPolicy(p Policy) {
 
 // IsPolicyOverridden checks if the provided Policy is overridden based on the tracking map maintained.
 func (o *OverriddenPolicyMap) IsPolicyOverridden(p Policy) bool {
-	return o.policies[p.GetUID()] && gatewayapi.IsTargetRefGateway(p.GetTargetRef())
+	return o.policies[p.GetUID()]
 }
 
 // ConditionMarshal marshals the set of conditions as a JSON array, sorted by condition type.

--- a/pkg/library/kuadrant/httproute_wrapper.go
+++ b/pkg/library/kuadrant/httproute_wrapper.go
@@ -1,0 +1,41 @@
+package kuadrant
+
+import (
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+type HTTPRouteWrapper struct {
+	*gatewayapiv1.HTTPRoute
+	Referrer
+}
+
+func (r HTTPRouteWrapper) PolicyRefs(t *kuadrantgatewayapi.Topology) []string {
+	if r.HTTPRoute == nil {
+		return make([]string, 0)
+	}
+	refs := make([]string, 0)
+	for _, gw := range t.Gateways() {
+		authPolicyRefs, ok := gw.GetAnnotations()[common.AuthPolicyBackRefAnnotation]
+		if !ok {
+			continue
+		}
+		refs = append(refs, authPolicyRefs)
+	}
+	return refs
+}
+
+// HTTPRouteWrapperList is a list of HTTPRouteWrapper that implements sort.interface
+// impl: sort.interface
+type HTTPRouteWrapperList []HTTPRouteWrapper
+
+func (l HTTPRouteWrapperList) Len() int { return len(l) }
+
+func (l HTTPRouteWrapperList) Less(i, j int) bool {
+	return l[i].CreationTimestamp.Before(&l[j].CreationTimestamp)
+}
+
+func (l HTTPRouteWrapperList) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}


### PR DESCRIPTION
Closes: #466 

# Verification
* Set up local cluster.
```shell
make local-setup
```
* Install kuadrant, toystore and route authPolicy
```shell
echo "  
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
  namespace: kuadrant-system
spec: {}
" | kubectl apply -f -
kubectl apply -f examples/toystore/toystore.yaml
echo "
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - path:
        type: Exact
        value: "/toy"
      method: GET
    backendRefs:
    - name: toystore
      port: 80
" | kubectl apply -f -
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: toystore
  namespace: default
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: TOYSTORE
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f - 
```
* Check the Enforced status of the authPolicy. Expected status True.
```shell
kubectl get authpolicy toystore -n default -o=jsonpath='{.status.conditions[?(@.type=="Enforced")]}{"\\n"}' | jq
```
* Apply gateway Authpolicy with override.
```shell
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gateway
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  overrides:
    rules:
      authentication:
        "api-key-users":
          apiKey:
            selector:
              matchLabels:
                app: toystore
            allNamespaces: true
          credentials:
            authorizationHeader:
              prefix: APIKEY
      response:
        success:
          dynamicMetadata:
            "identity":
              json:
                properties:
                  "userid":
                    selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f -
```
* Check the Enforced status of the authPolicy. Expected status Fasle, reason of Overridden and gateway authPolicy to be listed in the massage.
```shell
kubectl get authpolicy toystore -n default -o=jsonpath='{.status.conditions[?(@.type=="Enforced")]}{"\\n"}' | jq
```