### PR TITLE
tests: Use inmemory provider backed managed zones

### DIFF
--- a/config/dependencies/dns/deployment_patch.yaml
+++ b/config/dependencies/dns/deployment_patch.yaml
@@ -9,3 +9,7 @@
 - op: replace
   path: /spec/template/metadata/labels/control-plane
   value: dns-operator-controller-manager
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --provider=aws,google,inmemory

--- a/controllers/dnspolicy_controller_multi_cluster_test.go
+++ b/controllers/dnspolicy_controller_multi_cluster_test.go
@@ -5,12 +5,14 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	externaldns "sigs.k8s.io/external-dns/endpoint"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -28,6 +30,7 @@ import (
 var _ = Describe("DNSPolicy Multi Cluster", func() {
 
 	var gatewayClass *gatewayapiv1.GatewayClass
+	var dnsProviderSecret *corev1.Secret
 	var managedZone *kuadrantdnsv1alpha1.ManagedZone
 	var testNamespace string
 	var gateway *gatewayapiv1.Gateway
@@ -46,8 +49,21 @@ var _ = Describe("DNSPolicy Multi Cluster", func() {
 		gatewayClass = testBuildGatewayClass("gwc-"+testNamespace, "default", "kuadrant.io/bar")
 		Expect(k8sClient.Create(ctx, gatewayClass)).To(Succeed())
 
-		managedZone = testBuildManagedZone("mz-example-com", testNamespace, "example.com")
+		dnsProviderSecret = testBuildInMemoryCredentialsSecret("inmemory-credentials", testNamespace)
+		managedZone = testBuildManagedZone("mz-example-com", testNamespace, "example.com", dnsProviderSecret.Name)
+		Expect(k8sClient.Create(ctx, dnsProviderSecret)).To(Succeed())
 		Expect(k8sClient.Create(ctx, managedZone)).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := k8sClient.Get(ctx, client.ObjectKeyFromObject(managedZone), managedZone)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(managedZone.Status.Conditions).To(
+				ContainElement(MatchFields(IgnoreExtras, Fields{
+					"Type":               Equal(string(kuadrantdnsv1alpha1.ConditionTypeReady)),
+					"Status":             Equal(metav1.ConditionTrue),
+					"ObservedGeneration": Equal(managedZone.Generation),
+				})),
+			)
+		}, TestTimeoutMedium, time.Second).Should(Succeed())
 
 		gateway = NewGatewayBuilder(TestGatewayName, gatewayClass.Name, testNamespace).
 			WithHTTPListener(TestListenerNameOne, TestHostOne).
@@ -118,6 +134,10 @@ var _ = Describe("DNSPolicy Multi Cluster", func() {
 		}
 		if managedZone != nil {
 			err := k8sClient.Delete(ctx, managedZone)
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+		}
+		if dnsProviderSecret != nil {
+			err := k8sClient.Delete(ctx, dnsProviderSecret)
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
 		}
 		if gatewayClass != nil {

--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -9,6 +9,7 @@ import (
 
 	certmanv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,20 +137,30 @@ func testObjectDoesNotExist(obj client.Object) func() bool {
 
 // DNS
 
-func testBuildManagedZone(name, ns, domainName string) *kuadrantdnsv1alpha1.ManagedZone {
+func testBuildManagedZone(name, ns, domainName, secretName string) *kuadrantdnsv1alpha1.ManagedZone {
 	return &kuadrantdnsv1alpha1.ManagedZone{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
 		Spec: kuadrantdnsv1alpha1.ManagedZoneSpec{
-			ID:          "1234",
 			DomainName:  domainName,
 			Description: domainName,
 			SecretRef: kuadrantdnsv1alpha1.ProviderRef{
-				Name: "secretname",
+				Name: secretName,
 			},
 		},
+	}
+}
+
+func testBuildInMemoryCredentialsSecret(name, ns string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Data: map[string][]byte{},
+		Type: "kuadrant.io/inmemory",
 	}
 }
 


### PR DESCRIPTION
closes #601 

Update all DNSPolicy integration tests to use the inmemory provider. If the dns operator is running on the target cluster managedzones and dnsrecords should work as if they are targeting a real DNS Provider.

Requires: https://github.com/Kuadrant/dns-operator/pull/142