### PR TITLE
Fix status Enforced status when Accepted condition is False

### DIFF
--- a/controllers/authpolicy_status.go
+++ b/controllers/authpolicy_status.go
@@ -71,6 +71,7 @@ func (r *AuthPolicyReconciler) calculateStatus(ctx context.Context, ap *api.Auth
 
 	// Do not set enforced condition if Accepted condition is false
 	if meta.IsStatusConditionFalse(newStatus.Conditions, string(gatewayapiv1alpha2.PolicyReasonAccepted)) {
+		meta.RemoveStatusCondition(&newStatus.Conditions, string(kuadrant.PolicyConditionEnforced))
 		return newStatus
 	}
 

--- a/controllers/authpolicy_status_test.go
+++ b/controllers/authpolicy_status_test.go
@@ -1,0 +1,72 @@
+//go:build unit
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	api "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
+)
+
+func TestAuthPolicyReconciler_calculateStatus(t *testing.T) {
+	type args struct {
+		ctx     context.Context
+		ap      *api.AuthPolicy
+		specErr error
+	}
+	tests := []struct {
+		name string
+		args args
+		want *api.AuthPolicyStatus
+	}{
+		{
+			name: "Enforced status block removed if policy not Accepted. (Regression test)", // https://github.com/Kuadrant/kuadrant-operator/issues/588
+			args: args{
+				ap: &api.AuthPolicy{
+					Status: api.AuthPolicyStatus{
+						Conditions: []metav1.Condition{
+							{
+								Message: "not accepted",
+								Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
+								Status:  metav1.ConditionFalse,
+								Reason:  string(gatewayapiv1alpha2.PolicyReasonTargetNotFound),
+							},
+							{
+								Message: "AuthPolicy has been successfully enforced",
+								Type:    string(kuadrant.PolicyConditionEnforced),
+								Status:  metav1.ConditionTrue,
+								Reason:  string(kuadrant.PolicyConditionEnforced),
+							},
+						},
+					},
+				},
+				specErr: kuadrant.NewErrInvalid("placeholder", errors.New("placeholder")),
+			},
+			want: &api.AuthPolicyStatus{
+				Conditions: []metav1.Condition{
+					{
+						Message: "placeholder target is invalid: placeholder",
+						Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
+						Status:  metav1.ConditionFalse,
+						Reason:  string(gatewayapiv1alpha2.PolicyReasonInvalid),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &AuthPolicyReconciler{}
+			if got := r.calculateStatus(tt.args.ctx, tt.args.ap, tt.args.specErr); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("calculateStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/controllers/authpolicy_status_test.go
+++ b/controllers/authpolicy_status_test.go
@@ -47,12 +47,12 @@ func TestAuthPolicyReconciler_calculateStatus(t *testing.T) {
 						},
 					},
 				},
-				specErr: kuadrant.NewErrInvalid("placeholder", errors.New("placeholder")),
+				specErr: kuadrant.NewErrInvalid("AuthPolicy", errors.New("policy Error")),
 			},
 			want: &api.AuthPolicyStatus{
 				Conditions: []metav1.Condition{
 					{
-						Message: "placeholder target is invalid: placeholder",
+						Message: "AuthPolicy target is invalid: policy Error",
 						Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
 						Status:  metav1.ConditionFalse,
 						Reason:  string(gatewayapiv1alpha2.PolicyReasonInvalid),

--- a/controllers/dnspolicy_status.go
+++ b/controllers/dnspolicy_status.go
@@ -77,6 +77,7 @@ func (r *DNSPolicyReconciler) calculateStatus(ctx context.Context, dnsPolicy *v1
 
 	// Do not set enforced condition if Accepted condition is false
 	if meta.IsStatusConditionFalse(newStatus.Conditions, string(v1alpha2.PolicyConditionAccepted)) {
+		meta.RemoveStatusCondition(&newStatus.Conditions, string(kuadrant.PolicyConditionEnforced))
 		return newStatus
 	}
 

--- a/controllers/dnspolicy_status_test.go
+++ b/controllers/dnspolicy_status_test.go
@@ -179,7 +179,7 @@ func TestDNSPolicyReconciler_calculateStatus(t *testing.T) {
 								Reason:  string(gatewayapiv1alpha2.PolicyReasonTargetNotFound),
 							},
 							{
-								Message: "AuthPolicy has been successfully enforced",
+								Message: "DNSPolicy has been successfully enforced",
 								Type:    string(kuadrant.PolicyConditionEnforced),
 								Status:  metav1.ConditionTrue,
 								Reason:  string(kuadrant.PolicyConditionEnforced),
@@ -187,12 +187,12 @@ func TestDNSPolicyReconciler_calculateStatus(t *testing.T) {
 						},
 					},
 				},
-				specErr: kuadrant.NewErrInvalid("placeholder", errors.New("placeholder")),
+				specErr: kuadrant.NewErrInvalid("DNSPolicy", errors.New("policy Error")),
 			},
 			want: &v1alpha1.DNSPolicyStatus{
 				Conditions: []metav1.Condition{
 					{
-						Message: "placeholder target is invalid: placeholder",
+						Message: "DNSPolicy target is invalid: policy Error",
 						Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
 						Status:  metav1.ConditionFalse,
 						Reason:  string(gatewayapiv1alpha2.PolicyReasonInvalid),

--- a/controllers/ratelimitpolicy_status.go
+++ b/controllers/ratelimitpolicy_status.go
@@ -67,6 +67,7 @@ func (r *RateLimitPolicyReconciler) calculateStatus(ctx context.Context, rlp *ku
 
 	// Do not set enforced condition if Accepted condition is false
 	if meta.IsStatusConditionFalse(newStatus.Conditions, string(gatewayapiv1alpha2.PolicyReasonAccepted)) {
+		meta.RemoveStatusCondition(&newStatus.Conditions, string(kuadrant.PolicyConditionEnforced))
 		return newStatus
 	}
 

--- a/controllers/ratelimitpolicy_status_test.go
+++ b/controllers/ratelimitpolicy_status_test.go
@@ -37,7 +37,7 @@ func TestRateLimitPolicyReconciler_calculateStatus(t *testing.T) {
 								Reason:  string(gatewayapiv1alpha2.PolicyReasonTargetNotFound),
 							},
 							{
-								Message: "AuthPolicy has been successfully enforced",
+								Message: "RateLimitPolicy has been successfully enforced",
 								Type:    string(kuadrant.PolicyConditionEnforced),
 								Status:  metav1.ConditionTrue,
 								Reason:  string(kuadrant.PolicyConditionEnforced),
@@ -45,12 +45,12 @@ func TestRateLimitPolicyReconciler_calculateStatus(t *testing.T) {
 						},
 					},
 				},
-				specErr: kuadrant.NewErrInvalid("placeholder", errors.New("placeholder")),
+				specErr: kuadrant.NewErrInvalid("RateLimitPolicy", errors.New("policy Error")),
 			},
 			want: &kuadrantv1beta2.RateLimitPolicyStatus{
 				Conditions: []metav1.Condition{
 					{
-						Message: "placeholder target is invalid: placeholder",
+						Message: "RateLimitPolicy target is invalid: policy Error",
 						Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
 						Status:  metav1.ConditionFalse,
 						Reason:  string(gatewayapiv1alpha2.PolicyReasonInvalid),

--- a/controllers/ratelimitpolicy_status_test.go
+++ b/controllers/ratelimitpolicy_status_test.go
@@ -1,0 +1,70 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+
+	"reflect"
+	"testing"
+
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestRateLimitPolicyReconciler_calculateStatus(t *testing.T) {
+	type args struct {
+		ctx     context.Context
+		rlp     *kuadrantv1beta2.RateLimitPolicy
+		specErr error
+	}
+	tests := []struct {
+		name string
+		args args
+		want *kuadrantv1beta2.RateLimitPolicyStatus
+	}{
+		{
+			name: "Enforced status block removed if policy not Accepted. (Regression test)", // https://github.com/Kuadrant/kuadrant-operator/issues/588
+			args: args{
+				rlp: &kuadrantv1beta2.RateLimitPolicy{
+					Status: kuadrantv1beta2.RateLimitPolicyStatus{
+						Conditions: []metav1.Condition{
+							{
+								Message: "not accepted",
+								Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
+								Status:  metav1.ConditionFalse,
+								Reason:  string(gatewayapiv1alpha2.PolicyReasonTargetNotFound),
+							},
+							{
+								Message: "AuthPolicy has been successfully enforced",
+								Type:    string(kuadrant.PolicyConditionEnforced),
+								Status:  metav1.ConditionTrue,
+								Reason:  string(kuadrant.PolicyConditionEnforced),
+							},
+						},
+					},
+				},
+				specErr: kuadrant.NewErrInvalid("placeholder", errors.New("placeholder")),
+			},
+			want: &kuadrantv1beta2.RateLimitPolicyStatus{
+				Conditions: []metav1.Condition{
+					{
+						Message: "placeholder target is invalid: placeholder",
+						Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
+						Status:  metav1.ConditionFalse,
+						Reason:  string(gatewayapiv1alpha2.PolicyReasonInvalid),
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RateLimitPolicyReconciler{}
+			if got := r.calculateStatus(tt.args.ctx, tt.args.rlp, tt.args.specErr); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("calculateStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes: https://github.com/Kuadrant/kuadrant-operator/issues/588

# Verification Steps
- Create cluster `make local-setup`
- Create kuadrant CR
```sh
echo "
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {} 
" | kubectl apply -f -
```
- Create a gateway
``` sh
echo " 
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: gw-1
  namespace: istio-system
  annotations:
    kuadrant.io/namespace: kuadrant-system
    networking.istio.io/service-type: ClusterIP
spec:
  gatewayClassName: istio
  listeners:
    - name: websites
      port: 80
      protocol: HTTP
      hostname: '*.website'
      allowedRoutes:
        namespaces:
          from: All
    - name: apis
      port: 80
      protocol: HTTP
      hostname: '*.io'
      allowedRoutes:
        namespaces:
          from: All
" | kubectl apply -f -
```
- Create a Authpolicy. The `Enforced` status will be false as it is not fully setup, and not need to be.
``` sh
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gw-1
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: gw-1
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: APIKEY
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
" | kubectl apply -f -
```
- Set up watch on the authPolicy
```sh
watch kubectal get AuthPolicy gw-1 -n istio-system -o=jsonpath='{.status}'
```
- Delete the gateway
``` sh
kubectl delete Gateway gw-1 -n istio-system
```
- Expected result: In the watch the status block for the `Enforced` should be removed.