### PR TITLE
Using `PolicyTargetReference` instead of `Selector`

### DIFF
--- a/controllers/rate_limiting_wasmplugin_controller.go
+++ b/controllers/rate_limiting_wasmplugin_controller.go
@@ -113,7 +113,7 @@ func (r *RateLimitingWASMPluginReconciler) desiredRateLimitingWASMPlugin(ctx con
 			Namespace: gw.Namespace,
 		},
 		Spec: istioextensionsv1alpha1.WasmPlugin{
-			Selector:     kuadrantistioutils.WorkloadSelectorFromGateway(ctx, r.Client(), gw),
+			TargetRef:    kuadrantistioutils.PolicyTargetRefFromGateway(gw),
 			Url:          rlptools.WASMFilterImageURL,
 			PluginConfig: nil,
 			// Insert plugin before Istio stats filters and after Istio authorization filters.

--- a/controllers/rate_limiting_wasmplugin_controller_test.go
+++ b/controllers/rate_limiting_wasmplugin_controller_test.go
@@ -129,6 +129,10 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			err = k8sClient.Get(ctx, wasmPluginKey, existingWasmPlugin)
 			// must exist
 			Expect(err).ToNot(HaveOccurred())
+			// has the correct target ref
+			Expect(existingWasmPlugin.Spec.TargetRef.Group).To(Equal("gateway.networking.k8s.io"))
+			Expect(existingWasmPlugin.Spec.TargetRef.Kind).To(Equal("Gateway"))
+			Expect(existingWasmPlugin.Spec.TargetRef.Name).To(Equal(gateway.Name))
 			existingWASMConfig, err := rlptools.WASMPluginFromStruct(existingWasmPlugin.Spec.PluginConfig)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(existingWASMConfig).To(Equal(&wasm.Plugin{

--- a/pkg/istio/utils.go
+++ b/pkg/istio/utils.go
@@ -22,3 +22,11 @@ func WorkloadSelectorFromGateway(ctx context.Context, k8sClient client.Client, g
 		MatchLabels: gatewayWorkloadSelector,
 	}
 }
+
+func PolicyTargetRefFromGateway(gateway *gatewayapiv1.Gateway) *istiocommon.PolicyTargetReference {
+	return &istiocommon.PolicyTargetReference{
+		Group: gatewayapiv1.GroupName,
+		Kind:  "Gateway",
+		Name:  gateway.Name,
+	}
+}

--- a/pkg/istio/utils_test.go
+++ b/pkg/istio/utils_test.go
@@ -105,3 +105,17 @@ func TestWorkloadSelectorFromGatewayMissingHostnameAddress(t *testing.T) {
 		t.Error("should have built the istio workload selector from the gateway labels")
 	}
 }
+
+func TestPolicyTargetRefFromGateway(t *testing.T) {
+	gateway := &gatewayapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "my-ns",
+			Name:      "my-gw",
+		},
+	}
+
+	ref := PolicyTargetRefFromGateway(gateway)
+	if ref == nil || ref.Group != "gateway.networking.k8s.io" || ref.Kind != "Gateway" || ref.Name != "my-gw" {
+		t.Error("should have built the istio policy target reference from the gateway")
+	}
+}


### PR DESCRIPTION
In order to **not** rely on Gateway a̶n̶n̶o̶t̶a̶t̶i̶o̶n̶s̶ labels/selectors, we are now using [PolicyTargetReference](https://istio.io/latest/docs/reference/config/type/workload-selector/#PolicyTargetReference). This fixes the issue when no annotation has been added to the managed gateway (or removed/updated).

**Verification steps**

1. Set up the cluster
```sh
make local-setup
```

2. Remove the deployed gw label
```sh
kubectl -n istio-system label gateway istio-ingressgateway istio-
```

3. Apply Kuadrant CR
```sh
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```

4. Deploy ToyStore API and route the traffic
```sh
kubectl apply -f examples/toystore/toystore.yaml

kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - path:
        type: Exact
        value: "/toy"
      method: GET
    backendRefs:
    - name: toystore
      port: 80
EOF
```

5. Apply a RLP
```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:
    "default":
      rates:
      - limit: 5
        duration: 10
        unit: second
EOF
```

6. Check the envoy config for the wasm shim configuration for the RLP

```sh
kubectl port-forward --namespace istio-system deployment/istio-ingressgateway-istio 15000:15000 &

curl -v "<http://127.0.0.1:15000/config_dump?format=json>" | yq e -P -
```

It should contain
```sh
...
 config:
              name: istio-system.kuadrant-istio-ingressgateway
              vm_config:
                runtime: envoy.wasm.runtime.v8
                code:
                  local:
                    filename: /var/lib/istio/data/81221938ebcbc4550eb35f72aac65d0939d89335832b5a022226fb2526806e9e/9b28356942b98c2a73dd1428403ec45836f956114208dfceb88f8f957e94e45d.wasm
              configuration:
                '@type': type.googleapis.com/google.protobuf.StringValue
                value: '{"failureMode":"deny","rateLimitPolicies":[{"domain":"default/toystore","hostnames":["api.toystore.com"],"name":"default/toystore","rules":[{"conditions":[{"allOf":[{"operator":"eq","selector":"request.url_path","value":"/toy"},{"operator":"eq","selector":"request.method","value":"GET"}]}],"data":[{"static":{"key":"limit.default__37a8eec1","value":"1"}}]}],"service":"kuadrant-rate-limiting-service"}]}'
...
```



