### PR TITLE
docs: limitation on multiple network resources with identical hostnames

### DIFF
--- a/doc/auth.md
+++ b/doc/auth.md
@@ -224,14 +224,6 @@ spec:
 └───────────────────┘             └────────────────────┘
 ```
 
-#### Multiple HTTPRoutes with the same hostname
-
-Kuadrant currently does not support concurrent AuthPolicies targeting the exact same hostname.
-
-In case 2 or more AuthPolicies target resources that specify the same exact hostnames, the first AuthPolicy created claims the hostname; all the other AuthPolicies will not be enforced for the conflicting hostname and their status will be reported as not ready.
-
-This limitation only applies to identical hostnames. Different AuthPolicies can still be declared for different hostnames, as well as sets and strict subsets of hostnames.
-
 #### Hostnames and wildcards
 
 If an AuthPolicy targets a route defined for `*.com` and another AuthPolicy targets another route for `api.com`, the Kuadrant control plane will not merge these two AuthPolicies. Rather, it will mimic the behavior of gateway implementation by which the "most specific hostname wins", thus enforcing only the corresponding applicable policies and auth rules.

--- a/doc/auth.md
+++ b/doc/auth.md
@@ -365,7 +365,7 @@ Kuadrant currently does not support multiple AuthPolicies simultaneously targeti
 
 Moreover, having **multiple resources that declare identical hostnames** may lead to unexpected behavior and therefore **should be avoided**.
 
-This limitation is rooted at the underlying components configured by Kuadrant for the implementation of its polcies and the lack of information in the data plane regarding the exact route that honored by the API gateway in cases of conflicting hostnames.
+This limitation is rooted at the underlying components configured by Kuadrant for the implementation of its policies and the lack of information in the data plane regarding the exact route that is honored by the API gateway at each specific request, in cases of conflicting hostnames.
 
 To exemplify one way this limitation can impact deployments, consider the following topology:
 
@@ -397,7 +397,7 @@ To exemplify one way this limitation can impact deployments, consider the follow
     └────────────┘               └────────────┘
 ```
 
-In the example above, with the `policy-1` resource created before `policy-2`, `policy-1` will be enforced on all requests to `app.io/foo` while `policy-2` will be rejected. I.e. `app.io/bar` will not be secured. In fact, the status conditions of `policy-2` shall recflect `Enforced=false` with message _"AuthPolicy has encountered some issues: AuthScheme is not ready yet"_.
+In the example above, with the `policy-1` resource created before `policy-2`, `policy-1` will be enforced on all requests to `app.io/foo` while `policy-2` will be rejected. I.e. `app.io/bar` will not be secured. In fact, the status conditions of `policy-2` shall reflect `Enforced=false` with message _"AuthPolicy has encountered some issues: AuthScheme is not ready yet"_.
 
 Notice the enforcement of `policy-1` and no enforcement of `policy-2` is the opposite behavior as the [analogous problem with the Kuadrant RateLimitPolicy](rate-limiting.md#limitation-multiple-network-resources-with-identical-hostnames).
 

--- a/doc/rate-limiting.md
+++ b/doc/rate-limiting.md
@@ -280,6 +280,87 @@ Check out the following user guides for examples of rate limiting services with 
 * One HTTPRoute can only be targeted by one RateLimitPolicy.
 * One Gateway can only be targeted by one RateLimitPolicy.
 * RateLimitPolicies can only target HTTPRoutes/Gateways defined within the same namespace of the RateLimitPolicy.
+* 2+ RateLimitPolicies cannot target network resources that define/inherit the same exact hostname.
+
+#### Limitation: Multiple network resources with identical hostnames
+
+Kuadrant currently does not support multiple RateLimitPolicies simultaneously targeting network resources that declare identical hostnames. This includes multiple HTTPRoutes that specify the same hostnames in the `spec.hostnames` field, as well as HTTPRoutes that specify a hostname that is identical to a hostname specified in a listener of one of the route's parent gateways or HTTPRoutes that don't specify any hostname at all thus inheriting the hostnames from the parent gateways. In any of these cases, **a maximum of one RateLimitPolicy targeting any of those resources that specify identical hostnames is allowed**.
+
+Moreover, having **multiple resources that declare identical hostnames** may lead to unexpected behavior and therefore **should be avoided**.
+
+This limitation is rooted at the underlying components configured by Kuadrant for the implementation of its polcies and the lack of information in the data plane regarding the exact route that honored by the API gateway in cases of conflicting hostnames.
+
+To exemplify one way this limitation can impact deployments, consider the following topology:
+
+```
+                 ┌──────────────┐
+                 │   Gateway    │
+                 ├──────────────┤
+          ┌─────►│ listeners:   │◄──────┐
+          │      │ - host: *.io │       │
+          │      └──────────────┘       │
+          │                             │
+          │                             │
+┌─────────┴─────────┐        ┌──────────┴────────┐
+│     HTTPRoute     │        │     HTTPRoute     │
+│     (route-a)     │        │     (route-b)     │
+├───────────────────┤        ├───────────────────┤
+│ hostnames:        │        │ hostnames:        │
+│ - app.io          │        │ - app.io          │
+│ rules:            │        │ rules:            │
+│ - matches:        │        │ - matches:        │
+│   - path:         │        │   - path:         │
+│       value: /foo │        │       value: /bar │
+└───────────────────┘        └───────────────────┘
+          ▲                            ▲
+          │                            │
+ ┌────────┴────────┐           ┌───────┴─────────┐
+ │ RateLimitPolicy │           │ RateLimitPolicy │
+ │   (policy-1)    │           │   (policy-2)    │
+ └─────────────────┘           └─────────────────┘
+```
+
+In the example above, with the `policy-1` resource created before `policy-2`, `policy-2` will be enforced on all requests to `app.io/bar` while `policy-1` will be **not** be enforced at all. I.e. `app.io/foo` will not be rate-limited. Nevertheless, both policies will report status condition as `Enforced`.
+
+Notice the enforcement of `policy-2` and no enforcement of `policy-1` is the opposite behavior as the [analogous problem with the Kuadrant AuthPolicy](auth.md#limitation-multiple-network-resources-with-identical-hostnames).
+
+A different way the limitation applies is when two or more routes of a gateway declare the exact same hostname and a gateway policy is defined with expectation to set default rules for the cases not covered by more specific policies. E.g.:
+
+```
+                                    ┌─────────────────┐
+                         ┌──────────┤ RateLimitPolicy │
+                         │          │    (policy-2)   │
+                         ▼          └─────────────────┘
+                 ┌──────────────┐
+                 │   Gateway    │
+                 ├──────────────┤
+          ┌─────►│ listeners:   │◄──────┐
+          │      │ - host: *.io │       │
+          │      └──────────────┘       │
+          │                             │
+          │                             │
+┌─────────┴─────────┐        ┌──────────┴────────┐
+│     HTTPRoute     │        │     HTTPRoute     │
+│     (route-a)     │        │     (route-b)     │
+├───────────────────┤        ├───────────────────┤
+│ hostnames:        │        │ hostnames:        │
+│ - app.io          │        │ - app.io          │
+│ rules:            │        │ rules:            │
+│ - matches:        │        │ - matches:        │
+│   - path:         │        │   - path:         │
+│       value: /foo │        │       value: /bar │
+└───────────────────┘        └───────────────────┘
+          ▲
+          │
+ ┌────────┴────────┐
+ │ RateLimitPolicy │
+ │   (policy-1)    │
+ └─────────────────┘
+```
+
+Once again, both policies will report status condition as `Enforced`. However, in this case, only `policy-1` will be enforced on requests to `app.io/foo`, while `policy-2` will be **not** be enforced at all. I.e. `app.io/bar` will not be not rate-limited. This is same behavior as the [analogous problem with the Kuadrant AuthPolicy](auth.md#limitation-multiple-network-resources-with-identical-hostnames).
+
+To avoid these problems, use different hostnames in each route.
 
 ## Implementation details
 

--- a/doc/rate-limiting.md
+++ b/doc/rate-limiting.md
@@ -288,7 +288,7 @@ Kuadrant currently does not support multiple RateLimitPolicies simultaneously ta
 
 Moreover, having **multiple resources that declare identical hostnames** may lead to unexpected behavior and therefore **should be avoided**.
 
-This limitation is rooted at the underlying components configured by Kuadrant for the implementation of its polcies and the lack of information in the data plane regarding the exact route that honored by the API gateway in cases of conflicting hostnames.
+This limitation is rooted at the underlying components configured by Kuadrant for the implementation of its policies and the lack of information in the data plane regarding the exact route that honored by the API gateway in cases of conflicting hostnames.
 
 To exemplify one way this limitation can impact deployments, consider the following topology:
 
@@ -320,7 +320,7 @@ To exemplify one way this limitation can impact deployments, consider the follow
  └─────────────────┘           └─────────────────┘
 ```
 
-In the example above, with the `policy-1` resource created before `policy-2`, `policy-2` will be enforced on all requests to `app.io/bar` while `policy-1` will be **not** be enforced at all. I.e. `app.io/foo` will not be rate-limited. Nevertheless, both policies will report status condition as `Enforced`.
+In the example above, with the `policy-1` resource created before `policy-2`, `policy-2` will be enforced on all requests to `app.io/bar` while `policy-1` will **not** be enforced at all. I.e. `app.io/foo` will not be rate-limited. Nevertheless, both policies will report status condition as `Enforced`.
 
 Notice the enforcement of `policy-2` and no enforcement of `policy-1` is the opposite behavior as the [analogous problem with the Kuadrant AuthPolicy](auth.md#limitation-multiple-network-resources-with-identical-hostnames).
 
@@ -358,7 +358,7 @@ A different way the limitation applies is when two or more routes of a gateway d
  └─────────────────┘
 ```
 
-Once again, both policies will report status condition as `Enforced`. However, in this case, only `policy-1` will be enforced on requests to `app.io/foo`, while `policy-2` will be **not** be enforced at all. I.e. `app.io/bar` will not be not rate-limited. This is same behavior as the [analogous problem with the Kuadrant AuthPolicy](auth.md#limitation-multiple-network-resources-with-identical-hostnames).
+Once again, both policies will report status condition as `Enforced`. However, in this case, only `policy-1` will be enforced on requests to `app.io/foo`, while `policy-2` will **not** be enforced at all. I.e. `app.io/bar` will not be not rate-limited. This is same behavior as the [analogous problem with the Kuadrant AuthPolicy](auth.md#limitation-multiple-network-resources-with-identical-hostnames).
 
 To avoid these problems, use different hostnames in each route.
 

--- a/doc/rate-limiting.md
+++ b/doc/rate-limiting.md
@@ -122,10 +122,6 @@ spec:
 
 ![Rate limit policy targeting a HTTPRoute resource](https://i.imgur.com/ObfOp9u.png)
 
-#### Multiple HTTPRoutes with the same hostname
-
-When multiple HTTPRoutes state the same hostname, these HTTPRoutes are usually all admitted and merged together by the gateway implemetation in the same virtual host configuration of the gateway. Similarly, the Kuadrant control plane will also register all rate limit policies referencing the HTTPRoutes, activating the correct limits across policies according to the routing matching rules of the targeted HTTPRoutes.
-
 #### Hostnames and wildcards
 
 If a RateLimitPolicy targets a route defined for `*.com` and another RateLimitPolicy targets another route for `api.com`, the Kuadrant control plane will not merge these two RateLimitPolicies. Unless one of the policies declare an _overrides_ set of limites, the control plane will configure to mimic the behavior of gateway implementation by which the "most specific hostname wins", thus enforcing only the corresponding applicable policies and limit definitions.


### PR DESCRIPTION
Closes #547

### Verification steps

Albeit this is a docs PR, if you want to try the limitation it describes, use the following steps.

#### Setup

```sh
make local-setup
```

```sh
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```

```sh
kubectl apply -n istio-system -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: istio-ingressgateway
spec:
  gatewayClassName: istio
  listeners:
  - name: http
    allowedRoutes:
      namespaces:
        from: All
    port: 80
    hostname: "*.io"
    protocol: HTTP
EOF
```

```sh
kubectl apply -f examples/toystore/toystore.yaml

kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: route-a
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - app.io
  rules:
  - matches:
    - path:
        value: /foo
    backendRefs:
    - name: toystore
      port: 80
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: route-b
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - app.io
  rules:
  - matches:
    - path:
        value: /bar
    backendRefs:
    - name: toystore
      port: 80
EOF
```

```sh
kubectl port-forward -n istio-system service/istio-ingressgateway-istio 9080:80 2>&1 >/dev/null &
```

#### Scenario 1: 2 route policies

AuthPolicy:

```sh
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: policy-1
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: route-a
  rules:
    response:
      success:
        headers:
          "auth-policy":
            plain:
              value: policy-1
EOF
```

```sh
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: policy-2
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: route-b
  rules:
    response:
      success:
        headers:
          "auth-policy":
            plain:
              value: policy-2
EOF
```

```sh
kubectl get authpolicies -o jsonpath='{.items[*].status.conditions}' | jq
```

```sh
curl --silent -H 'Host: app.io' http://localhost:9080/foo | jq -r .headers.HTTP_AUTH_POLICY
# policy-1
```

```sh
curl --silent -H 'Host: app.io' http://localhost:9080/bar | jq -r .headers.HTTP_AUTH_POLICY
# null
```

RateLimitPolicy:

```sh
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: policy-1
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: route-a
  limits:
    limit-1:
      rates:
      - limit: 1
        duration: 5
        unit: second
EOF
```

```sh
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: policy-2
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: route-b
  limits:
    limit-2:
      rates:
      - limit: 2
        duration: 5
        unit: second
EOF
```

```sh
kubectl get ratelimitpolicies -o jsonpath='{.items[*].status.conditions}' | jq
```

```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: app.io' http://localhost:9080/foo | grep -E --color "\b(429)\b|$"; sleep 1; done
# 200
# 200
# 200
# 200
```

```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: app.io' http://localhost:9080/bar | grep -E --color "\b(429)\b|$"; sleep 1; done
# 200
# 200
# 429
# 429
```

#### Scenario 2: 1 route policy and 1 gateway policy

(Clean up all policies created in Scenario 1)

AuthPolicy:

```sh
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: policy-1
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: route-a
  rules:
    response:
      success:
        headers:
          "auth-policy":
            plain:
              value: policy-1
EOF
```

```sh
kubectl apply -n istio-system -f -<<EOF
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: policy-2
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  rules:
    response:
      success:
        headers:
          "auth-policy":
            plain:
              value: policy-2
EOF
```

```sh
kubectl get authpolicies --all-namespaces -o jsonpath='{.items[*].status.conditions}' | jq
```

```sh
curl --silent -H 'Host: app.io' http://localhost:9080/foo | jq -r .headers.HTTP_AUTH_POLICY
# policy-1
```

```sh
curl --silent -H 'Host: app.io' http://localhost:9080/bar | jq -r .headers.HTTP_AUTH_POLICY
# null
```

RateLimitPolicy:

```sh
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: policy-1
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: route-a
  limits:
    limit-1:
      rates:
      - limit: 1
        duration: 5
        unit: second
EOF
```

```sh
kubectl apply -n istio-system -f -<<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: policy-2
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  limits:
    limit-2:
      rates:
      - limit: 2
        duration: 5
        unit: second
EOF
```

```sh
kubectl get ratelimitpolicies --all-namespaces -o jsonpath='{.items[*].status.conditions}' | jq
```

```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: app.io' http://localhost:9080/foo | grep -E --color "\b(429)\b|$"; sleep 1; done
# 200
# 429
# 429
# 429
```

```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: app.io' http://localhost:9080/bar | grep -E --color "\b(429)\b|$"; sleep 1; done
# 200
# 200
# 200
# 200
```