### PR TITLE
disable HTTPRoute indexer when CRDs not present

### DIFF
--- a/controllers/rate_limiting_wasmplugin_controller.go
+++ b/controllers/rate_limiting_wasmplugin_controller.go
@@ -343,6 +343,16 @@ func (r *RateLimitingWASMPluginReconciler) routeFromRLP(ctx context.Context, t *
 // to prevent creating the same index field multiple times, the function is declared private to be
 // called only by this controller
 func addHTTPRouteByGatewayIndexer(mgr ctrl.Manager, baseLogger logr.Logger) error {
+	ok, err := kuadrantgatewayapi.IsGatewayAPIInstalled(mgr.GetRESTMapper())
+	if err != nil {
+		return nil
+	}
+
+	if !ok {
+		baseLogger.Info("GatewayAPI CRDs not found. Disabling HTTPRoute indexer")
+		return nil
+	}
+
 	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &gatewayapiv1.HTTPRoute{}, HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
 		// grab the route object, extract the parents
 		route, assertionOk := rawObj.(*gatewayapiv1.HTTPRoute)

--- a/pkg/library/gatewayapi/utils.go
+++ b/pkg/library/gatewayapi/utils.go
@@ -8,6 +8,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -147,4 +148,21 @@ func FilterValidSubdomains(domains, subdomains []gatewayapiv1.Hostname) []gatewa
 		}
 	}
 	return arr
+}
+
+func IsGatewayAPIInstalled(restMapper meta.RESTMapper) (bool, error) {
+	_, err := restMapper.RESTMapping(
+		schema.GroupKind{Group: gatewayapiv1.GroupName, Kind: "HTTPRoute"},
+		gatewayapiv1.SchemeGroupVersion.Version,
+	)
+
+	if err == nil {
+		return true, nil
+	}
+
+	if meta.IsNoMatchError(err) {
+		return false, nil
+	}
+
+	return false, err
 }


### PR DESCRIPTION
`mgr.GetFieldIndexer().IndexField()` returns error when HTTPRoute CRD not present, hence the operator dies when the GatewayAPI CRDS not installed in the cluster. 

While this is reasonable, it is causing failure on OLM catalog release tests. This should not be backported to `main`.