### PR TITLE
fix: affected RLP statuses not updated when current RLP is deleted

### DIFF
--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -201,7 +201,7 @@ func (r *RateLimitPolicyReconciler) deleteResources(ctx context.Context, rlp *ku
 		return err
 	}
 
-	if err := r.deleteLimits(ctx, rlp); err != nil && !apierrors.IsNotFound(err) {
+	if err := r.reconcileLimits(ctx, rlp); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 

--- a/controllers/ratelimitpolicy_controller_test.go
+++ b/controllers/ratelimitpolicy_controller_test.go
@@ -88,6 +88,16 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 		}
 	}
 
+	limitadorContainsLimit := func(ctx context.Context, limit limitadorv1alpha1.RateLimit) func(g Gomega) {
+		return func(g Gomega) {
+			// check limits - should contain HTTPRoute RLP values
+			limitadorKey := client.ObjectKey{Name: common.LimitadorName, Namespace: kuadrantInstallationNS}
+			existingLimitador := &limitadorv1alpha1.Limitador{}
+			g.Expect(k8sClient.Get(ctx, limitadorKey, existingLimitador)).To(Succeed())
+			g.Expect(existingLimitador.Spec.Limits).To(ContainElements(limit))
+		}
+	}
+
 	beforeEachCallback := func(ctx SpecContext) {
 		testNamespace = CreateNamespaceWithContext(ctx)
 		gateway = testBuildBasicGateway(gwName, testNamespace)
@@ -303,71 +313,92 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 	})
 
 	Context("RLP Defaults", func() {
-		It("HTTPRoute atomic default taking precedence over Gateway defaults", func(ctx SpecContext) {
-			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
-			Expect(k8sClient.Create(ctx, httpRoute)).To(Succeed())
-			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
+		Describe("Route policy defaults taking precedence over Gateway policy defaults", func() {
+			var (
+				gwRLP    *kuadrantv1beta2.RateLimitPolicy
+				routeRLP *kuadrantv1beta2.RateLimitPolicy
+			)
 
-			// create GW RLP
-			gwRLP := policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
-				policy.Spec.TargetRef.Kind = "Gateway"
-				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(gwName)
-			})
-			Expect(k8sClient.Create(ctx, gwRLP)).To(Succeed())
-			rlpKey := client.ObjectKey{Name: gwRLP.Name, Namespace: testNamespace}
-			Eventually(assertPolicyIsAcceptedAndEnforced(ctx, rlpKey)).WithContext(ctx).Should(BeTrue())
+			BeforeEach(func(ctx SpecContext) {
+				// Common setup
+				// GW policy defaults are overridden and not enforced when Route has their own policy attached
 
-			// Create HTTPRoute RLP with new default limits
-			routeRLP := policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
-				policy.Name = "httproute-rlp"
-				policy.Spec.CommonSpec().Limits = map[string]kuadrantv1beta2.Limit{
-					"l1": {
-						Rates: []kuadrantv1beta2.Rate{
-							{
-								Limit: 10, Duration: 5, Unit: "second",
+				// create httproute
+				httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
+				Expect(k8sClient.Create(ctx, httpRoute)).To(Succeed())
+				Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
+
+				// create GW RLP
+				gwRLP = policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
+					policy.Spec.TargetRef.Kind = "Gateway"
+					policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(gwName)
+				})
+				Expect(k8sClient.Create(ctx, gwRLP)).To(Succeed())
+				gwRLPKey := client.ObjectKey{Name: gwRLP.Name, Namespace: testNamespace}
+				Eventually(assertPolicyIsAcceptedAndEnforced(ctx, gwRLPKey)).WithContext(ctx).Should(BeTrue())
+
+				// Create HTTPRoute RLP with new default limits
+				routeRLP = policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
+					policy.Name = "httproute-rlp"
+					policy.Spec.CommonSpec().Limits = map[string]kuadrantv1beta2.Limit{
+						"l1": {
+							Rates: []kuadrantv1beta2.Rate{
+								{
+									Limit: 10, Duration: 5, Unit: "second",
+								},
 							},
 						},
-					},
-				}
-			})
-			Expect(k8sClient.Create(ctx, routeRLP)).To(Succeed())
-			rlpKey = client.ObjectKey{Name: routeRLP.Name, Namespace: testNamespace}
-			Eventually(assertPolicyIsAcceptedAndEnforced(ctx, rlpKey)).WithContext(ctx).Should(BeTrue())
+					}
+				})
+				Expect(k8sClient.Create(ctx, routeRLP)).To(Succeed())
+				routeRLPKey := client.ObjectKey{Name: routeRLP.Name, Namespace: testNamespace}
+				Eventually(assertPolicyIsAcceptedAndEnforced(ctx, routeRLPKey)).WithContext(ctx).Should(BeTrue())
+				Eventually(testRLPIsEnforced(ctx, gwRLPKey)).WithContext(ctx).Should(BeFalse())
 
-			// Check Gateway direct back reference
-			gwKey := client.ObjectKeyFromObject(gateway)
-			existingGateway := &gatewayapiv1.Gateway{}
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, gwKey, existingGateway)).To(Succeed())
-				g.Expect(existingGateway.GetAnnotations()).To(HaveKeyWithValue(
-					gwRLP.DirectReferenceAnnotationName(), client.ObjectKeyFromObject(gwRLP).String()))
-			}).WithContext(ctx).Should(Succeed())
+				// Check Gateway direct back reference
+				gwKey := client.ObjectKeyFromObject(gateway)
+				existingGateway := &gatewayapiv1.Gateway{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, gwKey, existingGateway)).To(Succeed())
+					g.Expect(existingGateway.GetAnnotations()).To(HaveKeyWithValue(
+						gwRLP.DirectReferenceAnnotationName(), client.ObjectKeyFromObject(gwRLP).String()))
+				}).WithContext(ctx).Should(Succeed())
 
-			// check limits
-			Eventually(func(g Gomega) {
-				limitadorKey := client.ObjectKey{Name: common.LimitadorName, Namespace: kuadrantInstallationNS}
-				existingLimitador := &limitadorv1alpha1.Limitador{}
-				g.Expect(k8sClient.Get(ctx, limitadorKey, existingLimitador)).To(Succeed())
-				g.Expect(existingLimitador.Spec.Limits).To(ContainElements(limitadorv1alpha1.RateLimit{
+				// check limits
+				Eventually(limitadorContainsLimit(ctx, limitadorv1alpha1.RateLimit{
 					MaxValue:   10,
 					Seconds:    5,
 					Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
 					Conditions: []string{`limit.l1__2804bad6 == "1"`},
 					Variables:  []string{},
 					Name:       rlptools.LimitsNameFromRLP(routeRLP),
-				}))
-			}).WithContext(ctx).Should(Succeed())
+				})).WithContext(ctx).Should(Succeed())
 
-			// Gateway should contain HTTPRoute RLP in backreference
-			Eventually(func(g Gomega) {
-				g.Expect(k8sClient.Get(ctx, gwKey, existingGateway)).To(Succeed())
-				serialized, err := json.Marshal(rlpKey)
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(existingGateway.GetAnnotations()).To(HaveKey(routeRLP.BackReferenceAnnotationName()))
-				g.Expect(existingGateway.GetAnnotations()[routeRLP.BackReferenceAnnotationName()]).To(ContainSubstring(string(serialized)))
-			}).WithContext(ctx).Should(Succeed())
-		}, testTimeOut)
+				// Gateway should contain HTTPRoute RLP in backreference
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, gwKey, existingGateway)).To(Succeed())
+					serialized, err := json.Marshal(routeRLPKey)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(existingGateway.GetAnnotations()).To(HaveKey(routeRLP.BackReferenceAnnotationName()))
+					g.Expect(existingGateway.GetAnnotations()[routeRLP.BackReferenceAnnotationName()]).To(ContainSubstring(string(serialized)))
+				}).WithContext(ctx).Should(Succeed())
+			})
+
+			When("Free route is created", func() {
+				It("Gateway policy should now be enforced", func(ctx SpecContext) {
+					route2 := testBuildBasicHttpRoute("route2", gwName, testNamespace, []string{"*.car.com"})
+					Expect(k8sClient.Create(ctx, route2)).To(Succeed())
+					Eventually(testRLPIsEnforced(ctx, client.ObjectKeyFromObject(gwRLP))).WithContext(ctx).Should(BeTrue())
+				}, testTimeOut)
+			})
+
+			When("Route policy is deleted", func() {
+				It("Gateway policy should now be enforced", func(ctx SpecContext) {
+					Expect(k8sClient.Delete(ctx, routeRLP)).To(Succeed())
+					Eventually(testRLPIsEnforced(ctx, client.ObjectKeyFromObject(gwRLP))).WithContext(ctx).Should(BeTrue())
+				}, testTimeOut)
+			})
+		})
 
 		It("Explicit defaults - no underlying routes to enforce policy", func(ctx SpecContext) {
 			gwRLP := policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
@@ -400,16 +431,6 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 		var gwRLP *kuadrantv1beta2.RateLimitPolicy
 		var routeRLP *kuadrantv1beta2.RateLimitPolicy
 
-		limitadorContainsLimit := func(ctx context.Context, limit limitadorv1alpha1.RateLimit) func(g Gomega) {
-			return func(g Gomega) {
-				// check limits - should contain HTTPRoute RLP values
-				limitadorKey := client.ObjectKey{Name: common.LimitadorName, Namespace: kuadrantInstallationNS}
-				existingLimitador := &limitadorv1alpha1.Limitador{}
-				g.Expect(k8sClient.Get(ctx, limitadorKey, existingLimitador)).To(Succeed())
-				g.Expect(existingLimitador.Spec.Limits).To(ContainElements(limit))
-			}
-		}
-
 		BeforeEach(func(ctx SpecContext) {
 			// create httproute
 			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
@@ -426,7 +447,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			routeRLP = policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
 				policy.Name = "httproute-rlp"
 				policy.Spec.CommonSpec().Limits = map[string]kuadrantv1beta2.Limit{
-					"l1": {
+					"route": {
 						Rates: []kuadrantv1beta2.Rate{
 							{
 								Limit: 10, Duration: 5, Unit: "second",
@@ -435,7 +456,6 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 					},
 				}
 			})
-
 		})
 
 		It("Gateway atomic override - gateway overrides exist and then route policy created", func(ctx SpecContext) {
@@ -477,6 +497,19 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				g.Expect(existingGateway.GetAnnotations()).To(HaveKey(routeRLP.BackReferenceAnnotationName()))
 				g.Expect(existingGateway.GetAnnotations()[routeRLP.BackReferenceAnnotationName()]).To(ContainSubstring(string(serialized)))
 			}).WithContext(ctx).Should(Succeed())
+
+			// Delete GW RLP -> Route RLP should be enforced
+			Expect(k8sClient.Delete(ctx, gwRLP)).To(Succeed())
+			Eventually(testRLPIsEnforced(ctx, routeRLPKey)).WithContext(ctx).Should(BeTrue())
+			// check limits - should be route RLP values
+			Eventually(limitadorContainsLimit(ctx, limitadorv1alpha1.RateLimit{
+				MaxValue:   10,
+				Seconds:    5,
+				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
+				Conditions: []string{`limit.route__8a84e406 == "1"`},
+				Variables:  []string{},
+				Name:       rlptools.LimitsNameFromRLP(routeRLP),
+			})).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
 
 		It("Gateway atomic override - route policy exits and then gateway policy created", func(ctx SpecContext) {
@@ -547,7 +580,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-				Conditions: []string{`limit.l1__2804bad6 == "1"`},
+				Conditions: []string{`limit.route__8a84e406 == "1"`},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(routeRLP),
 			})).WithContext(ctx).Should(Succeed())
@@ -619,7 +652,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-				Conditions: []string{`limit.l1__2804bad6 == "1"`},
+				Conditions: []string{`limit.route__8a84e406 == "1"`},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(routeRLP),
 			})).WithContext(ctx).Should(Succeed())


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/587

* Fixes RLP GW policy status is not updated when Route RLP is deleted and vice versa
* Additionally updates the AP integration test to check AP is working as expected

# Verification
Code changes are tested with the integration test changes, so passing integration tests should be sufficient.

If you want verify manually:
* Checkout this branch
* Deploy
```
make local-setup
```
* Deploy kuadrant
```
kubectl apply  -f - <<EOF               
---                                     
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
spec: {}
EOF
```
* Deploy toystore
```sh
kubectl apply -f examples/toystore/toystore.yaml
kubectl wait --timeout=300s --for=condition=Available deployment toystore
```

* Create  HTTP Route
```sh
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - method: GET
      path:
        type: PathPrefix
        value: "/toys"
    backendRefs:
    - name: toystore
      port: 80
  - matches: # it has to be a separate HTTPRouteRule so we do not rate limit other endpoints
    - method: POST
      path:
        type: Exact
        value: "/toys"
    backendRefs:
    - name: toystore
      port: 80
EOF
```
* Watch RLP statues 
```
kubectl get ratelimitpolicy -A -o yaml | yq '.items[].status'
```
* Create GW RLP with defaults
```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: gw-rlp
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  defaults:
    limits:
      "gateway":
        rates:
        - limit: 5
          duration: 10
          unit: second
EOF
```
* Verify GW Policy is accepted and enforced
* Port forward gateway service
```sh
kubectl port-forward -n istio-system service/istio-ingressgateway-istio 9080:80 2>&1 >/dev/null &
export GATEWAY_URL=localhost:9080
```
* Ensure HTTP Route is rate limit at 5 requests per 10 seconds
```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -X POST | grep -E --color "\b(429)\b|$"; sleep 1; done
```
* Create HTTPRoute RLP with implicit default limits
```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:
    "route":
      rates:
      - limit: 8
        duration: 10
        unit: second
EOF
```
* Verify Route policy is accepted and enforced
* Verify GW policy is accepted and not enforced - overridden by route policy
* Ensure HTTP Route is rate limted at 8 requests per second (Route RLP defaults takes precedence over gateway defaults) (Note: you might need to port forward the gateway service again)
```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -X POST | grep -E --color "\b(429)\b|$"; sleep 1; done
```
* Delete route RLP
```sh
kubectl delete ratelimitpolicy toystore
```
* Verify GW policy goes back to enforced true
* Ensure HTTP Route is rate limits at 5 requests per second again (GW RLP defaults)
```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -X POST | grep -E --color "\b(429)\b|$"; sleep 1; done
```