### PR TITLE
Add observability target

### DIFF
--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -82,6 +82,7 @@ KUADRANT_GATEWAY_API_KUSTOMIZATION="${KUADRANT_REPO}/config/dependencies/gateway
 KUADRANT_ISTIO_KUSTOMIZATION="${KUADRANT_REPO}/config/dependencies/istio/sail?ref=${KUADRANT_REF}"
 KUADRANT_CERT_MANAGER_KUSTOMIZATION="${KUADRANT_REPO}/config/dependencies/cert-manager?ref=${KUADRANT_REF}"
 KUADRANT_METALLB_KUSTOMIZATION="${KUADRANT_REPO}/config/metallb?ref=${KUADRANT_REF}"
+KUADARNT_OBSERVABILITY_KUSTOMIZATION="${KUADRANT_REPO}/config/observability?ref=${KUADRANT_REF}"
 MGC_REPO="github.com/${KUADRANT_ORG}/multicluster-gateway-controller.git"
 MGC_ISTIO_KUSTOMIZATION="${MGC_REPO}/config/istio?ref=${MGC_REF}"
 
@@ -501,6 +502,12 @@ fi
 info "Deploying Kuadrant sample configuration..."
 kubectl -n ${KUADRANT_NAMESPACE} apply -f ${KUADRANT_REPO_RAW}/config/samples/kuadrant_v1beta1_kuadrant.yaml
 success "Kuadrant sample configuration deployed."
+
+# Install observability stack
+info "Installing observability stack in ${KUADRANT_CLUSTER_NAME}..."
+kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | docker run --rm -i ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
+kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | docker run --rm -i ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -
+success "observability stack installed successfully."
 
 info "✨🌟 Setup Complete! Your Kuadrant Quick Start environment has been successfully created. 🌟✨"
 

--- a/make/observability.mk
+++ b/make/observability.mk
@@ -1,0 +1,5 @@
+
+.PHONY: deploy-observability
+deploy-observability: kustomize
+	$(KUSTOMIZE) build config/observability | docker run --rm -i ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
+	$(KUSTOMIZE) build config/observability | docker run --rm -i ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -


### PR DESCRIPTION
To verify, run the `quickstart-setup.sh` script and verify the observability stack comes up correctly (can access grafana, and the gateway api dashboards show data)

There is also a new make target `deploy-observability`.
To verify this, run `make local-cluster-setup` followed by `make deploy-observability`, and check the the observability stack as above.