### PR TITLE
Port back downstream fixes for dashboards

### DIFF
--- a/examples/dashboards/app_developer.json
+++ b/examples/dashboards/app_developer.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "description": "Stitch: App Developer Dashboard",
+  "description": "App Developer Dashboard",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "gnetId": 7630,
@@ -294,7 +294,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Requests per second, broken down by success (2xx,3xxx) and error (4xx,5xx)",
+      "description": "Requests per second, broken down by success (2xx,3xx) and error (4xx,5xx)",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -415,7 +415,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "legendFormat": "total",
           "range": true,
           "refId": "A"
@@ -426,7 +426,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"4.*|5.*\",destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"4.*|5.*\",destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "error (4xx,5xx)",
           "range": true,
@@ -438,7 +438,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"2.*|3.*\",destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"2.*|3.*\",destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "success (2xx,3xx)",
           "range": true,
@@ -505,7 +505,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(istio_requests_total{destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -573,7 +573,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(istio_requests_total{destination_service_name=~\"$api\"}[$__range])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{service=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(increase(istio_requests_total{destination_service_name=~\"$api\"}[$__range])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{service=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -712,7 +712,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "histogram_quantile(0.95, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "P95",
           "range": true,
@@ -724,7 +724,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "histogram_quantile(0.90, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "legendFormat": "P90",
           "range": true,
           "refId": "A"
@@ -735,7 +735,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "histogram_quantile(0.99, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "P99",
           "range": true,
@@ -801,7 +801,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.99, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "histogram_quantile(0.99, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "instant": true,
           "legendFormat": "P99 {{destination_service_name}}",
@@ -869,7 +869,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(istio_requests_total{response_code=~\"2.*|3.*\",destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"2.*|3.*\",destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -937,7 +937,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(istio_requests_total{response_code=~\"2.*|3.*\",destination_service_name=~\"$api\"}[$__range])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{service=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(increase(istio_requests_total{response_code=~\"2.*|3.*\",destination_service_name=~\"$api\"}[$__range])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{service=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -1004,7 +1004,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.95, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "histogram_quantile(0.95, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -1072,7 +1072,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(istio_requests_total{response_code=~\"4.*|5.*\",destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"4.*|5.*\",destination_service_name=~\"$api\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{deployment=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -1140,7 +1140,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(increase(istio_requests_total{response_code=~\"4.*|5.*\",destination_service_name=~\"$api\"}[$__range])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{service=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(increase(istio_requests_total{response_code=~\"4.*|5.*\",destination_service_name=~\"$api\"}[$__range])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{service=~\"$api\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "instant": true,
           "legendFormat": "__auto",
@@ -1207,7 +1207,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.90, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "histogram_quantile(0.90, sum(irate(istio_request_duration_milliseconds_bucket{destination_service_name=~\"$api\"}[5m])) by (le, destination_service_name)) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "instant": true,
           "legendFormat": "P90 {{destination_service_name}}",
           "range": false,

--- a/examples/dashboards/business_user.json
+++ b/examples/dashboards/business_user.json
@@ -176,7 +176,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "legendFormat": "API: {{name}}",
           "range": true,
           "refId": "A"
@@ -243,7 +243,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(istio_requests_total{}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "format": "time_series",
           "instant": false,
           "legendFormat": "most recent",
@@ -256,7 +256,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{}[5m] offset $__range)) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{}[5m] offset $__range)) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "format": "time_series",
           "hide": false,
           "legendFormat": "previous",
@@ -350,7 +350,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{}[5m])) by (destination_service_name, request_url_path) * on(destination_service_name) group_left label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{}[5m])) by (destination_service_name, request_url_path) * on(destination_service_name) group_left() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "legendFormat": "{{request_url_path}}",
           "range": true,
           "refId": "A"
@@ -417,7 +417,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(request_url_path) (increase(istio_requests_total{}[$__range]) * on(destination_service_name) group_left label_replace(gatewayapi_httproute_labels{name=~\"$route_name\",exported_namespace=~\"$api_namespace\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\"))",
+          "expr": "sum by(request_url_path) (increase(istio_requests_total{}[$__range]) * on(destination_service_name) group_left() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{name=~\"$route_name\",exported_namespace=~\"$api_namespace\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\"))))",
           "format": "table",
           "instant": true,
           "range": false,
@@ -430,7 +430,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(request_url_path) (increase(istio_requests_total{}[$__range] offset $__range) * on(destination_service_name) group_left label_replace(gatewayapi_httproute_labels{name=~\"$route_name\",exported_namespace=~\"$api_namespace\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\"))",
+          "expr": "sum by(request_url_path) (increase(istio_requests_total{}[$__range] offset $__range) * on(destination_service_name) group_left() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{name=~\"$route_name\",exported_namespace=~\"$api_namespace\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\"))))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -444,7 +444,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum by(request_url_path) (increase(istio_requests_total{}[$__range]) * on(destination_service_name) group_left label_replace(gatewayapi_httproute_labels{name=~\"$route_name\",exported_namespace=~\"$api_namespace\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")) - sum by(request_url_path) (increase(istio_requests_total{}[$__range] offset $__range) * on(destination_service_name) group_left label_replace(gatewayapi_httproute_labels{name=~\"$route_name\",exported_namespace=~\"$api_namespace\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\"))",
+          "expr": "sum by(request_url_path) (increase(istio_requests_total{}[$__range]) * on(destination_service_name) group_left() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{name=~\"$route_name\",exported_namespace=~\"$api_namespace\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))) - sum by(request_url_path) (increase(istio_requests_total{}[$__range] offset $__range) * on(destination_service_name) group_left() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{name=~\"$route_name\",exported_namespace=~\"$api_namespace\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\"))))",
           "format": "table",
           "hide": false,
           "instant": true,

--- a/examples/dashboards/platform_engineer.json
+++ b/examples/dashboards/platform_engineer.json
@@ -689,7 +689,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(gatewayapi_gateway_info unless (gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"} * on(name, namespace) group_left gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Programmed\"})\nor ignoring(type)\ngatewayapi_gateway_info unless (gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"} * on(name, namespace) group_left gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Accepted\"}))",
+          "expr": "count(gatewayapi_gateway_info unless (gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"} * on(name, exported_namespace, instance) group_left gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Programmed\"})\nor ignoring(type)\ngatewayapi_gateway_info unless (gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"} * on(name, exported_namespace, instance) group_left gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Accepted\"}))",
           "instant": true,
           "range": false,
           "refId": "A"
@@ -1141,7 +1141,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{name=~\"${route_name}\",exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "legendFormat": "API: {{name}}",
           "range": true,
           "refId": "A"
@@ -1323,7 +1323,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"4.*|5.*\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"4.*|5.*\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "legendFormat": "Total Errors: {{name}} ",
           "range": true,
           "refId": "A"
@@ -1334,7 +1334,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"4.*\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"4.*\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "4xx: {{name}} ",
           "range": true,
@@ -1346,7 +1346,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"5.*\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"5.*\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "5xx: {{name}} ",
           "range": true,
@@ -1358,7 +1358,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"404\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"404\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "404: {{name}}",
           "range": true,
@@ -1370,7 +1370,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"401\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"401\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "401: {{name}}",
           "range": true,
@@ -1382,7 +1382,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"429\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"429\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "429: {{name}}",
           "range": true,
@@ -1394,7 +1394,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"500\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"500\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "500: {{name}}",
           "range": true,
@@ -1406,7 +1406,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"501\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"501\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "501: {{name}}",
           "range": true,
@@ -1418,7 +1418,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(istio_requests_total{response_code=~\"503\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")",
+          "expr": "sum(rate(istio_requests_total{response_code=~\"503\"}[5m])) by (destination_service_name) * on(destination_service_name) group_right() (group without(instance, app_kubernetes_io_instance) (label_replace(gatewayapi_httproute_labels{exported_namespace=~\"${api_policy_namespace}\"}, \"destination_service_name\", \"$1\",\"service\", \"(.+)\")))",
           "hide": false,
           "legendFormat": "503: {{name}}",
           "range": true,


### PR DESCRIPTION
- small typo
- fixes for m:m errors with multi cluster metrics

I've done this manual for now.
The process should generally work the other way around (where a script exists in downstream repo already to pull the latest upstream dashboards from main).
If this becomes a regular thing, we can add a script to make the process easier in this direction too.