### PR TITLE
feat: test speed up

### DIFF
--- a/controllers/authpolicy_controller_test.go
+++ b/controllers/authpolicy_controller_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -85,11 +84,8 @@ var _ = Describe("AuthPolicy controller", func() {
 
 	Context("Basic HTTPRoute", func() {
 		BeforeEach(func() {
-			err := ApplyResources(filepath.Join("..", "examples", "toystore", "toystore.yaml"), k8sClient, testNamespace)
-			Expect(err).ToNot(HaveOccurred())
-
 			route := testBuildBasicHttpRoute(testHTTPRouteName, testGatewayName, testNamespace, []string{"*.toystore.com"})
-			err = k8sClient.Create(context.Background(), route)
+			err := k8sClient.Create(context.Background(), route)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(route)), time.Minute, 5*time.Second).Should(BeTrue())
 		})
@@ -693,11 +689,8 @@ var _ = Describe("AuthPolicy controller", func() {
 
 	Context("Complex HTTPRoute with multiple rules and hostnames", func() {
 		BeforeEach(func() {
-			err := ApplyResources(filepath.Join("..", "examples", "toystore", "toystore.yaml"), k8sClient, testNamespace)
-			Expect(err).ToNot(HaveOccurred())
-
 			route := testBuildMultipleRulesHttpRoute(testHTTPRouteName, testGatewayName, testNamespace, []string{"*.toystore.com", "*.admin.toystore.com"})
-			err = k8sClient.Create(context.Background(), route)
+			err := k8sClient.Create(context.Background(), route)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(route)), time.Minute, 5*time.Second).Should(BeTrue())
 		})
@@ -1185,11 +1178,8 @@ var _ = Describe("AuthPolicy controller", func() {
 		}
 
 		BeforeEach(func() {
-			err := ApplyResources(filepath.Join("..", "examples", "toystore", "toystore.yaml"), k8sClient, testNamespace)
-			Expect(err).ToNot(HaveOccurred())
-
 			route := testBuildBasicHttpRoute(testHTTPRouteName, testGatewayName, testNamespace, []string{"*.toystore.com"})
-			err = k8sClient.Create(context.Background(), route)
+			err := k8sClient.Create(context.Background(), route)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(route)), time.Minute, 5*time.Second).Should(BeTrue())
 		})
@@ -1282,11 +1272,8 @@ var _ = Describe("AuthPolicy controller", func() {
 
 	Context("AuthPolicies configured with overrides", func() {
 		BeforeEach(func() {
-			err := ApplyResources(filepath.Join("..", "examples", "toystore", "toystore.yaml"), k8sClient, testNamespace)
-			Expect(err).ToNot(HaveOccurred())
-
 			route := testBuildBasicHttpRoute(testHTTPRouteName, testGatewayName, testNamespace, []string{"*.toystore.com"})
-			err = k8sClient.Create(context.Background(), route)
+			err := k8sClient.Create(context.Background(), route)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(route)), time.Minute, 5*time.Second).Should(BeTrue())
 		})

--- a/controllers/rate_limiting_wasmplugin_controller_test.go
+++ b/controllers/rate_limiting_wasmplugin_controller_test.go
@@ -26,14 +26,23 @@ import (
 	"github.com/kuadrant/kuadrant-operator/pkg/rlptools/wasm"
 )
 
-var _ = Describe("Rate Limiting WasmPlugin controller", func() {
+var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 	var (
-		testNamespace string
+		testNamespace          string
+		kuadrantInstallationNS string
 	)
+
+	BeforeAll(func(ctx SpecContext) {
+		CreateNamespaceWithContext(ctx, &kuadrantInstallationNS)
+		ApplyKuadrantCR(kuadrantInstallationNS)
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		DeleteNamespaceCallbackWithContext(ctx, &kuadrantInstallationNS)
+	})
 
 	beforeEachCallback := func() {
 		CreateNamespace(&testNamespace)
-		ApplyKuadrantCR(testNamespace)
 	}
 
 	BeforeEach(beforeEachCallback)

--- a/controllers/target_status_controller_test.go
+++ b/controllers/target_status_controller_test.go
@@ -27,8 +27,20 @@ import (
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
 
-var _ = Describe("Target status reconciler", func() {
-	var testNamespace string
+var _ = Describe("Target status reconciler", Ordered, func() {
+	var (
+		testNamespace          string
+		kuadrantInstallationNS string
+	)
+
+	BeforeAll(func(ctx SpecContext) {
+		CreateNamespaceWithContext(ctx, &kuadrantInstallationNS)
+		ApplyKuadrantCR(kuadrantInstallationNS)
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		DeleteNamespaceCallbackWithContext(ctx, &kuadrantInstallationNS)
+	})
 
 	BeforeEach(func() {
 		// create namespace
@@ -47,9 +59,6 @@ var _ = Describe("Target status reconciler", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(testGatewayIsReady(gateway), 15*time.Second, 5*time.Second).Should(BeTrue())
-
-		// create kuadrant instance
-		ApplyKuadrantCR(testNamespace)
 
 		// create application
 		route := testBuildBasicHttpRoute(testHTTPRouteName, testGatewayName, testNamespace, []string{"*.toystore.com"})

--- a/controllers/target_status_controller_test.go
+++ b/controllers/target_status_controller_test.go
@@ -4,7 +4,6 @@ package controllers
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -53,8 +52,6 @@ var _ = Describe("Target status reconciler", func() {
 		ApplyKuadrantCR(testNamespace)
 
 		// create application
-		err = ApplyResources(filepath.Join("..", "examples", "toystore", "toystore.yaml"), k8sClient, testNamespace)
-		Expect(err).ToNot(HaveOccurred())
 		route := testBuildBasicHttpRoute(testHTTPRouteName, testGatewayName, testNamespace, []string{"*.toystore.com"})
 		err = k8sClient.Create(context.Background(), route)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Integration tests are failing by timeout at 1hour mark due to this is the default suite timeout for ginkgo

Introducing some changes to speed up general running of the tests to decrease test run time rather than increasing suite timeout:
* [tests: remove applying toystore](https://github.com/Kuadrant/kuadrant-operator/commit/a62b6828bab0c1ccdfdaf6c76e574937c6a3a837)
* [tests: kuadrant install in BeforeAll/AfterAll](https://github.com/Kuadrant/kuadrant-operator/commit/c00e889f944955c1769d35b9aa232c65769418b3)