### PR TITLE
use correct status type when enforcing policy

### DIFF
--- a/controllers/dnspolicy_controller_test.go
+++ b/controllers/dnspolicy_controller_test.go
@@ -344,9 +344,9 @@ var _ = Describe("DNSPolicy controller", func() {
 						}),
 						MatchFields(IgnoreExtras, Fields{
 							"Type":    Equal(string(kuadrant.PolicyConditionEnforced)),
-							"Status":  Equal(metav1.ConditionTrue),
+							"Status":  Equal(metav1.ConditionFalse),
 							"Reason":  Equal(string(kuadrant.PolicyReasonEnforced)),
-							"Message": Equal("DNSPolicy has been successfully enforced"),
+							"Message": Equal("DNSPolicy has been partially enforced"),
 						})),
 				)
 			}, TestTimeoutMedium, time.Second).Should(Succeed())

--- a/controllers/dnspolicy_status.go
+++ b/controllers/dnspolicy_status.go
@@ -115,7 +115,7 @@ func (r *DNSPolicyReconciler) enforcedCondition(recordsList *kuadrantdnsv1alpha1
 				controlled = true
 				// if at least one record not ready the policy is not enforced
 				for _, condition := range record.Status.Conditions {
-					if condition.Type == string(v1alpha2.PolicyConditionAccepted) && condition.Status == metav1.ConditionFalse {
+					if condition.Type == string(kuadrantdnsv1alpha1.ConditionTypeReady) && condition.Status == metav1.ConditionFalse {
 						return kuadrant.EnforcedCondition(dnsPolicy, nil, false)
 					}
 				}

--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -55,6 +55,7 @@ const (
 	TestListenerNameTwo      = "test-listener-2"
 	TestIPAddressOne         = "172.0.0.1"
 	TestIPAddressTwo         = "172.0.0.2"
+	TestHTTPRouteName        = "toystore-route"
 )
 
 func ApplyKuadrantCR(namespace string) {

--- a/controllers/limitador_cluster_envoyfilter_controller_test.go
+++ b/controllers/limitador_cluster_envoyfilter_controller_test.go
@@ -31,9 +31,8 @@ var _ = Describe("Limitador Cluster EnvoyFilter controller", Ordered, func() {
 	var (
 		testNamespace          string
 		kuadrantInstallationNS string
-		gwName                 = "toystore-gw"
 		rlpName                = "toystore-rlp"
-		efName                 = fmt.Sprintf("kuadrant-ratelimiting-cluster-%s", gwName)
+		efName                 = fmt.Sprintf("kuadrant-ratelimiting-cluster-%s", TestGatewayName)
 	)
 
 	BeforeAll(func(ctx SpecContext) {
@@ -47,7 +46,7 @@ var _ = Describe("Limitador Cluster EnvoyFilter controller", Ordered, func() {
 
 	beforeEachCallback := func(ctx SpecContext) {
 		testNamespace = CreateNamespaceWithContext(ctx)
-		gateway := testBuildBasicGateway(gwName, testNamespace)
+		gateway := testBuildBasicGateway(TestGatewayName, testNamespace)
 		err := k8sClient.Create(ctx, gateway)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -102,7 +101,7 @@ var _ = Describe("Limitador Cluster EnvoyFilter controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(gwName),
+						Name:  gatewayapiv1.ObjectName(TestGatewayName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{

--- a/controllers/rate_limiting_wasmplugin_controller_test.go
+++ b/controllers/rate_limiting_wasmplugin_controller_test.go
@@ -70,12 +70,11 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		var (
 			routeName = "toystore-route"
 			rlpName   = "toystore-rlp"
-			gwName    = "toystore-gw"
 			gateway   *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(gwName, testNamespace)
+			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -85,7 +84,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("Simple RLP targeting HTTPRoute creates wasmplugin", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -178,7 +177,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("Full featured RLP targeting HTTPRoute creates wasmplugin", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.toystore.acme.com", "api.toystore.io"})
+			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.toystore.acme.com", "api.toystore.io"})
 			httpRoute.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
 					Matches: []gatewayapiv1.HTTPRouteMatch{
@@ -392,7 +391,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("Simple RLP targeting Gateway parented by one HTTPRoute creates wasmplugin", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -407,7 +406,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(gwName),
+						Name:  gatewayapiv1.ObjectName(TestGatewayName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -483,12 +482,11 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 	Context("RLP targeting HTTPRoute-less Gateway", func() {
 		var (
 			rlpName = "toystore-rlp"
-			gwName  = "toystore-gw"
 			gateway *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(gwName, testNamespace)
+			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -507,7 +505,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(gwName),
+						Name:  gatewayapiv1.ObjectName(TestGatewayName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -545,12 +543,11 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		var (
 			routeName = "toystore-route"
 			rlpName   = "toystore-rlp"
-			gwName    = "toystore-gw"
 			gateway   *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(gwName, testNamespace)
+			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -560,7 +557,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("When the gateway does not have more policies, the wasmplugin resource is not created", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -634,7 +631,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			)
 
 			// create httproute B
-			httpRouteB := testBuildBasicHttpRoute(routeBName, gwName, testNamespace, []string{"*.b.example.com"})
+			httpRouteB := testBuildBasicHttpRoute(routeBName, TestGatewayName, testNamespace, []string{"*.b.example.com"})
 			err := k8sClient.Create(ctx, httpRouteB)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRouteB))).WithContext(ctx).Should(BeTrue())
@@ -649,7 +646,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(gwName),
+						Name:  gatewayapiv1.ObjectName(TestGatewayName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -672,7 +669,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			Eventually(assertPolicyIsAcceptedAndEnforced(ctx, rlpAKey)).WithContext(ctx).Should(BeTrue())
 
 			// create httproute C
-			httpRouteC := testBuildBasicHttpRoute(routeCName, gwName, testNamespace, []string{"*.c.example.com"})
+			httpRouteC := testBuildBasicHttpRoute(routeCName, TestGatewayName, testNamespace, []string{"*.c.example.com"})
 			httpRouteC.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
 					Matches: []gatewayapiv1.HTTPRouteMatch{
@@ -808,13 +805,12 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		var (
 			routeName = "route-a"
 			rlpName   = "rlp-a"
-			gwName    = "toystore-gw"
 			gateway   *gatewayapiv1.Gateway
 			gwBName   = "gw-b"
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(gwName, testNamespace)
+			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -847,7 +843,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(gwName),
+						Name:  gatewayapiv1.ObjectName(TestGatewayName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -870,7 +866,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			Expect(testRLPEnforcedCondition(ctx, rlpKey, kuadrant.PolicyReasonUnknown, "RateLimitPolicy has encountered some issues: no free routes to enforce policy"))
 
 			// create Route A -> Gw A
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
 			err = k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -1041,7 +1037,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			Eventually(testGatewayIsReady(gwB)).WithContext(ctx).Should(BeTrue())
 
 			// create Route A -> Gw A
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
 			err = k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -1265,12 +1261,11 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 	Context("RLP switches targetRef from one route A to another route B", func() {
 		var (
-			gwName  = "toystore-gw"
 			gateway *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(gwName, testNamespace)
+			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -1300,7 +1295,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route A -> Gw A on *.a.example.com
 			//
-			httpRouteA := testBuildBasicHttpRoute(routeAName, gwName, testNamespace, []string{"*.a.example.com"})
+			httpRouteA := testBuildBasicHttpRoute(routeAName, TestGatewayName, testNamespace, []string{"*.a.example.com"})
 			// GET /routeA
 			httpRouteA.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -1322,7 +1317,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route B -> Gw A on *.b.example.com
 			//
-			httpRouteB := testBuildBasicHttpRoute(routeBName, gwName, testNamespace, []string{"*.b.example.com"})
+			httpRouteB := testBuildBasicHttpRoute(routeBName, TestGatewayName, testNamespace, []string{"*.b.example.com"})
 			// GET /routeB
 			httpRouteB.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -1525,12 +1520,11 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 	Context("Free Route gets dedicated RLP", func() {
 		var (
-			gwName  = "toystore-gw"
 			gateway *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(gwName, testNamespace)
+			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -1559,7 +1553,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route A -> Gw A on *.a.example.com
 			//
-			httpRouteA := testBuildBasicHttpRoute(routeAName, gwName, testNamespace, []string{"*.a.example.com"})
+			httpRouteA := testBuildBasicHttpRoute(routeAName, TestGatewayName, testNamespace, []string{"*.a.example.com"})
 			// GET /routeA
 			httpRouteA.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -1588,7 +1582,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(gwName),
+						Name:  gatewayapiv1.ObjectName(TestGatewayName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -1785,12 +1779,11 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 	Context("New free route on a Gateway with RLP", func() {
 		var (
-			gwName  = "toystore-gw"
 			gateway *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(gwName, testNamespace)
+			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -1822,7 +1815,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route A -> Gw A on *.a.example.com
 			//
-			httpRouteA := testBuildBasicHttpRoute(routeAName, gwName, testNamespace, []string{"*.a.example.com"})
+			httpRouteA := testBuildBasicHttpRoute(routeAName, TestGatewayName, testNamespace, []string{"*.a.example.com"})
 			// GET /routeA
 			httpRouteA.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -1851,7 +1844,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(gwName),
+						Name:  gatewayapiv1.ObjectName(TestGatewayName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -1977,7 +1970,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route B -> Gw A on *.b.example.com
 			//
-			httpRouteB := testBuildBasicHttpRoute(routeBName, gwName, testNamespace, []string{"*.b.example.com"})
+			httpRouteB := testBuildBasicHttpRoute(routeBName, TestGatewayName, testNamespace, []string{"*.b.example.com"})
 			// GET /routeB
 			httpRouteB.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -2104,7 +2097,6 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 	Context("Gateway with hostname in listener", func() {
 		var (
-			gwName     = "toystore-gw"
 			routeName  = "toystore-route"
 			rlpName    = "rlp-a"
 			gateway    *gatewayapiv1.Gateway
@@ -2112,7 +2104,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(gwName, testNamespace)
+			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
 			gateway.Spec.Listeners[0].Hostname = ptr.To(gatewayapiv1.Hostname(gwHostname))
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
@@ -2124,7 +2116,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		It("RLP with hostnames in route selector targeting hostname less HTTPRoute creates wasmplugin", func(ctx SpecContext) {
 			// create httproute
 			var emptyRouteHostnames []string
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, emptyRouteHostnames)
+			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, emptyRouteHostnames)
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -2225,12 +2217,11 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			routeName    = "toystore-route"
 			gwRLPName    = "gw-rlp"
 			routeRLPName = "route-rlp"
-			gwName       = "toystore-gw"
 			gateway      *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(gwName, testNamespace)
+			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -2282,7 +2273,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("Limit key shifts correctly from Gateway RLP default -> Route RLP -> Gateway RLP overrides", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
 			Expect(k8sClient.Create(ctx, httpRoute)).To(Succeed())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
 
@@ -2296,7 +2287,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(gwName),
+						Name:  gatewayapiv1.ObjectName(TestGatewayName),
 					},
 					Defaults: &kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{

--- a/controllers/ratelimitpolicy_status_test.go
+++ b/controllers/ratelimitpolicy_status_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package controllers
 
 import (

--- a/controllers/target_status_controller_test.go
+++ b/controllers/target_status_controller_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		testNamespace = CreateNamespaceWithContext(ctx)
 
 		// create gateway
-		gateway := testBuildBasicGateway(testGatewayName, testNamespace, func(gateway *gatewayapiv1.Gateway) {
+		gateway := testBuildBasicGateway(TestGatewayName, testNamespace, func(gateway *gatewayapiv1.Gateway) {
 			gateway.Spec.Listeners = []gatewayapiv1.Listener{{
 				Name:     gatewayapiv1.SectionName("test-listener-toystore-com"),
 				Hostname: ptr.To(gatewayapiv1.Hostname("*.toystore.com")),
@@ -65,7 +65,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
 
 		// create application
-		route := testBuildBasicHttpRoute(testHTTPRouteName, testGatewayName, testNamespace, []string{"*.toystore.com"})
+		route := testBuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
 		err = k8sClient.Create(ctx, route)
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
@@ -91,7 +91,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		if err != nil {
 			return false
 		}
-		routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+		routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 		if !found {
 			return false
 		}
@@ -105,7 +105,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		if err != nil {
 			return false
 		}
-		routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+		routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 		if !found {
 			return false
 		}
@@ -150,7 +150,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group:     gatewayapiv1.GroupName,
 						Kind:      "HTTPRoute",
-						Name:      testHTTPRouteName,
+						Name:      TestHTTPRouteName,
 						Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 					},
 					Defaults: &v1beta2.AuthPolicyCommonSpec{
@@ -206,7 +206,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool {
 				return policyAcceptedAndTargetsAffected(ctx, routePolicy1)() &&
-					!isAuthPolicyAccepted(ctx, routePolicy2)() && !routeAffected(ctx, testHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy2))
+					!isAuthPolicyAccepted(ctx, routePolicy2)() && !routeAffected(ctx, TestHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy2))
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -224,8 +224,8 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 			Expect(k8sClient.Create(ctx, routePolicy2)).To(Succeed())
 
 			Eventually(func() bool {
-				return !isAuthPolicyAccepted(ctx, routePolicy1)() && routeNotAffected(ctx, testHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy1)) &&
-					!isAuthPolicyAccepted(ctx, routePolicy2)() && !routeAffected(ctx, testHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy2))
+				return !isAuthPolicyAccepted(ctx, routePolicy1)() && routeNotAffected(ctx, TestHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy1)) &&
+					!isAuthPolicyAccepted(ctx, routePolicy2)() && !routeAffected(ctx, TestHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy2))
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -238,11 +238,11 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool { // route is not affected by the policy
 				route := &gatewayapiv1.HTTPRoute{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: testHTTPRouteName, Namespace: testNamespace}, route)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestHTTPRouteName, Namespace: testNamespace}, route)
 				if err != nil {
 					return false
 				}
-				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 				return !found || meta.IsStatusConditionFalse(routeParentStatus.Conditions, policyAffectedCondition)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
@@ -253,12 +253,12 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      testGatewayName,
+					Name:      TestGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
-			Eventually(policyAcceptedAndTargetsAffected(ctx, policy, testHTTPRouteName)).WithContext(ctx).Should(BeTrue())
+			Eventually(policyAcceptedAndTargetsAffected(ctx, policy, TestHTTPRouteName)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
 		It("removes PolicyAffected status condition from the targeted gateway and routes when the policy is deleted", func(ctx SpecContext) {
@@ -267,7 +267,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      testGatewayName,
+					Name:      TestGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
@@ -278,17 +278,17 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool { // gateway and route not affected by the policy
 				gateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, gateway)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, gateway)
 				if err != nil || meta.IsStatusConditionTrue(gateway.Status.Conditions, policyAffectedCondition) {
 					return false
 				}
 
 				route := &gatewayapiv1.HTTPRoute{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Name: testHTTPRouteName, Namespace: testNamespace}, route)
+				err = k8sClient.Get(ctx, client.ObjectKey{Name: TestHTTPRouteName, Namespace: testNamespace}, route)
 				if err != nil {
 					return false
 				}
-				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 				return !found || meta.IsStatusConditionFalse(routeParentStatus.Conditions, policyAffectedCondition)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
@@ -298,8 +298,8 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 			Expect(k8sClient.Create(ctx, routePolicy)).To(Succeed())
 			Eventually(policyAcceptedAndTargetsAffected(ctx, routePolicy)).WithContext(ctx).Should(BeTrue())
 
-			otherRouteName := testHTTPRouteName + "-other"
-			otherRoute := testBuildBasicHttpRoute(otherRouteName, testGatewayName, testNamespace, []string{"other.toystore.com"})
+			otherRouteName := TestHTTPRouteName + "-other"
+			otherRoute := testBuildBasicHttpRoute(otherRouteName, TestGatewayName, testNamespace, []string{"other.toystore.com"})
 			Expect(k8sClient.Create(ctx, otherRoute)).To(Succeed())
 
 			gatewayPolicy := policyFactory(func(policy *v1beta2.AuthPolicy) {
@@ -307,7 +307,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      testGatewayName,
+					Name:      TestGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
@@ -321,7 +321,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			// remove route policy and check if the gateway policy has been rolled out to the status of the newly non-targeted route
 			Expect(k8sClient.Delete(ctx, routePolicy)).To(Succeed())
-			Eventually(policyAcceptedAndTargetsAffected(ctx, gatewayPolicy, otherRouteName, testHTTPRouteName)).WithContext(ctx).Should(BeTrue())
+			Eventually(policyAcceptedAndTargetsAffected(ctx, gatewayPolicy, otherRouteName, TestHTTPRouteName)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 	})
 
@@ -343,7 +343,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "HTTPRoute",
-						Name:  gatewayapiv1.ObjectName(testHTTPRouteName),
+						Name:  gatewayapiv1.ObjectName(TestHTTPRouteName),
 					},
 					Defaults: &v1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]v1beta2.Limit{
@@ -391,11 +391,11 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool { // route is not affected by the policy
 				route := &gatewayapiv1.HTTPRoute{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: testHTTPRouteName, Namespace: testNamespace}, route)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestHTTPRouteName, Namespace: testNamespace}, route)
 				if err != nil {
 					return false
 				}
-				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 				return !found || meta.IsStatusConditionFalse(routeParentStatus.Conditions, policyAffectedCondition)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
@@ -406,12 +406,12 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      testGatewayName,
+					Name:      TestGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
-			Eventually(policyAcceptedAndTargetsAffected(ctx, policy, testHTTPRouteName)).WithContext(ctx).Should(BeTrue())
+			Eventually(policyAcceptedAndTargetsAffected(ctx, policy, TestHTTPRouteName)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
 		It("removes PolicyAffected status condition from the targeted gateway and routes when the policy is deleted", func(ctx SpecContext) {
@@ -420,7 +420,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      testGatewayName,
+					Name:      TestGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
@@ -431,17 +431,17 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool { // gateway and route not affected by the policy
 				gateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, gateway)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, gateway)
 				if err != nil || meta.IsStatusConditionTrue(gateway.Status.Conditions, policyAffectedCondition) {
 					return false
 				}
 
 				route := &gatewayapiv1.HTTPRoute{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Name: testHTTPRouteName, Namespace: testNamespace}, route)
+				err = k8sClient.Get(ctx, client.ObjectKey{Name: TestHTTPRouteName, Namespace: testNamespace}, route)
 				if err != nil {
 					return false
 				}
-				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 				return !found || meta.IsStatusConditionFalse(routeParentStatus.Conditions, policyAffectedCondition)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
@@ -451,8 +451,8 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 			Expect(k8sClient.Create(ctx, routePolicy)).To(Succeed())
 			Eventually(policyAcceptedAndTargetsAffected(ctx, routePolicy)).WithContext(ctx).Should(BeTrue())
 
-			otherRouteName := testHTTPRouteName + "-other"
-			otherRoute := testBuildBasicHttpRoute(otherRouteName, testGatewayName, testNamespace, []string{"other.toystore.com"})
+			otherRouteName := TestHTTPRouteName + "-other"
+			otherRoute := testBuildBasicHttpRoute(otherRouteName, TestGatewayName, testNamespace, []string{"other.toystore.com"})
 			Expect(k8sClient.Create(ctx, otherRoute)).To(Succeed())
 
 			gatewayPolicy := policyFactory(func(policy *v1beta2.RateLimitPolicy) {
@@ -460,7 +460,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      testGatewayName,
+					Name:      TestGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
@@ -474,7 +474,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			// remove route policy and check if the gateway policy has been rolled out to the status of the newly non-targeted route
 			Expect(k8sClient.Delete(ctx, routePolicy)).To(Succeed())
-			Eventually(policyAcceptedAndTargetsAffected(ctx, gatewayPolicy, otherRouteName, testHTTPRouteName)).WithContext(ctx).Should(BeTrue())
+			Eventually(policyAcceptedAndTargetsAffected(ctx, gatewayPolicy, otherRouteName, TestHTTPRouteName)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 	})
 
@@ -483,7 +483,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 		// policyFactory builds a standards DNSPolicy object that targets the test gateway by default, with the given mutate functions applied
 		policyFactory := func(mutateFns ...func(policy *v1alpha1.DNSPolicy)) *v1alpha1.DNSPolicy {
-			policy := v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).WithTargetGateway(testGatewayName).WithRoutingStrategy(v1alpha1.SimpleRoutingStrategy)
+			policy := v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).WithTargetGateway(TestGatewayName).WithRoutingStrategy(v1alpha1.SimpleRoutingStrategy)
 			for _, mutateFn := range mutateFns {
 				mutateFn(policy)
 			}
@@ -499,15 +499,21 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 			return meta.IsStatusConditionTrue(policy.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted))
 		}
 
+		isDNSPolicyEnforced := func(ctx context.Context, policyKey client.ObjectKey) bool {
+			policy := &v1alpha1.DNSPolicy{}
+			err := k8sClient.Get(ctx, policyKey, policy)
+			if err != nil {
+				return false
+			}
+			return meta.IsStatusConditionTrue(policy.Status.Conditions, string(kuadrant.PolicyConditionEnforced))
+		}
+
 		// policyAcceptedAndTargetsAffected returns an assertion function that checks if a DNSPolicy is accepted
 		// and the statuses of its target object has been all updated as affected by the policy
 		policyAcceptedAndTargetsAffected := func(ctx context.Context, policy *v1alpha1.DNSPolicy) func() bool {
 			return func() bool {
 				policyKey := client.ObjectKeyFromObject(policy)
-				if !isDNSPolicyAccepted(ctx, policyKey) {
-					return false
-				}
-				return targetsAffected(ctx, policyKey, policyAffectedCondition, policy.Spec.TargetRef)
+				return isDNSPolicyAccepted(ctx, policyKey) && targetsAffected(ctx, policyKey, policyAffectedCondition, policy.Spec.TargetRef)
 			}
 		}
 
@@ -525,6 +531,8 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		It("adds PolicyAffected status condition to the targeted gateway", func(ctx SpecContext) {
 			policy := policyFactory()
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+			// policy should not be enforced since DNS Record is not ready because of the missing secret on the MZ
+			Eventually(isDNSPolicyEnforced(ctx, client.ObjectKeyFromObject(policy))).ShouldNot(BeTrue())
 			Eventually(policyAcceptedAndTargetsAffected(ctx, policy)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -538,11 +546,11 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool {
 				gateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, gateway)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, gateway)
 				if err != nil {
 					return false
 				}
-				condition := meta.FindStatusCondition(gateway.Status.Conditions, testGatewayName)
+				condition := meta.FindStatusCondition(gateway.Status.Conditions, TestGatewayName)
 				return condition == nil || !strings.Contains(condition.Message, policyKey.String()) || condition.Status == metav1.ConditionFalse
 			})
 		}, testTimeOut)
@@ -556,7 +564,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 		// policyFactory builds a standards TLSPolicy object that targets the test gateway by default, with the given mutate functions applied
 		policyFactory := func(mutateFns ...func(policy *v1alpha1.TLSPolicy)) *v1alpha1.TLSPolicy {
-			policy := v1alpha1.NewTLSPolicy("test-tls-policy", testNamespace).WithTargetGateway(testGatewayName).WithIssuerRef(*issuerRef)
+			policy := v1alpha1.NewTLSPolicy("test-tls-policy", testNamespace).WithTargetGateway(TestGatewayName).WithIssuerRef(*issuerRef)
 			for _, mutateFn := range mutateFns {
 				mutateFn(policy)
 			}
@@ -612,11 +620,11 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool {
 				gateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, gateway)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, gateway)
 				if err != nil {
 					return false
 				}
-				condition := meta.FindStatusCondition(gateway.Status.Conditions, testGatewayName)
+				condition := meta.FindStatusCondition(gateway.Status.Conditions, TestGatewayName)
 				return condition == nil || !strings.Contains(condition.Message, policyKey.String()) || condition.Status == metav1.ConditionFalse
 			})
 		}, testTimeOut)

--- a/controllers/tlspolicy_status_test.go
+++ b/controllers/tlspolicy_status_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package controllers
 
 import (
@@ -28,8 +30,8 @@ func TestTLSPolicyReconciler_enforcedCondition(t *testing.T) {
 		ns              = "default"
 		tlsPolicyName   = "kuadrant-tls-policy"
 		issuerName      = "kuadrant-issuer"
-		gwName          = "kuadrant-gateway"
 		certificateName = "kuadrant-certifcate"
+		gwName          = "kuadrant-gateway"
 	)
 
 	scheme := runtime.NewScheme()

--- a/pkg/library/kuadrant/apimachinery_status_conditions.go
+++ b/pkg/library/kuadrant/apimachinery_status_conditions.go
@@ -107,12 +107,14 @@ func AcceptedCondition(p Policy, err error) *metav1.Condition {
 func EnforcedCondition(policy Policy, err PolicyError, allSubresourcesReady bool) *metav1.Condition {
 	// Enforced
 	message := fmt.Sprintf("%s has been successfully enforced", policy.Kind())
+	status := metav1.ConditionTrue
 	if !allSubresourcesReady {
 		message = fmt.Sprintf("%s has been partially enforced", policy.Kind())
+		status = metav1.ConditionFalse
 	}
 	cond := &metav1.Condition{
 		Type:    string(PolicyConditionEnforced),
-		Status:  metav1.ConditionTrue,
+		Status:  status,
 		Reason:  string(PolicyReasonEnforced),
 		Message: message,
 	}


### PR DESCRIPTION
Now `Enforced` will be false even on partially enforced records. If there are no ready records it will still say  "partially enforced" (which implies it is enforced on some of them which is not true). This will be addressed in #586 
Adding a check to one of the tests to ensure we are not marking policy as `Enforced - True` when the record is not ready. 

Aslo a tinny refactor - moved some vars around for convenience 