### PR TITLE
add istio and gatewayapi olm.gvk as deps

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-05-01T08:31:48Z"
+    createdAt: "2024-05-07T08:39:55Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -15,3 +15,28 @@ dependencies:
     value:
       packageName: cert-manager
       version: "1.14.2"
+  - type: olm.gvk
+    value:
+      group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      version: v1
+  - type: olm.gvk
+    value:
+      group: gateway.networking.k8s.io
+      kind: Gateway
+      version: v1
+  - type: olm.gvk
+    value:
+      group: extensions.istio.io
+      kind: WasmPlugin
+      version: v1alpha1
+  - type: olm.gvk
+    value:
+      group: networking.istio.io
+      kind: EnvoyFilter
+      version: v1alpha3
+  - type: olm.gvk
+    value:
+      group: security.istio.io
+      kind: AuthorizationPolicy
+      version: v1beta1

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -6,4 +6,6 @@ spec:
   sourceType: grpc
   image: quay.io/kuadrant/kuadrant-operator-catalog:latest
   displayName: Kuadrant Operators
+  grpcPodConfig:
+    securityContextConfig: restricted
   publisher: grpc

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -12,6 +12,8 @@ $(CATALOG_DOCKERFILE): $(OPM)
 	cd $(PROJECT_PATH)/catalog && $(OPM) generate dockerfile kuadrant-operator-catalog
 catalog-dockerfile: $(CATALOG_DOCKERFILE) ## Generate catalog dockerfile.
 
+CHANNELS ?= preview
+
 $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo "************************************************************"
 	@echo Build kuadrant operator catalog
@@ -22,6 +24,7 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo AUTHORINO_OPERATOR_BUNDLE_IMG  = $(AUTHORINO_OPERATOR_BUNDLE_IMG)
 	@echo DNS_OPERATOR_BUNDLE_IMG  		 = $(DNS_OPERATOR_BUNDLE_IMG)
 	@echo CHANNELS  					 = $(CHANNELS)
+	@echo CATALOG_FILE                   = $@
 	@echo "************************************************************"
 	@echo
 	@echo Please check this matches your expectations and override variables if needed.

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -4,11 +4,6 @@
 
 set -euo pipefail
 
-### CONSTANTS
-# Used as well in the subscription object
-DEFAULT_CHANNEL=preview
-###
-
 OPM="${1?:Error \$OPM not set. Bye}"
 YQ="${2?:Error \$YQ not set. Bye}"
 BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
@@ -16,7 +11,7 @@ REPLACES_VERSION="${4?:Error \$REPLACES_VERSION not set. Bye}"
 LIMITADOR_OPERATOR_BUNDLE_IMG="${5?:Error \$LIMITADOR_OPERATOR_BUNDLE_IMG not set. Bye}"
 AUTHORINO_OPERATOR_BUNDLE_IMG="${6?:Error \$AUTHORINO_OPERATOR_BUNDLE_IMG not set. Bye}"
 DNS_OPERATOR_BUNDLE_IMG="${7?:Error \$DNS_OPERATOR_BUNDLE_IMG not set. Bye}"
-CHANNELS="${8:-$DEFAULT_CHANNEL}"
+CHANNELS="${8?:Error \$CHANNELS not set. Bye}"
 CATALOG_FILE="${9?:Error \$CATALOG_FILE not set. Bye}"
 
 CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE})" )" && pwd )"


### PR DESCRIPTION
### What

Add Istio and GatewayAPI CRDs as required dependency to have the kuadrant operator installed

### Verification Steps

* Build custom bundle https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/development.md#build-kuadrant-operator-bundle-image
```
# manifests
make bundle VERSION=0.8.0

# bundle image
make bundle-build BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:my-bundle

# push bundle image
make bundle-push BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:my-bundle
```
* Build custom catalog https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/development.md#build-custom-catalog

````
make catalog BUNDLE_IMG=quay.io/kuadrant/kuadrant-operator-bundle:my-bundle
make catalog-build CATALOG_IMG=quay.io/kuadrant/kuadrant-operator-catalog:my-catalog
make catalog-push CATALOG_IMG=quay.io/kuadrant/kuadrant-operator-catalog:my-catalog
````

* Create kind cluster
```
make kind-create-cluster
```
* Deploy OLM system
```
make install-olm
```
* Deploy kuadrant operator using OLM. Since the Istio and GatewayAPI are not installed, the operation should fail.
```
make deploy-catalog CATALOG_IMG=quay.io/kuadrant/kuadrant-operator-catalog:my-catalog
```
The subscription status eventually reports `constraints not satisfiable`
```
kubectl get subscriptions kuadrant -n kuadrant-system -o jsonpath='{.status.conditions}' | yq e -P
```
Condition type `ResolutionFailed` should report that GatewayAPI or Istio API is required.
```yaml
- message: 'constraints not satisfiable: subscription kuadrant exists, bundle kuadrant-operator.v0.8.0 requires an operator providing an API with group: security.istio.io, version: v1beta1, kind: AuthorizationPolicy, subscription kuadrant requires kuadrant-operator-catalog/kuadrant-system/preview/kuadrant-operator.v0.8.0'
  reason: ConstraintsNotSatisfiable
  status: "True"
  type: ResolutionFailed
```
*let's install Gateway API

```
make gateway-api-install
```
* Let's install Istio
```
make istio-install
```

* Remove the subscription and create again
```
kubectl delete subscriptions kuadrant -n kuadrant-system
```
deploy the operator
```
make deploy-catalog CATALOG_IMG=quay.io/kuadrant/kuadrant-operator-catalog:my-catalog
```
```
kubectl get subscriptions kuadrant -n kuadrant-system -o jsonpath='{.status.conditions}' | yq e -P
```