### PR TITLE
fix: isAuthPolicyEnforcedCondition failing in eventually

### DIFF
--- a/controllers/authpolicy_controller_test.go
+++ b/controllers/authpolicy_controller_test.go
@@ -2044,18 +2044,20 @@ func isAuthPolicyEnforced(ctx context.Context, policy *api.AuthPolicy) func() bo
 	return isAuthPolicyConditionTrue(ctx, policy, string(kuadrant.PolicyConditionEnforced))
 }
 
-func isAuthPolicyEnforcedCondition(ctx context.Context, key client.ObjectKey, reason gatewayapiv1alpha2.PolicyConditionReason, message string) bool {
-	p := &api.AuthPolicy{}
-	if err := k8sClient.Get(ctx, key, p); err != nil {
-		return false
-	}
+func isAuthPolicyEnforcedCondition(ctx context.Context, key client.ObjectKey, reason gatewayapiv1alpha2.PolicyConditionReason, message string) func() bool {
+	return func() bool {
+		p := &api.AuthPolicy{}
+		if err := k8sClient.Get(ctx, key, p); err != nil {
+			return false
+		}
 
-	cond := meta.FindStatusCondition(p.Status.Conditions, string(kuadrant.PolicyConditionEnforced))
-	if cond == nil {
-		return false
-	}
+		cond := meta.FindStatusCondition(p.Status.Conditions, string(kuadrant.PolicyConditionEnforced))
+		if cond == nil {
+			return false
+		}
 
-	return cond.Reason == string(reason) && cond.Message == message
+		return cond.Reason == string(reason) && cond.Message == message
+	}
 }
 
 func isAuthPolicyConditionTrue(ctx context.Context, policy *api.AuthPolicy, condition string) func() bool {


### PR DESCRIPTION
# Description
The test "Route and Gateway AuthPolicies exist. Gateway AuthPolicy updated to remove overrides." is flaky since `isAuthPolicyEnforcedCondition` previously was not a function that can be executed continuously in an `Eventually` block so sometimes the AuthPolicy may not be enforced by the time the condition is checked. 

Since previously it was only checked once, it will always timeout even if the AuthPolicy eventually transitions to the expected status condition. Changing the function to return `func() bool` should fix this.

Test failing in pipeline example:
- https://github.com/Kuadrant/kuadrant-operator/actions/runs/8940795775/job/24559692965