### PR TITLE
Make selection of subnet using docker more flexible.

### DIFF
--- a/utils/docker-network-ipaddresspool.sh
+++ b/utils/docker-network-ipaddresspool.sh
@@ -29,7 +29,7 @@ set -e
 
 # Fallback to docker version of cmd
 if [[ -z "$SUBNET" ]]; then
-  SUBNET=$(docker network inspect $networkName | ${YQ} e '.[] | select(.IPAM.Config[] | has("Gateway")) | .IPAM.Config[] | select(has("Gateway")) | .Subnet' -)
+  SUBNET=$(docker network inspect $networkName --format '{{json .IPAM.Config}}' | ${YQ} '.[] | select( .Subnet | test("^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}/\d+$")) | .Subnet')
 fi
 # Neither worked, error out
 if [[ -z "$SUBNET" ]]; then

--- a/utils/docker-network-ipaddresspool.sh
+++ b/utils/docker-network-ipaddresspool.sh
@@ -29,7 +29,7 @@ set -e
 
 # Fallback to docker version of cmd
 if [[ -z "$SUBNET" ]]; then
-  SUBNET=$(docker network inspect $networkName -f '{{ (index .IPAM.Config 0).Subnet }}')
+  SUBNET=$(docker network inspect $networkName | ${YQ} e '.[] | select(.IPAM.Config[] | has("Gateway")) | .IPAM.Config[] | select(has("Gateway")) | .Subnet' -)
 fi
 # Neither worked, error out
 if [[ -z "$SUBNET" ]]; then


### PR DESCRIPTION
This removes the assumption that the first item in IPAM.Config is the IPv4 entry. However the assumption that only the IPv4 has a value for the gateway is being made. 