### PR TITLE
feat: tlspolicy enforced condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,7 +390,7 @@ run: generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: ## Build docker image with the manager.
-	docker build -t $(IMG) .  --load
+	docker build -t $(IMG) .
 
 docker-push: ## Push docker image with the manager.
 	docker push $(IMG)

--- a/api/v1alpha1/dnspolicy_types.go
+++ b/api/v1alpha1/dnspolicy_types.go
@@ -145,7 +145,8 @@ var _ kuadrant.Referrer = &DNSPolicy{}
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=direct"
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`,description="DNSPolicy Status",priority=2
+// +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=`.status.conditions[?(@.type=="Accepted")].status`,description="DNSPolicy Accepted",priority=2
+// +kubebuilder:printcolumn:name="Enforced",type=string,JSONPath=`.status.conditions[?(@.type=="Enforced")].status`,description="DNSPolicy Enforced",priority=2
 // +kubebuilder:printcolumn:name="TargetRefKind",type="string",JSONPath=".spec.targetRef.kind",description="Type of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="TargetRefName",type="string",JSONPath=".spec.targetRef.name",description="Name of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/api/v1alpha1/tlspolicy_types.go
+++ b/api/v1alpha1/tlspolicy_types.go
@@ -129,7 +129,8 @@ var _ kuadrant.Referrer = &TLSPolicy{}
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:metadata:labels="gateway.networking.k8s.io/policy=direct"
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.conditions[0].reason`,description="TLSPolicy Status",priority=2
+// +kubebuilder:printcolumn:name="Accepted",type=string,JSONPath=`.status.conditions[?(@.type=="Accepted")].status`,description="TLSPolicy Accepted",priority=2
+// +kubebuilder:printcolumn:name="Enforced",type=string,JSONPath=`.status.conditions[?(@.type=="Enforced")].status`,description="TLSPolicy Enforced",priority=2
 // +kubebuilder:printcolumn:name="TargetRefKind",type="string",JSONPath=".spec.targetRef.kind",description="Type of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="TargetRefName",type="string",JSONPath=".spec.targetRef.name",description="Name of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -18,9 +18,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: DNSPolicy Status
-      jsonPath: .status.conditions[0].reason
-      name: Status
+    - description: DNSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: DNSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
       priority: 2
       type: string
     - description: Type of the referenced Gateway API resource

--- a/bundle/manifests/kuadrant.io_tlspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_tlspolicies.yaml
@@ -18,9 +18,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: TLSPolicy Status
-      jsonPath: .status.conditions[0].reason
-      name: Status
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
       priority: 2
       type: string
     - description: Type of the referenced Gateway API resource

--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -17,9 +17,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: DNSPolicy Status
-      jsonPath: .status.conditions[0].reason
-      name: Status
+    - description: DNSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: DNSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
       priority: 2
       type: string
     - description: Type of the referenced Gateway API resource

--- a/config/crd/bases/kuadrant.io_tlspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_tlspolicies.yaml
@@ -17,9 +17,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: TLSPolicy Status
-      jsonPath: .status.conditions[0].reason
-      name: Status
+    - description: TLSPolicy Accepted
+      jsonPath: .status.conditions[?(@.type=="Accepted")].status
+      name: Accepted
+      priority: 2
+      type: string
+    - description: TLSPolicy Enforced
+      jsonPath: .status.conditions[?(@.type=="Enforced")].status
+      name: Enforced
       priority: 2
       type: string
     - description: Type of the referenced Gateway API resource

--- a/controllers/tlspolicy_controller.go
+++ b/controllers/tlspolicy_controller.go
@@ -80,7 +80,7 @@ func (r *TLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				if delResErr == nil {
 					delResErr = err
 				}
-				return r.reconcileStatus(ctx, tlsPolicy, kuadrant.NewErrTargetNotFound(tlsPolicy.Kind(), tlsPolicy.GetTargetRef(), delResErr))
+				return r.reconcileStatus(ctx, tlsPolicy, targetReferenceObject, kuadrant.NewErrTargetNotFound(tlsPolicy.Kind(), tlsPolicy.GetTargetRef(), delResErr))
 			}
 			return ctrl.Result{}, err
 		}
@@ -109,7 +109,7 @@ func (r *TLSPolicyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	specErr := r.reconcileResources(ctx, tlsPolicy, targetReferenceObject)
 
-	statusResult, statusErr := r.reconcileStatus(ctx, tlsPolicy, specErr)
+	statusResult, statusErr := r.reconcileStatus(ctx, tlsPolicy, targetReferenceObject, specErr)
 
 	if specErr != nil {
 		return ctrl.Result{}, specErr

--- a/controllers/tlspolicy_controller_test.go
+++ b/controllers/tlspolicy_controller_test.go
@@ -22,6 +22,7 @@ import (
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 )
 
 var _ = Describe("TLSPolicy controller", func() {
@@ -85,6 +86,11 @@ var _ = Describe("TLSPolicy controller", func() {
 						"Message": Equal("TLSPolicy target test-gateway was not found"),
 					})),
 				)
+				g.Expect(tlsPolicy.Status.Conditions).ToNot(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(string(kuadrant.PolicyConditionEnforced)),
+					})),
+				)
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
 		})
 
@@ -98,6 +104,11 @@ var _ = Describe("TLSPolicy controller", func() {
 						"Status":  Equal(metav1.ConditionFalse),
 						"Reason":  Equal(string(gatewayapiv1alpha2.PolicyReasonTargetNotFound)),
 						"Message": Equal("TLSPolicy target test-gateway was not found"),
+					})),
+				)
+				g.Expect(tlsPolicy.Status.Conditions).ToNot(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type": Equal(string(kuadrant.PolicyConditionEnforced)),
 					})),
 				)
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
@@ -116,6 +127,14 @@ var _ = Describe("TLSPolicy controller", func() {
 						"Status":  Equal(metav1.ConditionTrue),
 						"Reason":  Equal(string(gatewayapiv1alpha2.PolicyConditionAccepted)),
 						"Message": Equal("TLSPolicy has been accepted"),
+					})),
+				)
+				g.Expect(tlsPolicy.Status.Conditions).To(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(kuadrant.PolicyConditionEnforced)),
+						"Status":  Equal(metav1.ConditionTrue),
+						"Reason":  Equal(string(kuadrant.PolicyConditionEnforced)),
+						"Message": Equal("TLSPolicy has been successfully enforced"),
 					})),
 				)
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
@@ -144,6 +163,14 @@ var _ = Describe("TLSPolicy controller", func() {
 						"Status":  Equal(metav1.ConditionTrue),
 						"Reason":  Equal(string(gatewayapiv1alpha2.PolicyConditionAccepted)),
 						"Message": Equal("TLSPolicy has been accepted"),
+					})),
+				)
+				g.Expect(tlsPolicy.Status.Conditions).To(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(kuadrant.PolicyConditionEnforced)),
+						"Status":  Equal(metav1.ConditionTrue),
+						"Reason":  Equal(string(kuadrant.PolicyConditionEnforced)),
+						"Message": Equal("TLSPolicy has been successfully enforced"),
 					})),
 				)
 			}, TestTimeoutMedium, time.Second).Should(Succeed())
@@ -186,7 +213,7 @@ var _ = Describe("TLSPolicy controller", func() {
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 		})
 
-		It("should have accepted condition with status true", func() {
+		It("should have accepted and enforced condition with status true", func() {
 			Eventually(func(g Gomega) {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tlsPolicy), tlsPolicy)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -196,6 +223,14 @@ var _ = Describe("TLSPolicy controller", func() {
 						"Status":  Equal(metav1.ConditionTrue),
 						"Reason":  Equal(string(gatewayapiv1alpha2.PolicyConditionAccepted)),
 						"Message": Equal("TLSPolicy has been accepted"),
+					})),
+				)
+				g.Expect(tlsPolicy.Status.Conditions).To(
+					ContainElement(MatchFields(IgnoreExtras, Fields{
+						"Type":    Equal(string(kuadrant.PolicyConditionEnforced)),
+						"Status":  Equal(metav1.ConditionTrue),
+						"Reason":  Equal(string(kuadrant.PolicyConditionEnforced)),
+						"Message": Equal("TLSPolicy has been successfully enforced"),
 					})),
 				)
 			}, TestTimeoutMedium, time.Second).Should(Succeed())

--- a/controllers/tlspolicy_status.go
+++ b/controllers/tlspolicy_status.go
@@ -18,20 +18,28 @@ package controllers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"slices"
 
+	certmanv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/reconcilers"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
 
-func (r *TLSPolicyReconciler) reconcileStatus(ctx context.Context, tlsPolicy *v1alpha1.TLSPolicy, specErr error) (ctrl.Result, error) {
-	newStatus := r.calculateStatus(tlsPolicy, specErr)
+func (r *TLSPolicyReconciler) reconcileStatus(ctx context.Context, tlsPolicy *v1alpha1.TLSPolicy, targetNetworkObject client.Object, specErr error) (ctrl.Result, error) {
+	newStatus := r.calculateStatus(ctx, tlsPolicy, targetNetworkObject, specErr)
 
 	equalStatus := equality.Semantic.DeepEqual(newStatus, tlsPolicy.Status)
 	if equalStatus && tlsPolicy.Generation == tlsPolicy.Status.ObservedGeneration {
@@ -57,7 +65,7 @@ func (r *TLSPolicyReconciler) reconcileStatus(ctx context.Context, tlsPolicy *v1
 	return ctrl.Result{}, nil
 }
 
-func (r *TLSPolicyReconciler) calculateStatus(tlsPolicy *v1alpha1.TLSPolicy, specErr error) *v1alpha1.TLSPolicyStatus {
+func (r *TLSPolicyReconciler) calculateStatus(ctx context.Context, tlsPolicy *v1alpha1.TLSPolicy, targetNetworkObject client.Object, specErr error) *v1alpha1.TLSPolicyStatus {
 	newStatus := &v1alpha1.TLSPolicyStatus{
 		// Copy initial conditions. Otherwise, status will always be updated
 		Conditions:         slices.Clone(tlsPolicy.Status.Conditions),
@@ -67,5 +75,88 @@ func (r *TLSPolicyReconciler) calculateStatus(tlsPolicy *v1alpha1.TLSPolicy, spe
 	acceptedCond := kuadrant.AcceptedCondition(tlsPolicy, specErr)
 	meta.SetStatusCondition(&newStatus.Conditions, *acceptedCond)
 
+	// Do not set enforced condition if Accepted condition is false
+	if meta.IsStatusConditionFalse(newStatus.Conditions, string(gatewayapiv1alpha2.PolicyReasonAccepted)) {
+		meta.RemoveStatusCondition(&newStatus.Conditions, string(kuadrant.PolicyConditionEnforced))
+		return newStatus
+	}
+
+	enforcedCond := r.enforcedCondition(ctx, tlsPolicy, targetNetworkObject)
+	meta.SetStatusCondition(&newStatus.Conditions, *enforcedCond)
+
 	return newStatus
+}
+
+func (r *TLSPolicyReconciler) enforcedCondition(ctx context.Context, tlsPolicy *v1alpha1.TLSPolicy, targetNetworkObject client.Object) *metav1.Condition {
+	if err := r.isIssuerReady(ctx, tlsPolicy); err != nil {
+		return kuadrant.EnforcedCondition(tlsPolicy, kuadrant.NewErrUnknown(tlsPolicy.Kind(), err), false)
+	}
+
+	if err := r.isCertificatesReady(ctx, tlsPolicy, targetNetworkObject); err != nil {
+		return kuadrant.EnforcedCondition(tlsPolicy, kuadrant.NewErrUnknown(tlsPolicy.Kind(), err), false)
+	}
+
+	return kuadrant.EnforcedCondition(tlsPolicy, nil, true)
+}
+
+func (r *TLSPolicyReconciler) isIssuerReady(ctx context.Context, tlsPolicy *v1alpha1.TLSPolicy) error {
+	var conditions []certmanv1.IssuerCondition
+
+	switch tlsPolicy.Spec.IssuerRef.Kind {
+	case "", certmanv1.IssuerKind:
+		issuer := &certmanv1.Issuer{}
+		if err := r.Client().Get(ctx, client.ObjectKey{Name: tlsPolicy.Spec.IssuerRef.Name, Namespace: tlsPolicy.Namespace}, issuer); err != nil {
+			return err
+		}
+		conditions = issuer.Status.Conditions
+	case certmanv1.ClusterIssuerKind:
+		issuer := &certmanv1.ClusterIssuer{}
+		if err := r.Client().Get(ctx, client.ObjectKey{Name: tlsPolicy.Spec.IssuerRef.Name}, issuer); err != nil {
+			return err
+		}
+		conditions = issuer.Status.Conditions
+	default:
+		return fmt.Errorf(`invalid value %q for issuerRef.kind. Must be empty, %q or %q`, tlsPolicy.Spec.IssuerRef.Kind, certmanv1.IssuerKind, certmanv1.ClusterIssuerKind)
+	}
+
+	transformedCond := utils.Map(conditions, func(c certmanv1.IssuerCondition) metav1.Condition {
+		return metav1.Condition{Reason: c.Reason, Status: metav1.ConditionStatus(c.Status), Type: string(c.Type), Message: c.Message}
+	})
+
+	if meta.IsStatusConditionFalse(transformedCond, string(certmanv1.IssuerConditionReady)) {
+		return errors.New("issuer not ready")
+	}
+
+	return nil
+}
+
+func (r *TLSPolicyReconciler) isCertificatesReady(ctx context.Context, tlsPolicy *v1alpha1.TLSPolicy, targetNetworkObject client.Object) error {
+	gwDiffObj, err := reconcilers.ComputeGatewayDiffs(ctx, r.Client(), tlsPolicy, targetNetworkObject)
+	if err != nil {
+		return err
+	}
+
+	if len(gwDiffObj.GatewaysWithValidPolicyRef) == 0 {
+		return errors.New("no valid gateways found")
+	}
+
+	for _, gw := range gwDiffObj.GatewaysWithValidPolicyRef {
+		expectedCertificates := r.expectedCertificatesForGateway(ctx, gw.Gateway, tlsPolicy)
+
+		for _, cert := range expectedCertificates {
+			c := &certmanv1.Certificate{}
+			if err := r.Client().Get(ctx, client.ObjectKeyFromObject(cert), c); err != nil {
+				return err
+			}
+			conditions := utils.Map(c.Status.Conditions, func(c certmanv1.CertificateCondition) metav1.Condition {
+				return metav1.Condition{Reason: c.Reason, Status: metav1.ConditionStatus(c.Status), Type: string(c.Type), Message: c.Message}
+			})
+
+			if meta.IsStatusConditionFalse(conditions, string(certmanv1.CertificateConditionReady)) {
+				return fmt.Errorf("certificate %s not ready", cert.Name)
+			}
+		}
+	}
+
+	return nil
 }

--- a/controllers/tlspolicy_status_test.go
+++ b/controllers/tlspolicy_status_test.go
@@ -1,0 +1,321 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	certmanv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/reconcilers"
+	"github.com/kuadrant/kuadrant-operator/pkg/log"
+)
+
+func TestTLSPolicyReconciler_enforcedCondition(t *testing.T) {
+	const (
+		ns              = "default"
+		tlsPolicyName   = "kuadrant-tls-policy"
+		issuerName      = "kuadrant-issuer"
+		gwName          = "kuadrant-gateway"
+		certificateName = "kuadrant-certifcate"
+	)
+
+	scheme := runtime.NewScheme()
+	sb := runtime.NewSchemeBuilder(certmanv1.AddToScheme, gatewayapiv1.AddToScheme)
+	if err := sb.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	policyFactory := func(mutateFn ...func(policy *v1alpha1.TLSPolicy)) *v1alpha1.TLSPolicy {
+		p := &v1alpha1.TLSPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      tlsPolicyName,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind: "TLSPolicy",
+			},
+			Spec: v1alpha1.TLSPolicySpec{
+				CertificateSpec: v1alpha1.CertificateSpec{
+					IssuerRef: certmanmetav1.ObjectReference{
+						Name: issuerName,
+					},
+				},
+				TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
+					Name: gwName,
+				},
+			},
+		}
+		for _, mutate := range mutateFn {
+			mutate(p)
+		}
+
+		return p
+	}
+
+	withClusterIssuerMutater := func(p *v1alpha1.TLSPolicy) {
+		p.Spec.CertificateSpec.IssuerRef.Kind = certmanv1.ClusterIssuerKind
+	}
+
+	issuerFactory := func(mutateFn ...func(issuer *certmanv1.Issuer)) *certmanv1.Issuer {
+		issuer := &certmanv1.Issuer{
+			ObjectMeta: metav1.ObjectMeta{Name: issuerName, Namespace: ns},
+			Status: certmanv1.IssuerStatus{
+				Conditions: []certmanv1.IssuerCondition{
+					{
+						Type:   certmanv1.IssuerConditionReady,
+						Status: certmanmetav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		for _, mutate := range mutateFn {
+			mutate(issuer)
+		}
+
+		return issuer
+	}
+
+	issuerNotReadyMutater := func(issuer *certmanv1.Issuer) {
+		issuer.Status = certmanv1.IssuerStatus{
+			Conditions: []certmanv1.IssuerCondition{
+				{
+					Type:   certmanv1.IssuerConditionReady,
+					Status: certmanmetav1.ConditionFalse,
+				},
+			},
+		}
+	}
+
+	certificateFactory := func(mutateFn ...func(certificate *certmanv1.Certificate)) *certmanv1.Certificate {
+		c := &certmanv1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{Name: certificateName, Namespace: ns},
+			Status: certmanv1.CertificateStatus{
+				Conditions: []certmanv1.CertificateCondition{
+					{
+						Type:   certmanv1.CertificateConditionReady,
+						Status: certmanmetav1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		for _, mutate := range mutateFn {
+			mutate(c)
+		}
+
+		return c
+	}
+
+	certificateNotReadyMutater := func(certificate *certmanv1.Certificate) {
+		certificate.Status = certmanv1.CertificateStatus{
+			Conditions: []certmanv1.CertificateCondition{
+				{
+					Type:   certmanv1.CertificateConditionReady,
+					Status: certmanmetav1.ConditionFalse,
+				},
+			},
+		}
+	}
+
+	refs, err := json.Marshal([]client.ObjectKey{{Name: tlsPolicyName, Namespace: ns}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gwFactory := func() *gatewayapiv1.Gateway {
+		return &gatewayapiv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gwName,
+				Namespace: ns,
+				Annotations: map[string]string{
+					v1alpha1.TLSPolicyBackReferenceAnnotationName: string(refs),
+				},
+			},
+			Spec: gatewayapiv1.GatewaySpec{
+				Listeners: []gatewayapiv1.Listener{
+					{
+						Name:     "http",
+						Hostname: ptr.To[gatewayapiv1.Hostname]("localhost"),
+						TLS: &gatewayapiv1.GatewayTLSConfig{
+							CertificateRefs: []gatewayapiv1.SecretObjectReference{{
+								Group:     ptr.To[gatewayapiv1.Group]("core"),
+								Kind:      ptr.To[gatewayapiv1.Kind]("Secret"),
+								Name:      certificateName,
+								Namespace: ptr.To[gatewayapiv1.Namespace]("default"),
+							}},
+							Mode: ptr.To(gatewayapiv1.TLSModeTerminate),
+						},
+					},
+				},
+			},
+		}
+	}
+
+	type fields struct {
+		BaseReconciler *reconcilers.BaseReconciler
+	}
+	type args struct {
+		tlsPolicy           *v1alpha1.TLSPolicy
+		targetNetworkObject client.Object
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *metav1.Condition
+	}{
+		{
+			name: "unable to get issuer",
+			fields: fields{
+				BaseReconciler: reconcilers.NewBaseReconciler(
+					fake.NewClientBuilder().WithScheme(scheme).Build(), nil, nil, log.NewLogger(), nil,
+				),
+			},
+			args: args{
+				tlsPolicy: policyFactory(),
+			},
+			want: &metav1.Condition{
+				Type:    string(kuadrant.PolicyConditionEnforced),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(kuadrant.PolicyReasonUnknown),
+				Message: fmt.Sprintf("TLSPolicy has encountered some issues: issuers.cert-manager.io \"%s\" not found", issuerName),
+			},
+		},
+		{
+			name: "unable to get cluster issuer",
+			fields: fields{
+				BaseReconciler: reconcilers.NewBaseReconciler(
+					fake.NewClientBuilder().WithScheme(scheme).Build(), nil, nil, log.NewLogger(), nil,
+				),
+			},
+			args: args{
+				tlsPolicy: policyFactory(withClusterIssuerMutater),
+			},
+			want: &metav1.Condition{
+				Type:    string(kuadrant.PolicyConditionEnforced),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(kuadrant.PolicyReasonUnknown),
+				Message: fmt.Sprintf("TLSPolicy has encountered some issues: clusterissuers.cert-manager.io \"%s\" not found", issuerName),
+			},
+		},
+		{
+			name: "issuer not ready",
+			fields: fields{
+				BaseReconciler: reconcilers.NewBaseReconciler(
+					fake.NewClientBuilder().
+						WithObjects(issuerFactory(issuerNotReadyMutater)).
+						WithScheme(scheme).Build(), nil, nil, log.NewLogger(), nil,
+				),
+			},
+			args: args{
+				tlsPolicy: policyFactory(),
+			},
+			want: &metav1.Condition{
+				Type:    string(kuadrant.PolicyConditionEnforced),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(kuadrant.PolicyReasonUnknown),
+				Message: "TLSPolicy has encountered some issues: issuer not ready",
+			},
+		},
+		{
+			name: "no valid gateways found",
+			fields: fields{
+				BaseReconciler: reconcilers.NewBaseReconciler(
+					fake.NewClientBuilder().WithObjects(issuerFactory()).
+						WithScheme(scheme).Build(), nil, nil, log.NewLogger(), nil,
+				),
+			},
+			args: args{
+				tlsPolicy:           policyFactory(),
+				targetNetworkObject: gwFactory(),
+			},
+			want: &metav1.Condition{
+				Type:    string(kuadrant.PolicyConditionEnforced),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(kuadrant.PolicyReasonUnknown),
+				Message: "TLSPolicy has encountered some issues: no valid gateways found",
+			},
+		},
+		{
+			name: "unable to get certificate",
+			fields: fields{
+				BaseReconciler: reconcilers.NewBaseReconciler(
+					fake.NewClientBuilder().WithObjects(issuerFactory(), gwFactory()).
+						WithScheme(scheme).Build(), nil, nil, log.NewLogger(), nil,
+				),
+			},
+			args: args{
+				tlsPolicy:           policyFactory(),
+				targetNetworkObject: gwFactory(),
+			},
+			want: &metav1.Condition{
+				Type:    string(kuadrant.PolicyConditionEnforced),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(kuadrant.PolicyReasonUnknown),
+				Message: fmt.Sprintf("TLSPolicy has encountered some issues: certificates.cert-manager.io \"%s\" not found", certificateName),
+			},
+		},
+		{
+			name: "certificate is not ready",
+			fields: fields{
+				BaseReconciler: reconcilers.NewBaseReconciler(
+					fake.NewClientBuilder().WithObjects(issuerFactory(), gwFactory(), certificateFactory(certificateNotReadyMutater)).
+						WithScheme(scheme).Build(), nil, nil, log.NewLogger(), nil,
+				),
+			},
+			args: args{
+				tlsPolicy:           policyFactory(),
+				targetNetworkObject: gwFactory(),
+			},
+			want: &metav1.Condition{
+				Type:    string(kuadrant.PolicyConditionEnforced),
+				Status:  metav1.ConditionFalse,
+				Reason:  string(kuadrant.PolicyReasonUnknown),
+				Message: fmt.Sprintf("TLSPolicy has encountered some issues: certificate %s not ready", certificateName),
+			},
+		},
+		{
+			name: "is enforced",
+			fields: fields{
+				BaseReconciler: reconcilers.NewBaseReconciler(
+					fake.NewClientBuilder().WithObjects(issuerFactory(), gwFactory(), certificateFactory()).
+						WithScheme(scheme).Build(), nil, nil, log.NewLogger(), nil,
+				),
+			},
+			args: args{
+				tlsPolicy:           policyFactory(),
+				targetNetworkObject: gwFactory(),
+			},
+			want: &metav1.Condition{
+				Type:    string(kuadrant.PolicyConditionEnforced),
+				Status:  metav1.ConditionTrue,
+				Reason:  string(kuadrant.PolicyConditionEnforced),
+				Message: "TLSPolicy has been successfully enforced",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &TLSPolicyReconciler{
+				BaseReconciler: tt.fields.BaseReconciler,
+			}
+			if got := r.enforcedCondition(context.Background(), tt.args.tlsPolicy, tt.args.targetNetworkObject); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("enforcedCondition() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/572

Add enforced condition for TLSPolicy. This is based on whether the underlying `Issuer` and `Certificates` are in a `Ready` state.

# Verification
Happy path is integration tested but if you want to verify manually

* Checkout this branch
* Deploy
```
make local-setup
```
* Deploy policy 
```
kubectl apply -n istio-system -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: istio-ingressgateway
spec:
  gatewayClassName: istio
  listeners:
  - name: http
    hostname: '*.toys.io'
    port: 443
    protocol: HTTPS
    tls:
      mode: Terminate
      certificateRefs:
      - name: toys
        kind: Secret
    allowedRoutes:
      namespaces:
        from: All    
---
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: selfsigned-issuer
spec:
  selfSigned: {}
---
apiVersion: kuadrant.io/v1alpha1
kind: TLSPolicy
metadata:
  name: gw-tls
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: istio-ingressgateway
  issuerRef:
    group: cert-manager.io
    kind: Issuer
    name: selfsigned-issuer
EOF
```
* Check that the TLSPolicy has an enforced condition
```
kubectl get tlspolicy -A -o yaml | yq '.items[].status'
```
<img width="476" alt="image" src="https://github.com/Kuadrant/kuadrant-operator/assets/24636860/3e7f5689-f644-402b-8ba8-445f52148c94">

* Check that there is a new column for the enforced condition
```
kubectl get tlspolicy -A -o wide 
```

<img width="749" alt="image" src="https://github.com/Kuadrant/kuadrant-operator/assets/24636860/5c99d122-c9c9-4234-8e7c-406ff66552f4">
