### PR TITLE
Add thanos to hub quickstart cluster & remote write from all clusters

### DIFF
--- a/config/observability/grafana_datasources.yaml
+++ b/config/observability/grafana_datasources.yaml
@@ -4,10 +4,10 @@
         {
             "access": "proxy",
             "editable": false,
-            "name": "prometheus",
+            "name": "Kuadrant-Thanos-Hub",
             "orgId": 1,
             "type": "prometheus",
-            "url": "http://prometheus-k8s.monitoring.svc:9090",
+            "url": "http://thanos-query.monitoring.svc:9090",
             "version": 1
         }
     ]

--- a/config/thanos/kustomization.yaml
+++ b/config/thanos/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+resources:
+  - ./namespace.yaml
+  - ./manifests/thanos-query-deployment.yaml
+  - ./manifests/thanos-query-service.yaml
+  - ./manifests/thanos-query-serviceAccount.yaml
+  - ./manifests/thanos-receive-ingestor-default-service.yaml
+  - ./manifests/thanos-receive-ingestor-default-statefulSet.yaml
+  - ./manifests/thanos-receive-ingestor-serviceAccount.yaml
+  - ./manifests/thanos-receive-router-configmap.yaml
+  - ./manifests/thanos-receive-router-deployment.yaml
+  - ./manifests/thanos-receive-router-service.yaml
+  - ./manifests/thanos-receive-router-serviceAccount.yaml
+  - ./thanos-receive-router-service-loadbalancer.yaml

--- a/config/thanos/manifests/thanos-query-deployment.yaml
+++ b/config/thanos/manifests/thanos-query-deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/version: v0.29.0
+  name: thanos-query
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: thanos-query
+      app.kubernetes.io/name: thanos-query
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: thanos-query
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/version: v0.29.0
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-query
+              namespaces:
+              - monitoring
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      containers:
+      - args:
+        - query
+        - --grpc-address=0.0.0.0:10901
+        - --http-address=0.0.0.0:9090
+        - --log.level=info
+        - --log.format=logfmt
+        - --query.replica-label=prometheus_replica
+        - --query.replica-label=rule_replica
+        - --endpoint=dnssrv+_grpc._tcp.thanos-receive-ingestor-default.monitoring.svc.cluster.local:10901
+        - --query.auto-downsampling
+        env:
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: quay.io/thanos/thanos:v0.29.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 4
+          httpGet:
+            path: /-/healthy
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 30
+        name: thanos-query
+        ports:
+        - containerPort: 10901
+          name: grpc
+        - containerPort: 9090
+          name: http
+        readinessProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 5
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: thanos-query
+      terminationGracePeriodSeconds: 120

--- a/config/thanos/manifests/thanos-query-service.yaml
+++ b/config/thanos/manifests/thanos-query-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/version: v0.29.0
+  name: thanos-query
+  namespace: monitoring
+spec:
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: 10901
+  - name: http
+    port: 9090
+    targetPort: 9090
+  selector:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query

--- a/config/thanos/manifests/thanos-query-serviceAccount.yaml
+++ b/config/thanos/manifests/thanos-query-serviceAccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/version: v0.29.0
+  name: thanos-query
+  namespace: monitoring

--- a/config/thanos/manifests/thanos-query-serviceMonitor.yaml
+++ b/config/thanos/manifests/thanos-query-serviceMonitor.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: query-layer
+    app.kubernetes.io/instance: thanos-query
+    app.kubernetes.io/name: thanos-query
+    app.kubernetes.io/version: v0.29.0
+  name: thanos-query
+  namespace: monitoring
+spec:
+  endpoints:
+  - port: http
+    relabelings:
+    - action: replace
+      separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: query-layer
+      app.kubernetes.io/instance: thanos-query
+      app.kubernetes.io/name: thanos-query

--- a/config/thanos/manifests/thanos-receive-ingestor-default-service.yaml
+++ b/config/thanos/manifests/thanos-receive-ingestor-default-service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: database-write-hashring
+    app.kubernetes.io/instance: thanos-receive-ingestor-default
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.29.0
+    controller.receive.thanos.io/hashring: default
+  name: thanos-receive-ingestor-default
+  namespace: monitoring
+spec:
+  clusterIP: None
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: 10901
+  - name: http
+    port: 10902
+    targetPort: 10902
+  - name: remote-write
+    port: 19291
+    targetPort: 19291
+  selector:
+    app.kubernetes.io/component: database-write-hashring
+    app.kubernetes.io/instance: thanos-receive-ingestor-default
+    app.kubernetes.io/name: thanos-receive
+    controller.receive.thanos.io/hashring: default

--- a/config/thanos/manifests/thanos-receive-ingestor-default-statefulSet.yaml
+++ b/config/thanos/manifests/thanos-receive-ingestor-default-statefulSet.yaml
@@ -1,0 +1,149 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/component: database-write-hashring
+    app.kubernetes.io/instance: thanos-receive-ingestor-default
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.29.0
+    controller.receive.thanos.io: thanos-receive-controller
+    controller.receive.thanos.io/hashring: default
+  name: thanos-receive-ingestor-default
+  namespace: monitoring
+spec:
+  minReadySeconds: 0
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database-write-hashring
+      app.kubernetes.io/instance: thanos-receive-ingestor-default
+      app.kubernetes.io/name: thanos-receive
+      controller.receive.thanos.io/hashring: default
+  serviceName: thanos-receive-ingestor-default
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-write-hashring
+        app.kubernetes.io/instance: thanos-receive-ingestor-default
+        app.kubernetes.io/name: thanos-receive
+        app.kubernetes.io/version: v0.29.0
+        controller.receive.thanos.io/hashring: default
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-receive
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-receive-ingestor-default
+              namespaces:
+              - monitoring
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - thanos-receive
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - thanos-receive-ingestor-default
+              namespaces:
+              - monitoring
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+      containers:
+      - args:
+        - receive
+        - --log.level=info
+        - --log.format=logfmt
+        - --grpc-address=0.0.0.0:10901
+        - --http-address=0.0.0.0:10902
+        - --remote-write.address=0.0.0.0:19291
+        - --receive.replication-factor=1
+        - --tsdb.path=/var/thanos/receive
+        - --tsdb.retention=15d
+        - --label=replica="$(NAME)"
+        - --label=receive="true"
+        - --receive.local-endpoint=$(NAME).thanos-receive-ingestor-default.$(NAMESPACE).svc.cluster.local:10901
+        - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
+        env:
+        - name: NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: quay.io/thanos/thanos:v0.29.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 30
+        name: thanos-receive
+        ports:
+        - containerPort: 10901
+          name: grpc
+        - containerPort: 10902
+          name: http
+        - containerPort: 19291
+          name: remote-write
+        readinessProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /-/ready
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 5
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/thanos/receive
+          name: data
+          readOnly: false
+        - mountPath: /var/lib/thanos-receive
+          name: hashring-config
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: thanos-receive-ingestor
+      terminationGracePeriodSeconds: 900
+      volumes:
+      - configMap:
+          name: hashring-config
+        name: hashring-config
+  volumeClaimTemplates:
+  - metadata:
+      labels:
+        app.kubernetes.io/component: database-write-hashring
+        app.kubernetes.io/instance: thanos-receive-ingestor-default
+        app.kubernetes.io/name: thanos-receive
+        controller.receive.thanos.io/hashring: default
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/config/thanos/manifests/thanos-receive-ingestor-serviceAccount.yaml
+++ b/config/thanos/manifests/thanos-receive-ingestor-serviceAccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: database-write-hashring
+    app.kubernetes.io/instance: thanos-receive-ingestor
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.29.0
+  name: thanos-receive-ingestor
+  namespace: monitoring

--- a/config/thanos/manifests/thanos-receive-ingestor-serviceMonitor.yaml
+++ b/config/thanos/manifests/thanos-receive-ingestor-serviceMonitor.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/component: database-write-hashring
+    app.kubernetes.io/instance: thanos-receive-ingestor
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.29.0
+  name: thanos-receive-ingestor
+  namespace: monitoring
+spec:
+  endpoints:
+  - port: http
+    relabelings:
+    - action: replace
+      separator: /
+      sourceLabels:
+      - namespace
+      - pod
+      targetLabel: instance
+    - action: replace
+      sourceLabels:
+      - __meta_kubernetes_service_label_controller_receive_thanos_io_shard
+      targetLabel: hashring
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: database-write-hashring
+      app.kubernetes.io/name: thanos-receive

--- a/config/thanos/manifests/thanos-receive-router-configmap.yaml
+++ b/config/thanos/manifests/thanos-receive-router-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  hashrings.json: '[{"endpoints": ["thanos-receive-ingestor-default-0.thanos-receive-ingestor-default.monitoring.svc.cluster.local:10901"], "hashring": "default", "tenants": [ ]}]'
+kind: ConfigMap
+metadata:
+  name: hashring-config
+  namespace: monitoring

--- a/config/thanos/manifests/thanos-receive-router-deployment.yaml
+++ b/config/thanos/manifests/thanos-receive-router-deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: thanos-receive-router
+    app.kubernetes.io/instance: thanos-receive
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.29.0
+  name: thanos-receive-router
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: thanos-receive-router
+      app.kubernetes.io/instance: thanos-receive
+      app.kubernetes.io/name: thanos-receive
+      app.kubernetes.io/version: v0.29.0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: thanos-receive-router
+        app.kubernetes.io/instance: thanos-receive
+        app.kubernetes.io/name: thanos-receive
+        app.kubernetes.io/version: v0.29.0
+    spec:
+      containers:
+      - args:
+        - receive
+        - --log.level=info
+        - --log.format=logfmt
+        - --grpc-address=0.0.0.0:10901
+        - --http-address=0.0.0.0:10902
+        - --remote-write.address=0.0.0.0:19291
+        - --receive.replication-factor=1
+        - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
+        - --label=replica="$(NAME)"
+        - --label=receive="true"
+        env:
+        - name: NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: quay.io/thanos/thanos:v0.29.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /-/healthy
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 30
+        name: thanos-receive
+        ports:
+        - containerPort: 10901
+          name: grpc
+        - containerPort: 10902
+          name: http
+        - containerPort: 19291
+          name: remote-write
+        readinessProbe:
+          failureThreshold: 20
+          httpGet:
+            path: /-/ready
+            port: 10902
+            scheme: HTTP
+          periodSeconds: 5
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/lib/thanos-receive
+          name: hashring-config
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+      serviceAccountName: thanos-receive-router
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          name: hashring-config
+        name: hashring-config

--- a/config/thanos/manifests/thanos-receive-router-service.yaml
+++ b/config/thanos/manifests/thanos-receive-router-service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: thanos-receive-router
+    app.kubernetes.io/instance: thanos-receive
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.29.0
+  name: thanos-receive-router
+  namespace: monitoring
+spec:
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: 10901
+  - name: http
+    port: 10902
+    targetPort: 10902
+  - name: remote-write
+    port: 19291
+    targetPort: 19291
+  selector:
+    app.kubernetes.io/component: thanos-receive-router
+    app.kubernetes.io/instance: thanos-receive
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.29.0

--- a/config/thanos/manifests/thanos-receive-router-serviceAccount.yaml
+++ b/config/thanos/manifests/thanos-receive-router-serviceAccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/component: thanos-receive-router
+    app.kubernetes.io/instance: thanos-receive
+    app.kubernetes.io/name: thanos-receive
+    app.kubernetes.io/version: v0.29.0
+  name: thanos-receive-router
+  namespace: monitoring

--- a/config/thanos/namespace.yaml
+++ b/config/thanos/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring

--- a/config/thanos/thanos-receive-router-service-loadbalancer.yaml
+++ b/config/thanos/thanos-receive-router-service-loadbalancer.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: thanos-receive-router
+    app.kubernetes.io/instance: thanos-receive
+    app.kubernetes.io/name: thanos-receive
+  name: thanos-receive-router-lb
+  namespace: monitoring
+spec:
+  type: LoadBalancer
+  ports:
+  - name: grpc
+    port: 10901
+    targetPort: 10901
+  - name: http
+    port: 10902
+    targetPort: 10902
+  - name: remote-write
+    port: 19291
+    targetPort: 19291
+  selector:
+    app.kubernetes.io/component: thanos-receive-router
+    app.kubernetes.io/instance: thanos-receive
+    app.kubernetes.io/name: thanos-receive

--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -515,8 +515,8 @@ fi
 
 # Install observability stack
 info "Installing observability stack in ${KUADRANT_CLUSTER_NAME}..."
-kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | docker run --rm -i ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
-kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | docker run --rm -i ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -
+kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | $CONTAINER_RUNTIME_BIN run --rm -i ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
+kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | $CONTAINER_RUNTIME_BIN run --rm -i ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -
 kubectl kustomize ${KUADRANT_DASHBOARDS_KUSTOMIZATION} | kubectl apply --server-side -f -
 success "observability stack installed successfully."
 

--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -82,6 +82,7 @@ KUADRANT_GATEWAY_API_KUSTOMIZATION="${KUADRANT_REPO}/config/dependencies/gateway
 KUADRANT_ISTIO_KUSTOMIZATION="${KUADRANT_REPO}/config/dependencies/istio/sail?ref=${KUADRANT_REF}"
 KUADRANT_CERT_MANAGER_KUSTOMIZATION="${KUADRANT_REPO}/config/dependencies/cert-manager?ref=${KUADRANT_REF}"
 KUADRANT_METALLB_KUSTOMIZATION="${KUADRANT_REPO}/config/metallb?ref=${KUADRANT_REF}"
+KUADARNT_THANOS_KUSTOMIZATION="${KUADRANT_REPO}/config/thanos?ref=${KUADRANT_REF}"
 KUADARNT_OBSERVABILITY_KUSTOMIZATION="${KUADRANT_REPO}/config/observability?ref=${KUADRANT_REF}"
 KUADRANT_DASHBOARDS_KUSTOMIZATION="${KUADRANT_REPO}/examples/dashboards?ref=${KUADRANT_REF}"
 MGC_REPO="github.com/${KUADRANT_ORG}/multicluster-gateway-controller.git"
@@ -90,7 +91,8 @@ MGC_ISTIO_KUSTOMIZATION="${MGC_REPO}/config/istio?ref=${MGC_REF}"
 # Make temporary directory
 mkdir -p ${TMP_DIR}
 
-KUADRANT_CLUSTER_NAME=kuadrant-local
+KUADRANT_CLUSTER_NAME_BASE=kuadrant-local
+KUADRANT_CLUSTER_NAME="${KUADRANT_CLUSTER_NAME_BASE}"
 KUADRANT_NAMESPACE=kuadrant-system
 
 info() {
@@ -504,12 +506,25 @@ info "Deploying Kuadrant sample configuration..."
 kubectl -n ${KUADRANT_NAMESPACE} apply -f ${KUADRANT_REPO_RAW}/config/samples/kuadrant_v1beta1_kuadrant.yaml
 success "Kuadrant sample configuration deployed."
 
+# Install thanos on hub cluster
+if [ "$HUB" -eq 1 ]; then
+  info "Installing thanos in ${KUADRANT_CLUSTER_NAME}... (as hub cluster)"
+  kubectl apply -k ${KUADARNT_THANOS_KUSTOMIZATION}
+  success "thanos installed successfully."
+fi
+
 # Install observability stack
 info "Installing observability stack in ${KUADRANT_CLUSTER_NAME}..."
 kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | docker run --rm -i ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
 kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | docker run --rm -i ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -
 kubectl kustomize ${KUADRANT_DASHBOARDS_KUSTOMIZATION} | kubectl apply --server-side -f -
 success "observability stack installed successfully."
+
+# Patch prometheus to remote write metrics to thanos in hub
+info "Patching prometheus remote write config in ${KUADRANT_CLUSTER_NAME}..."
+THANOS_RECEIVE_ROUTER_IP=$(kubectl --context="kind-$KUADRANT_CLUSTER_NAME_BASE" -n monitoring get svc thanos-receive-router-lb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+kubectl -n monitoring patch prometheus k8s --type='merge' -p '{"spec":{"remoteWrite":[{"url":"http://'"$THANOS_RECEIVE_ROUTER_IP"':19291/api/v1/receive"}]}}'
+success "prometheus remote write config patched successfully."
 
 info "✨🌟 Setup Complete! Your Kuadrant Quick Start environment has been successfully created. 🌟✨"
 

--- a/hack/thanos/README.md
+++ b/hack/thanos/README.md
@@ -1,0 +1,15 @@
+# Generating Thanos manifests using jsonnet
+
+Thanos manifests in the config/thanos/manifests directory are generated using jsonnet.
+This typically only needs to be done if updating the thanos version.
+Generated manifests are checked in to source control.
+
+To generate them, first you need [jsonnet](https://github.com/google/jsonnet#packages).
+
+Then you can run `jb install && make thanos-manifests` from the root of the repo.
+If there are changes to the files in the config/thanos/manifests directory, check them in to source control.
+
+There is a jsonnetfile.json and jsonnetfile.lock.json file in the root of the repo.
+These files contain jsonnet dependency information and can be managed by the `jb` cli.
+More info on configuring the thanos dependency can found at https://github.com/thanos-io/kube-thanos/tree/main#installing
+

--- a/hack/thanos/thanos.jsonnet
+++ b/hack/thanos/thanos.jsonnet
@@ -1,0 +1,70 @@
+local t = import 'kube-thanos/thanos.libsonnet';
+
+// For an example with every option and component, please check all.jsonnet
+
+local commonConfig = {
+  config+:: {
+    local cfg = self,
+    namespace: 'monitoring',
+    version: 'v0.29.0',
+    image: 'quay.io/thanos/thanos:' + cfg.version,
+    imagePullPolicy: 'IfNotPresent',
+    objectStorageConfig: {
+      name: 'thanos-objectstorage',
+      key: 'thanos.yaml',
+    },
+    hashringConfigMapName: 'hashring-config',
+    volumeClaimTemplate: {
+      spec: {
+        accessModes: ['ReadWriteOnce'],
+        resources: {
+          requests: {
+            storage: '10Gi',
+          },
+        },
+      },
+    },
+  },
+};
+
+local i = t.receiveIngestor(commonConfig.config {
+  replicas: 1,
+  replicaLabels: ['receive_replica'],
+  replicationFactor: 1,
+  // Disable shipping to object storage for the purposes of this example
+  objectStorageConfig: null,
+  serviceMonitor: true,
+});
+
+local r = t.receiveRouter(commonConfig.config {
+  replicas: 1,
+  replicaLabels: ['receive_replica'],
+  replicationFactor: 1,
+  // Disable shipping to object storage for the purposes of this example
+  objectStorageConfig: null,
+  endpoints: i.endpoints,
+});
+
+// local s = t.store(commonConfig.config {
+//   replicas: 1,
+//   serviceMonitor: false,
+// });
+
+local q = t.query(commonConfig.config {
+  replicas: 1,
+  replicaLabels: ['prometheus_replica', 'rule_replica'],
+  serviceMonitor: true,
+  stores: i.storeEndpoints,
+  // stores: [s.storeEndpoint] + i.storeEndpoints,
+});
+
+// { ['thanos-store-' + name]: s[name] for name in std.objectFields(s) } +
+{ ['thanos-query-' + name]: q[name] for name in std.objectFields(q) } +
+{ ['thanos-receive-router-' + resource]: r[resource] for resource in std.objectFields(r) } +
+{ ['thanos-receive-ingestor-' + resource]: i[resource] for resource in std.objectFields(i) if resource != 'ingestors' } +
+{
+  ['thanos-receive-ingestor-' + hashring + '-' + resource]: i.ingestors[hashring][resource]
+  for hashring in std.objectFields(i.ingestors)
+  for resource in std.objectFields(i.ingestors[hashring])
+  if i.ingestors[hashring][resource] != null
+}

--- a/hack/thanos/thanos_build.sh
+++ b/hack/thanos/thanos_build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# This script uses arg $1 (name of *.jsonnet file to use) to generate the manifests/*.yaml files.
+
+set -e
+set -x
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+THANOS_MANIFESTS_KUSTOMIZATION_DIR=${SCRIPT_DIR}/../../config/thanos/manifests
+THANOS_JSONNET_FILE=${SCRIPT_DIR}/thanos.jsonnet
+
+JSONNET=${JSONNET:-jsonnet}
+GOJSONTOYAML=${GOJSONTOYAML:-gojsontoyaml}
+
+# Make sure to start with a clean 'manifests' dir
+rm -rf ${THANOS_MANIFESTS_KUSTOMIZATION_DIR}
+mkdir ${THANOS_MANIFESTS_KUSTOMIZATION_DIR}
+
+# optional, but we would like to generate yaml, not json
+${JSONNET} -J vendor -m ${THANOS_MANIFESTS_KUSTOMIZATION_DIR} "${THANOS_JSONNET_FILE}" | xargs -I{} sh -c "cat {} | ${GOJSONTOYAML} > {}.yaml; rm -f {}" -- {}
+find ${THANOS_MANIFESTS_KUSTOMIZATION_DIR} -type f ! -name '*.yaml' -delete

--- a/jsonnetfile.json
+++ b/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/thanos-io/kube-thanos",
+          "subdir": "jsonnet/kube-thanos"
+        }
+      },
+      "version": "main"
+    }
+  ],
+  "legacyImports": true
+}

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/thanos-io/kube-thanos",
+          "subdir": "jsonnet/kube-thanos"
+        }
+      },
+      "version": "4c734188ca0745a8cd9cb7824d25abe663e89627",
+      "sum": "mLrmkfibHnj5IP2r0zAmYIJelh3KbaaKXSoRUW/fASc="
+    }
+  ],
+  "legacyImports": false
+}

--- a/make/observability.mk
+++ b/make/observability.mk
@@ -3,3 +3,7 @@
 deploy-observability: kustomize
 	$(KUSTOMIZE) build config/observability | docker run --rm -i ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
 	$(KUSTOMIZE) build config/observability | docker run --rm -i ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -
+
+.PHONY: thanos-manifests
+thanos-manifests: ./hack/thanos/thanos_build.sh ./hack/thanos/thanos.jsonnet
+	./hack/thanos/thanos_build.sh


### PR DESCRIPTION
- adds installation of thanos to the first/hub cluster
- configures grafana in the first/hub cluster with thanos-query as a data source
- configures every cluster to remote write metrics to the hub thanos instance

To verify, the PR branch `thanos` will need to be referenced until changes are back on main.

- Setup a hub cluster with `KUADRANT_REF=thanos ./hack/quickstart-setup.sh`
- then at least 1 more cluster with `KUADRANT_REF=thanos ./hack/quickstart-setup.sh` again.

In the first/hub cluster, you should see metrics from both clusters in the Grafana explore view. e.g. the `up{app="metallb",component="controller"}` metric should have 1 entry for each cluster.
To access grafana in the hub, you'll need to port-forward to the service with `kubectl --context kind-kuadrant-local -n monitoring port-forward svc/grafana 3000:3000` then access it at http://127.0.0.1:3000/explore

