### PR TITLE
Deploy example alerts during quickstart

### DIFF
--- a/examples/alerts/kustomization.yaml
+++ b/examples/alerts/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - prometheusrules_policies_missing.yaml
+  - slo-availability.yaml
+  - slo-latency.yaml

--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -85,6 +85,7 @@ KUADRANT_METALLB_KUSTOMIZATION="${KUADRANT_REPO}/config/metallb?ref=${KUADRANT_R
 KUADARNT_THANOS_KUSTOMIZATION="${KUADRANT_REPO}/config/thanos?ref=${KUADRANT_REF}"
 KUADARNT_OBSERVABILITY_KUSTOMIZATION="${KUADRANT_REPO}/config/observability?ref=${KUADRANT_REF}"
 KUADRANT_DASHBOARDS_KUSTOMIZATION="${KUADRANT_REPO}/examples/dashboards?ref=${KUADRANT_REF}"
+KUADRANT_ALERTS_KUSTOMIZATION="${KUADRANT_REPO}/examples/alerts?ref=${KUADRANT_REF}"
 MGC_REPO="github.com/${KUADRANT_ORG}/multicluster-gateway-controller.git"
 MGC_ISTIO_KUSTOMIZATION="${MGC_REPO}/config/istio?ref=${MGC_REF}"
 
@@ -518,6 +519,7 @@ info "Installing observability stack in ${KUADRANT_CLUSTER_NAME}..."
 kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | $CONTAINER_RUNTIME_BIN run --rm -i ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
 kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | $CONTAINER_RUNTIME_BIN run --rm -i ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -
 kubectl kustomize ${KUADRANT_DASHBOARDS_KUSTOMIZATION} | kubectl apply --server-side -f -
+kubectl kustomize ${KUADRANT_ALERTS_KUSTOMIZATION} | kubectl apply --server-side -f -
 success "observability stack installed successfully."
 
 # Patch prometheus to remote write metrics to thanos in hub


### PR DESCRIPTION
To round out https://github.com/Kuadrant/kuadrant-operator/issues/440 and https://github.com/Kuadrant/kuadrant-operator/issues/441 , this change deploys the example alert rules during the quickstart setup.

To verify, run the quickstart-setup script (referencing this branch for now until back on `main`)

- `KUADRANT_REF=deploy-alerts ./hack/quickstart-setup.sh`
- Port forward to the prometheus service with `kubectl --context kind-kuadrant-local -n monitoring port-forward svc/prometheus-k8s 9090:9090`
- Verify the 4x kuadrant sli/slo alerts and 4x gateway/policy alerts show up in promethues
  - http://127.0.0.1:9090/alerts?search=kuadrant
  - http://127.0.0.1:9090/alerts?search=policy

![image](https://github.com/Kuadrant/kuadrant-operator/assets/878251/28b8a58d-7d74-4c4a-b8f5-a0cce71119ab)

![image](https://github.com/Kuadrant/kuadrant-operator/assets/878251/412f1245-28d4-4dde-a332-8292e5d8a4d6)
