### PR TITLE
kuadrant wasm server component

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,9 +159,9 @@ WASM_SHIM_VERSION ?= latest
 shim_version_is_semantic := $(call is_semantic_version,$(WASM_SHIM_VERSION))
 
 ifeq (true,$(shim_version_is_semantic))
-RELATED_IMAGE_WASMSHIM ?= oci://quay.io/kuadrant/wasm-shim:v$(WASM_SHIM_VERSION)
+RELATED_IMAGE_WASMSHIM ?= quay.io/kuadrant/wasm-server:v$(WASM_SHIM_VERSION)
 else
-RELATED_IMAGE_WASMSHIM ?= oci://quay.io/kuadrant/wasm-shim:$(WASM_SHIM_VERSION)
+RELATED_IMAGE_WASMSHIM ?= quay.io/kuadrant/wasm-server:$(WASM_SHIM_VERSION)
 endif
 
 all: build

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ to operate the cluster (Istio's) ingress gateway to provide API management with 
 
 ### Kuadrant components
 
-| CRD                                                                  | Description                                                                                                                                                                                                                                                                               |
+| Component                                                            | Description                                                                                                                                                                                                                                                                               |
 |----------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Control Plane                                                        | The control plane takes the customer desired configuration (declaratively as kubernetes custom resources) as input and ensures all components are configured to obey customer's desired behavior.<br> This repository contains the source code of the kuadrant control plane              |
 | [Kuadrant Operator](https://github.com/Kuadrant/kuadrant-operator)   | A Kubernetes Operator to manage the lifecycle of the kuadrant deployment                                                                                                                                                                                                                  |
@@ -39,6 +39,7 @@ to operate the cluster (Istio's) ingress gateway to provide API management with 
 | [Authorino Operator](https://github.com/Kuadrant/authorino-operator) | A Kubernetes Operator to manage Authorino instances                                                                                                                                                                                                                                       |
 | [Limitador Operator](https://github.com/Kuadrant/limitador-operator) | A Kubernetes Operator to manage Limitador instances                                                                                                                                                                                                                                       |
 | [DNS Operator](https://github.com/Kuadrant/dns-operator)             | A Kubernetes Operator to manage DNS records in external providers                                                                                                                                                                                                                         |
+| [Wasm Server](doc/wasm-server.md)                                    | Static file server to serve Wasm binaries internally. Lifecycle managed by the Kuadrant Operator.                                                                                                                                                                                         |
 
 ### Provided APIs
 
@@ -69,7 +70,7 @@ Additionally, Kuadrant provides the following CRDs
   [Istio getting started guide](https://istio.io/latest/docs/setup/getting-started/).
 * Kubernetes Gateway API is installed in the cluster. Otherwise,
   [configure Istio to expose a service using the Kubernetes Gateway API](https://istio.io/latest/docs/tasks/traffic-management/ingress/gateway-api/).
-* cert-manager is installed in the cluster. Otherwise, refer to the 
+* cert-manager is installed in the cluster. Otherwise, refer to the
   [cert-manager installation guide](https://cert-manager.io/docs/installation/).
 
 ### Installing Kuadrant

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -236,6 +236,19 @@ spec:
           - list
           - watch
         - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - configmaps
+          - leases
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - ""
           resources:
           - configmaps

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -236,19 +236,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - coordination.k8s.io
-          resources:
-          - configmaps
-          - leases
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - ""
           resources:
           - configmaps

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -599,7 +599,7 @@ spec:
                 - /manager
                 env:
                 - name: RELATED_IMAGE_WASMSHIM
-                  value: oci://quay.io/kuadrant/wasm-shim:latest
+                  value: quay.io/kuadrant/wasm-server:latest
                 image: quay.io/kuadrant/kuadrant-operator:latest
                 livenessProbe:
                   httpGet:
@@ -702,7 +702,7 @@ spec:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
   relatedImages:
-  - image: oci://quay.io/kuadrant/wasm-shim:latest
+  - image: quay.io/kuadrant/wasm-server:latest
     name: wasmshim
   replaces: kuadrant-operator.v0.0.0-alpha
   version: 0.0.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
             - /manager
           env:
             - name: RELATED_IMAGE_WASMSHIM
-              value: "oci://quay.io/kuadrant/wasm-shim:latest"
+              value: quay.io/kuadrant/wasm-server:latest
           image: controller:latest
           name: manager
           securityContext:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -84,6 +84,19 @@ rules:
   - list
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - configmaps
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -84,19 +84,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - configmaps
-  - leases
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - ""
   resources:
   - configmaps

--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -15,6 +15,7 @@ import (
 	certmanmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	. "github.com/onsi/gomega"
 	istioclientgoextensionv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -659,5 +660,15 @@ func createSelfSignedIssuerSpec() certmanv1.IssuerSpec {
 		IssuerConfig: certmanv1.IssuerConfig{
 			SelfSigned: &certmanv1.SelfSignedIssuer{},
 		},
+	}
+}
+
+func testDeploymentIsReady(ctx context.Context, key client.ObjectKey) func(g Gomega) {
+	return func(g Gomega) {
+		deployment := &appsv1.Deployment{}
+		g.Expect(k8sClient.Get(ctx, key, deployment)).To(Succeed())
+		availableCondition := utils.FindDeploymentStatusCondition(deployment.Status.Conditions, string(appsv1.DeploymentAvailable))
+		g.Expect(availableCondition).NotTo(BeNil())
+		g.Expect(availableCondition.Status).To(Equal(corev1.ConditionTrue))
 	}
 }

--- a/controllers/kuadrant_controller.go
+++ b/controllers/kuadrant_controller.go
@@ -63,7 +63,6 @@ type KuadrantReconciler struct {
 
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts;configmaps;services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=coordination.k8s.io,resources=configmaps;leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=leases,verbs=get;list;watch;create;update;patch;delete
 
@@ -374,7 +373,11 @@ func (r *KuadrantReconciler) reconcileSpec(ctx context.Context, kObj *kuadrantv1
 		return err
 	}
 
-	return r.reconcileAuthorino(ctx, kObj)
+	if err := r.reconcileAuthorino(ctx, kObj); err != nil {
+		return err
+	}
+
+	return r.reconcileWasmServer(ctx, kObj)
 }
 
 func controlPlaneProviderName() string {
@@ -499,6 +502,8 @@ func (r *KuadrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kuadrantv1beta1.Kuadrant{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Service{}).
 		Owns(&limitadorv1alpha1.Limitador{}).
 		Owns(&authorinov1beta1.Authorino{}).
 		Complete(r)

--- a/controllers/kuadrant_controller.go
+++ b/controllers/kuadrant_controller.go
@@ -63,6 +63,7 @@ type KuadrantReconciler struct {
 
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts;configmaps;services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=configmaps;leases,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=leases,verbs=get;list;watch;create;update;patch;delete
 

--- a/controllers/kuadrant_controller_test.go
+++ b/controllers/kuadrant_controller_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+)
+
+var _ = Describe("Kuadrant controller deploys wasm server", func() {
+	var (
+		testNamespace    string
+		kuadrantName     string = "local"
+		afterEachTimeOut        = NodeTimeout(3 * time.Minute)
+		specTimeOut             = SpecTimeout(time.Minute * 2)
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		testNamespace = CreateNamespaceWithContext(ctx)
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		DeleteNamespaceCallbackWithContext(ctx, testNamespace)
+	}, afterEachTimeOut)
+
+	Context("when default kuadrant CR is created", func() {
+		It("wasm server is being deployed", func(ctx SpecContext) {
+			// this method checks kuadrant status is available
+			// kuadrant status is checking wasm server availability as well
+			ApplyKuadrantCRWithName(testNamespace, kuadrantName)
+			kObj := &kuadrantv1beta1.Kuadrant{}
+			err := k8sClient.Get(
+				ctx,
+				types.NamespacedName{Namespace: testNamespace, Name: kuadrantName},
+				kObj)
+			Expect(err).ToNot(HaveOccurred())
+			// Should create a service
+			service := &corev1.Service{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
+					client.ObjectKey{Namespace: testNamespace, Name: WasmServerServiceName(kObj)},
+					service)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+			Expect(service.Spec.Ports).To(HaveLen(1))
+			Expect(service.Spec.Ports[0].Name).Should(Equal("http"))
+			Expect(service.Spec.Ports[0].Port).Should(Equal(int32(80)))
+			Expect(service.Spec.Ports[0].TargetPort).Should(Equal(intstr.FromString("http")))
+
+			//Should create a deployment
+			deploymentKey := client.ObjectKey{Namespace: testNamespace, Name: WasmServerDeploymentName(kObj)}
+			Eventually(testDeploymentIsReady(ctx, deploymentKey)).WithContext(ctx).Should(Succeed())
+
+			deployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, deploymentKey, deployment)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(deployment.Spec.Template.Spec.Containers[0].Image).Should(
+				Equal(WASMServerImageURL),
+			)
+			Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			Expect(deployment.Spec.Template.Spec.InitContainers[0].Image).Should(
+				Equal(WASMServerImageURL),
+			)
+			Expect(deployment.Spec.Template.Spec.InitContainers[0].Name).Should(
+				Equal(WASMServerInitContainerName),
+			)
+
+			// Should create a ConfigMap with empty limits
+			configMap := &corev1.ConfigMap{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(
+					ctx,
+					client.ObjectKey{Namespace: testNamespace, Name: WasmServerConfigMapName(kObj)},
+					configMap)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(configMap.Data).To(HaveKey(WASMServerConfigMapDataKey))
+		}, specTimeOut)
+	})
+})

--- a/controllers/kuadrant_controller_wasm_server.go
+++ b/controllers/kuadrant_controller_wasm_server.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/env"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/reconcilers"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
+)
+
+var (
+	WASMServerImageURL = env.GetString("RELATED_IMAGE_WASMSHIM", "quay.io/kuadrant/wasm-server:latest")
+)
+
+func (r *KuadrantReconciler) reconcileWasmServer(ctx context.Context, kObj *kuadrantv1beta1.Kuadrant) error {
+	if err := r.reconcileWamsServerDeployment(ctx, kObj); err != nil {
+		return err
+	}
+
+	if err := r.reconcileWamsServerService(ctx, kObj); err != nil {
+		return err
+	}
+
+	return r.reconcileWamsServerConfigMap(ctx, kObj)
+}
+
+func WasmServerConfigMapName(kObj *kuadrantv1beta1.Kuadrant) string {
+	return fmt.Sprintf("wasm-server-%s", kObj.Name)
+}
+
+func WasmServerServiceName(kObj *kuadrantv1beta1.Kuadrant) string {
+	return fmt.Sprintf("wasm-server-%s", kObj.Name)
+}
+
+func WasmServerDeploymentName(kObj *kuadrantv1beta1.Kuadrant) string {
+	return fmt.Sprintf("wasm-server-%s", kObj.Name)
+}
+
+func WasmServerLabels() map[string]string {
+	return map[string]string{
+		"kuadrant_component_element": "wasm-server",
+		"app":                        "nginx",
+	}
+}
+
+func (r *KuadrantReconciler) reconcileWamsServerConfigMap(ctx context.Context, kObj *kuadrantv1beta1.Kuadrant) error {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	desiredDeployment := wasmServerDeployment(kObj)
+
+	deployment := &appsv1.Deployment{}
+	if err := r.Client().Get(ctx, client.ObjectKeyFromObject(desiredDeployment), deployment); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("wasm-server deployment not found yet. waiting",
+				"key", client.ObjectKeyFromObject(desiredDeployment))
+			return nil
+		}
+		return err
+	}
+
+	if deployment.Generation != deployment.Status.ObservedGeneration {
+		logger.Info("wasm-server deployment updating and ready yet. waiting",
+			"key", client.ObjectKeyFromObject(desiredDeployment))
+		return nil
+	}
+
+	if deployment.Generation != deployment.Status.ObservedGeneration {
+		logger.Info("wasm-server deployment updating and generation not ready yet. waiting",
+			"key", client.ObjectKeyFromObject(desiredDeployment))
+		return nil
+	}
+
+	availableCondition := utils.FindDeploymentStatusCondition(
+		deployment.Status.Conditions, string(appsv1.DeploymentAvailable),
+	)
+	if availableCondition == nil {
+		logger.Info("wasm-server deployment Available condition not found. waiting",
+			"key", client.ObjectKeyFromObject(desiredDeployment))
+		return nil
+	}
+
+	if availableCondition.Status != corev1.ConditionTrue {
+		logger.Info("wasm-server deployment not available, yet. waiting",
+			"key", client.ObjectKeyFromObject(desiredDeployment),
+			"message", availableCondition.Message,
+		)
+		return nil
+	}
+
+	podList := &corev1.PodList{}
+
+	err = r.Client().List(ctx, podList, client.InNamespace(deployment.Namespace), client.MatchingLabels(deployment.Spec.Template.Labels))
+	if err != nil {
+		return err
+	}
+
+	if len(podList.Items) == 0 {
+		logger.Info("wasm-server pods not found yet. waiting",
+			"key", client.ObjectKeyFromObject(desiredDeployment))
+		return nil
+	}
+
+	pod := podList.Items[0]
+
+	podLogOpts := corev1.PodLogOptions{Container: "compute-rate-limit-wasm-sha256"}
+
+	config, err := config.GetConfig()
+	//config, err := rest.InClusterConfig()
+	if err != nil {
+		logger.V(1).Info("wasm-server: error in getting config")
+		return err
+	}
+
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logger.V(1).Info("wasm-server: error in getting access to K8S")
+		return err
+	}
+
+	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		logger.V(1).Info("wasm-server: error in opening stream")
+		return err
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		logger.V(1).Info("wasm-server: error in copy information from podLogs to buf")
+		return err
+	}
+	wasmSha256 := strings.TrimSuffix(buf.String(), "\n")
+	logger.V(1).Info("wasm-server: got rate limit wasm sha256", "sha256", wasmSha256)
+
+	configMap := &v1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      WasmServerConfigMapName(kObj),
+			Namespace: kObj.Namespace,
+			Labels:    WasmServerLabels(),
+		},
+		Data: map[string]string{
+			"rate-limit-wasm-sha256": wasmSha256,
+		},
+	}
+
+	// controller reference
+	if err := r.SetOwnerReference(kObj, configMap); err != nil {
+		logger.V(1).Info("set ownerref", "error", err)
+		return err
+	}
+
+	configMapMutator := reconcilers.ConfigMapMutator(func(desired, existing *v1.ConfigMap) bool {
+		return reconcilers.ConfigMapReconcileField(desired, existing, "rate-limit-wasm-sha256")
+	})
+
+	err = r.ReconcileResource(ctx, &corev1.ConfigMap{}, configMap, configMapMutator)
+	logger.V(1).Info("reconcile configmap", "error", err)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *KuadrantReconciler) reconcileWamsServerService(ctx context.Context, kObj *kuadrantv1beta1.Kuadrant) error {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	service := &v1.Service{
+		TypeMeta: metav1.TypeMeta{Kind: "Service", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      WasmServerServiceName(kObj),
+			Namespace: kObj.Namespace,
+			Labels:    WasmServerLabels(),
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:       "http",
+					Protocol:   v1.ProtocolTCP,
+					Port:       80,
+					TargetPort: intstr.FromString("http"),
+				},
+			},
+			Selector: WasmServerLabels(),
+			Type:     v1.ServiceTypeClusterIP,
+		},
+	}
+
+	// controller reference
+	if err := r.SetOwnerReference(kObj, service); err != nil {
+		logger.V(1).Info("set ownerref", "error", err)
+		return err
+	}
+
+	serviceMutator := reconcilers.ServiceMutator(reconcilers.ServicePortsMutator)
+
+	err = r.ReconcileResource(ctx, &corev1.Service{}, service, serviceMutator)
+	logger.V(1).Info("reconcile service", "error", err)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func wasmServerDeployment(kObj *kuadrantv1beta1.Kuadrant) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      WasmServerDeploymentName(kObj),
+			Namespace: kObj.Namespace,
+			Labels:    WasmServerLabels(),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: WasmServerLabels(),
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: WasmServerLabels(),
+				},
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:            "compute-rate-limit-wasm-sha256",
+							Image:           WASMServerImageURL,
+							Command:         []string{"cat", "/data/plugin.wasm.sha256"},
+							ImagePullPolicy: v1.PullIfNotPresent,
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "wasm-server",
+							Image: WASMServerImageURL,
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "http",
+									ContainerPort: 80,
+									Protocol:      v1.ProtocolTCP,
+								},
+							},
+							LivenessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									HTTPGet: &v1.HTTPGetAction{
+										Path:   "/health",
+										Port:   intstr.FromInt(80),
+										Scheme: v1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 5,
+								TimeoutSeconds:      2,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									HTTPGet: &v1.HTTPGetAction{
+										Path:   "/health",
+										Port:   intstr.FromInt(80),
+										Scheme: v1.URISchemeHTTP,
+									},
+								},
+								InitialDelaySeconds: 5,
+								TimeoutSeconds:      5,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+							ImagePullPolicy: v1.PullIfNotPresent,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *KuadrantReconciler) reconcileWamsServerDeployment(ctx context.Context, kObj *kuadrantv1beta1.Kuadrant) error {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	deployment := wasmServerDeployment(kObj)
+
+	// controller reference
+	err = r.SetOwnerReference(kObj, deployment)
+	if err != nil {
+		logger.V(1).Info("set ownerref", "error", err)
+		return err
+	}
+
+	customDeploymentImageMutator := func(desired, existing *appsv1.Deployment) bool {
+		update := false
+
+		if existing.Spec.Template.Spec.Containers[0].Image != desired.Spec.Template.Spec.Containers[0].Image {
+			existing.Spec.Template.Spec.Containers[0].Image = desired.Spec.Template.Spec.Containers[0].Image
+			update = true
+		}
+
+		if existing.Spec.Template.Spec.InitContainers[0].Image != desired.Spec.Template.Spec.InitContainers[0].Image {
+			existing.Spec.Template.Spec.InitContainers[0].Image = desired.Spec.Template.Spec.InitContainers[0].Image
+			update = true
+		}
+
+		return update
+	}
+
+	deploymentMutators := []reconcilers.DeploymentMutateFn{
+		reconcilers.DeploymentContainerListMutator,
+		customDeploymentImageMutator,
+		reconcilers.DeploymentPortsMutator,
+		reconcilers.DeploymentLivenessProbeMutator,
+	}
+
+	err = r.ReconcileResource(ctx, &appsv1.Deployment{}, deployment, reconcilers.DeploymentMutator(deploymentMutators...))
+	logger.V(1).Info("reconcile deployment", "error", err)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/controllers/kuadrant_status.go
+++ b/controllers/kuadrant_status.go
@@ -9,7 +9,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -193,11 +192,11 @@ func (r *KuadrantReconciler) checkWasmServerAvailable(ctx context.Context, kObj 
 	dKey := client.ObjectKeyFromObject(desiredDeployment)
 	deployment := &appsv1.Deployment{}
 	err := r.Client().Get(ctx, dKey, deployment)
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil && !errors.IsNotFound(err) {
 		return nil, err
 	}
 
-	if err != nil && apierrors.IsNotFound(err) {
+	if err != nil && errors.IsNotFound(err) {
 		tmp := err.Error()
 		return &tmp, nil
 	}

--- a/controllers/rate_limiting_wasmplugin_controller.go
+++ b/controllers/rate_limiting_wasmplugin_controller.go
@@ -27,7 +27,6 @@ import (
 	istioextensionsv1alpha1 "istio.io/api/extensions/v1alpha1"
 	istioclientgoextensionv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
@@ -112,7 +111,7 @@ func (r *RateLimitingWASMPluginReconciler) Reconcile(eventCtx context.Context, r
 		return ctrl.Result{}, nil
 	}
 
-	logger.Info("wasm server", "sha256", sha256)
+	logger.Info("wasm server", "sha256", *sha256, "image", WASMServerImageURL)
 
 	desired, err := r.desiredRateLimitingWASMPlugin(ctx, gw, *sha256, kObj)
 	if err != nil {
@@ -135,7 +134,7 @@ func (r *RateLimitingWASMPluginReconciler) getWasmSHA256(ctx context.Context, kO
 	}
 
 	configMapKey := client.ObjectKey{Name: WasmServerDeploymentName(kObj), Namespace: kObj.Namespace}
-	configMap := &v1.ConfigMap{}
+	configMap := &corev1.ConfigMap{}
 	if err := r.Client().Get(ctx, configMapKey, configMap); err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.V(1).Info("getWasmSHA256: no configmap found", "configmapKey", configMapKey)
@@ -442,7 +441,7 @@ func wasmSha256ConfigMaptoGateways(baselogger logr.Logger, cl client.Client) han
 	return func(ctx context.Context, obj client.Object) []reconcile.Request {
 		logger := baselogger.WithValues("configmap", client.ObjectKeyFromObject(obj))
 
-		configMap, ok := obj.(*v1.ConfigMap)
+		configMap, ok := obj.(*corev1.ConfigMap)
 		if !ok {
 			logger.Info("cannot map configmap event to gateways", "error", fmt.Sprintf("%T is not a *v1.ConfigMap", obj))
 			return []reconcile.Request{}

--- a/controllers/rate_limiting_wasmplugin_controller.go
+++ b/controllers/rate_limiting_wasmplugin_controller.go
@@ -143,10 +143,13 @@ func (r *RateLimitingWASMPluginReconciler) getWasmSHA256(ctx context.Context, kO
 		return nil, err
 	}
 
-	sha256, ok := configMap.Data["rate-limit-wasm-sha256"]
+	sha256, ok := configMap.Data[WASMServerConfigMapDataKey]
 	if !ok {
-		logger.V(1).Info("getWasmSHA256: configmaps does not have expected rate-limit-wasm-sha256 key",
-			"configmap key", configMapKey)
+		logger.V(1).Info(
+			"getWasmSHA256: configmaps does not have expected key",
+			"object key", configMapKey,
+			"data key", WASMServerConfigMapDataKey,
+		)
 		return nil, nil
 	}
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -94,7 +94,7 @@ The `make bundle` target accepts the following variables:
 | `LIMITADOR_OPERATOR_BUNDLE_IMG` | Limitador operator bundle URL | `quay.io/kuadrant/limitador-operator-bundle:latest` | `LIMITADOR_OPERATOR_VERSION` var could be used to build this, defaults to _latest_ if not provided |
 | `AUTHORINO_OPERATOR_BUNDLE_IMG` | Authorino operator bundle URL | `quay.io/kuadrant/authorino-operator-bundle:latest` | `AUTHORINO_OPERATOR_VERSION` var could be used to build this, defaults to _latest_ if not provided |
 | `DNS_OPERATOR_BUNDLE_IMG`       | DNS operator bundle URL       | `quay.io/kuadrant/dns-operator-bundle:latest`       | `DNS_OPERATOR_BUNDLE_IMG` var could be used to build this, defaults to _latest_ if not provided    |
-| `RELATED_IMAGE_WASMSHIM`        | WASM shim image URL           | `oci://quay.io/kuadrant/wasm-shim:latest`           | `WASM_SHIM_VERSION` var could be used to build this, defaults to _latest_ if not provided          |
+| `RELATED_IMAGE_WASMSHIM`        | WASM shim image URL           | `quay.io/kuadrant/wasm-server:latest`               | `WASM_SHIM_VERSION` var could be used to build this, defaults to _latest_ if not provided          |
 
 * Build the bundle manifests
 
@@ -105,7 +105,7 @@ make bundle [IMG=quay.io/kuadrant/kuadrant-operator:latest] \
             [LIMITADOR_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest] \
             [AUTHORINO_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/authorino-operator-bundle:latest] \
             [DNS_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:latest] \
-            [RELATED_IMAGE_WASMSHIM=oci://quay.io/kuadrant/wasm-shim:latest]
+            [RELATED_IMAGE_WASMSHIM=quay.io/kuadrant/wasm-server:latest]
 ```
 
 * Build the bundle image from the manifests

--- a/doc/wasm-server.md
+++ b/doc/wasm-server.md
@@ -1,0 +1,50 @@
+# Kuadrant Wasm Server
+
+### What
+
+Kuadrant's Wasm Server is an HTTP-based static file server that serves
+Kuadrant's Wasm module binaries. The wasm module integrates with the gateway in the data plane via
+the [Wasm Network filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/wasm_filter).
+The source code of the compiled Wasm binaries is hosted at
+[Kuadrant's Wasm-Shim project](https://github.com/Kuadrant/wasm-shim)."
+
+### Why
+
+Envoy dynamically loads the Wasm module during runtime, and it is used to extend Envoy's
+capabilities. Kuadrant cannot inject a local .wasm file that is accessible by the Envoy proxy.
+Instead, Kuadrant tells Envoy to download the Wasm module from a source using existing
+Envoy control plane APIs.
+The main goal of Kuadrant's Wasm Server component is to be the source of the Wasm module running
+inside the same Kubernetes cluster. This way, Envoy does not need to fetch the Wasm module from
+external sources, which adds security protection against malicious code injection.
+
+This architecture enables so-called *offline* or *disconnected* installs,
+which allow having the entire cluster disconnected from the internet,
+at least regarding the Wasm module.
+
+### How
+
+The Wasm Server is implemented using [nginx](https://nginx.org) HTTP server.
+The compiled [Kuadrant's Wasm module](https://github.com/Kuadrant/wasm-shim) is being copied
+to a docker image containing the nginx server configured to serve it on the `/plugin.wasm` path.
+
+The following sequence diagram shows the workflow:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    box transparent Kubernetes cluster
+    participant K as Kuadrant
+    participant W as Wasm Server
+    participant WP as WasmPlugin
+    participant I as Istio
+    participant E as Envoy
+    end
+    K->>+W: sha256?
+    W->>-K: sha256
+    K->>WP: Wasm Server internal URL, sha256
+    WP->>I: Wasm Server internal URL, sha256
+    I->>W: Fetch Wasm binary, verify sha256 checksum
+    I->>E: Push Wasm binary
+    I->>E: Setup Wasm filter
+```

--- a/doc/wasm-server.md
+++ b/doc/wasm-server.md
@@ -28,7 +28,10 @@ The Wasm Server is implemented using [nginx](https://nginx.org) HTTP server.
 The compiled [Kuadrant's Wasm module](https://github.com/Kuadrant/wasm-shim) is being copied
 to a docker image containing the nginx server configured to serve it on the `/plugin.wasm` path.
 
-The following sequence diagram shows the workflow:
+
+#### Istio
+
+The following sequence diagram shows the workflow when Envoy is managed by [Istio](https://istio.io/)
 
 ```mermaid
 sequenceDiagram

--- a/pkg/kuadranttools/tools.go
+++ b/pkg/kuadranttools/tools.go
@@ -1,0 +1,45 @@
+package kuadranttools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
+)
+
+func KuadrantFromGateway(ctx context.Context, cl client.Client, gw *gatewayapiv1.Gateway) (*kuadrantv1beta1.Kuadrant, error) {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	kNS, isSet := gw.GetAnnotations()[kuadrant.KuadrantNamespaceAnnotation]
+	if !isSet {
+		logger.Info("gateway not assigned to kuadrant")
+		return nil, nil
+	}
+
+	// Currently only one kuadrant CR is supported
+	kuadrantList := &kuadrantv1beta1.KuadrantList{}
+	err = cl.List(ctx, kuadrantList, client.InNamespace(kNS))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(kuadrantList.Items) == 0 {
+		logger.V(1).Info("no kuadrant instance found", "namespace", kNS)
+		return nil, nil
+	}
+
+	if len(kuadrantList.Items) > 1 {
+		return nil, fmt.Errorf("multiple kuadrant instances found (%d kuadrant instances)",
+			len(kuadrantList.Items))
+	}
+
+	return &kuadrantList.Items[0], nil
+}

--- a/pkg/library/reconcilers/configmap.go
+++ b/pkg/library/reconcilers/configmap.go
@@ -1,0 +1,49 @@
+package reconcilers
+
+import (
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConfigMapMutateFn is a function which mutates the existing ConfigMap into it's desired state.
+type ConfigMapMutateFn func(desired, existing *v1.ConfigMap) bool
+
+func ConfigMapMutator(opts ...ConfigMapMutateFn) MutateFn {
+	return func(existingObj, desiredObj client.Object) (bool, error) {
+		existing, ok := existingObj.(*v1.ConfigMap)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *v1.ConfigMap", existingObj)
+		}
+		desired, ok := desiredObj.(*v1.ConfigMap)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *v1.ConfigMap", desiredObj)
+		}
+
+		update := false
+
+		// Loop through each option
+		for _, opt := range opts {
+			tmpUpdate := opt(desired, existing)
+			update = update || tmpUpdate
+		}
+
+		return update, nil
+	}
+}
+
+func ConfigMapReconcileField(desired, existing *v1.ConfigMap, fieldName string) bool {
+	updated := false
+
+	if existingVal, ok := existing.Data[fieldName]; !ok {
+		existing.Data[fieldName] = desired.Data[fieldName]
+		updated = true
+	} else {
+		if desired.Data[fieldName] != existingVal {
+			existing.Data[fieldName] = desired.Data[fieldName]
+			updated = true
+		}
+	}
+	return updated
+}

--- a/pkg/library/reconcilers/deployment.go
+++ b/pkg/library/reconcilers/deployment.go
@@ -1,0 +1,191 @@
+package reconcilers
+
+import (
+	"fmt"
+	"reflect"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DeploymentMutateFn is a function which mutates the existing Deployment into it's desired state.
+type DeploymentMutateFn func(desired, existing *appsv1.Deployment) bool
+
+func DeploymentMutator(opts ...DeploymentMutateFn) MutateFn {
+	return func(existingObj, desiredObj client.Object) (bool, error) {
+		existing, ok := existingObj.(*appsv1.Deployment)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *appsv1.Deployment", existingObj)
+		}
+		desired, ok := desiredObj.(*appsv1.Deployment)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *appsv1.Deployment", desiredObj)
+		}
+
+		update := false
+
+		// Loop through each option
+		for _, opt := range opts {
+			tmpUpdate := opt(desired, existing)
+			update = update || tmpUpdate
+		}
+
+		return update, nil
+	}
+}
+
+func DeploymentAffinityMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Affinity, desired.Spec.Template.Spec.Affinity) {
+		existing.Spec.Template.Spec.Affinity = desired.Spec.Template.Spec.Affinity
+		update = true
+	}
+	return update
+}
+
+func DeploymentReplicasMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	var existingReplicas int32 = 1
+	if existing.Spec.Replicas != nil {
+		existingReplicas = *existing.Spec.Replicas
+	}
+
+	var desiredReplicas int32 = 1
+	if desired.Spec.Replicas != nil {
+		desiredReplicas = *desired.Spec.Replicas
+	}
+
+	if desiredReplicas != existingReplicas {
+		existing.Spec.Replicas = &desiredReplicas
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentContainerListMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if len(existing.Spec.Template.Spec.Containers) != len(desired.Spec.Template.Spec.Containers) {
+		existing.Spec.Template.Spec.Containers = desired.Spec.Template.Spec.Containers
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentImageMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if existing.Spec.Template.Spec.Containers[0].Image != desired.Spec.Template.Spec.Containers[0].Image {
+		existing.Spec.Template.Spec.Containers[0].Image = desired.Spec.Template.Spec.Containers[0].Image
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentCommandMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Command, desired.Spec.Template.Spec.Containers[0].Command) {
+		existing.Spec.Template.Spec.Containers[0].Command = desired.Spec.Template.Spec.Containers[0].Command
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentEnvMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Env, desired.Spec.Template.Spec.Containers[0].Env) {
+		existing.Spec.Template.Spec.Containers[0].Env = desired.Spec.Template.Spec.Containers[0].Env
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentResourcesMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Containers[0].Resources, desired.Spec.Template.Spec.Containers[0].Resources) {
+		existing.Spec.Template.Spec.Containers[0].Resources = desired.Spec.Template.Spec.Containers[0].Resources
+		update = true
+	}
+
+	return update
+}
+
+// DeploymentVolumesMutator implements strict Volumes reconcilliation
+// Does not allow manually added volumes
+func DeploymentVolumesMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	if !reflect.DeepEqual(existing.Spec.Template.Spec.Volumes, desired.Spec.Template.Spec.Volumes) {
+		existing.Spec.Template.Spec.Volumes = desired.Spec.Template.Spec.Volumes
+		update = true
+	}
+
+	return update
+}
+
+// DeploymentVolumesMutator implements strict VolumeMounts reconcilliation
+// Does not allow manually added volumeMounts
+func DeploymentVolumeMountsMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	existingContainer := &existing.Spec.Template.Spec.Containers[0]
+	desiredContainer := &desired.Spec.Template.Spec.Containers[0]
+
+	if !reflect.DeepEqual(existingContainer.VolumeMounts, desiredContainer.VolumeMounts) {
+		existingContainer.VolumeMounts = desiredContainer.VolumeMounts
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentPortsMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	existingContainer := &existing.Spec.Template.Spec.Containers[0]
+	desiredContainer := &desired.Spec.Template.Spec.Containers[0]
+
+	if !reflect.DeepEqual(existingContainer.Ports, desiredContainer.Ports) {
+		existingContainer.Ports = desiredContainer.Ports
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentLivenessProbeMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	existingContainer := &existing.Spec.Template.Spec.Containers[0]
+	desiredContainer := &desired.Spec.Template.Spec.Containers[0]
+
+	if !reflect.DeepEqual(existingContainer.LivenessProbe, desiredContainer.LivenessProbe) {
+		existingContainer.LivenessProbe = desiredContainer.LivenessProbe
+		update = true
+	}
+
+	return update
+}
+
+func DeploymentReadinessProbeMutator(desired, existing *appsv1.Deployment) bool {
+	update := false
+
+	existingContainer := &existing.Spec.Template.Spec.Containers[0]
+	desiredContainer := &desired.Spec.Template.Spec.Containers[0]
+
+	if !reflect.DeepEqual(existingContainer.ReadinessProbe, desiredContainer.ReadinessProbe) {
+		existingContainer.ReadinessProbe = desiredContainer.ReadinessProbe
+		update = true
+	}
+
+	return update
+}

--- a/pkg/library/reconcilers/deployment_test.go
+++ b/pkg/library/reconcilers/deployment_test.go
@@ -1,0 +1,392 @@
+package reconcilers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gotest.tools/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kuadrant/limitador-operator/pkg/reconcilers"
+)
+
+var _ = Describe("Deployment", func() {
+	var desired *appsv1.Deployment
+
+	BeforeEach(func() {
+		desired = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sample",
+				Namespace: "test",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "expected",
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	Describe("DeploymentContainerListMutator()", func() {
+		It("Container image length is correct", func() {
+			existing := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sample",
+					Namespace: "test",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "expected",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := reconcilers.DeploymentContainerListMutator(desired, existing)
+
+			Expect(result).To(Equal(false))
+
+		})
+
+		It("Container spec has too many containers", func() {
+			existing := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sample",
+					Namespace: "test",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "expected",
+								},
+								{
+									Name: "unexpected",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			result := reconcilers.DeploymentContainerListMutator(desired, existing)
+
+			Expect(result).To(Equal(true))
+			Expect(len(existing.Spec.Template.Spec.Containers)).To(Equal(len(desired.Spec.Template.Spec.Containers)))
+
+		})
+	})
+})
+
+func TestDeploymentResourcesMutator(t *testing.T) {
+	deploymentFactory := func(requirements corev1.ResourceRequirements) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Resources: requirements,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	requirementsFactory := func(reqCPU, reqMem, limCPU, limMem string) corev1.ResourceRequirements {
+		return corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(reqCPU),
+				corev1.ResourceMemory: resource.MustParse(reqMem),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(limCPU),
+				corev1.ResourceMemory: resource.MustParse(limMem),
+			},
+		}
+	}
+
+	requirementsA := requirementsFactory("1m", "1Mi", "2m", "2Mi")
+	requirementsB := requirementsFactory("2m", "2Mi", "4m", "4Mi")
+
+	t.Run("test false when desired and existing are the same", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentResourcesMutator(deploymentFactory(requirementsA), deploymentFactory(requirementsA)), false)
+	})
+
+	t.Run("test true when desired and existing are different", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentResourcesMutator(deploymentFactory(requirementsA), deploymentFactory(requirementsB)), true)
+	})
+}
+
+func TestDeploymentEnvMutator(t *testing.T) {
+	deploymentFactory := func(env []corev1.EnvVar) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Env: env,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	envFactory := func(name string) []corev1.EnvVar {
+		return []corev1.EnvVar{
+			{
+				Name: name,
+			},
+		}
+	}
+
+	envA := envFactory("envA")
+	envB := envFactory("envB")
+
+	t.Run("test false when desired and existing are the same", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentEnvMutator(deploymentFactory(envA), deploymentFactory(envA)), false)
+	})
+
+	t.Run("test true when desired and existing are different", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentEnvMutator(deploymentFactory(envA), deploymentFactory(envB)), true)
+	})
+}
+
+func TestDeploymentVolumesMutator(t *testing.T) {
+	deploymentFactory := func(volumes []corev1.Volume) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PodSpec{
+						Volumes: volumes,
+					},
+				},
+			},
+		}
+	}
+
+	existing := deploymentFactory([]corev1.Volume{
+		{
+			Name: "A",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "secretA",
+					},
+				},
+			},
+		},
+	})
+
+	desired := deploymentFactory([]corev1.Volume{
+		{
+			Name: "B",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "secretB",
+					},
+				},
+			},
+		},
+	})
+
+	desiredCopy := desired.DeepCopyObject()
+
+	t.Run("test false when desired and existing are the same", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentVolumesMutator(existing, existing), false)
+	})
+
+	t.Run("test true when desired and existing are different", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentVolumesMutator(desired, existing), true)
+		assert.DeepEqual(subT, desired, desiredCopy)
+		assert.DeepEqual(subT, desired, existing)
+	})
+}
+
+func TestDeploymentVolumeMountsMutator(t *testing.T) {
+	deploymentFactory := func(volumeMounts []corev1.VolumeMount) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								VolumeMounts: volumeMounts,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	existing := deploymentFactory([]corev1.VolumeMount{
+		{
+			Name:      "A",
+			MountPath: "/path/A",
+		},
+	})
+
+	desired := deploymentFactory([]corev1.VolumeMount{
+		{
+			Name:      "B",
+			MountPath: "/path/B",
+		},
+	})
+
+	desiredCopy := desired.DeepCopyObject()
+
+	t.Run("test false when desired and existing are the same", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentVolumeMountsMutator(existing, existing), false)
+	})
+
+	t.Run("test true when desired and existing are different", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentVolumeMountsMutator(desired, existing), true)
+		assert.DeepEqual(subT, desired, desiredCopy)
+		assert.DeepEqual(subT, desired, existing)
+	})
+}
+
+func TestDeploymentCommandMutator(t *testing.T) {
+	deploymentFactory := func(command []string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Command: command,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	existing := deploymentFactory([]string{"A", "B"})
+
+	desired := deploymentFactory([]string{"C", "D"})
+
+	desiredCopy := desired.DeepCopyObject()
+
+	t.Run("test false when desired and existing are the same", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentCommandMutator(existing, existing), false)
+	})
+
+	t.Run("test true when desired and existing are different", func(subT *testing.T) {
+		assert.Equal(subT, reconcilers.DeploymentCommandMutator(desired, existing), true)
+		assert.DeepEqual(subT, desired, desiredCopy)
+		assert.DeepEqual(subT, desired, existing)
+	})
+}
+
+func TestDeploymentMutator(t *testing.T) {
+	newExistingDeployment := func() *appsv1.Deployment {
+		return &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:    "originalName",
+								Command: []string{"original", "name"},
+								Image:   "example.com/limitador-operator:original",
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("desired object is not deployment", func(subT *testing.T) {
+		emptyMutator := reconcilers.DeploymentMutator()
+		existing := &appsv1.Deployment{}
+		desired := &corev1.Service{}
+		_, err := emptyMutator(existing, desired)
+		assert.Error(subT, err, "*v1.Service is not a *appsv1.Deployment")
+	})
+
+	t.Run("existing object is not deployment", func(subT *testing.T) {
+		emptyMutator := reconcilers.DeploymentMutator()
+		existing := &corev1.Service{}
+		desired := &appsv1.Deployment{}
+		_, err := emptyMutator(existing, desired)
+		assert.Error(subT, err, "*v1.Service is not a *appsv1.Deployment")
+	})
+
+	t.Run("no mutator", func(subT *testing.T) {
+		existing := newExistingDeployment()
+		emptyMutator := reconcilers.DeploymentMutator()
+		updated, err := emptyMutator(existing, &appsv1.Deployment{})
+		assert.NilError(subT, err)
+		assert.Assert(subT, !updated)
+		// object has not been mutated
+		assert.DeepEqual(subT, existing, newExistingDeployment())
+	})
+
+	t.Run("all mutators return false", func(subT *testing.T) {
+		mutatorList := make([]reconcilers.DeploymentMutateFn, 10)
+		for i := 0; i < len(mutatorList); i++ {
+			mutatorList[i] = func(_, _ *appsv1.Deployment) bool { return false }
+		}
+
+		mutator := reconcilers.DeploymentMutator(mutatorList...)
+		updated, err := mutator(&appsv1.Deployment{}, &appsv1.Deployment{})
+		assert.NilError(subT, err)
+		assert.Assert(subT, !updated)
+	})
+
+	t.Run("all mutators are applied", func(subT *testing.T) {
+		nameMutator := func(_, existing *appsv1.Deployment) bool {
+			existing.Spec.Template.Spec.Containers[0].Name = "newName"
+			return true
+		}
+		commandMutator := func(_, existing *appsv1.Deployment) bool {
+			existing.Spec.Template.Spec.Containers[0].Command = []string{"new", "command"}
+			return true
+		}
+		imageMutator := func(_, existing *appsv1.Deployment) bool {
+			existing.Spec.Template.Spec.Containers[0].Image = "newImage"
+			return true
+		}
+
+		existing := newExistingDeployment()
+		mutator := reconcilers.DeploymentMutator(
+			nameMutator, commandMutator, imageMutator,
+		)
+		updated, err := mutator(existing, &appsv1.Deployment{})
+		assert.NilError(subT, err)
+		assert.Assert(subT, updated)
+		assert.Equal(subT, existing.Spec.Template.Spec.Containers[0].Name, "newName")
+		assert.DeepEqual(subT, existing.Spec.Template.Spec.Containers[0].Command, []string{"new", "command"})
+		assert.Equal(subT, existing.Spec.Template.Spec.Containers[0].Image, "newImage")
+	})
+}

--- a/pkg/library/reconcilers/service.go
+++ b/pkg/library/reconcilers/service.go
@@ -1,0 +1,46 @@
+package reconcilers
+
+import (
+	"fmt"
+	"reflect"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ServiceMutateFn is a function which mutates the existing Service into it's desired state.
+type ServiceMutateFn func(desired, existing *v1.Service) bool
+
+func ServiceMutator(opts ...ServiceMutateFn) MutateFn {
+	return func(existingObj, desiredObj client.Object) (bool, error) {
+		existing, ok := existingObj.(*v1.Service)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *v1.Service", existingObj)
+		}
+		desired, ok := desiredObj.(*v1.Service)
+		if !ok {
+			return false, fmt.Errorf("%T is not a *v1.Service", desiredObj)
+		}
+
+		update := false
+
+		// Loop through each option
+		for _, opt := range opts {
+			tmpUpdate := opt(desired, existing)
+			update = update || tmpUpdate
+		}
+
+		return update, nil
+	}
+}
+
+func ServicePortsMutator(desired, existing *v1.Service) bool {
+	update := false
+
+	if !reflect.DeepEqual(existing.Spec.Ports, desired.Spec.Ports) {
+		existing.Spec.Ports = desired.Spec.Ports
+		update = true
+	}
+
+	return update
+}

--- a/pkg/library/utils/k8s_utils.go
+++ b/pkg/library/utils/k8s_utils.go
@@ -168,3 +168,14 @@ func GetClusterUID(ctx context.Context, c client.Client) (string, error) {
 	clusterUID = string(ns.UID)
 	return clusterUID, nil
 }
+
+func IsPodReady(pod *corev1.Pod) bool {
+	for i := range pod.Status.Conditions {
+		if pod.Status.Conditions[i].Type == corev1.PodReady &&
+			pod.Status.Conditions[i].Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/rlptools/wasm_utils.go
+++ b/pkg/rlptools/wasm_utils.go
@@ -10,16 +10,11 @@ import (
 
 	_struct "google.golang.org/protobuf/types/known/structpb"
 	istioclientgoextensionv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
-	"k8s.io/utils/env"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	"github.com/kuadrant/kuadrant-operator/pkg/rlptools/wasm"
-)
-
-var (
-	WASMFilterImageURL = env.GetString("RELATED_IMAGE_WASMSHIM", "quay.io/kuadrant/wasm-server:latest")
 )
 
 // WasmRules computes WASM rules from the policy and the targeted route.

--- a/pkg/rlptools/wasm_utils.go
+++ b/pkg/rlptools/wasm_utils.go
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	WASMFilterImageURL = env.GetString("RELATED_IMAGE_WASMSHIM", "oci://quay.io/kuadrant/wasm-shim:latest")
+	WASMFilterImageURL = env.GetString("RELATED_IMAGE_WASMSHIM", "quay.io/kuadrant/wasm-server:latest")
 )
 
 // WasmRules computes WASM rules from the policy and the targeted route.

--- a/pkg/rlptools/wasm_utils.go
+++ b/pkg/rlptools/wasm_utils.go
@@ -283,6 +283,16 @@ func WASMPluginMutator(existingObj, desiredObj client.Object) (bool, error) {
 		return false, err
 	}
 
+	if desired.Spec.Sha256 != existing.Spec.Sha256 {
+		update = true
+		existing.Spec.Sha256 = desired.Spec.Sha256
+	}
+
+	if desired.Spec.Url != existing.Spec.Url {
+		update = true
+		existing.Spec.Url = desired.Spec.Url
+	}
+
 	// TODO(eastizle): reflect.DeepEqual does not work well with lists without order
 	if !reflect.DeepEqual(desiredWASMPlugin, existingWASMPlugin) {
 		update = true


### PR DESCRIPTION
Requires https://github.com/Kuadrant/wasm-shim/pull/52

### What

Kuadrant's Wasm Server is an HTTP-based static file server that serves
Kuadrant's Wasm module binaries. The wasm module integrates with the gateway in the data plane via
the [Wasm Network filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/network_filters/wasm_filter).
The source code of the compiled Wasm binaries is hosted at
[Kuadrant's Wasm-Shim project](https://github.com/Kuadrant/wasm-shim).

Currently, at runtime, the istio control plane downloads an [oci wasm image](https://istio.io/latest/docs/reference/config/proxy_extensions/wasm-plugin/). Usually from cluster external image repo like quay.io. This clearly opens a risky door to inject malicious code. 

### Why

Envoy dynamically loads the Wasm module during runtime, and it is used to extend Envoy's
capabilities. Kuadrant cannot inject a local .wasm file that is accessible by the Envoy proxy.
Instead, Kuadrant tells Envoy to download the Wasm module from a source using existing
Envoy control plane APIs.
The main goal of Kuadrant's Wasm Server component is to be the source of the Wasm module running
inside the same Kubernetes cluster. This way, Envoy does not need to fetch the Wasm module from
external sources, which adds security protection against malicious code injection.

This architecture enables so-called *offline* or *disconnected* installs,
which allow having the entire cluster disconnected from the internet,
at least regarding the Wasm module.
> Disconnected install is itself a full feature and we did not tested that yet. 

### How

The Wasm Server is implemented using [nginx](https://nginx.org) HTTP server.
The compiled [Kuadrant's Wasm module](https://github.com/Kuadrant/wasm-shim) is being copied
to a docker image containing the nginx server configured to serve it on the `/plugin.wasm` path.

#### Istio

The following sequence diagram shows the workflow when Envoy is managed by [Istio](https://istio.io/)

```mermaid
sequenceDiagram
    autonumber
    box transparent Kubernetes cluster
    participant K as Kuadrant
    participant W as Wasm Server
    participant WP as WasmPlugin
    participant I as Istio
    participant E as Envoy
    end
    K->>+W: sha256?
    W->>-K: sha256
    K->>WP: Wasm Server internal URL, sha256
    WP->>I: Wasm Server internal URL, sha256
    I->>W: Fetch Wasm binary, verify sha256 checksum
    I->>E: Push Wasm binary
    I->>E: Setup Wasm filter
```

## Verification Steps

* Setup the environment:   
                         
```sh                    
make local-env-setup   
```        

* run the operator manually with custom wasm-server image. (It will allow verifying the upgrading of the Wasm image)

```sh
RELATED_IMAGE_WASMSHIM=quay.io/kuadrant/wasm-server:wasm-server make run
```

* Request an instance of Kuadrant:

```sh
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```
* Deploy toystore

```sh
kubectl apply -f examples/toystore/toystore.yaml
```

Create a HTTPRoute to route traffic to the service via Istio Ingress Gateway:

```sh
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - method: GET
      path:
        type: PathPrefix
        value: "/toys"
    backendRefs:
    - name: toystore
      port: 80
  - matches: # it has to be a separate HTTPRouteRule so we do not rate limit other endpoints
    - method: POST
      path:
        type: Exact
        value: "/toys"
    backendRefs:
    - name: toystore
      port: 80
EOF
```

Export the gateway hostname and port:

```sh
export INGRESS_HOST=$(kubectl get gtw istio-ingressgateway -n istio-system -o jsonpath='{.status.addresses[0].value}')
export INGRESS_PORT=$(kubectl get gtw istio-ingressgateway -n istio-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
```

Verify the route works:

```sh
curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -i
# HTTP/1.1 200 OK
```
* Enforce rate limiting on requests to the Toy Store API
```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:
    "create-toy":
      rates:
      - limit: 5
        duration: 10
        unit: second
      routeSelectors:
      - matches: # selects the 2nd HTTPRouteRule of the targeted route
        - method: POST
          path:
            type: Exact
            value: "/toys"
EOF
```

* Check wasm plugin has been created and it contains the url of local service of the Wasm Server
```sh
kubectl get wasmplugin kuadrant-istio-ingressgateway -n istio-system -o jsonpath="{.spec.url}"
```
It should return 
```
http://wasm-server-kuadrant.kuadrant-system.svc.cluster.local/plugin.wasm
```

* Check wasm plugin has been created and it contains the *sha256* checksum of the Wasm binary served by the Wasm Server
```sh
kubectl get wasmplugin kuadrant-istio-ingressgateway -n istio-system -o jsonpath="{.spec.sha256}"
```
It should return some sha256 value (may not be the same)
```
d5bd8b7a21e2369e130a9a2bd80345df30102b08d4fe070c1896a75769e7e2c0
```
* Check Wasm Server configmap is created and it contains the *sha256* checksum of the Wasm binary served by the Wasm Server
```sh
kubectl get configmap wasm-server-kuadrant -n kuadrant-system -o jsonpath="{.data.rate-limit-wasm-sha256}"
```
It should return some sha256 value (may not be the same)
```sh
d5bd8b7a21e2369e130a9a2bd80345df30102b08d4fe070c1896a75769e7e2c0
```
* Run requests (5 out of 10 allowed)
```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -X POST | grep -E --color "\b(429)\b|$"; sleep 1; done
```

* Let's verify upgrade of the Wasm Server version
There is no need to stop http client... it should not be affected and rate limiting should work all the time

Cancel operator process (CTRL+C) and run new version of the Wasm Server
```sh
RELATED_IMAGE_WASMSHIM=quay.io/kuadrant/wasm-server:wasm-server-v2 make run
```

* Check wasm plugin has been updated and it contains the **new** *sha256* checksum of the Wasm binary served by the Wasm Server
```sh
kubectl get wasmplugin kuadrant-istio-ingressgateway -n istio-system -o jsonpath="{.spec.sha256}"
```
It should return some sha256 value (may not be the same)
```
f835ebeaaa49cbba135cc4175644af343feb3a06ec46a91e69281f09048bad3f
```
* Check Wasm Server configmap has been updated and it contains the **new** *sha256* checksum of the Wasm binary served by the Wasm Server
```sh
kubectl get configmap wasm-server-kuadrant -n kuadrant-system -o jsonpath="{.data.rate-limit-wasm-sha256}"
```
It should return some sha256 value (may not be the same)
```sh
f835ebeaaa49cbba135cc4175644af343feb3a06ec46a91e69281f09048bad3f
```

