### PR TITLE
elliminate premature termination of DNS controller logic

### DIFF
--- a/controllers/dnspolicy_dnsrecords.go
+++ b/controllers/dnspolicy_dnsrecords.go
@@ -90,7 +90,7 @@ func (r *DNSPolicyReconciler) reconcileGatewayDNSRecords(ctx context.Context, gw
 			if err := r.dnsHelper.deleteDNSRecordForListener(ctx, gatewayWrapper, listener); client.IgnoreNotFound(err) != nil {
 				return fmt.Errorf("failed to delete dns record for listener %s : %w", listener.Name, err)
 			}
-			return nil
+			continue
 		}
 
 		dnsRecord, err := r.desiredDNSRecord(gatewayWrapper, dnsPolicy, listener, listenerGateways, mz)


### PR DESCRIPTION
## What 
If we specify the first listener in the GW spec to be the one without attached routes we never get to the second and never create DNS records for it (even if there are attached routes). This PR fixes it. 
I'm not including integration test for this case - the suite has over 150 cases now and I do not consider this scenario to be critical for testing on each pull request 