### PR TITLE
Return early if the AuthPolicy being filtered is marked for deletion

### DIFF
--- a/controllers/authpolicy_authconfig.go
+++ b/controllers/authpolicy_authconfig.go
@@ -203,9 +203,13 @@ func routeGatewayAuthOverrides(t *kuadrantgatewayapi.Topology, ap *api.AuthPolic
 	// 1. targets a gateway
 	// 2. is not the current AP that is being assessed
 	// 3. is an overriding policy
+	// 4. is not marked for deletion
 	affectedPolicies = utils.Filter(affectedPolicies, func(policy kuadrantgatewayapi.Policy) bool {
 		p, ok := policy.(*api.AuthPolicy)
 		if !ok {
+			return false
+		}
+		if p.DeletionTimestamp != nil {
 			return false
 		}
 		return kuadrantgatewayapi.IsTargetRefGateway(policy.GetTargetRef()) &&

--- a/controllers/authpolicy_authconfig.go
+++ b/controllers/authpolicy_authconfig.go
@@ -206,14 +206,11 @@ func routeGatewayAuthOverrides(t *kuadrantgatewayapi.Topology, ap *api.AuthPolic
 	// 4. is not marked for deletion
 	affectedPolicies = utils.Filter(affectedPolicies, func(policy kuadrantgatewayapi.Policy) bool {
 		p, ok := policy.(*api.AuthPolicy)
-		if !ok {
-			return false
-		}
-		if p.DeletionTimestamp != nil {
-			return false
-		}
-		return kuadrantgatewayapi.IsTargetRefGateway(policy.GetTargetRef()) &&
-			ap.GetUID() != policy.GetUID() && p.IsAtomicOverride()
+		return ok &&
+			p.DeletionTimestamp == nil &&
+			kuadrantgatewayapi.IsTargetRefGateway(policy.GetTargetRef()) &&
+			ap.GetUID() != policy.GetUID() &&
+			p.IsAtomicOverride()
 	})
 
 	return utils.Map(affectedPolicies, func(policy kuadrantgatewayapi.Policy) client.ObjectKey {


### PR DESCRIPTION
Improves filter function and returns early when searching for AuthPolicies attached to the Gateway. 