### PR TITLE
Add goimports to the golangci-lint configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
     - unconvert
     - unparam
     - whitespace
+    - goimports
   disable:
     - errcheck
 
@@ -25,3 +26,7 @@ issues:
     - text: "var-naming: don't use leading k in Go names"
       linters:
         - revive
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/kuadrant/kuadrant-operator

--- a/controllers/kuadrant_status.go
+++ b/controllers/kuadrant_status.go
@@ -15,9 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	authorinov1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
-	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 )
 
 const (

--- a/controllers/ratelimitpolicy_status_test.go
+++ b/controllers/ratelimitpolicy_status_test.go
@@ -7,10 +7,11 @@ import (
 	"reflect"
 	"testing"
 
-	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 )
 
 func TestRateLimitPolicyReconciler_calculateStatus(t *testing.T) {

--- a/pkg/istio/mesh_config.go
+++ b/pkg/istio/mesh_config.go
@@ -3,7 +3,6 @@ package istio
 import (
 	"fmt"
 
-	maistrav2 "github.com/kuadrant/kuadrant-operator/api/external/maistra/v2"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 	istiomeshv1alpha1 "istio.io/api/mesh/v1alpha1"
@@ -14,6 +13,8 @@ import (
 	istiov1alpha1 "maistra.io/istio-operator/api/v1alpha1"
 	"maistra.io/istio-operator/pkg/helm"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	maistrav2 "github.com/kuadrant/kuadrant-operator/api/external/maistra/v2"
 )
 
 // The structs below implement the interface defined in pkg/common/mesh_config.go `ConfigWrapper`

--- a/pkg/kuadranttools/limitador_tools.go
+++ b/pkg/kuadranttools/limitador_tools.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kuadrant/kuadrant-operator/api/v1beta1"
 )
 
 func LimitadorMutator(existingObj, desiredObj client.Object) (bool, error) {

--- a/pkg/rlptools/rate_limit_index.go
+++ b/pkg/rlptools/rate_limit_index.go
@@ -6,9 +6,10 @@ import (
 	"strings"
 
 	"github.com/elliotchance/orderedmap/v2"
-	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
 
 type RateLimitIndexKey = client.ObjectKey


### PR DESCRIPTION
Closes: #426 

This enforces ordering of imports to standard library packages, third party library packages, kuadrant-operator packages.

The problem I have is when the checks fail the message is cryptic but running `golangci-lint run --fix` locally will fix any of the issues around the goimports. 