### PR TITLE
dnsrecord condition only propagate owned records status

### DIFF
--- a/api/v1alpha1/dnspolicy_types.go
+++ b/api/v1alpha1/dnspolicy_types.go
@@ -133,7 +133,7 @@ type DNSPolicyStatus struct {
 	HealthCheck *HealthCheckStatus `json:"healthCheck,omitempty"`
 
 	// +optional
-	ProbeConditions map[string][]metav1.Condition `json:"probeConditions,omitempty"`
+	RecordConditions map[string][]metav1.Condition `json:"recordConditions,omitempty"`
 }
 
 func (s *DNSPolicyStatus) GetConditions() []metav1.Condition {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -187,8 +187,8 @@ func (in *DNSPolicyStatus) DeepCopyInto(out *DNSPolicyStatus) {
 		*out = new(HealthCheckStatus)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.ProbeConditions != nil {
-		in, out := &in.ProbeConditions, &out.ProbeConditions
+	if in.RecordConditions != nil {
+		in, out := &in.RecordConditions, &out.RecordConditions
 		*out = make(map[string][]v1.Condition, len(*in))
 		for key, val := range *in {
 			var outVal []v1.Condition

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-04-25T14:21:46Z"
+    createdAt: "2024-05-01T08:22:16Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -401,7 +401,7 @@ spec:
                   recorded in the status condition
                 format: int64
                 type: integer
-              probeConditions:
+              recordConditions:
                 additionalProperties:
                   items:
                     description: "Condition contains details for one aspect of the

--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -400,7 +400,7 @@ spec:
                   recorded in the status condition
                 format: int64
                 type: integer
-              probeConditions:
+              recordConditions:
                 additionalProperties:
                   items:
                     description: "Condition contains details for one aspect of the

--- a/controllers/dnspolicy_status_test.go
+++ b/controllers/dnspolicy_status_test.go
@@ -94,7 +94,7 @@ func TestPropagateRecordConditions(t *testing.T) {
 			},
 			PolicyStatus: &v1alpha1.DNSPolicyStatus{},
 			Validate: func(t *testing.T, policyStatus *v1alpha1.DNSPolicyStatus) {
-				if conditions, ok := policyStatus.ProbeConditions[rootHost]; ok {
+				if conditions, ok := policyStatus.RecordConditions[rootHost]; ok {
 					t.Fatalf("expected no probe conditions for root host, found %v", len(conditions))
 				}
 			},
@@ -127,7 +127,7 @@ func TestPropagateRecordConditions(t *testing.T) {
 			},
 			PolicyStatus: &v1alpha1.DNSPolicyStatus{},
 			Validate: func(t *testing.T, policyStatus *v1alpha1.DNSPolicyStatus) {
-				if conditions, ok := policyStatus.ProbeConditions[rootHost]; !ok {
+				if conditions, ok := policyStatus.RecordConditions[rootHost]; !ok {
 					t.Fatalf("expected probe conditions for root host, found none")
 				} else {
 					if len(conditions) != 2 {


### PR DESCRIPTION
All listed records were propagating to all dns policies.

This PR does 2 things:
- rename ProbeConditions to RecordConditions
- only propagates owned DNS Record conditions to the policy.