### PR TITLE
tests: Allow parallel execution of DNS and TLS Policy tests

### DIFF
--- a/controllers/dnspolicy_controller_multi_cluster_test.go
+++ b/controllers/dnspolicy_controller_multi_cluster_test.go
@@ -42,7 +42,7 @@ var _ = Describe("DNSPolicy Multi Cluster", func() {
 		ownerID, err = utils.GetClusterUID(ctx, k8sClient)
 		Expect(err).To(BeNil())
 
-		gatewayClass = testBuildGatewayClass("foo", "default", "kuadrant.io/bar")
+		gatewayClass = testBuildGatewayClass("gwc-"+testNamespace, "default", "kuadrant.io/bar")
 		Expect(k8sClient.Create(ctx, gatewayClass)).To(Succeed())
 
 		managedZone = testBuildManagedZone("mz-example-com", testNamespace, "example.com")

--- a/controllers/dnspolicy_controller_single_cluster_test.go
+++ b/controllers/dnspolicy_controller_single_cluster_test.go
@@ -41,7 +41,7 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 		clusterUID, err := utils.GetClusterUID(ctx, k8sClient)
 		Expect(err).To(BeNil())
 
-		gatewayClass = testBuildGatewayClass("foo", "default", "kuadrant.io/bar")
+		gatewayClass = testBuildGatewayClass("gwc-"+testNamespace, "default", "kuadrant.io/bar")
 		Expect(k8sClient.Create(ctx, gatewayClass)).To(Succeed())
 
 		managedZone = testBuildManagedZone("mz-example-com", testNamespace, "example.com")

--- a/controllers/dnspolicy_controller_test.go
+++ b/controllers/dnspolicy_controller_test.go
@@ -39,7 +39,7 @@ var _ = Describe("DNSPolicy controller", func() {
 		ctx = context.Background()
 		testNamespace = CreateNamespaceWithContext(ctx)
 
-		gatewayClass = testBuildGatewayClass("foo", "default", "kuadrant.io/bar")
+		gatewayClass = testBuildGatewayClass("gwc-"+testNamespace, "default", "kuadrant.io/bar")
 		Expect(k8sClient.Create(ctx, gatewayClass)).To(Succeed())
 
 		managedZone = testBuildManagedZone("mz-example-com", testNamespace, "example.com")

--- a/controllers/tlspolicy_controller_test.go
+++ b/controllers/tlspolicy_controller_test.go
@@ -24,24 +24,23 @@ import (
 	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 )
 
-var _ = Describe("TLSPolicy controller", Ordered, func() {
+var _ = Describe("TLSPolicy controller", func() {
 
-	var testNamespace string
 	var gatewayClass *gatewayapiv1.GatewayClass
+	var testNamespace string
 	var issuer *certmanv1.Issuer
 	var issuerRef *certmanmetav1.ObjectReference
 	var gateway *gatewayapiv1.Gateway
 	var tlsPolicy *v1alpha1.TLSPolicy
 	var ctx context.Context
 
-	BeforeAll(func() {
-		ctx = context.Background()
-		gatewayClass = testBuildGatewayClass("foo", "default", "kuadrant.io/bar")
-		Expect(k8sClient.Create(ctx, gatewayClass)).To(Succeed())
-	})
-
 	BeforeEach(func() {
+		ctx = context.Background()
 		testNamespace = CreateNamespaceWithContext(ctx)
+
+		gatewayClass = testBuildGatewayClass("gwc-"+testNamespace, "default", "kuadrant.io/bar")
+		Expect(k8sClient.Create(ctx, gatewayClass)).To(Succeed())
+
 		issuer, issuerRef = testBuildSelfSignedIssuer("testissuer", testNamespace)
 		Expect(k8sClient.Create(ctx, issuer)).To(BeNil())
 	})
@@ -64,11 +63,6 @@ var _ = Describe("TLSPolicy controller", Ordered, func() {
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 		}
 		DeleteNamespaceCallbackWithContext(ctx, testNamespace)
-	})
-
-	AfterAll(func() {
-		err := k8sClient.Delete(ctx, gatewayClass)
-		Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 	})
 
 	Context("invalid target", func() {


### PR DESCRIPTION
Creates a unique gateway class per test case and removes `Ordered` from the TLS policy tests.

**Parallel (30.102542988s):**
```
./bin/ginkgo -p --procs 20 --focus "DNSPolicy" --focus "TLSPolicy" --skip "Target status reconciler" -tags integration ./controllers/...
Running Suite: Controller Suite - /home/mnairn/go/src/github.com/kuadrant/kuadrant-operator/controllers
=======================================================================================================
Random Seed: 1714117888

Will run 31 of 147 specs
Running in parallel across 20 processes
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••••••SSSSSSSSSSSSS••SSSS•••••SSSSSSSSSSSSSS•SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••••••••••••••

Ran 31 of 147 Specs in 23.773 seconds
SUCCESS! -- 31 Passed | 0 Failed | 0 Pending | 116 Skipped


Ginkgo ran 1 suite in 30.102542988s
Test Suite Passed
```
**Serial(4m21.733588392s):**
```
./bin/ginkgo --focus "DNSPolicy" --focus "TLSPolicy" --skip "Target status reconciler" -tags integration ./controllers/...
Running Suite: Controller Suite - /home/mnairn/go/src/github.com/kuadrant/kuadrant-operator/controllers
=======================================================================================================
Random Seed: 1714117926

Will run 31 of 147 specs
••••••SSSSSSSSSSSSSSSSSSSSSSSSS•••••••••••••SSSSSSSSSSSS••••••••••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 31 of 147 Specs in 255.389 seconds
SUCCESS! -- 31 Passed | 0 Failed | 0 Pending | 116 Skipped
PASS

Ginkgo ran 1 suite in 4m21.733588392s
Test Suite Passed
```

Created follow on task to look into using the istio gateway class since that's what all the other policy tests (Auth and RLP) are doing https://github.com/Kuadrant/kuadrant-operator/issues/582 