### PR TITLE
refactor: rate limit policy enforced status controller

### DIFF
--- a/controllers/limitador_status_to_rlp_gateway_event_handler.go
+++ b/controllers/limitador_status_to_rlp_gateway_event_handler.go
@@ -7,7 +7,6 @@ import (
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/util/workqueue"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -15,19 +14,20 @@ import (
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/mappers"
 )
 
-var _ handler.EventHandler = &limitadorStatusEventHandler{}
+var _ handler.EventHandler = &limitadorStatusRLPGatewayEventHandler{}
 
-type limitadorStatusEventHandler struct {
+type limitadorStatusRLPGatewayEventHandler struct {
 	Client client.Client
 	Logger logr.Logger
 }
 
-func (eh limitadorStatusEventHandler) Create(_ context.Context, _ event.CreateEvent, _ workqueue.RateLimitingInterface) {
+func (eh limitadorStatusRLPGatewayEventHandler) Create(_ context.Context, _ event.CreateEvent, _ workqueue.RateLimitingInterface) {
 }
 
-func (eh limitadorStatusEventHandler) Update(ctx context.Context, e event.UpdateEvent, limitingInterface workqueue.RateLimitingInterface) {
+func (eh limitadorStatusRLPGatewayEventHandler) Update(ctx context.Context, e event.UpdateEvent, limitingInterface workqueue.RateLimitingInterface) {
 	oldL := e.ObjectOld.(*limitadorv1alpha1.Limitador)
 	newL := e.ObjectNew.(*limitadorv1alpha1.Limitador)
 
@@ -44,17 +44,17 @@ func (eh limitadorStatusEventHandler) Update(ctx context.Context, e event.Update
 	}
 }
 
-func (eh limitadorStatusEventHandler) Delete(ctx context.Context, e event.DeleteEvent, limitingInterface workqueue.RateLimitingInterface) {
+func (eh limitadorStatusRLPGatewayEventHandler) Delete(ctx context.Context, e event.DeleteEvent, limitingInterface workqueue.RateLimitingInterface) {
 	eh.Logger.V(1).Info("Limitador delete event detected")
 	if !eh.IsKuadrantInstalled(ctx, e.Object) || e.Object.GetName() == common.LimitadorName {
 		eh.enqueue(ctx, limitingInterface)
 	}
 }
 
-func (eh limitadorStatusEventHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.RateLimitingInterface) {
+func (eh limitadorStatusRLPGatewayEventHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.RateLimitingInterface) {
 }
 
-func (eh limitadorStatusEventHandler) IsKuadrantInstalled(ctx context.Context, obj client.Object) bool {
+func (eh limitadorStatusRLPGatewayEventHandler) IsKuadrantInstalled(ctx context.Context, obj client.Object) bool {
 	kuadrantList := &kuadrantv1beta1.KuadrantList{}
 	if err := eh.Client.List(ctx, kuadrantList, &client.ListOptions{Namespace: obj.GetNamespace()}); err != nil {
 		eh.Logger.V(1).Error(err, "failed to list kuadrant in namespace", "namespace", obj.GetNamespace())
@@ -69,16 +69,16 @@ func (eh limitadorStatusEventHandler) IsKuadrantInstalled(ctx context.Context, o
 
 	return true
 }
-func (eh limitadorStatusEventHandler) enqueue(ctx context.Context, limitingInterface workqueue.RateLimitingInterface) {
+func (eh limitadorStatusRLPGatewayEventHandler) enqueue(ctx context.Context, limitingInterface workqueue.RateLimitingInterface) {
 	// List all RLPs as there's been an event from Limitador which may affect RLP status
 	rlpList := &kuadrantv1beta2.RateLimitPolicyList{}
 	if err := eh.Client.List(ctx, rlpList); err != nil {
 		eh.Logger.V(1).Error(err, "failed to list RLPs")
 	}
 	for idx := range rlpList.Items {
-		eh.Logger.V(1).Info("queueing rate limiting policy", "policy", rlpList.Items[idx].Name)
-		limitingInterface.Add(ctrl.Request{
-			NamespacedName: client.ObjectKeyFromObject(&rlpList.Items[idx]),
-		})
+		gwRequests := mappers.NewPolicyToParentGatewaysEventMapper(mappers.WithClient(eh.Client), mappers.WithLogger(eh.Logger)).Map(ctx, &rlpList.Items[idx])
+		for _, gwRequest := range gwRequests {
+			limitingInterface.Add(gwRequest)
+		}
 	}
 }

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,8 +42,6 @@ const rateLimitPolicyFinalizer = "ratelimitpolicy.kuadrant.io/finalizer"
 type RateLimitPolicyReconciler struct {
 	*reconcilers.BaseReconciler
 	TargetRefReconciler reconcilers.TargetRefReconciler
-	// AffectedPolicyMap tracks the affected policies to report their status.
-	AffectedPolicyMap *kuadrant.AffectedPolicyMap
 }
 
 //+kubebuilder:rbac:groups=kuadrant.io,resources=ratelimitpolicies,verbs=get;list;watch;create;update;patch;delete
@@ -232,7 +229,6 @@ func (r *RateLimitPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kuadrantv1beta2.RateLimitPolicy{}).
-		Watches(&limitadorv1alpha1.Limitador{}, limitadorStatusEventHandler{Client: r.Client(), Logger: r.Logger().WithName("limitadorStatusToRLPsEventHandler")}).
 		Watches(
 			&gatewayapiv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {

--- a/controllers/ratelimitpolicy_enforced_status_controller.go
+++ b/controllers/ratelimitpolicy_enforced_status_controller.go
@@ -1,0 +1,228 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/mappers"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/reconcilers"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
+)
+
+type RateLimitPolicyEnforcedStatusReconciler struct {
+	*reconcilers.BaseReconciler
+}
+
+func (r *RateLimitPolicyEnforcedStatusReconciler) Reconcile(eventCtx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := r.Logger().WithValues("gateway", req.NamespacedName, "request id", uuid.NewString())
+	logger.Info("Reconciling policy status")
+	ctx := logr.NewContext(eventCtx, logger)
+
+	gw := &gatewayapiv1.Gateway{}
+	if err := r.Client().Get(ctx, req.NamespacedName, gw); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("no gateway found")
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "failed to get gateway")
+		return ctrl.Result{}, err
+	}
+
+	t, err := BuildTopology(ctx, r.Client(), gw, (&kuadrantv1beta2.RateLimitPolicy{}).Kind(), &kuadrantv1beta2.RateLimitPolicyList{})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	policies := t.PoliciesFromGateway(gw)
+	unTargetedRoutes := len(t.GetUntargetedRoutes(gw))
+
+	sort.Sort(kuadrantgatewayapi.PolicyByTargetRefKindAndCreationTimeStamp(policies))
+
+	for i := range policies {
+		policy := policies[i]
+		p := policy.(*kuadrantv1beta2.RateLimitPolicy)
+		conditions := p.GetStatus().GetConditions()
+
+		// Skip policies if accepted condition is false
+		if meta.IsStatusConditionFalse(policy.GetStatus().GetConditions(), string(gatewayapiv1alpha2.PolicyConditionAccepted)) {
+			continue
+		}
+
+		// Policy has been accepted
+		// Ensure no error on underlying subresource (i.e. Limitador)
+		if cond := r.HasErrCondOnSubResource(ctx, logger, p); cond != nil {
+			if err := r.SetCondition(ctx, logger, p, &conditions, *cond); err != nil {
+				return ctrl.Result{}, err
+			}
+			continue
+		}
+
+		if kuadrantgatewayapi.IsTargetRefGateway(policy.GetTargetRef()) {
+			if p.Spec.Overrides != nil {
+				// Only have this policy and no free routes
+				if len(policies) == 1 && unTargetedRoutes == 0 {
+					if err := r.SetCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, kuadrant.NewErrUnknown(p.Kind(), errors.New("no free routes to enforce policy")), true)); err != nil {
+						return ctrl.Result{}, err
+					}
+					continue
+				}
+
+				// Has free routes or is overriding policies
+				// Set Enforced true condition for this GW policy
+				if err := r.SetCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, nil, true)); err != nil {
+					return ctrl.Result{}, err
+				}
+
+				// Update the rest of the policies as overridden
+				affectedPolices := utils.Filter(policies, func(p kuadrantgatewayapi.Policy) bool {
+					return policy != p && p.GetDeletionTimestamp() == nil
+				})
+
+				for i := range affectedPolices {
+					af := affectedPolices[i]
+					afp := af.(*kuadrantv1beta2.RateLimitPolicy)
+					afConditions := afp.GetStatus().GetConditions()
+
+					if err := r.SetCondition(ctx, logger, afp, &afConditions, *kuadrant.EnforcedCondition(afp, kuadrant.NewErrOverridden(afp.Kind(), []client.ObjectKey{client.ObjectKeyFromObject(p)}), true)); err != nil {
+						return ctrl.Result{}, err
+					}
+				}
+				break
+			}
+			// GW Policy defaults is defined
+			// Only have this policy or no free routes -> nothing to enforce policy
+			if len(policies) == 1 && unTargetedRoutes == 0 {
+				if err := r.SetCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, kuadrant.NewErrUnknown(p.Kind(), errors.New("no free routes to enforce policy")), true)); err != nil {
+					return ctrl.Result{}, err
+				}
+				continue
+			} else if len(policies) > 1 && unTargetedRoutes == 0 {
+				// GW policy defaults are overridden by child policies
+				affectedPolices := utils.Filter(policies, func(p kuadrantgatewayapi.Policy) bool {
+					return policy != p && p.GetDeletionTimestamp() == nil
+				})
+
+				if err := r.SetCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, kuadrant.NewErrOverridden(p.Kind(), utils.Map(affectedPolices, func(p kuadrantgatewayapi.Policy) client.ObjectKey {
+					return client.ObjectKeyFromObject(p)
+				})), true)); err != nil {
+					return ctrl.Result{}, err
+				}
+				continue
+			} else {
+				// Is enforcing default policy on a free route
+				if err := r.SetCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, nil, true)); err != nil {
+					return ctrl.Result{}, err
+				}
+				continue
+			}
+		}
+
+		// Is a Route Policy and has no GW Policy since it's sorted => is enforced
+		if err := r.SetCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, nil, true)); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	logger.Info("Policy status reconciled successfully")
+	return ctrl.Result{}, nil
+}
+
+func (r *RateLimitPolicyEnforcedStatusReconciler) HasErrCondOnSubResource(ctx context.Context, logger logr.Logger, p *kuadrantv1beta2.RateLimitPolicy) *metav1.Condition {
+	limitador, err := GetLimitador(ctx, r.Client(), p)
+	if err != nil {
+		logger.V(1).Error(err, "failed to get limitador")
+		return kuadrant.EnforcedCondition(p, kuadrant.NewErrUnknown(p.Kind(), err), false)
+	}
+	if meta.IsStatusConditionFalse(limitador.Status.Conditions, "Ready") {
+		logger.V(1).Info("Limitador is not ready")
+		return kuadrant.EnforcedCondition(p, kuadrant.NewErrUnknown(p.Kind(), errors.New("limitador is not ready")), false)
+	}
+
+	logger.V(1).Info("limitador is ready and enforcing limits")
+	return nil
+}
+
+func (r *RateLimitPolicyEnforcedStatusReconciler) SetCondition(ctx context.Context, logger logr.Logger, p *kuadrantv1beta2.RateLimitPolicy, conditions *[]metav1.Condition, cond metav1.Condition) error {
+	idx := utils.Index(*conditions, func(c metav1.Condition) bool {
+		return c.Type == cond.Type && c.Status == cond.Status && c.Reason == cond.Reason && c.Message == cond.Message
+	})
+	if idx == -1 {
+		meta.SetStatusCondition(conditions, cond)
+		p.Status.Conditions = *conditions
+		if err := r.Client().Status().Update(ctx, p); err != nil {
+			logger.Error(err, "failed to update policy status")
+			return err
+		}
+		return nil
+	}
+
+	logger.V(1).Info("skipping policy enforced condition status update - already up to date")
+	return nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *RateLimitPolicyEnforcedStatusReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	httpRouteToParentGatewaysEventMapper := mappers.NewHTTPRouteToParentGatewaysEventMapper(
+		mappers.WithLogger(r.Logger().WithName("httpRouteToParentGatewaysEventMapper")),
+	)
+
+	policyToParentGatewaysEventMapper := mappers.NewPolicyToParentGatewaysEventMapper(
+		mappers.WithLogger(r.Logger().WithName("policyToParentGatewaysEventMapper")),
+		mappers.WithClient(r.Client()),
+	)
+
+	limitadorStatusToParentGatewayEventMapper := limitadorStatusRLPGatewayEventHandler{
+		Client: r.Client(),
+		Logger: r.Logger().WithName("limitadorStatusToRLPsEventHandler"),
+	}
+
+	policyStatusChangedPredicate := predicate.Funcs{
+		UpdateFunc: func(ev event.UpdateEvent) bool {
+			oldPolicy, ok := ev.ObjectOld.(kuadrantgatewayapi.Policy)
+			if !ok {
+				return false
+			}
+			newPolicy, ok := ev.ObjectNew.(kuadrantgatewayapi.Policy)
+			if !ok {
+				return false
+			}
+			oldStatus := oldPolicy.GetStatus()
+			newStatus := newPolicy.GetStatus()
+			return !reflect.DeepEqual(oldStatus, newStatus)
+		},
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&gatewayapiv1.Gateway{}).
+		Watches(
+			&gatewayapiv1.HTTPRoute{},
+			handler.EnqueueRequestsFromMapFunc(httpRouteToParentGatewaysEventMapper.Map),
+		).
+		Watches(
+			&kuadrantv1beta2.RateLimitPolicy{},
+			handler.EnqueueRequestsFromMapFunc(policyToParentGatewaysEventMapper.Map),
+			builder.WithPredicates(policyStatusChangedPredicate),
+		).
+		Watches(&limitadorv1alpha1.Limitador{}, limitadorStatusToParentGatewayEventMapper).
+		Complete(r)
+}

--- a/controllers/ratelimitpolicy_status_test.go
+++ b/controllers/ratelimitpolicy_status_test.go
@@ -1,21 +1,19 @@
 package controllers
 
 import (
-	"context"
 	"errors"
-
 	"reflect"
 	"testing"
 
-	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 )
 
 func TestRateLimitPolicyReconciler_calculateStatus(t *testing.T) {
 	type args struct {
-		ctx     context.Context
 		rlp     *kuadrantv1beta2.RateLimitPolicy
 		specErr error
 	}
@@ -62,7 +60,7 @@ func TestRateLimitPolicyReconciler_calculateStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &RateLimitPolicyReconciler{}
-			if got := r.calculateStatus(tt.args.ctx, tt.args.rlp, tt.args.specErr); !reflect.DeepEqual(got, tt.want) {
+			if got := r.calculateStatus(tt.args.rlp, tt.args.specErr); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("calculateStatus() = %v, want %v", got, tt.want)
 			}
 		})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -161,7 +161,6 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	err = (&RateLimitPolicyReconciler{
 		BaseReconciler:      rateLimitPolicyBaseReconciler,
 		TargetRefReconciler: reconcilers.TargetRefReconciler{Client: mgr.GetClient()},
-		AffectedPolicyMap:   kuadrant.NewAffectedPolicyMap(),
 	}).SetupWithManager(mgr)
 
 	Expect(err).NotTo(HaveOccurred())
@@ -248,6 +247,17 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 
 	err = (&TargetStatusReconciler{
 		BaseReconciler: targetStatusBaseReconciler,
+	}).SetupWithManager(mgr)
+
+	Expect(err).NotTo(HaveOccurred())
+
+	policyStatusBaseReconciler := reconcilers.NewBaseReconciler(
+		mgr.GetClient(), mgr.GetScheme(), mgr.GetAPIReader(),
+		log.Log.WithName("ratelimitpolicy").WithName("status"),
+		mgr.GetEventRecorderFor("RateLimitPolicyStatus"),
+	)
+	err = (&RateLimitPolicyEnforcedStatusReconciler{
+		BaseReconciler: policyStatusBaseReconciler,
 	}).SetupWithManager(mgr)
 
 	Expect(err).NotTo(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -154,7 +154,6 @@ func main() {
 	if err = (&controllers.RateLimitPolicyReconciler{
 		TargetRefReconciler: reconcilers.TargetRefReconciler{Client: mgr.GetClient()},
 		BaseReconciler:      rateLimitPolicyBaseReconciler,
-		AffectedPolicyMap:   kuadrant.NewAffectedPolicyMap(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RateLimitPolicy")
 		os.Exit(1)
@@ -251,6 +250,18 @@ func main() {
 		BaseReconciler: targetStatusBaseReconciler,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TargetStatusReconciler")
+		os.Exit(1)
+	}
+
+	policyStatusBaseReconciler := reconcilers.NewBaseReconciler(
+		mgr.GetClient(), mgr.GetScheme(), mgr.GetAPIReader(),
+		log.Log.WithName("ratelimitpolicy").WithName("status"),
+		mgr.GetEventRecorderFor("RateLimitPolicyStatus"),
+	)
+	if err = (&controllers.RateLimitPolicyEnforcedStatusReconciler{
+		BaseReconciler: policyStatusBaseReconciler,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "RateLimitPolicyEnforcedStatusReconciler")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/587

Introduces a new controller for reconciling enforcement status for RLPs as with the default / overrides work, the enforecement status of multiple RLPs need to be calculated from a singular RLP event. 

Superseds https://github.com/Kuadrant/kuadrant-operator/pull/591

* Fixes RLP GW policy status is not updated when Route RLP is deleted and vice versa

# Verification
Code changes are tested with the integration test changes, so passing integration tests should be sufficient.

If you want verify manually:
* Checkout this branch
* Deploy
```
make local-setup
```
* Deploy kuadrant
```
kubectl apply  -f - <<EOF               
---                                     
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
spec: {}
EOF
```
* Deploy toystore
```sh
kubectl apply -f examples/toystore/toystore.yaml
kubectl wait --timeout=300s --for=condition=Available deployment toystore
```

* Create  HTTP Route
```sh
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - method: GET
      path:
        type: PathPrefix
        value: "/toys"
    backendRefs:
    - name: toystore
      port: 80
  - matches: # it has to be a separate HTTPRouteRule so we do not rate limit other endpoints
    - method: POST
      path:
        type: Exact
        value: "/toys"
    backendRefs:
    - name: toystore
      port: 80
EOF
```
* Watch RLP statues 
```
watch -n 0.1 "kubectl get ratelimitpolicy -A -o yaml | yq '.items[].status'"
```
* Create GW RLP with defaults
```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: gw-rlp
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  defaults:
    limits:
      "gateway":
        rates:
        - limit: 5
          duration: 10
          unit: second
EOF
```
* Verify GW Policy is accepted and enforced

![image](https://github.com/Kuadrant/kuadrant-operator/assets/24636860/6c093165-37d8-40be-bc52-79d10d8f6e0c)

* Port forward gateway service
```sh
kubectl port-forward -n istio-system service/istio-ingressgateway-istio 9080:80 2>&1 >/dev/null &
export GATEWAY_URL=localhost:9080
```
* Ensure HTTP Route is rate limit at 5 requests per 10 seconds
```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -X POST | grep -E --color "\b(429)\b|$"; sleep 1; done
```
* Create HTTPRoute RLP with implicit default limits
```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:
    "route":
      rates:
      - limit: 8
        duration: 10
        unit: second
EOF
```
* Verify Route policy is accepted and enforced
* Verify GW policy is accepted and not enforced - overridden by route policy

![image](https://github.com/Kuadrant/kuadrant-operator/assets/24636860/3a4dbddd-f39e-4708-9e3b-bb2f6c4222a7)

* Ensure HTTP Route is rate limted at 8 requests per second (Route RLP defaults takes precedence over gateway defaults) (Note: you might need to port forward the gateway service again)
```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -X POST | grep -E --color "\b(429)\b|$"; sleep 1; done
```
* Delete route RLP
```sh
kubectl delete ratelimitpolicy toystore
```
* Verify GW policy goes back to enforced true

![image](https://github.com/Kuadrant/kuadrant-operator/assets/24636860/a340b652-a117-4c6f-99d6-13685b8749d3)

* Ensure HTTP Route is rate limits at 5 requests per second again (GW RLP defaults)
```sh
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -X POST | grep -E --color "\b(429)\b|$"; sleep 1; done
```