### PR TITLE
Fixing broken hyperlinks in user guides

### DIFF
--- a/doc/user-guides/secure-protect-connect.md
+++ b/doc/user-guides/secure-protect-connect.md
@@ -10,28 +10,28 @@ In this guide, we will cover the different policies from Kuadrant and how you ca
 
 Here are the steps we will go through:
 
-1) [Deploy a sample application](#-deploy-the-example-app-we-will-serve-via-our-gateway)
+1) [Deploy a sample application](#deploy-the-example-app-we-will-serve-via-our-gateway)
 
 
-2) [Define a new Gateway](#-define-a-new-istio-managed-gateway)
+2) [Define a new Gateway](#define-a-new-istio-managed-gateway)
 
 
-3) [Ensure TLS-based secure connectivity to the gateway with a TLSPolicy](#-define-the-tlspolicy)
+3) [Ensure TLS-based secure connectivity to the gateway with a TLSPolicy](#define-the-tlspolicy)
 
 
-4) [Define a default RateLimitPolicy to set some infrastructure limits on your gateway](#-define-infrastructure-rate-limiting)
+4) [Define a default RateLimitPolicy to set some infrastructure limits on your gateway](#define-infrastructure-rate-limiting)
 
 
-5) [Define a default AuthPolicy to deny all access to the gateway](#-define-the-gateway-authpolicy)
+5) [Define a default AuthPolicy to deny all access to the gateway](#define-the-gateway-authpolicy)
 
 
-6) [Define a DNSPolicy to bring traffic to the gateway](#-define-the-dnspolicy)
+6) [Define a DNSPolicy to bring traffic to the gateway](#define-the-dnspolicy)
 
 
-7) [Override the Gateway's deny-all AuthPolicy with an endpoint-specific policy](#-override-the-gateways-deny-all-authpolicy)
+7) [Override the Gateway's deny-all AuthPolicy with an endpoint-specific policy](#override-the-gateways-deny-all-authpolicy)
 
 
-8) [Override the Gateway rate limits with an endpoint-specific policy](#-override-the-gateways-ratelimitpolicy)
+8) [Override the Gateway rate limits with an endpoint-specific policy](#override-the-gateways-ratelimitpolicy)
 
 
 You will need to set the `KUBECTL_CONTEXT` environment variable for the kubectl context of the cluster you are targeting.


### PR DESCRIPTION
**What**
Currently the hyperlinks listed in the secure, protect and connect user guide do not work due to an additional `-` character in the url
