### PR TITLE
Reconcile out of order gateway resource creation.

### DIFF
--- a/api/v1alpha1/dnspolicy_types.go
+++ b/api/v1alpha1/dnspolicy_types.go
@@ -187,7 +187,7 @@ func (p *DNSPolicy) List(ctx context.Context, c client.Client, namespace string)
 	if err != nil {
 		return []kuadrantgatewayapi.Policy{}
 	}
-	policies := make([]kuadrantgatewayapi.Policy, 0)
+	policies := make([]kuadrantgatewayapi.Policy, 0, len(policyList.Items))
 	for i := range policyList.Items {
 		policies = append(policies, &policyList.Items[i])
 	}

--- a/api/v1alpha1/dnspolicy_types.go
+++ b/api/v1alpha1/dnspolicy_types.go
@@ -17,9 +17,11 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
@@ -177,6 +179,21 @@ func (p *DNSPolicy) GetStatus() kuadrantgatewayapi.PolicyStatus {
 }
 
 func (p *DNSPolicy) Kind() string { return p.TypeMeta.Kind }
+
+func (p *DNSPolicy) List(ctx context.Context, c client.Client, namespace string) []kuadrantgatewayapi.Policy {
+	policyList := &DNSPolicyList{}
+	listOptions := &client.ListOptions{Namespace: namespace}
+	err := c.List(ctx, policyList, listOptions)
+	if err != nil {
+		return []kuadrantgatewayapi.Policy{}
+	}
+	policies := make([]kuadrantgatewayapi.Policy, 0)
+	for i := range policyList.Items {
+		policies = append(policies, &policyList.Items[i])
+	}
+
+	return policies
+}
 
 func (p *DNSPolicy) PolicyClass() kuadrantgatewayapi.PolicyClass {
 	return kuadrantgatewayapi.DirectPolicy

--- a/api/v1alpha1/tlspolicy_types.go
+++ b/api/v1alpha1/tlspolicy_types.go
@@ -17,11 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"fmt"
 
 	certmanv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
@@ -145,6 +147,21 @@ type TLSPolicy struct {
 }
 
 func (p *TLSPolicy) Kind() string { return p.TypeMeta.Kind }
+
+func (p *TLSPolicy) List(ctx context.Context, c client.Client, namespace string) []kuadrantgatewayapi.Policy {
+	policyList := &TLSPolicyList{}
+	listOptions := &client.ListOptions{Namespace: namespace}
+	err := c.List(ctx, policyList, listOptions)
+	if err != nil {
+		return []kuadrantgatewayapi.Policy{}
+	}
+	policies := make([]kuadrantgatewayapi.Policy, 0)
+	for i := range policyList.Items {
+		policies = append(policies, &policyList.Items[i])
+	}
+
+	return policies
+}
 
 func (p *TLSPolicy) PolicyClass() kuadrantgatewayapi.PolicyClass {
 	return kuadrantgatewayapi.DirectPolicy

--- a/api/v1alpha1/tlspolicy_types.go
+++ b/api/v1alpha1/tlspolicy_types.go
@@ -155,7 +155,7 @@ func (p *TLSPolicy) List(ctx context.Context, c client.Client, namespace string)
 	if err != nil {
 		return []kuadrantgatewayapi.Policy{}
 	}
-	policies := make([]kuadrantgatewayapi.Policy, 0)
+	policies := make([]kuadrantgatewayapi.Policy, 0, len(policyList.Items))
 	for i := range policyList.Items {
 		policies = append(policies, &policyList.Items[i])
 	}

--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -1,12 +1,14 @@
 package v1beta2
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	authorinoapi "github.com/kuadrant/authorino/api/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
@@ -336,6 +338,21 @@ func (ap *AuthPolicy) GetRulesHostnames() (ruleHosts []string) {
 
 func (ap *AuthPolicy) Kind() string {
 	return ap.TypeMeta.Kind
+}
+
+func (ap *AuthPolicy) List(ctx context.Context, c client.Client, namespace string) []kuadrantgatewayapi.Policy {
+	policyList := &AuthPolicyList{}
+	listOptions := &client.ListOptions{Namespace: namespace}
+	err := c.List(ctx, policyList, listOptions)
+	if err != nil {
+		return []kuadrantgatewayapi.Policy{}
+	}
+	policies := make([]kuadrantgatewayapi.Policy, 0)
+	for i := range policyList.Items {
+		policies = append(policies, &policyList.Items[i])
+	}
+
+	return policies
 }
 
 func (ap *AuthPolicy) PolicyClass() kuadrantgatewayapi.PolicyClass {

--- a/api/v1beta2/authpolicy_types.go
+++ b/api/v1beta2/authpolicy_types.go
@@ -347,7 +347,7 @@ func (ap *AuthPolicy) List(ctx context.Context, c client.Client, namespace strin
 	if err != nil {
 		return []kuadrantgatewayapi.Policy{}
 	}
-	policies := make([]kuadrantgatewayapi.Policy, 0)
+	policies := make([]kuadrantgatewayapi.Policy, 0, len(policyList.Items))
 	for i := range policyList.Items {
 		policies = append(policies, &policyList.Items[i])
 	}

--- a/api/v1beta2/ratelimitpolicy_types.go
+++ b/api/v1beta2/ratelimitpolicy_types.go
@@ -276,8 +276,7 @@ func (r *RateLimitPolicy) Kind() string {
 
 func (r *RateLimitPolicy) List(ctx context.Context, c client.Client, namespace string) []kuadrantgatewayapi.Policy {
 	policyList := &RateLimitPolicyList{}
-	listOptions := &client.ListOptions{Namespace: namespace}
-	err := c.List(ctx, policyList, listOptions)
+	err := c.List(ctx, policyList, client.InNamespace(namespace))
 	if err != nil {
 		return []kuadrantgatewayapi.Policy{}
 	}

--- a/api/v1beta2/ratelimitpolicy_types.go
+++ b/api/v1beta2/ratelimitpolicy_types.go
@@ -281,7 +281,7 @@ func (r *RateLimitPolicy) List(ctx context.Context, c client.Client, namespace s
 	if err != nil {
 		return []kuadrantgatewayapi.Policy{}
 	}
-	policies := make([]kuadrantgatewayapi.Policy, 0)
+	policies := make([]kuadrantgatewayapi.Policy, 0, len(policyList.Items))
 	for i := range policyList.Items {
 		policies = append(policies, &policyList.Items[i])
 	}

--- a/api/v1beta2/ratelimitpolicy_types.go
+++ b/api/v1beta2/ratelimitpolicy_types.go
@@ -17,11 +17,13 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
@@ -270,6 +272,21 @@ func (r *RateLimitPolicy) GetRulesHostnames() (ruleHosts []string) {
 
 func (r *RateLimitPolicy) Kind() string {
 	return r.TypeMeta.Kind
+}
+
+func (r *RateLimitPolicy) List(ctx context.Context, c client.Client, namespace string) []kuadrantgatewayapi.Policy {
+	policyList := &RateLimitPolicyList{}
+	listOptions := &client.ListOptions{Namespace: namespace}
+	err := c.List(ctx, policyList, listOptions)
+	if err != nil {
+		return []kuadrantgatewayapi.Policy{}
+	}
+	policies := make([]kuadrantgatewayapi.Policy, 0)
+	for i := range policyList.Items {
+		policies = append(policies, &policyList.Items[i])
+	}
+
+	return policies
 }
 
 func (r *RateLimitPolicy) PolicyClass() kuadrantgatewayapi.PolicyClass {

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -272,7 +272,7 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return nil
 	}
 
-	httpRouteEventMapper := mappers.NewHTTPRouteEventMapper(mappers.WithLogger(r.Logger().WithName("httpRouteEventMapper")))
+	httpRouteEventMapper := mappers.NewHTTPRouteEventMapper(mappers.WithLogger(r.Logger().WithName("httpRouteEventMapper")), mappers.WithClient(mgr.GetClient()))
 	gatewayEventMapper := mappers.NewGatewayEventMapper(mappers.WithLogger(r.Logger().WithName("gatewayEventMapper")), mappers.WithClient(mgr.GetClient()))
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -281,7 +281,7 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return httpRouteEventMapper.MapToPolicy(object, &api.AuthPolicy{})
+				return httpRouteEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
 			}),
 		).
 		Watches(&gatewayapiv1.Gateway{},

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -281,12 +281,12 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return httpRouteEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+				return httpRouteEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
 			}),
 		).
 		Watches(&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+				return gatewayEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
 			}),
 		).
 		Complete(r)

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -271,7 +271,7 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	httpRouteEventMapper := mappers.NewHTTPRouteEventMapper(mappers.WithLogger(r.Logger().WithName("httpRouteEventMapper")))
-	gatewayEventMapper := mappers.NewGatewayEventMapper(mappers.WithLogger(r.Logger().WithName("gatewayEventMapper")))
+	//gatewayEventMapper := mappers.NewGatewayEventMapper(mappers.WithLogger(r.Logger().WithName("gatewayEventMapper")))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&api.AuthPolicy{}).
@@ -284,7 +284,7 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Watches(&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(object, &api.AuthPolicy{})
+				return mappers.MapToPolicyAP(ctx, mgr.GetClient(), object, &api.AuthPolicy{})
 			}),
 		).
 		Complete(r)

--- a/controllers/authpolicy_controller.go
+++ b/controllers/authpolicy_controller.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/go-logr/logr"
 	authorinoapi "github.com/kuadrant/authorino/api/v1beta2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -281,12 +279,12 @@ func (r *AuthPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return httpRouteEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+				return httpRouteEventMapper.MapToPolicy(ctx, object, &api.AuthPolicy{})
 			}),
 		).
 		Watches(&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+				return gatewayEventMapper.MapToPolicy(ctx, object, &api.AuthPolicy{})
 			}),
 		).
 		Complete(r)

--- a/controllers/dnspolicy_controller.go
+++ b/controllers/dnspolicy_controller.go
@@ -197,7 +197,7 @@ func (r *DNSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "DNSPolicy"})
+				return gatewayEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "DNSPolicy"})
 			}),
 		)
 	return ctrlr.Complete(r)

--- a/controllers/dnspolicy_controller.go
+++ b/controllers/dnspolicy_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -187,7 +188,7 @@ func (r *DNSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return nil
 	}
 
-	gatewayEventMapper := mappers.NewGatewayEventMapper(mappers.WithLogger(r.Logger().WithName("gatewayEventMapper")))
+	gatewayEventMapper := mappers.NewGatewayEventMapper(mappers.WithLogger(r.Logger().WithName("gatewayEventMapper")), mappers.WithClient(mgr.GetClient()))
 
 	r.dnsHelper = dnsHelper{Client: r.Client()}
 	ctrlr := ctrl.NewControllerManagedBy(mgr).
@@ -196,7 +197,7 @@ func (r *DNSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(object, &v1alpha1.DNSPolicy{})
+				return gatewayEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "DNSPolicy"})
 			}),
 		)
 	return ctrlr.Complete(r)

--- a/controllers/dnspolicy_controller.go
+++ b/controllers/dnspolicy_controller.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/controllers/dnspolicy_controller.go
+++ b/controllers/dnspolicy_controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -197,7 +196,7 @@ func (r *DNSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "v1alpha1", Kind: "DNSPolicy"})
+				return gatewayEventMapper.MapToPolicy(ctx, object, &v1alpha1.DNSPolicy{})
 			}),
 		)
 	return ctrlr.Complete(r)

--- a/controllers/dnspolicy_status_test.go
+++ b/controllers/dnspolicy_status_test.go
@@ -8,13 +8,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
-	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-
 	kuadrantdnsv1alpha1 "github.com/kuadrant/dns-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 )
 
 func TestPropagateRecordConditions(t *testing.T) {

--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -186,7 +186,6 @@ func testEndpointsTraversable(endpoints []*endpoint.Endpoint, host string, desti
 					// this means that at least one of the targets on the endpoint leads to the destination
 					allTargetsFound = allTargetsFound || testEndpointsTraversable(endpoints, target, []string{destination})
 				}
-
 			}
 		}
 		// we must match all destinations

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -237,7 +237,7 @@ func (r *RateLimitPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return nil
 	}
 
-	httpRouteEventMapper := mappers.NewHTTPRouteEventMapper(mappers.WithLogger(r.Logger().WithName("httpRouteEventMapper")))
+	httpRouteEventMapper := mappers.NewHTTPRouteEventMapper(mappers.WithLogger(r.Logger().WithName("httpRouteEventMapper")), mappers.WithClient(mgr.GetClient()))
 	gatewayEventMapper := mappers.NewGatewayEventMapper(mappers.WithLogger(r.Logger().WithName("gatewayEventMapper")), mappers.WithClient(mgr.GetClient()))
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -245,7 +245,7 @@ func (r *RateLimitPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return httpRouteEventMapper.MapToPolicy(object, &kuadrantv1beta2.RateLimitPolicy{})
+				return httpRouteEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
 			}),
 		).
 		// Currently the purpose is to generate events when rlp references change in gateways

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -245,7 +245,7 @@ func (r *RateLimitPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return httpRouteEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
+				return httpRouteEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
 			}),
 		).
 		// Currently the purpose is to generate events when rlp references change in gateways
@@ -253,7 +253,7 @@ func (r *RateLimitPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
+				return gatewayEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
 			}),
 		).
 		Complete(r)

--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -21,8 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -245,7 +243,7 @@ func (r *RateLimitPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.HTTPRoute{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return httpRouteEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
+				return httpRouteEventMapper.MapToPolicy(ctx, object, &kuadrantv1beta2.RateLimitPolicy{})
 			}),
 		).
 		// Currently the purpose is to generate events when rlp references change in gateways
@@ -253,7 +251,7 @@ func (r *RateLimitPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
+				return gatewayEventMapper.MapToPolicy(ctx, object, &kuadrantv1beta2.RateLimitPolicy{})
 			}),
 		).
 		Complete(r)

--- a/controllers/tlspolicy_certmanager_certificates.go
+++ b/controllers/tlspolicy_certmanager_certificates.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"time"
 
 	certmanv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -32,9 +31,7 @@ func (r *TLSPolicyReconciler) reconcileCertificates(ctx context.Context, tlsPoli
 	}
 
 	// Reconcile Certificates for each gateway directly referred by the policy (existing and new)
-	gwList := append(gwDiffObj.GatewaysWithValidPolicyRef, gwDiffObj.GatewaysMissingPolicyRef...)
-	time.Sleep(250 * time.Millisecond) // Sleep required to make "should delete tls certificate when listener is removed" integration test pass.
-	for _, gw := range gwList {
+	for _, gw := range append(gwDiffObj.GatewaysWithValidPolicyRef, gwDiffObj.GatewaysMissingPolicyRef...) {
 		log.V(1).Info("reconcileCertificates: gateway with valid or missing policy ref", "key", gw.Key())
 		expectedCertificates := r.expectedCertificatesForGateway(ctx, gw.Gateway, tlsPolicy)
 		if err := r.createOrUpdateGatewayCertificates(ctx, expectedCertificates); err != nil {

--- a/controllers/tlspolicy_certmanager_certificates.go
+++ b/controllers/tlspolicy_certmanager_certificates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	certmanv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -31,7 +32,9 @@ func (r *TLSPolicyReconciler) reconcileCertificates(ctx context.Context, tlsPoli
 	}
 
 	// Reconcile Certificates for each gateway directly referred by the policy (existing and new)
-	for _, gw := range append(gwDiffObj.GatewaysWithValidPolicyRef, gwDiffObj.GatewaysMissingPolicyRef...) {
+	gwList := append(gwDiffObj.GatewaysWithValidPolicyRef, gwDiffObj.GatewaysMissingPolicyRef...)
+	time.Sleep(250 * time.Millisecond) // Sleep required to make "should delete tls certificate when listener is removed" integration test pass.
+	for _, gw := range gwList {
 		log.V(1).Info("reconcileCertificates: gateway with valid or missing policy ref", "key", gw.Key())
 		expectedCertificates := r.expectedCertificatesForGateway(ctx, gw.Gateway, tlsPolicy)
 		if err := r.createOrUpdateGatewayCertificates(ctx, expectedCertificates); err != nil {

--- a/controllers/tlspolicy_controller.go
+++ b/controllers/tlspolicy_controller.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/controllers/tlspolicy_controller.go
+++ b/controllers/tlspolicy_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -196,14 +197,14 @@ func (r *TLSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return nil
 	}
 
-	gatewayEventMapper := mappers.NewGatewayEventMapper(mappers.WithLogger(r.Logger().WithName("gatewayEventMapper")))
+	gatewayEventMapper := mappers.NewGatewayEventMapper(mappers.WithLogger(r.Logger().WithName("gatewayEventMapper")), mappers.WithClient(mgr.GetClient()))
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.TLSPolicy{}).
 		Watches(
 			&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(object, &v1alpha1.TLSPolicy{})
+				return gatewayEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1alpha1", Kind: "TLSPolicy"})
 			}),
 		).
 		Complete(r)

--- a/controllers/tlspolicy_controller.go
+++ b/controllers/tlspolicy_controller.go
@@ -204,7 +204,7 @@ func (r *TLSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1alpha1", Kind: "TLSPolicy"})
+				return gatewayEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1alpha1", Kind: "TLSPolicy"})
 			}),
 		).
 		Complete(r)

--- a/controllers/tlspolicy_controller.go
+++ b/controllers/tlspolicy_controller.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -204,7 +203,7 @@ func (r *TLSPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&gatewayapiv1.Gateway{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
-				return gatewayEventMapper.MapToPolicy(ctx, object, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1alpha1", Kind: "TLSPolicy"})
+				return gatewayEventMapper.MapToPolicy(ctx, object, &v1alpha1.TLSPolicy{})
 			}),
 		).
 		Complete(r)

--- a/pkg/common/yaml_decoder_test.go
+++ b/pkg/common/yaml_decoder_test.go
@@ -9,13 +9,13 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/kuadrant/kuadrant-operator/pkg/log"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kuadrant/kuadrant-operator/pkg/log"
 )
 
 type testCase struct {

--- a/pkg/istio/mesh_config_test.go
+++ b/pkg/istio/mesh_config_test.go
@@ -5,8 +5,6 @@ package istio
 import (
 	"testing"
 
-	maistrav1 "github.com/kuadrant/kuadrant-operator/api/external/maistra/v1"
-	maistrav2 "github.com/kuadrant/kuadrant-operator/api/external/maistra/v2"
 	"google.golang.org/protobuf/types/known/structpb"
 	"gotest.tools/assert"
 	istiomeshv1alpha1 "istio.io/api/mesh/v1alpha1"
@@ -16,6 +14,9 @@ import (
 	istiov1alpha1 "maistra.io/istio-operator/api/v1alpha1"
 	"maistra.io/istio-operator/pkg/helm"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	maistrav1 "github.com/kuadrant/kuadrant-operator/api/external/maistra/v1"
+	maistrav2 "github.com/kuadrant/kuadrant-operator/api/external/maistra/v2"
 )
 
 type stubbedConfigWrapper struct {

--- a/pkg/kuadranttools/limitador_tools_test.go
+++ b/pkg/kuadranttools/limitador_tools_test.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/utils/ptr"
-
-	"github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kuadrant/kuadrant-operator/api/v1beta1"
 )
 
 func TestLimitadorMutator(t *testing.T) {

--- a/pkg/library/gatewayapi/helper_test.go
+++ b/pkg/library/gatewayapi/helper_test.go
@@ -3,11 +3,12 @@
 package gatewayapi
 
 import (
-	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
 
 const (

--- a/pkg/library/gatewayapi/topology.go
+++ b/pkg/library/gatewayapi/topology.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	typeField      dag.Field     = dag.Field("type")
-	gatewayLabel   dag.NodeLabel = dag.NodeLabel("gateway")
-	httprouteLabel dag.NodeLabel = dag.NodeLabel("httproute")
+	typeField                   dag.Field     = dag.Field("type")
+	gatewayLabel                dag.NodeLabel = dag.NodeLabel("gateway")
+	httprouteLabel              dag.NodeLabel = dag.NodeLabel("httproute")
+	HTTPRouteGatewayParentField               = ".metadata.parentRefs.gateway"
 )
 
 type RouteNode struct {

--- a/pkg/library/gatewayapi/topology.go
+++ b/pkg/library/gatewayapi/topology.go
@@ -15,10 +15,9 @@ import (
 )
 
 const (
-	typeField                   dag.Field     = dag.Field("type")
-	gatewayLabel                dag.NodeLabel = dag.NodeLabel("gateway")
-	httprouteLabel              dag.NodeLabel = dag.NodeLabel("httproute")
-	HTTPRouteGatewayParentField               = ".metadata.parentRefs.gateway"
+	typeField      dag.Field     = dag.Field("type")
+	gatewayLabel   dag.NodeLabel = dag.NodeLabel("gateway")
+	httprouteLabel dag.NodeLabel = dag.NodeLabel("httproute")
 )
 
 type RouteNode struct {

--- a/pkg/library/gatewayapi/types.go
+++ b/pkg/library/gatewayapi/types.go
@@ -1,9 +1,9 @@
 package gatewayapi
 
 import (
-	"k8s.io/apimachinery/pkg/api/meta"
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/library/gatewayapi/types.go
+++ b/pkg/library/gatewayapi/types.go
@@ -2,6 +2,8 @@ package gatewayapi
 
 import (
 	"k8s.io/apimachinery/pkg/api/meta"
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,6 +22,10 @@ type Policy interface {
 	PolicyClass() PolicyClass
 	GetTargetRef() gatewayapiv1alpha2.PolicyTargetReference
 	GetStatus() PolicyStatus
+	List(context.Context, client.Client, string) []Policy
+	Kind() string
+	BackReferenceAnnotationName() string
+	DirectReferenceAnnotationName() string
 }
 
 type PolicyStatus interface {

--- a/pkg/library/gatewayapi/types_test.go
+++ b/pkg/library/gatewayapi/types_test.go
@@ -3,10 +3,13 @@
 package gatewayapi
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -27,6 +30,22 @@ type TestPolicy struct {
 
 	TargetRef gatewayapiv1alpha2.PolicyTargetReference `json:"targetRef"`
 	Status    FakePolicyStatus                         `json:"status"`
+}
+
+func (p *TestPolicy) Kind() string {
+	return "FakePolicy"
+}
+
+func (p *TestPolicy) List(ctx context.Context, c client.Client, namespace string) []Policy {
+	return nil
+}
+
+func (p *TestPolicy) BackReferenceAnnotationName() string {
+	return ""
+}
+
+func (p *TestPolicy) DirectReferenceAnnotationName() string {
+	return ""
 }
 
 func (p *TestPolicy) PolicyClass() PolicyClass {

--- a/pkg/library/kuadrant/referrer.go
+++ b/pkg/library/kuadrant/referrer.go
@@ -2,6 +2,7 @@ package kuadrant
 
 import (
 	"encoding/json"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,4 +33,18 @@ func BackReferencesFromObject(obj client.Object, referrer Referrer) []client.Obj
 	}
 
 	return refs
+}
+
+func DirectReferencesFromObject(obj client.Object, referrer Referrer) client.ObjectKey {
+	annotations := utils.ReadAnnotationsFromObject(obj)
+	key := referrer.DirectReferenceAnnotationName()
+	directRefs, found := annotations[key]
+	if !found {
+		return client.ObjectKey{}
+	}
+
+	parts := strings.Split(directRefs, "/")
+	ref := client.ObjectKey{Namespace: parts[0], Name: parts[1]}
+
+	return ref
 }

--- a/pkg/library/kuadrant/referrer.go
+++ b/pkg/library/kuadrant/referrer.go
@@ -2,6 +2,7 @@ package kuadrant
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,16 +36,16 @@ func BackReferencesFromObject(obj client.Object, referrer Referrer) []client.Obj
 	return refs
 }
 
-func DirectReferencesFromObject(obj client.Object, referrer Referrer) client.ObjectKey {
+func DirectReferencesFromObject(obj client.Object, referrer Referrer) (client.ObjectKey, error) {
 	annotations := utils.ReadAnnotationsFromObject(obj)
 	key := referrer.DirectReferenceAnnotationName()
 	directRefs, found := annotations[key]
 	if !found {
-		return client.ObjectKey{}
+		return client.ObjectKey{}, fmt.Errorf("annotation %s not found", key)
 	}
 
 	parts := strings.Split(directRefs, "/")
 	ref := client.ObjectKey{Namespace: parts[0], Name: parts[1]}
 
-	return ref
+	return ref, nil
 }

--- a/pkg/library/kuadrant/test_utils.go
+++ b/pkg/library/kuadrant/test_utils.go
@@ -3,6 +3,8 @@
 package kuadrant
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -55,6 +57,10 @@ func (p *FakePolicy) GetRulesHostnames() []string {
 
 func (p *FakePolicy) Kind() string {
 	return "FakePolicy"
+}
+
+func (p *FakePolicy) List(ctx context.Context, client client.Client, namespace string) []Policy {
+	return nil
 }
 
 func (_ *FakePolicy) PolicyClass() kuadrantgatewayapi.PolicyClass {

--- a/pkg/library/kuadrant/test_utils.go
+++ b/pkg/library/kuadrant/test_utils.go
@@ -59,8 +59,16 @@ func (p *FakePolicy) Kind() string {
 	return "FakePolicy"
 }
 
-func (p *FakePolicy) List(ctx context.Context, client client.Client, namespace string) []Policy {
+func (p *FakePolicy) List(ctx context.Context, c client.Client, namespace string) []kuadrantgatewayapi.Policy {
 	return nil
+}
+
+func (p *FakePolicy) BackReferenceAnnotationName() string {
+	return ""
+}
+
+func (p *FakePolicy) DirectReferenceAnnotationName() string {
+	return ""
 }
 
 func (_ *FakePolicy) PolicyClass() kuadrantgatewayapi.PolicyClass {

--- a/pkg/library/mappers/event_mapper.go
+++ b/pkg/library/mappers/event_mapper.go
@@ -4,14 +4,15 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 )
 
 type EventMapper interface {
-	MapToPolicy(context.Context, client.Object, schema.GroupVersionKind) []reconcile.Request
+	MapToPolicy(context.Context, client.Object, kuadrantgatewayapi.Policy) []reconcile.Request
 }
 
 // options

--- a/pkg/library/mappers/event_mapper.go
+++ b/pkg/library/mappers/event_mapper.go
@@ -1,16 +1,17 @@
 package mappers
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 )
 
 type EventMapper interface {
-	MapToPolicy(client.Object, kuadrant.Referrer) []reconcile.Request
+	MapToPolicy(context.Context, client.Object, schema.GroupVersionKind) []reconcile.Request
 }
 
 // options

--- a/pkg/library/mappers/gateway.go
+++ b/pkg/library/mappers/gateway.go
@@ -19,24 +19,18 @@ import (
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
 
-// TODO: Clean this up
-type EventMapperTwo interface {
-	MapToPolicy(client.Object, schema.GroupVersionKind) []reconcile.Request
-}
-
-func NewGatewayEventMapper(o ...MapperOption) EventMapperTwo {
+func NewGatewayEventMapper(o ...MapperOption) EventMapper {
 	return &gatewayEventMapper{opts: Apply(o...)}
 }
 
-var _ EventMapperTwo = &gatewayEventMapper{}
+var _ EventMapper = &gatewayEventMapper{}
 
 type gatewayEventMapper struct {
 	opts MapperOptions
 }
 
-func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyGVK schema.GroupVersionKind) []reconcile.Request {
+func (m *gatewayEventMapper) MapToPolicy(ctx context.Context, obj client.Object, policyGVK schema.GroupVersionKind) []reconcile.Request {
 	logger := m.opts.Logger.WithValues("gateway", client.ObjectKeyFromObject(obj))
-	ctx := context.Background()
 	gateway, ok := obj.(*gatewayapiv1.Gateway)
 	if !ok {
 		logger.V(1).Info(fmt.Sprintf("%T is not type gateway, unable to map policies to gateway", obj))
@@ -53,7 +47,7 @@ func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyGVK schema.Gro
 	policyList.SetAPIVersion(policyGVK.Version)
 	policyList.SetKind(policyGVK.Kind)
 	if err := m.opts.Client.List(ctx, policyList, client.InNamespace(obj.GetNamespace())); err != nil {
-		logger.V(1).Info("unable to list UnstructuredList of policies, %T", policyGVK)
+		logger.V(1).Info("unable to list UnstructuredList of policies, %T", "policyGVl", policyGVK)
 		return []reconcile.Request{}
 	}
 

--- a/pkg/library/mappers/gateway.go
+++ b/pkg/library/mappers/gateway.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kuadrant/kuadrant-operator/pkg/library/fieldindexers"
 	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
@@ -31,7 +32,7 @@ func (m *gatewayEventMapper) MapToPolicy(ctx context.Context, obj client.Object,
 		return []reconcile.Request{}
 	}
 	routeList := &gatewayapiv1.HTTPRouteList{}
-	fields := client.MatchingFields{kuadrantgatewayapi.HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gateway).String()}
+	fields := client.MatchingFields{fieldindexers.HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gateway).String()}
 	if err := m.opts.Client.List(ctx, routeList, fields); err != nil {
 		logger.V(1).Error(err, "unable to list HTTPRoutes")
 		return []reconcile.Request{}

--- a/pkg/library/mappers/gateway.go
+++ b/pkg/library/mappers/gateway.go
@@ -4,47 +4,60 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 	api "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
 
-func NewGatewayEventMapper(o ...MapperOption) EventMapper {
+// TODO: Clean this up
+type EventMapperTwo interface {
+	MapToPolicy(client.Object, schema.GroupVersionKind) []reconcile.Request
+}
+
+func NewGatewayEventMapper(o ...MapperOption) EventMapperTwo {
 	return &gatewayEventMapper{opts: Apply(o...)}
 }
 
-var _ EventMapper = &gatewayEventMapper{}
+var _ EventMapperTwo = &gatewayEventMapper{}
 
 type gatewayEventMapper struct {
 	opts MapperOptions
 }
 
-func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyKind kuadrant.Referrer) []reconcile.Request {
-	logger := m.opts.Logger.WithValues("gateway", client.ObjectKeyFromObject(obj))
-
-	gateway, ok := obj.(*gatewayapiv1.Gateway)
-	if !ok {
-		logger.Info("cannot map gateway related event to kuadrant policy", "error", fmt.Sprintf("%T is not a *gatewayapiv1beta1.Gateway", obj))
-		return []reconcile.Request{}
-	}
-
-	requests := make([]reconcile.Request, 0)
-
-	for _, policyKey := range kuadrant.BackReferencesFromObject(gateway, policyKind) {
-		logger.V(1).Info("kuadrant policy possibly affected by the gateway related event found", policyKind.Kind(), policyKey)
-		requests = append(requests, reconcile.Request{NamespacedName: policyKey})
-	}
-
-	if len(requests) == 0 {
-		logger.V(1).Info("no kuadrant policy possibly affected by the gateway related event")
-	}
-
-	return requests
-}
+//func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyKind kuadrant.Referrer) []reconcile.Request {
+//	logger := m.opts.Logger.WithValues("gateway", client.ObjectKeyFromObject(obj))
+//
+//	gateway, ok := obj.(*gatewayapiv1.Gateway)
+//	if !ok {
+//		logger.Info("cannot map gateway related event to kuadrant policy", "error", fmt.Sprintf("%T is not a *gatewayapiv1beta1.Gateway", obj))
+//		return []reconcile.Request{}
+//	}
+//
+//	requests := make([]reconcile.Request, 0)
+//
+//	for _, policyKey := range kuadrant.BackReferencesFromObject(gateway, policyKind) {
+//		logger.V(1).Info("kuadrant policy possibly affected by the gateway related event found", policyKind.Kind(), policyKey)
+//		requests = append(requests, reconcile.Request{NamespacedName: policyKey})
+//	}
+//
+//	if len(requests) == 0 {
+//		logger.V(1).Info("no kuadrant policy possibly affected by the gateway related event")
+//	}
+//
+//	return requests
+//}
 
 func MapToPolicyAP(ctx context.Context, apiClient client.Client, obj client.Object, policyKind kuadrant.Referrer) []reconcile.Request {
 	// TODO: logger removed as function is not part of gatewayEventMapper interface.
@@ -81,4 +94,104 @@ func MapToPolicyAP(ctx context.Context, apiClient client.Client, obj client.Obje
 	}
 
 	return requests
+}
+
+func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyGVK schema.GroupVersionKind) []reconcile.Request {
+	logger := m.opts.Logger.WithValues("gateway", client.ObjectKeyFromObject(obj))
+	ctx := context.Background()
+	gateway, ok := obj.(*gatewayapiv1.Gateway)
+	if !ok {
+		logger.V(1).Info(fmt.Sprintf("%T is not type gateway, unable to map policies to gateway", obj))
+		return []reconcile.Request{}
+	}
+	// TODO: get this block in. Current unit test is failing with this
+	routeList := &gatewayapiv1.HTTPRouteList{}
+	fields := client.MatchingFields{kuadrantgatewayapi.HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gateway).String()}
+	if err := m.opts.Client.List(ctx, routeList, fields); err != nil {
+		logger.V(1).Error(err, "unable to list HTTPRoutes")
+		return []reconcile.Request{}
+	}
+
+	// TODO: remove this block. Add to not block unit test updates
+	//routeList := &gatewayapiv1.HTTPRouteList{}
+	//if err := m.opts.Client.List(ctx, routeList); err != nil {
+	//	logger.V(1).Error(err, "unable to list HTTPRoutes")
+	//	return []reconcile.Request{}
+	//}
+
+	policyList := &unstructured.UnstructuredList{}
+	policyList.SetAPIVersion(policyGVK.Version)
+	policyList.SetKind(policyGVK.Kind)
+	if err := m.opts.Client.List(ctx, policyList, client.InNamespace(obj.GetNamespace())); err != nil {
+		logger.V(1).Error(err, fmt.Sprintf("unable to list UnstructuredList of policies, %T", policyGVK))
+		return []reconcile.Request{}
+	}
+
+	var policies []kuadrantgatewayapi.Policy
+	if err := policyList.EachListItem(func(obj runtime.Object) error {
+		objBytes, err := json.Marshal(obj)
+		if err != nil {
+			return err
+		}
+
+		switch obj.GetObjectKind().GroupVersionKind().Kind {
+		case "AuthPolicy":
+			policy := &api.AuthPolicy{}
+			err = json.Unmarshal(objBytes, policy)
+			if err != nil {
+				return err
+			}
+			policies = append(policies, policy)
+		case "DNSPolicy":
+			policy := &v1alpha1.DNSPolicy{}
+			err = json.Unmarshal(objBytes, policy)
+			if err != nil {
+				return err
+			}
+			policies = append(policies, policy)
+		case "TLSPolicy":
+			policy := &v1alpha1.TLSPolicy{}
+			err = json.Unmarshal(objBytes, policy)
+			if err != nil {
+				return err
+			}
+			policies = append(policies, policy)
+		case "RateLimitPolicy":
+			policy := &api.RateLimitPolicy{}
+			err = json.Unmarshal(objBytes, policy)
+			if err != nil {
+				return err
+			}
+			policies = append(policies, policy)
+		default:
+			return fmt.Errorf("unknown policy kind: %s", obj.GetObjectKind().GroupVersionKind().Kind)
+		}
+		return nil
+	}); err != nil {
+		logger.V(1).Error(err, "unable to map unstructured List of policies")
+		return []reconcile.Request{}
+	}
+
+	if len(policies) == 0 {
+		logger.V(1).Info("no kuadrant policy possibly affected by teh gateway related event")
+		return []reconcile.Request{}
+	}
+
+	topology, err := kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithGateways([]*gatewayapiv1.Gateway{gateway}),
+		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
+		kuadrantgatewayapi.WithPolicies(policies),
+		kuadrantgatewayapi.WithLogger(logger),
+	)
+	if err != nil {
+		logger.V(1).Error(err, "unable to build topology for gateway")
+		return []reconcile.Request{}
+	}
+
+	index := kuadrantgatewayapi.NewTopologyIndexes(topology)
+	return utils.Map(index.PoliciesFromGateway(gateway), func(p kuadrantgatewayapi.Policy) reconcile.Request {
+		policyKey := client.ObjectKeyFromObject(p)
+		logger.V(1).Info("kuadrant policy possibly affected by the gateway related event found", policyGVK.Kind, policyKey)
+		return reconcile.Request{NamespacedName: policyKey}
+	})
 }

--- a/pkg/library/mappers/gateway.go
+++ b/pkg/library/mappers/gateway.go
@@ -53,7 +53,7 @@ func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyGVK schema.Gro
 	policyList.SetAPIVersion(policyGVK.Version)
 	policyList.SetKind(policyGVK.Kind)
 	if err := m.opts.Client.List(ctx, policyList, client.InNamespace(obj.GetNamespace())); err != nil {
-		logger.V(1).Error(err, fmt.Sprintf("unable to list UnstructuredList of policies, %T", policyGVK))
+		logger.V(1).Info("unable to list UnstructuredList of policies, %T", policyGVK)
 		return []reconcile.Request{}
 	}
 

--- a/pkg/library/mappers/gateway.go
+++ b/pkg/library/mappers/gateway.go
@@ -4,17 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
-	api "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
@@ -29,11 +23,11 @@ type gatewayEventMapper struct {
 	opts MapperOptions
 }
 
-func (m *gatewayEventMapper) MapToPolicy(ctx context.Context, obj client.Object, policyGVK schema.GroupVersionKind) []reconcile.Request {
+func (m *gatewayEventMapper) MapToPolicy(ctx context.Context, obj client.Object, policyKind kuadrantgatewayapi.Policy) []reconcile.Request {
 	logger := m.opts.Logger.WithValues("gateway", client.ObjectKeyFromObject(obj))
 	gateway, ok := obj.(*gatewayapiv1.Gateway)
 	if !ok {
-		logger.V(1).Info(fmt.Sprintf("%T is not type gateway, unable to map policies to gateway", obj))
+		logger.Info("cannot map gateway related event to kuadrant policy", "error", fmt.Sprintf("%T is not a *gatewayapiv1beta1.Gateway", obj))
 		return []reconcile.Request{}
 	}
 	routeList := &gatewayapiv1.HTTPRouteList{}
@@ -43,59 +37,7 @@ func (m *gatewayEventMapper) MapToPolicy(ctx context.Context, obj client.Object,
 		return []reconcile.Request{}
 	}
 
-	policyList := &unstructured.UnstructuredList{}
-	policyList.SetAPIVersion(policyGVK.Version)
-	policyList.SetKind(policyGVK.Kind)
-	if err := m.opts.Client.List(ctx, policyList, client.InNamespace(obj.GetNamespace())); err != nil {
-		logger.V(1).Info("unable to list UnstructuredList of policies, %T", "policyGVl", policyGVK)
-		return []reconcile.Request{}
-	}
-
-	var policies []kuadrantgatewayapi.Policy
-	if err := policyList.EachListItem(func(obj runtime.Object) error {
-		objBytes, err := json.Marshal(obj)
-		if err != nil {
-			return err
-		}
-
-		switch obj.GetObjectKind().GroupVersionKind().Kind {
-		case "AuthPolicy":
-			policy := &api.AuthPolicy{}
-			err = json.Unmarshal(objBytes, policy)
-			if err != nil {
-				return err
-			}
-			policies = append(policies, policy)
-		case "DNSPolicy":
-			policy := &v1alpha1.DNSPolicy{}
-			err = json.Unmarshal(objBytes, policy)
-			if err != nil {
-				return err
-			}
-			policies = append(policies, policy)
-		case "TLSPolicy":
-			policy := &v1alpha1.TLSPolicy{}
-			err = json.Unmarshal(objBytes, policy)
-			if err != nil {
-				return err
-			}
-			policies = append(policies, policy)
-		case "RateLimitPolicy":
-			policy := &api.RateLimitPolicy{}
-			err = json.Unmarshal(objBytes, policy)
-			if err != nil {
-				return err
-			}
-			policies = append(policies, policy)
-		default:
-			return fmt.Errorf("unknown policy kind: %s", obj.GetObjectKind().GroupVersionKind().Kind)
-		}
-		return nil
-	}); err != nil {
-		logger.V(1).Error(err, "unable to map unstructured List of policies")
-		return []reconcile.Request{}
-	}
-
+	policies := policyKind.List(ctx, m.opts.Client, obj.GetNamespace())
 	if len(policies) == 0 {
 		logger.V(1).Info("no kuadrant policy possibly affected by the gateway related event")
 		return []reconcile.Request{}
@@ -115,7 +57,7 @@ func (m *gatewayEventMapper) MapToPolicy(ctx context.Context, obj client.Object,
 	index := kuadrantgatewayapi.NewTopologyIndexes(topology)
 	return utils.Map(index.PoliciesFromGateway(gateway), func(p kuadrantgatewayapi.Policy) reconcile.Request {
 		policyKey := client.ObjectKeyFromObject(p)
-		logger.V(1).Info("kuadrant policy possibly affected by the gateway related event found", policyGVK.Kind, policyKey)
+		logger.V(1).Info("kuadrant policy possibly affected by the gateway related event found")
 		return reconcile.Request{NamespacedName: policyKey}
 	})
 }

--- a/pkg/library/mappers/gateway.go
+++ b/pkg/library/mappers/gateway.go
@@ -104,20 +104,12 @@ func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyGVK schema.Gro
 		logger.V(1).Info(fmt.Sprintf("%T is not type gateway, unable to map policies to gateway", obj))
 		return []reconcile.Request{}
 	}
-	// TODO: get this block in. Current unit test is failing with this
 	routeList := &gatewayapiv1.HTTPRouteList{}
 	fields := client.MatchingFields{kuadrantgatewayapi.HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gateway).String()}
 	if err := m.opts.Client.List(ctx, routeList, fields); err != nil {
 		logger.V(1).Error(err, "unable to list HTTPRoutes")
 		return []reconcile.Request{}
 	}
-
-	// TODO: remove this block. Add to not block unit test updates
-	//routeList := &gatewayapiv1.HTTPRouteList{}
-	//if err := m.opts.Client.List(ctx, routeList); err != nil {
-	//	logger.V(1).Error(err, "unable to list HTTPRoutes")
-	//	return []reconcile.Request{}
-	//}
 
 	policyList := &unstructured.UnstructuredList{}
 	policyList.SetAPIVersion(policyGVK.Version)

--- a/pkg/library/mappers/gateway.go
+++ b/pkg/library/mappers/gateway.go
@@ -12,12 +12,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 	api "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
 
@@ -34,66 +32,6 @@ var _ EventMapperTwo = &gatewayEventMapper{}
 
 type gatewayEventMapper struct {
 	opts MapperOptions
-}
-
-//func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyKind kuadrant.Referrer) []reconcile.Request {
-//	logger := m.opts.Logger.WithValues("gateway", client.ObjectKeyFromObject(obj))
-//
-//	gateway, ok := obj.(*gatewayapiv1.Gateway)
-//	if !ok {
-//		logger.Info("cannot map gateway related event to kuadrant policy", "error", fmt.Sprintf("%T is not a *gatewayapiv1beta1.Gateway", obj))
-//		return []reconcile.Request{}
-//	}
-//
-//	requests := make([]reconcile.Request, 0)
-//
-//	for _, policyKey := range kuadrant.BackReferencesFromObject(gateway, policyKind) {
-//		logger.V(1).Info("kuadrant policy possibly affected by the gateway related event found", policyKind.Kind(), policyKey)
-//		requests = append(requests, reconcile.Request{NamespacedName: policyKey})
-//	}
-//
-//	if len(requests) == 0 {
-//		logger.V(1).Info("no kuadrant policy possibly affected by the gateway related event")
-//	}
-//
-//	return requests
-//}
-
-func MapToPolicyAP(ctx context.Context, apiClient client.Client, obj client.Object, policyKind kuadrant.Referrer) []reconcile.Request {
-	// TODO: logger removed as function is not part of gatewayEventMapper interface.
-	//logger := m.opts.Logger.WithValues("gateway", client.ObjectKeyFromObject(obj))
-
-	gateway, ok := obj.(*gatewayapiv1.Gateway)
-	if !ok {
-		//logger.Info("cannot map gateway related event to kuadrant policy", "error", fmt.Sprintf("%T is not a *gatewayapiv1beta1.Gateway", obj))
-		return []reconcile.Request{}
-	}
-
-	requests := make([]reconcile.Request, 0)
-
-	for _, policyKey := range kuadrant.BackReferencesFromObject(gateway, policyKind) {
-		//logger.V(1).Info("kuadrant policy possibly affected by the gateway related event found", policyKind.Kind(), policyKey)
-		requests = append(requests, reconcile.Request{NamespacedName: policyKey})
-	}
-
-	if len(requests) == 0 {
-		authPolices := &api.AuthPolicyList{}
-		err := apiClient.List(ctx, authPolices, client.InNamespace(obj.GetNamespace()))
-		if err != nil {
-			return requests
-			// TODO: add some logging or something.
-		}
-		//logger.V(1).Info("no kuadrant policy possibly affected by the gateway related event")
-		for idx, authPolicy := range authPolices.Items {
-			for _, cond := range authPolicy.Status.Conditions {
-				if cond.Type == string(gatewayapiv1alpha2.PolicyConditionAccepted) && cond.Reason == string(gatewayapiv1alpha2.PolicyReasonTargetNotFound) {
-					requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&authPolices.Items[idx])})
-				}
-			}
-		}
-	}
-
-	return requests
 }
 
 func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyGVK schema.GroupVersionKind) []reconcile.Request {
@@ -165,7 +103,7 @@ func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyGVK schema.Gro
 	}
 
 	if len(policies) == 0 {
-		logger.V(1).Info("no kuadrant policy possibly affected by teh gateway related event")
+		logger.V(1).Info("no kuadrant policy possibly affected by the gateway related event")
 		return []reconcile.Request{}
 	}
 

--- a/pkg/library/mappers/gateway.go
+++ b/pkg/library/mappers/gateway.go
@@ -1,12 +1,15 @@
 package mappers
 
 import (
+	"context"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	api "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 )
 
@@ -38,6 +41,43 @@ func (m *gatewayEventMapper) MapToPolicy(obj client.Object, policyKind kuadrant.
 
 	if len(requests) == 0 {
 		logger.V(1).Info("no kuadrant policy possibly affected by the gateway related event")
+	}
+
+	return requests
+}
+
+func MapToPolicyAP(ctx context.Context, apiClient client.Client, obj client.Object, policyKind kuadrant.Referrer) []reconcile.Request {
+	// TODO: logger removed as function is not part of gatewayEventMapper interface.
+	//logger := m.opts.Logger.WithValues("gateway", client.ObjectKeyFromObject(obj))
+
+	gateway, ok := obj.(*gatewayapiv1.Gateway)
+	if !ok {
+		//logger.Info("cannot map gateway related event to kuadrant policy", "error", fmt.Sprintf("%T is not a *gatewayapiv1beta1.Gateway", obj))
+		return []reconcile.Request{}
+	}
+
+	requests := make([]reconcile.Request, 0)
+
+	for _, policyKey := range kuadrant.BackReferencesFromObject(gateway, policyKind) {
+		//logger.V(1).Info("kuadrant policy possibly affected by the gateway related event found", policyKind.Kind(), policyKey)
+		requests = append(requests, reconcile.Request{NamespacedName: policyKey})
+	}
+
+	if len(requests) == 0 {
+		authPolices := &api.AuthPolicyList{}
+		err := apiClient.List(ctx, authPolices, client.InNamespace(obj.GetNamespace()))
+		if err != nil {
+			return requests
+			// TODO: add some logging or something.
+		}
+		//logger.V(1).Info("no kuadrant policy possibly affected by the gateway related event")
+		for idx, authPolicy := range authPolices.Items {
+			for _, cond := range authPolicy.Status.Conditions {
+				if cond.Type == string(gatewayapiv1alpha2.PolicyConditionAccepted) && cond.Reason == string(gatewayapiv1alpha2.PolicyReasonTargetNotFound) {
+					requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&authPolices.Items[idx])})
+				}
+			}
+		}
 	}
 
 	return requests

--- a/pkg/library/mappers/gateway_test.go
+++ b/pkg/library/mappers/gateway_test.go
@@ -3,21 +3,23 @@
 package mappers
 
 import (
+	"testing"
+
+	"gotest.tools/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
-
-	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 	"github.com/kuadrant/kuadrant-operator/pkg/log"
 )
 
@@ -60,7 +62,9 @@ func TestNewGatewayEventMapper(t *testing.T) {
 		},
 	}}
 	objs := []runtime.Object{routeList, authPolicyList}
-	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).Build()
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).WithIndex(&gatewayapiv1.HTTPRoute{}, kuadrantgatewayapi.HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
+		return nil
+	}).Build()
 	em := NewGatewayEventMapper(WithLogger(log.NewLogger()), WithClient(cl))
 
 	t.Run("not gateway related event", func(subT *testing.T) {

--- a/pkg/library/mappers/gateway_test.go
+++ b/pkg/library/mappers/gateway_test.go
@@ -3,6 +3,7 @@
 package mappers
 
 import (
+	"context"
 	"testing"
 
 	"gotest.tools/assert"
@@ -68,12 +69,12 @@ func TestNewGatewayEventMapper(t *testing.T) {
 	em := NewGatewayEventMapper(WithLogger(log.NewLogger()), WithClient(cl))
 
 	t.Run("not gateway related event", func(subT *testing.T) {
-		requests := em.MapToPolicy(&gatewayapiv1.HTTPRoute{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
+		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.HTTPRoute{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
 	t.Run("gateway related event - no requests", func(subT *testing.T) {
-		requests := em.MapToPolicy(&gatewayapiv1.Gateway{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
+		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.Gateway{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
@@ -89,7 +90,7 @@ func TestNewGatewayEventMapper(t *testing.T) {
 				},
 			},
 		}
-		requests := em.MapToPolicy(gateway, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+		requests := em.MapToPolicy(context.Background(), gateway, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
 		expected := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-1"}}, {NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-2"}}}
 		assert.DeepEqual(subT, expected, requests)
 	})

--- a/pkg/library/mappers/gateway_test.go
+++ b/pkg/library/mappers/gateway_test.go
@@ -3,34 +3,89 @@
 package mappers
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 
 	"gotest.tools/assert"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	"github.com/kuadrant/kuadrant-operator/pkg/log"
 )
 
 func TestNewGatewayEventMapper(t *testing.T) {
-	em := NewGatewayEventMapper(WithLogger(log.NewLogger()))
+	err := appsv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = gatewayapiv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = kuadrantv1beta2.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec := kuadrantv1beta2.AuthPolicySpec{
+		TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
+			Group: "gateway.networking.k8s.io",
+			Kind:  "Gateway",
+			Name:  "test-gw",
+		},
+	}
+	routeList := &gatewayapiv1.HTTPRouteList{Items: make([]gatewayapiv1.HTTPRoute, 0)}
+	authPolicyList := &kuadrantv1beta2.AuthPolicyList{Items: []kuadrantv1beta2.AuthPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "policy-1",
+				Namespace: "app-ns",
+			},
+			Spec: spec,
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "policy-2",
+				Namespace: "app-ns",
+			},
+			Spec: spec,
+		},
+	}}
+	objs := []runtime.Object{routeList, authPolicyList}
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).Build()
+	em := NewGatewayEventMapper(WithLogger(log.NewLogger()), WithClient(cl))
 
 	t.Run("not gateway related event", func(subT *testing.T) {
-		requests := em.MapToPolicy(&gatewayapiv1.HTTPRoute{}, &kuadrant.PolicyKindStub{})
+		requests := em.MapToPolicy(&gatewayapiv1.HTTPRoute{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
 	t.Run("gateway related event - no requests", func(subT *testing.T) {
-		requests := em.MapToPolicy(&gatewayapiv1.Gateway{}, &kuadrant.PolicyKindStub{})
+		requests := em.MapToPolicy(&gatewayapiv1.Gateway{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
 	t.Run("gateway related event - requests", func(subT *testing.T) {
-		gateway := &gatewayapiv1.Gateway{}
-		gateway.SetAnnotations(map[string]string{"kuadrant.io/testpolicies": `[{"Namespace":"app-ns","Name":"policy-1"},{"Namespace":"app-ns","Name":"policy-2"}]`})
-		requests := em.MapToPolicy(gateway, &kuadrant.PolicyKindStub{})
+		gateway := &gatewayapiv1.Gateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-gw", Namespace: "app-ns"},
+			Status: gatewayapiv1alpha2.GatewayStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   "Programmed",
+						Status: "True",
+					},
+				},
+			},
+		}
+		requests := em.MapToPolicy(gateway, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
 		expected := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-1"}}, {NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-2"}}}
 		assert.DeepEqual(subT, expected, requests)
 	})

--- a/pkg/library/mappers/gateway_test.go
+++ b/pkg/library/mappers/gateway_test.go
@@ -19,7 +19,7 @@ import (
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
-	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/fieldindexers"
 	"github.com/kuadrant/kuadrant-operator/pkg/log"
 )
 
@@ -62,7 +62,7 @@ func TestNewGatewayEventMapper(t *testing.T) {
 		},
 	}}
 	objs := []runtime.Object{routeList, authPolicyList}
-	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).WithIndex(&gatewayapiv1.HTTPRoute{}, kuadrantgatewayapi.HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).WithIndex(&gatewayapiv1.HTTPRoute{}, fieldindexers.HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
 		return nil
 	}).Build()
 	em := NewGatewayEventMapper(WithLogger(log.NewLogger()), WithClient(cl))

--- a/pkg/library/mappers/gateway_test.go
+++ b/pkg/library/mappers/gateway_test.go
@@ -10,7 +10,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,12 +68,12 @@ func TestNewGatewayEventMapper(t *testing.T) {
 	em := NewGatewayEventMapper(WithLogger(log.NewLogger()), WithClient(cl))
 
 	t.Run("not gateway related event", func(subT *testing.T) {
-		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.HTTPRoute{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
+		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.HTTPRoute{}, &kuadrantv1beta2.RateLimitPolicy{})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
 	t.Run("gateway related event - no requests", func(subT *testing.T) {
-		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.Gateway{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "RateLimitPolicy"})
+		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.Gateway{}, &kuadrantv1beta2.RateLimitPolicy{})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
@@ -90,7 +89,7 @@ func TestNewGatewayEventMapper(t *testing.T) {
 				},
 			},
 		}
-		requests := em.MapToPolicy(context.Background(), gateway, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+		requests := em.MapToPolicy(context.Background(), gateway, &kuadrantv1beta2.AuthPolicy{})
 		expected := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-1"}}, {NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-2"}}}
 		assert.DeepEqual(subT, expected, requests)
 	})

--- a/pkg/library/mappers/httproute.go
+++ b/pkg/library/mappers/httproute.go
@@ -1,44 +1,153 @@
 package mappers
 
 import (
+	"context"
 	"fmt"
-
+	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
+	api "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
-
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 )
 
-func NewHTTPRouteEventMapper(o ...MapperOption) EventMapper {
+func NewHTTPRouteEventMapper(o ...MapperOption) EventMapperTwo {
 	return &httpRouteEventMapper{opts: Apply(o...)}
 }
 
-var _ EventMapper = &httpRouteEventMapper{}
+var _ EventMapperTwo = &httpRouteEventMapper{}
 
 type httpRouteEventMapper struct {
 	opts MapperOptions
 }
 
-func (m *httpRouteEventMapper) MapToPolicy(obj client.Object, policyKind kuadrant.Referrer) []reconcile.Request {
+func (m *httpRouteEventMapper) MapToPolicy(obj client.Object, policyGVK schema.GroupVersionKind) []reconcile.Request {
 	logger := m.opts.Logger.WithValues("httproute", client.ObjectKeyFromObject(obj))
-
+	ctx := context.Background()
+	requests := make([]reconcile.Request, 0)
 	httpRoute, ok := obj.(*gatewayapiv1.HTTPRoute)
 	if !ok {
 		logger.Info("cannot map httproute event to kuadrant policy", "error", fmt.Sprintf("%T is not a *gatewayapiv1beta1.HTTPRoute", obj))
 		return []reconcile.Request{}
 	}
 
-	requests := make([]reconcile.Request, 0)
+	gatewayKeys := kuadrantgatewayapi.GetRouteAcceptedGatewayParentKeys(httpRoute)
 
-	for _, policyKey := range kuadrant.BackReferencesFromObject(httpRoute, policyKind) {
-		logger.V(1).Info("kuadrant policy possibly affected by the httproute related event found", policyKind.Kind(), policyKey)
-		requests = append(requests, reconcile.Request{NamespacedName: policyKey})
+	for _, gatewayKey := range gatewayKeys {
+		gateway := &gatewayapiv1.Gateway{}
+		err := m.opts.Client.Get(ctx, gatewayKey, gateway)
+		if err != nil {
+			logger.Info("cannot get gateway", "error", err)
+			continue
+		}
+
+		routeList := &gatewayapiv1.HTTPRouteList{}
+		fields := client.MatchingFields{kuadrantgatewayapi.HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gateway).String()}
+		if err = m.opts.Client.List(ctx, routeList, fields); err != nil {
+			logger.Info("cannot list httproutes", "error", err)
+			continue
+		}
+		policyList := &unstructured.UnstructuredList{}
+		policyList.SetAPIVersion(policyGVK.Version)
+		policyList.SetKind(policyGVK.Kind)
+		if err = m.opts.Client.List(ctx, policyList, client.InNamespace(obj.GetNamespace())); err != nil {
+			logger.V(1).Info("unable to list UnstructuredList of policies, %T", policyGVK)
+			continue
+		}
+
+		var policies []kuadrantgatewayapi.Policy
+		if err = policyList.EachListItem(func(obj runtime.Object) error {
+			objBytes, err := json.Marshal(obj)
+			if err != nil {
+				return err
+			}
+
+			switch obj.GetObjectKind().GroupVersionKind().Kind {
+			case "AuthPolicy":
+				policy := &api.AuthPolicy{}
+				err = json.Unmarshal(objBytes, policy)
+				if err != nil {
+					return err
+				}
+				policies = append(policies, policy)
+			case "DNSPolicy":
+				policy := &v1alpha1.DNSPolicy{}
+				err = json.Unmarshal(objBytes, policy)
+				if err != nil {
+					return err
+				}
+				policies = append(policies, policy)
+			case "TLSPolicy":
+				policy := &v1alpha1.TLSPolicy{}
+				err = json.Unmarshal(objBytes, policy)
+				if err != nil {
+					return err
+				}
+				policies = append(policies, policy)
+			case "RateLimitPolicy":
+				policy := &api.RateLimitPolicy{}
+				err = json.Unmarshal(objBytes, policy)
+				if err != nil {
+					return err
+				}
+				policies = append(policies, policy)
+			default:
+				return fmt.Errorf("unknown policy kind: %s", obj.GetObjectKind().GroupVersionKind().Kind)
+			}
+			return nil
+		}); err != nil {
+			logger.Info("unable to list UnstructuredList of policies, %T", policyGVK)
+			continue
+		}
+		if len(policies) == 0 {
+			logger.Info("no kuadrant policy possibly affected by the gateway related event")
+			continue
+		}
+		topology, err := kuadrantgatewayapi.NewTopology(
+			kuadrantgatewayapi.WithGateways([]*gatewayapiv1.Gateway{gateway}),
+			kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
+			kuadrantgatewayapi.WithPolicies(policies),
+			kuadrantgatewayapi.WithLogger(logger),
+		)
+		if err != nil {
+			logger.Info("unable to build topology for gateway", "error", err)
+			continue
+		}
+		index := kuadrantgatewayapi.NewTopologyIndexes(topology)
+		data := utils.Map(index.PoliciesFromGateway(gateway), func(p kuadrantgatewayapi.Policy) reconcile.Request {
+			policyKey := client.ObjectKeyFromObject(p)
+			logger.V(1).Info("kuadrant policy possibly affected by the gateway related event found", policyGVK.Kind, policyKey)
+			return reconcile.Request{NamespacedName: policyKey}
+		})
+		requests = append(requests, data...)
 	}
 
-	if len(requests) == 0 {
-		logger.V(1).Info("no kuadrant policy possibly affected by the httproute related event")
+	if len(requests) != 0 {
+		return requests
 	}
 
+	// This block is required when a HTTProute has being deleted
+	var policy kuadrant.Referrer
+	switch policyGVK.Kind {
+	case "AuthPolicy":
+		policy = &api.AuthPolicy{}
+	case "DNSPolicy":
+		policy = &v1alpha1.DNSPolicy{}
+	case "TLSPolicy":
+		policy = &v1alpha1.TLSPolicy{}
+	case "RateLimitPolicy":
+		policy = &api.RateLimitPolicy{}
+	default:
+		return requests
+	}
+	policyKey := kuadrant.DirectReferencesFromObject(httpRoute, policy)
+	requests = append(requests, reconcile.Request{NamespacedName: policyKey})
 	return requests
 }

--- a/pkg/library/mappers/httproute.go
+++ b/pkg/library/mappers/httproute.go
@@ -80,6 +80,7 @@ func (m *httpRouteEventMapper) MapToPolicy(ctx context.Context, obj client.Objec
 
 	policyKey, err := kuadrant.DirectReferencesFromObject(httpRoute, policyKind)
 	if err != nil {
+		logger.Info("could not create direct reference from object", "error", err)
 		return requests
 	}
 	requests = append(requests, reconcile.Request{NamespacedName: policyKey})

--- a/pkg/library/mappers/httproute.go
+++ b/pkg/library/mappers/httproute.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kuadrant/kuadrant-operator/pkg/library/fieldindexers"
 	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
@@ -44,7 +45,7 @@ func (m *httpRouteEventMapper) MapToPolicy(ctx context.Context, obj client.Objec
 		}
 
 		routeList := &gatewayapiv1.HTTPRouteList{}
-		fields := client.MatchingFields{kuadrantgatewayapi.HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gateway).String()}
+		fields := client.MatchingFields{fieldindexers.HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gateway).String()}
 		if err = m.opts.Client.List(ctx, routeList, fields); err != nil {
 			logger.Info("cannot list httproutes", "error", err)
 			continue

--- a/pkg/library/mappers/httproute_test.go
+++ b/pkg/library/mappers/httproute_test.go
@@ -6,14 +6,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
-	"github.com/kuadrant/kuadrant-operator/pkg/log"
 	"gotest.tools/assert"
 	"istio.io/client-go/pkg/clientset/versioned/scheme"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -21,6 +18,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
+	"github.com/kuadrant/kuadrant-operator/pkg/log"
 
 	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
@@ -75,12 +75,12 @@ func TestNewHTTPRouteEventMapper(t *testing.T) {
 	em := NewHTTPRouteEventMapper(WithLogger(log.NewLogger()), WithClient(cl))
 
 	t.Run("not http route related event", func(subT *testing.T) {
-		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.Gateway{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.Gateway{}, &kuadrantv1beta2.AuthPolicy{})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
 	t.Run("http route related event - no requests", func(subT *testing.T) {
-		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.HTTPRoute{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.HTTPRoute{}, &kuadrantv1beta2.AuthPolicy{})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
@@ -129,7 +129,7 @@ func TestNewHTTPRouteEventMapper(t *testing.T) {
 			})
 		}).Build()
 		em = NewHTTPRouteEventMapper(WithLogger(log.NewLogger()), WithClient(cl))
-		requests := em.MapToPolicy(context.Background(), httpRoute, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+		requests := em.MapToPolicy(context.Background(), httpRoute, &kuadrantv1beta2.AuthPolicy{})
 		expected := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-1"}}}
 		assert.DeepEqual(subT, expected, requests)
 	})

--- a/pkg/library/mappers/httproute_test.go
+++ b/pkg/library/mappers/httproute_test.go
@@ -19,11 +19,11 @@ import (
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/library/fieldindexers"
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 	"github.com/kuadrant/kuadrant-operator/pkg/log"
-
-	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
-	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 )
 
 func TestNewHTTPRouteEventMapper(t *testing.T) {
@@ -69,7 +69,7 @@ func TestNewHTTPRouteEventMapper(t *testing.T) {
 		},
 	}
 	objs := []runtime.Object{routeList, authPolicyList, gateway}
-	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).WithIndex(&gatewayapiv1.HTTPRoute{}, kuadrantgatewayapi.HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).WithIndex(&gatewayapiv1.HTTPRoute{}, fieldindexers.HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
 		return nil
 	}).Build()
 	em := NewHTTPRouteEventMapper(WithLogger(log.NewLogger()), WithClient(cl))
@@ -118,7 +118,7 @@ func TestNewHTTPRouteEventMapper(t *testing.T) {
 		}
 
 		objs = []runtime.Object{routeList, authPolicyList, gateway, httpRoute}
-		cl = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).WithIndex(&gatewayapiv1.HTTPRoute{}, kuadrantgatewayapi.HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
+		cl = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).WithIndex(&gatewayapiv1.HTTPRoute{}, fieldindexers.HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
 			route, assertionOk := rawObj.(*gatewayapiv1.HTTPRoute)
 			if !assertionOk {
 				return nil

--- a/pkg/library/mappers/httproute_test.go
+++ b/pkg/library/mappers/httproute_test.go
@@ -3,35 +3,134 @@
 package mappers
 
 import (
+	"context"
 	"testing"
 
+	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
+	"github.com/kuadrant/kuadrant-operator/pkg/log"
 	"gotest.tools/assert"
+	"istio.io/client-go/pkg/clientset/versioned/scheme"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
-	"github.com/kuadrant/kuadrant-operator/pkg/log"
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 )
 
 func TestNewHTTPRouteEventMapper(t *testing.T) {
-	em := NewHTTPRouteEventMapper(WithLogger(log.NewLogger()))
+	err := appsv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = gatewayapiv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = kuadrantv1beta2.AddToScheme(scheme.Scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	spec := kuadrantv1beta2.AuthPolicySpec{
+		TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
+			Group: "gateway.networking.k8s.io",
+			Kind:  "HTTPRoute",
+			Name:  "test-route",
+		},
+	}
+	routeList := &gatewayapiv1.HTTPRouteList{Items: make([]gatewayapiv1.HTTPRoute, 0)}
+	authPolicyList := &kuadrantv1beta2.AuthPolicyList{Items: []kuadrantv1beta2.AuthPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "policy-1",
+				Namespace: "app-ns",
+			},
+			Spec: spec,
+		},
+	}}
+	gateway := &gatewayapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gw", Namespace: "app-ns"},
+		Status: gatewayapiv1alpha2.GatewayStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:   "Programmed",
+					Status: "True",
+				},
+			},
+		},
+	}
+	objs := []runtime.Object{routeList, authPolicyList, gateway}
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).WithIndex(&gatewayapiv1.HTTPRoute{}, kuadrantgatewayapi.HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
+		return nil
+	}).Build()
+	em := NewHTTPRouteEventMapper(WithLogger(log.NewLogger()), WithClient(cl))
 
 	t.Run("not http route related event", func(subT *testing.T) {
-		requests := em.MapToPolicy(&gatewayapiv1.Gateway{}, &kuadrant.PolicyKindStub{})
+		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.Gateway{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
 	t.Run("http route related event - no requests", func(subT *testing.T) {
-		requests := em.MapToPolicy(&gatewayapiv1.HTTPRoute{}, &kuadrant.PolicyKindStub{})
+		requests := em.MapToPolicy(context.Background(), &gatewayapiv1.HTTPRoute{}, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
 		assert.DeepEqual(subT, []reconcile.Request{}, requests)
 	})
 
 	t.Run("http related event - requests", func(subT *testing.T) {
-		httpRoute := &gatewayapiv1.HTTPRoute{}
-		httpRoute.SetAnnotations(map[string]string{"kuadrant.io/testpolicies": `[{"Namespace":"app-ns","Name":"policy-1"},{"Namespace":"app-ns","Name":"policy-2"}]`})
-		requests := em.MapToPolicy(httpRoute, &kuadrant.PolicyKindStub{})
-		expected := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-1"}}, {NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-2"}}}
+		httpRoute := &gatewayapiv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-route",
+				Namespace:   "app-ns",
+				Annotations: map[string]string{"kuadrant.io/testpolicies": `[{"Namespace":"app-ns","Name":"policy-1"},{"Namespace":"app-ns","Name":"policy-2"}]`},
+			},
+			Spec: gatewayapiv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+					ParentRefs: []gatewayapiv1.ParentReference{{Namespace: ptr.To(gatewayapiv1.Namespace("app-ns")), Name: "test-gw"}},
+				},
+			},
+
+			Status: gatewayapiv1.HTTPRouteStatus{
+				RouteStatus: gatewayapiv1.RouteStatus{
+					Parents: []gatewayapiv1.RouteParentStatus{
+						{
+							ParentRef: gatewayapiv1.ParentReference{
+								Name:      "test-gw",
+								Namespace: ptr.To(gatewayapiv1.Namespace("app-ns")),
+							},
+							Conditions: []metav1.Condition{
+								{
+									Type:   "Accepted",
+									Status: metav1.ConditionTrue,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		objs = []runtime.Object{routeList, authPolicyList, gateway, httpRoute}
+		cl = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).WithIndex(&gatewayapiv1.HTTPRoute{}, kuadrantgatewayapi.HTTPRouteGatewayParentField, func(rawObj client.Object) []string {
+			route, assertionOk := rawObj.(*gatewayapiv1.HTTPRoute)
+			if !assertionOk {
+				return nil
+			}
+
+			return utils.Map(kuadrantgatewayapi.GetRouteAcceptedGatewayParentKeys(route), func(key client.ObjectKey) string {
+				return key.String()
+			})
+		}).Build()
+		em = NewHTTPRouteEventMapper(WithLogger(log.NewLogger()), WithClient(cl))
+		requests := em.MapToPolicy(context.Background(), httpRoute, schema.GroupVersionKind{Group: "kuadrant.io", Version: "kuadrant.io/v1beta2", Kind: "AuthPolicy"})
+		expected := []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: "app-ns", Name: "policy-1"}}}
 		assert.DeepEqual(subT, expected, requests)
 	})
 }

--- a/pkg/library/utils/k8s_utils_test.go
+++ b/pkg/library/utils/k8s_utils_test.go
@@ -507,7 +507,7 @@ func TestGetServicePortNumber(t *testing.T) {
 						{
 							Name:       "http",
 							Port:       80,
-							TargetPort: intstr.FromInt(8080),
+							TargetPort: intstr.FromInt32(8080),
 						},
 					},
 				},
@@ -525,7 +525,7 @@ func TestGetServicePortNumber(t *testing.T) {
 						{
 							Name:       "http",
 							Port:       80,
-							TargetPort: intstr.FromInt(8080),
+							TargetPort: intstr.FromInt32(8080),
 						},
 					},
 				},
@@ -550,17 +550,17 @@ func TestGetServicePortNumber(t *testing.T) {
 						{
 							Name:       "http1",
 							Port:       8080,
-							TargetPort: intstr.FromInt(8080),
+							TargetPort: intstr.FromInt32(8080),
 						},
 						{
 							Name:       "http2",
 							Port:       8090,
-							TargetPort: intstr.FromInt(8090),
+							TargetPort: intstr.FromInt32(8090),
 						},
 						{
 							Name:       "http3",
 							Port:       8100,
-							TargetPort: intstr.FromInt(8100),
+							TargetPort: intstr.FromInt32(8100),
 						},
 					},
 				},
@@ -578,17 +578,17 @@ func TestGetServicePortNumber(t *testing.T) {
 						{
 							Name:       "http1",
 							Port:       8080,
-							TargetPort: intstr.FromInt(8080),
+							TargetPort: intstr.FromInt32(8080),
 						},
 						{
 							Name:       "http2",
 							Port:       8090,
-							TargetPort: intstr.FromInt(8090),
+							TargetPort: intstr.FromInt32(8090),
 						},
 						{
 							Name:       "http3",
 							Port:       8100,
-							TargetPort: intstr.FromInt(8100),
+							TargetPort: intstr.FromInt32(8100),
 						},
 					},
 				},

--- a/pkg/library/utils/k8s_utils_test.go
+++ b/pkg/library/utils/k8s_utils_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestObjectKeyListDifference(t *testing.T) {
-
 	key1 := client.ObjectKey{Namespace: "ns1", Name: "obj1"}
 	key2 := client.ObjectKey{Namespace: "ns2", Name: "obj2"}
 	key3 := client.ObjectKey{Namespace: "ns3", Name: "obj3"}

--- a/tests/commons.go
+++ b/tests/commons.go
@@ -497,7 +497,6 @@ func EndpointsTraversable(endpoints []*endpoint.Endpoint, host string, destinati
 					// this means that at least one of the targets on the endpoint leads to the destination
 					allTargetsFound = allTargetsFound || EndpointsTraversable(endpoints, target, []string{destination})
 				}
-
 			}
 		}
 		// we must match all destinations


### PR DESCRIPTION
closes:  #614 

This address the issue by selecting all the AuthPolicies in the namespace of the Gateway CR that have `ACCEPTED: false` and `REASON: TargetNotFound`. With this list of resources the reconcile loop is triggered. In the diagram below this PR adds the "missing steps".
![diagram](https://github.com/Kuadrant/kuadrant-operator/assets/10224565/4e73b877-c168-4494-b36f-c542707c32a9)

# Verification Steps
- Step up an instance of kuadrant and the toystore.
```sh
make local-setup
kubectl apply -f examples/toystore/kuadrant.yaml
kubectl apply -f examples/toystore/toystore.yaml
```
- Create the AuthPolicies
```sh
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gw-1
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: gw-1
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: APIKEY
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
---
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: toystore
  namespace: default
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authentication:
      "api-key-users":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: TOYSTORE
    response:
      success:
        dynamicMetadata:
          "identity":
            json:
              properties:
                "userid":
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
""" | kubectl apply -f -
```
- check the status of the AuthPolices, both should be `Accepted: False`
- deploy the gateway
```sh
echo "
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: gw-1
  namespace: istio-system
  annotations:
    kuadrant.io/namespace: kuadrant-system
    networking.istio.io/service-type: ClusterIP
spec:
  gatewayClassName: istio
  listeners:
    - name: apis
      port: 80
      protocol: HTTP
      hostname: '*.io'
      allowedRoutes:
        namespaces:
          from: All
" | kubectl apply -f -
- Expect AuthPolicy gw-1 to change its status to `Accepted: True, Enforced: False`. Policy is not enforced as there is no routes attached to the gateway.
- Create route
```sh
echo "
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
  namespace: default
spec:
  parentRefs:
  - name: gw-1
    namespace: istio-system
  hostnames:
  - api.toystore.io
  rules:
  - matches:
    - path:
        type: Exact
        value: "/toy"
      method: GET
    backendRefs:
    - name: toystore
      port: 80
" | kubectl apply -f -
```
- expected AuthPolicy toystore to change its status to `Accepted: True, Enforced: True`