### PR TITLE
Fix override RLPs on multiple gateway parents

### DIFF
--- a/controllers/ratelimitpolicy_controller.go
+++ b/controllers/ratelimitpolicy_controller.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -60,7 +61,7 @@ type RateLimitPolicyReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.10.0/pkg/reconcile
 func (r *RateLimitPolicyReconciler) Reconcile(eventCtx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := r.Logger().WithValues("RateLimitPolicy", req.NamespacedName)
+	logger := r.Logger().WithValues("RateLimitPolicy", req.NamespacedName, "request id", uuid.NewString())
 	logger.Info("Reconciling RateLimitPolicy")
 	ctx := logr.NewContext(eventCtx, logger)
 

--- a/controllers/ratelimitpolicy_controller_test.go
+++ b/controllers/ratelimitpolicy_controller_test.go
@@ -157,7 +157,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   1,
 				Seconds:    3 * 60,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(rlp),
-				Conditions: []string{`limit.l1__2804bad6 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(rlp),
 			}))
@@ -243,7 +243,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   1,
 				Seconds:    3 * 60,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(rlp),
-				Conditions: []string{`limit.l1__2804bad6 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(rlp),
 			}))
@@ -293,7 +293,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   1,
 				Seconds:    3 * 60,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(rlp),
-				Conditions: []string{`limit.l1__2804bad6 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(rlp),
 			}))
@@ -368,7 +368,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 					MaxValue:   10,
 					Seconds:    5,
 					Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-					Conditions: []string{`limit.l1__2804bad6 == "1"`},
+					Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(routeRLPKey, "l1"))},
 					Variables:  []string{},
 					Name:       rlptools.LimitsNameFromRLP(routeRLP),
 				})).WithContext(ctx).Should(Succeed())
@@ -483,7 +483,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-				Conditions: []string{`limit.l1__2804bad6 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(routeRLP),
 			})).WithContext(ctx).Should(Succeed())
@@ -505,7 +505,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-				Conditions: []string{`limit.route__8a84e406 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(routeRLP),
 			})).WithContext(ctx).Should(Succeed())
@@ -540,7 +540,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-				Conditions: []string{`limit.l1__2804bad6 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(routeRLP),
 			})).WithContext(ctx).Should(Succeed())
@@ -579,7 +579,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-				Conditions: []string{`limit.route__8a84e406 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(routeRLP),
 			})).WithContext(ctx).Should(Succeed())
@@ -602,7 +602,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-				Conditions: []string{`limit.l1__2804bad6 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(routeRLP),
 			})).WithContext(ctx).Should(Succeed())
@@ -628,7 +628,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-				Conditions: []string{`limit.l1__2804bad6 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(routeRLP),
 			})).WithContext(ctx).Should(Succeed())
@@ -651,7 +651,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  rlptools.LimitsNamespaceFromRLP(routeRLP),
-				Conditions: []string{`limit.route__8a84e406 == "1"`},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, rlptools.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
 				Variables:  []string{},
 				Name:       rlptools.LimitsNameFromRLP(routeRLP),
 			})).WithContext(ctx).Should(Succeed())

--- a/controllers/ratelimitpolicy_enforced_status_controller.go
+++ b/controllers/ratelimitpolicy_enforced_status_controller.go
@@ -9,9 +9,11 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+	"github.com/samber/lo"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,50 +50,113 @@ func (r *RateLimitPolicyEnforcedStatusReconciler) Reconcile(eventCtx context.Con
 		return ctrl.Result{}, err
 	}
 
-	t, err := BuildTopology(ctx, r.Client(), gw, (&kuadrantv1beta2.RateLimitPolicy{}).Kind(), &kuadrantv1beta2.RateLimitPolicyList{})
+	topology, err := r.buildTopology(ctx, gw)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	policies := t.PoliciesFromGateway(gw)
-	unTargetedRoutes := len(t.GetUntargetedRoutes(gw))
+	indexes := kuadrantgatewayapi.NewTopologyIndexes(topology)
+	policies := indexes.PoliciesFromGateway(gw)
+	numRoutes := len(topology.Routes())
+	numUntargetedRoutes := len(indexes.GetUntargetedRoutes(gw))
 
 	sort.Sort(kuadrantgatewayapi.PolicyByTargetRefKindAndCreationTimeStamp(policies))
 
+	// for each policy:
+	//   if the policy is a gateway policy:
+	//     and no route exists (numRoutes == 0) → set the Enforced condition of the gateway policy to 'false' (unknown)
+	//     and the gateway contains routes (numRoutes > 0)
+	//       and the gateway policy contains overrides → set the Enforced condition of the gateway policy to 'true'
+	//       and the gateway policy contains defaults:
+	//         and no routes have an attached policy (numUntargetedRoutes == numRoutes) → set the Enforced condition of the gateway policy to 'true'
+	//         and some routes have attached policy (numUntargetedRoutes < numRoutes && numUntargetedRoutes > 1) → set the Enforced condition of the gateway policy to 'true' (partially enforced)
+	//         and all routes have attached policy (numUntargetedRoutes == 0) → set the Enforced condition of the gateway policy to 'false' (overridden)
+	//   if the policy is a route policy:
+	//     and the route has no gateway parent (numGatewayParents == 0) → set the Enforced condition of the route policy to 'false' (unknown)
+	//     and the route has gateway parents (numGatewayParents > 0)
+	//       and all gateway parents of the route have gateway policies with overrides (numGatewayParentsWithOverrides == numGatewayParents) → set the Enforced condition of the route policy to 'false' (overridden)
+	//       and some gateway parents of the route have gateway policies with overrides (numGatewayParentsWithOverrides < numGatewayParents && numGatewayParentsWithOverrides > 1) → set the Enforced condition of the route policy to 'true' (partially enforced)
+	//       and no gateway parent of the route has gateway policies with overrides (numGatewayParentsWithOverrides == 0) → set the Enforced condition of the route policy to 'true'
+
 	for i := range policies {
 		policy := policies[i]
-		p := policy.(*kuadrantv1beta2.RateLimitPolicy)
-		conditions := p.GetStatus().GetConditions()
+		rlpKey := client.ObjectKeyFromObject(policy)
+		rlp := policy.(*kuadrantv1beta2.RateLimitPolicy)
+		conditions := rlp.GetStatus().GetConditions()
 
-		// Skip policies if accepted condition is false
+		// skip policy if accepted condition is false
 		if meta.IsStatusConditionFalse(policy.GetStatus().GetConditions(), string(gatewayapiv1alpha2.PolicyConditionAccepted)) {
 			continue
 		}
 
-		// Policy has been accepted
-		// Ensure no error on underlying subresource (i.e. Limitador)
-		if cond := r.hasErrCondOnSubResource(ctx, logger, p); cond != nil {
-			if err := r.setCondition(ctx, logger, p, &conditions, *cond); err != nil {
+		// ensure no error on underlying subresource (i.e. Limitador)
+		if condition := r.hasErrCondOnSubResource(ctx, rlp); condition != nil {
+			if err := r.setCondition(ctx, rlp, &conditions, *condition); err != nil {
 				return ctrl.Result{}, err
 			}
 			continue
 		}
 
-		if kuadrantgatewayapi.IsTargetRefGateway(p.GetTargetRef()) {
-			if p.Spec.Overrides != nil {
-				if err := r.setConditionForGWPolicyWithOverrides(ctx, logger, p, conditions, policies, unTargetedRoutes); err != nil {
-					return ctrl.Result{}, err
+		var condition *metav1.Condition
+
+		if kuadrantgatewayapi.IsTargetRefGateway(rlp.GetTargetRef()) { // gateway policy
+			if numRoutes == 0 {
+				condition = kuadrant.EnforcedCondition(rlp, kuadrant.NewErrUnknown(rlp.Kind(), errors.New("no free routes to enforce policy")), true) // unknown
+			} else {
+				if rlp.Spec.Overrides != nil {
+					condition = kuadrant.EnforcedCondition(rlp, nil, true) // fully enforced
+				} else {
+					if numUntargetedRoutes == numRoutes {
+						condition = kuadrant.EnforcedCondition(rlp, nil, true) // fully enforced
+					} else if numUntargetedRoutes > 0 {
+						condition = kuadrant.EnforcedCondition(rlp, nil, false) // partially enforced
+					} else {
+						otherPolicies := lo.FilterMap(policies, func(p kuadrantgatewayapi.Policy, _ int) (client.ObjectKey, bool) {
+							key := client.ObjectKeyFromObject(p)
+							return key, key != rlpKey
+						})
+						condition = kuadrant.EnforcedCondition(rlp, kuadrant.NewErrOverridden(rlp.Kind(), otherPolicies), true) // overridden
+					}
 				}
-				break
 			}
-			if err := r.setConditionForGWPolicyWithDefaults(ctx, logger, p, conditions, policies, unTargetedRoutes); err != nil {
-				return ctrl.Result{}, err
+		} else { // route policy
+			route := indexes.GetPolicyHTTPRoute(rlp)
+			gatewayParents := lo.FilterMap(kuadrantgatewayapi.GetRouteAcceptedGatewayParentKeys(route), func(parentKey client.ObjectKey, _ int) (*gatewayapiv1.Gateway, bool) {
+				g, found := utils.Find(topology.Gateways(), func(g kuadrantgatewayapi.GatewayNode) bool { return client.ObjectKeyFromObject(g.Gateway) == parentKey })
+				if !found {
+					return nil, false
+				}
+				return g.Gateway, true
+			})
+			numGatewayParents := len(gatewayParents)
+			if numGatewayParents == 0 {
+				condition = kuadrant.EnforcedCondition(rlp, kuadrant.NewErrUnknown(rlp.Kind(), errors.New("the targeted route has not been accepted by any gateway parent")), true) // unknown
+			} else {
+				var gatewayParentOverridePolicies []kuadrantgatewayapi.Policy
+				gatewayParentsWithOverrides := utils.Filter(gatewayParents, func(gatewayParent *gatewayapiv1.Gateway) bool {
+					_, found := utils.Find(indexes.PoliciesFromGateway(gatewayParent), func(p kuadrantgatewayapi.Policy) bool {
+						rlp := p.(*kuadrantv1beta2.RateLimitPolicy)
+						if kuadrantgatewayapi.IsTargetRefGateway(p.GetTargetRef()) && rlp != nil && rlp.Spec.Overrides != nil {
+							gatewayParentOverridePolicies = append(gatewayParentOverridePolicies, p)
+							return true
+						}
+						return false
+					})
+					return found
+				})
+				numGatewayParentsWithOverrides := len(gatewayParentsWithOverrides)
+				if numGatewayParentsWithOverrides == numGatewayParents {
+					sort.Sort(kuadrantgatewayapi.PolicyByTargetRefKindAndCreationTimeStamp(gatewayParentOverridePolicies))
+					condition = kuadrant.EnforcedCondition(rlp, kuadrant.NewErrOverridden(rlp.Kind(), utils.Map(gatewayParentOverridePolicies, func(p kuadrantgatewayapi.Policy) client.ObjectKey { return client.ObjectKeyFromObject(p) })), true) // overridden
+				} else if numGatewayParentsWithOverrides > 0 {
+					condition = kuadrant.EnforcedCondition(rlp, nil, false) // partially enforced
+				} else {
+					condition = kuadrant.EnforcedCondition(rlp, nil, true) // fully enforced
+				}
 			}
-			continue
 		}
 
-		// Route Policy
-		if err := r.setCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, nil, true)); err != nil {
+		if err := r.setCondition(ctx, rlp, &conditions, *condition); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
@@ -100,67 +165,49 @@ func (r *RateLimitPolicyEnforcedStatusReconciler) Reconcile(eventCtx context.Con
 	return ctrl.Result{}, nil
 }
 
-func (r *RateLimitPolicyEnforcedStatusReconciler) setConditionForGWPolicyWithOverrides(ctx context.Context, logger logr.Logger, p *kuadrantv1beta2.RateLimitPolicy, conditions []metav1.Condition, policies []kuadrantgatewayapi.Policy, unTargetedRoutes int) error {
-	// Only have this policy and no free routes
-	if len(policies) == 1 && unTargetedRoutes == 0 {
-		if err := r.setCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, kuadrant.NewErrUnknown(p.Kind(), errors.New("no free routes to enforce policy")), true)); err != nil {
-			return err
-		}
+func (r *RateLimitPolicyEnforcedStatusReconciler) buildTopology(ctx context.Context, gw *gatewayapiv1.Gateway) (*kuadrantgatewayapi.Topology, error) {
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	// Has free routes or is overriding policies
-	// Set Enforced true condition for this GW policy
-	if err := r.setCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, nil, true)); err != nil {
-		return err
+	gatewayList := &gatewayapiv1.GatewayList{}
+	err = r.Client().List(ctx, gatewayList)
+	logger.V(1).Info("list gateways", "#gateways", len(gatewayList.Items), "err", err)
+	if err != nil {
+		return nil, err
 	}
 
-	// Update the rest of the policies as overridden
-	affectedPolices := utils.Filter(policies, func(ap kuadrantgatewayapi.Policy) bool {
-		return p != ap && ap.GetDeletionTimestamp() == nil
-	})
-
-	for i := range affectedPolices {
-		af := affectedPolices[i]
-		afp := af.(*kuadrantv1beta2.RateLimitPolicy)
-		afConditions := afp.GetStatus().GetConditions()
-
-		if err := r.setCondition(ctx, logger, afp, &afConditions, *kuadrant.EnforcedCondition(afp, kuadrant.NewErrOverridden(afp.Kind(), []client.ObjectKey{client.ObjectKeyFromObject(p)}), true)); err != nil {
-			return err
-		}
+	routeList := &gatewayapiv1.HTTPRouteList{}
+	// Get all the routes having the gateway as parent
+	err = r.Client().List(ctx, routeList, client.MatchingFields{HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gw).String()})
+	logger.V(1).Info("list routes by gateway", "#routes", len(routeList.Items), "err", err)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil
+	policyList := &kuadrantv1beta2.RateLimitPolicyList{}
+	err = r.Client().List(ctx, policyList)
+	logger.V(1).Info("list rate limit policies", "#policies", len(policyList.Items), "err", err)
+	if err != nil {
+		return nil, err
+	}
+
+	return kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithGateways(utils.Map(gatewayList.Items, ptr.To[gatewayapiv1.Gateway])),
+		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
+		kuadrantgatewayapi.WithPolicies(utils.Map(policyList.Items, func(p kuadrantv1beta2.RateLimitPolicy) kuadrantgatewayapi.Policy { return &p })),
+		kuadrantgatewayapi.WithLogger(logger),
+	)
 }
 
-func (r *RateLimitPolicyEnforcedStatusReconciler) setConditionForGWPolicyWithDefaults(ctx context.Context, logger logr.Logger, p *kuadrantv1beta2.RateLimitPolicy, conditions []metav1.Condition, policies []kuadrantgatewayapi.Policy, unTargetedRoutes int) error {
-	// GW Policy defaults is defined
-	// Only have this policy or no free routes -> nothing to enforce policy
-	if len(policies) == 1 && unTargetedRoutes == 0 {
-		if err := r.setCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, kuadrant.NewErrUnknown(p.Kind(), errors.New("no free routes to enforce policy")), true)); err != nil {
-			return err
-		}
-	} else if len(policies) > 1 && unTargetedRoutes == 0 {
-		// GW policy defaults are overridden by child policies
-		affectedPolices := utils.Filter(policies, func(ap kuadrantgatewayapi.Policy) bool {
-			return p != ap && ap.GetDeletionTimestamp() == nil
-		})
-
-		if err := r.setCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, kuadrant.NewErrOverridden(p.Kind(), utils.Map(affectedPolices, func(ap kuadrantgatewayapi.Policy) client.ObjectKey {
-			return client.ObjectKeyFromObject(ap)
-		})), true)); err != nil {
-			return err
-		}
-	} else {
-		// Is enforcing default policy on a free route
-		if err := r.setCondition(ctx, logger, p, &conditions, *kuadrant.EnforcedCondition(p, nil, true)); err != nil {
-			return err
-		}
+func (r *RateLimitPolicyEnforcedStatusReconciler) hasErrCondOnSubResource(ctx context.Context, p *kuadrantv1beta2.RateLimitPolicy) *metav1.Condition {
+	logger, err := logr.FromContext(ctx)
+	logger.WithName("hasErrCondOnSubResource")
+	if err != nil {
+		logger = r.Logger()
 	}
 
-	return nil
-}
-
-func (r *RateLimitPolicyEnforcedStatusReconciler) hasErrCondOnSubResource(ctx context.Context, logger logr.Logger, p *kuadrantv1beta2.RateLimitPolicy) *metav1.Condition {
 	limitador, err := GetLimitador(ctx, r.Client(), p)
 	if err != nil {
 		logger.V(1).Error(err, "failed to get limitador")
@@ -175,9 +222,15 @@ func (r *RateLimitPolicyEnforcedStatusReconciler) hasErrCondOnSubResource(ctx co
 	return nil
 }
 
-func (r *RateLimitPolicyEnforcedStatusReconciler) setCondition(ctx context.Context, logger logr.Logger, p *kuadrantv1beta2.RateLimitPolicy, conditions *[]metav1.Condition, cond metav1.Condition) error {
+func (r *RateLimitPolicyEnforcedStatusReconciler) setCondition(ctx context.Context, p *kuadrantv1beta2.RateLimitPolicy, conditions *[]metav1.Condition, cond metav1.Condition) error {
+	logger, err := logr.FromContext(ctx)
+	logger.WithName("setCondition")
+	if err != nil {
+		logger = r.Logger()
+	}
+
 	idx := utils.Index(*conditions, func(c metav1.Condition) bool {
-		return c.Type == cond.Type && c.Status == cond.Status && c.Reason == cond.Reason
+		return c.Type == cond.Type && c.Status == cond.Status && c.Reason == cond.Reason && c.Message == cond.Message
 	})
 	if idx == -1 {
 		meta.SetStatusCondition(conditions, cond)

--- a/controllers/ratelimitpolicy_enforced_status_controller.go
+++ b/controllers/ratelimitpolicy_enforced_status_controller.go
@@ -177,7 +177,7 @@ func (r *RateLimitPolicyEnforcedStatusReconciler) hasErrCondOnSubResource(ctx co
 
 func (r *RateLimitPolicyEnforcedStatusReconciler) setCondition(ctx context.Context, logger logr.Logger, p *kuadrantv1beta2.RateLimitPolicy, conditions *[]metav1.Condition, cond metav1.Condition) error {
 	idx := utils.Index(*conditions, func(c metav1.Condition) bool {
-		return c.Type == cond.Type && c.Status == cond.Status && c.Reason == cond.Reason && c.Message == cond.Message
+		return c.Type == cond.Type && c.Status == cond.Status && c.Reason == cond.Reason
 	})
 	if idx == -1 {
 		meta.SetStatusCondition(conditions, cond)

--- a/controllers/ratelimitpolicy_limits.go
+++ b/controllers/ratelimitpolicy_limits.go
@@ -2,11 +2,16 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/go-logr/logr"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+	"github.com/samber/lo"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
@@ -21,7 +26,11 @@ func (r *RateLimitPolicyReconciler) reconcileLimits(ctx context.Context, rlp *ku
 	if err != nil {
 		return err
 	}
-	return r.reconcileLimitador(ctx, rlp, policies)
+	topology, err := r.buildTopology(ctx, policies)
+	if err != nil {
+		return err
+	}
+	return r.reconcileLimitador(ctx, rlp, topology)
 }
 
 func (r *RateLimitPolicyReconciler) deleteLimits(ctx context.Context, rlp *kuadrantv1beta2.RateLimitPolicy) error {
@@ -32,14 +41,18 @@ func (r *RateLimitPolicyReconciler) deleteLimits(ctx context.Context, rlp *kuadr
 	policiesWithoutRLP := utils.Filter(policies, func(policy kuadrantgatewayapi.Policy) bool {
 		return client.ObjectKeyFromObject(policy) != client.ObjectKeyFromObject(rlp)
 	})
-	return r.reconcileLimitador(ctx, rlp, policiesWithoutRLP)
+	topology, err := r.buildTopology(ctx, policiesWithoutRLP)
+	if err != nil {
+		return err
+	}
+	return r.reconcileLimitador(ctx, rlp, topology)
 }
 
-func (r *RateLimitPolicyReconciler) reconcileLimitador(ctx context.Context, rlp *kuadrantv1beta2.RateLimitPolicy, policies []kuadrantgatewayapi.Policy) error {
+func (r *RateLimitPolicyReconciler) reconcileLimitador(ctx context.Context, rlp *kuadrantv1beta2.RateLimitPolicy, topology *kuadrantgatewayapi.Topology) error {
 	logger, _ := logr.FromContext(ctx)
-	logger = logger.WithName("reconcileLimitador").WithValues("policies", utils.Map(policies, func(p kuadrantgatewayapi.Policy) string { return client.ObjectKeyFromObject(p).String() }))
+	logger = logger.WithName("reconcileLimitador")
 
-	rateLimitIndex := r.buildRateLimitIndex(policies)
+	rateLimitIndex := r.buildRateLimitIndex(ctx, topology)
 
 	// get the current limitador cr for the kuadrant instance so we can compare if it needs to be updated
 	limitador, err := GetLimitador(ctx, r.Client(), rlp)
@@ -109,16 +122,74 @@ func (r *RateLimitPolicyReconciler) getPolicies(ctx context.Context) ([]kuadrant
 	return policies, nil
 }
 
-func (r *RateLimitPolicyReconciler) buildRateLimitIndex(policies []kuadrantgatewayapi.Policy) *rlptools.RateLimitIndex {
+func (r *RateLimitPolicyReconciler) buildTopology(ctx context.Context, policies []kuadrantgatewayapi.Policy) (*kuadrantgatewayapi.Topology, error) {
+	logger, _ := logr.FromContext(ctx)
+
+	gwList := &gatewayapiv1.GatewayList{}
+	err := r.Client().List(ctx, gwList)
+	logger.V(1).Info("topology: list gateways", "#Gateways", len(gwList.Items), "err", err)
+	if err != nil {
+		return nil, err
+	}
+
+	routeList := &gatewayapiv1.HTTPRouteList{}
+	err = r.Client().List(ctx, routeList)
+	logger.V(1).Info("topology: list httproutes", "#HTTPRoutes", len(routeList.Items), "err", err)
+	if err != nil {
+		return nil, err
+	}
+
+	return kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithGateways(utils.Map(gwList.Items, ptr.To[gatewayapiv1.Gateway])),
+		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
+		kuadrantgatewayapi.WithPolicies(policies),
+		kuadrantgatewayapi.WithLogger(logger),
+	)
+}
+
+func (r *RateLimitPolicyReconciler) buildRateLimitIndex(ctx context.Context, topology *kuadrantgatewayapi.Topology) *rlptools.RateLimitIndex {
+	logger, _ := logr.FromContext(ctx)
+	logger = logger.WithName("buildRateLimitIndex")
+
+	gateways := lo.KeyBy(topology.Gateways(), func(gateway kuadrantgatewayapi.GatewayNode) string {
+		return client.ObjectKeyFromObject(gateway.Gateway).String()
+	})
+
+	// sort the gateways for deterministic output and consistent comparison against existing objects
+	gatewayNames := lo.Keys(gateways)
+	slices.Sort(gatewayNames)
+
 	rateLimitIndex := rlptools.NewRateLimitIndex()
 
-	sort.Sort(kuadrantgatewayapi.PolicyByTargetRefKindAndCreationTimeStamp(policies))
+	for _, gatewayName := range gatewayNames {
+		gateway := gateways[gatewayName].Gateway
+		topologyWithOverrides, err := rlptools.ApplyOverrides(topology, gateway)
+		if err != nil {
+			logger.Error(err, "failed to apply overrides")
+			return nil
+		}
 
-	for i := range policies {
-		policy := policies[i]
-		rlpKey := client.ObjectKeyFromObject(policy)
-		rlp := policy.(*kuadrantv1beta2.RateLimitPolicy)
-		rateLimitIndex.Set(rlpKey, rlptools.LimitadorRateLimitsFromRLP(rlp))
+		// sort the policies for deterministic output and consistent comparison against existing objects
+		indexes := kuadrantgatewayapi.NewTopologyIndexes(topologyWithOverrides)
+		policies := indexes.PoliciesFromGateway(gateway)
+		sort.Sort(kuadrantgatewayapi.PolicyByTargetRefKindAndCreationTimeStamp(policies))
+
+		logger.V(1).Info("new rate limit index", "gateway", client.ObjectKeyFromObject(gateway), "policies", lo.Map(policies, func(p kuadrantgatewayapi.Policy, _ int) string { return client.ObjectKeyFromObject(p).String() }))
+
+		for _, policy := range policies {
+			rlpKey := client.ObjectKeyFromObject(policy)
+			gatewayKey := client.ObjectKeyFromObject(gateway)
+			key := rlptools.RateLimitIndexKey{
+				RateLimitPolicyKey: rlpKey,
+				GatewayKey:         gatewayKey,
+			}
+			if _, ok := rateLimitIndex.Get(key); ok { // should never happen
+				logger.Error(fmt.Errorf("unexpected duplicate rate limit policy key found"), "failed do add rate limit policy to index", "RateLimitPolicy", rlpKey.String(), "Gateway", gatewayKey)
+				continue
+			}
+			rlp := policy.(*kuadrantv1beta2.RateLimitPolicy)
+			rateLimitIndex.Set(key, rlptools.LimitadorRateLimitsFromRLP(rlp))
+		}
 	}
 
 	return rateLimitIndex

--- a/controllers/target_status_controller.go
+++ b/controllers/target_status_controller.go
@@ -105,7 +105,7 @@ func (r *TargetStatusReconciler) reconcileResourcesForPolicyKind(parentCtx conte
 	policyKind := policy.GetObjectKind().GroupVersionKind().Kind
 	ctx := logr.NewContext(parentCtx, logger.WithValues("kind", policyKind))
 
-	topology, err := BuildTopology(ctx, r.Client(), gw, policyKind, listPolicyKind)
+	topology, err := r.buildTopology(ctx, gw, policyKind, listPolicyKind)
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func (r *TargetStatusReconciler) reconcileResourcesForPolicyKind(parentCtx conte
 	return errs
 }
 
-func BuildTopology(ctx context.Context, ks8sClient client.Client, gw *gatewayapiv1.Gateway, policyKind string, listPolicyKind client.ObjectList) (*kuadrantgatewayapi.TopologyIndexes, error) {
+func (r *TargetStatusReconciler) buildTopology(ctx context.Context, gw *gatewayapiv1.Gateway, policyKind string, listPolicyKind client.ObjectList) (*kuadrantgatewayapi.TopologyIndexes, error) {
 	logger, err := logr.FromContext(ctx)
 	if err != nil {
 		return nil, err
@@ -203,13 +203,13 @@ func BuildTopology(ctx context.Context, ks8sClient client.Client, gw *gatewayapi
 
 	routeList := &gatewayapiv1.HTTPRouteList{}
 	// Get all the routes having the gateway as parent
-	err = ks8sClient.List(ctx, routeList, client.MatchingFields{HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gw).String()})
+	err = r.Client().List(ctx, routeList, client.MatchingFields{HTTPRouteGatewayParentField: client.ObjectKeyFromObject(gw).String()})
 	logger.V(1).Info("list routes by gateway", "#routes", len(routeList.Items), "err", err)
 	if err != nil {
 		return nil, err
 	}
 
-	policies, err := GetPoliciesByKind(ctx, ks8sClient, policyKind, listPolicyKind)
+	policies, err := r.getPoliciesByKind(ctx, policyKind, listPolicyKind)
 	if err != nil {
 		return nil, err
 	}
@@ -227,12 +227,12 @@ func BuildTopology(ctx context.Context, ks8sClient client.Client, gw *gatewayapi
 	return kuadrantgatewayapi.NewTopologyIndexes(t), nil
 }
 
-func GetPoliciesByKind(ctx context.Context, ks8sClient client.Client, policyKind string, listKind client.ObjectList) ([]kuadrantgatewayapi.Policy, error) {
+func (r *TargetStatusReconciler) getPoliciesByKind(ctx context.Context, policyKind string, listKind client.ObjectList) ([]kuadrantgatewayapi.Policy, error) {
 	logger, _ := logr.FromContext(ctx)
 	logger = logger.WithValues("kind", policyKind)
 
 	// Get all policies of the given kind
-	err := ks8sClient.List(ctx, listKind)
+	err := r.Client().List(ctx, listKind)
 	policyList, ok := listKind.(kuadrant.PolicyList)
 	if !ok {
 		return nil, fmt.Errorf("%T is not a kuadrant.PolicyList", listKind)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/onsi/gomega v1.30.0
+	github.com/samber/lo v1.39.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/net v0.23.0
 	google.golang.org/protobuf v1.33.0
@@ -129,7 +130,6 @@ require (
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rubenv/sql-migrate v1.5.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/samber/lo v1.39.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rubenv/sql-migrate v1.5.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/samber/lo v1.39.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,6 @@ require (
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rubenv/sql-migrate v1.5.2 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/samber/lo v1.39.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -392,6 +392,8 @@ github.com/rubenv/sql-migrate v1.5.2 h1:bMDqOnrJVV/6JQgQ/MxOpU+AdO8uzYYA/TxFUBzF
 github.com/rubenv/sql-migrate v1.5.2/go.mod h1:H38GW8Vqf8F0Su5XignRyaRcbXbJunSWxs+kmzlg0Is=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
+github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,6 @@ github.com/rubenv/sql-migrate v1.5.2 h1:bMDqOnrJVV/6JQgQ/MxOpU+AdO8uzYYA/TxFUBzF
 github.com/rubenv/sql-migrate v1.5.2/go.mod h1:H38GW8Vqf8F0Su5XignRyaRcbXbJunSWxs+kmzlg0Is=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
-github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/pkg/library/gatewayapi/topology_indexes.go
+++ b/pkg/library/gatewayapi/topology_indexes.go
@@ -22,6 +22,9 @@ type TopologyIndexes struct {
 	// Type: Policy -> HTTPRoute
 	policyRoute map[client.ObjectKey]*gatewayapiv1.HTTPRoute
 
+	// routes is an index of gateways mapping to HTTPRoutes that are children of the gateway
+	routes map[client.ObjectKey][]*gatewayapiv1.HTTPRoute
+
 	// untargetedRoutes is an index of gateways mapping to HTTPRoutes not targeted by a kuadrant policy
 	// Gateway -> []HTTPRoute
 	untargetedRoutes map[client.ObjectKey][]*gatewayapiv1.HTTPRoute
@@ -39,6 +42,7 @@ func NewTopologyIndexes(t *Topology) *TopologyIndexes {
 	return &TopologyIndexes{
 		gatewayPolicies:  buildGatewayPoliciesIndex(t),
 		policyRoute:      buildPolicyRouteIndex(t),
+		routes:           buildRoutesIndex(t),
 		untargetedRoutes: buildUntargetedRoutesIndex(t),
 		internalTopology: t,
 	}
@@ -56,6 +60,12 @@ func (k *TopologyIndexes) PoliciesFromGateway(gateway *gatewayapiv1.Gateway) []P
 // Type: Policy -> HTTPRoute
 func (k *TopologyIndexes) GetPolicyHTTPRoute(policy Policy) *gatewayapiv1.HTTPRoute {
 	return k.policyRoute[client.ObjectKeyFromObject(policy)]
+}
+
+// GetRoutes returns the HTTPRoutes having the gateway given as input as parent.
+// Gateway -> []HTTPRoute
+func (k *TopologyIndexes) GetRoutes(gateway *gatewayapiv1.Gateway) []*gatewayapiv1.HTTPRoute {
+	return k.routes[client.ObjectKeyFromObject(gateway)]
 }
 
 // GetUntargetedRoutes returns the HTTPRoutes not targeted by any kuadrant policy
@@ -150,6 +160,19 @@ func buildPolicyRouteIndex(t *Topology) map[client.ObjectKey]*gatewayapiv1.HTTPR
 		for _, policy := range routeNode.AttachedPolicies() {
 			index[client.ObjectKeyFromObject(policy)] = routeNode.Route()
 		}
+	}
+
+	return index
+}
+
+func buildRoutesIndex(t *Topology) map[client.ObjectKey][]*gatewayapiv1.HTTPRoute {
+	// Build Gateway -> []HTTPRoute index with all the routes
+	index := make(map[client.ObjectKey][]*gatewayapiv1.HTTPRoute, 0)
+
+	for _, gatewayNode := range t.Gateways() {
+		index[gatewayNode.ObjectKey()] = utils.Map(gatewayNode.Routes(), func(node RouteNode) *gatewayapiv1.HTTPRoute {
+			return node.Route()
+		})
 	}
 
 	return index

--- a/pkg/library/kuadrant/apimachinery_status_conditions.go
+++ b/pkg/library/kuadrant/apimachinery_status_conditions.go
@@ -104,10 +104,10 @@ func AcceptedCondition(p Policy, err error) *metav1.Condition {
 }
 
 // EnforcedCondition returns an enforced conditions with common reasons for a kuadrant policy
-func EnforcedCondition(policy Policy, err PolicyError, allSubresourcesReady bool) *metav1.Condition {
+func EnforcedCondition(policy Policy, err PolicyError, fully bool) *metav1.Condition {
 	// Enforced
 	message := fmt.Sprintf("%s has been successfully enforced", policy.Kind())
-	if !allSubresourcesReady {
+	if !fully {
 		message = fmt.Sprintf("%s has been partially enforced", policy.Kind())
 	}
 	cond := &metav1.Condition{

--- a/pkg/rlptools/overrides.go
+++ b/pkg/rlptools/overrides.go
@@ -1,0 +1,57 @@
+package rlptools
+
+import (
+	"slices"
+
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
+)
+
+// ApplyOverrides applies the overrides defined in the RateLimitPolicies attached to the gateway policies for a given
+// gateway, and returns a new topology with all policies overridden as applicable.
+func ApplyOverrides(topology *kuadrantgatewayapi.Topology, gateway *gatewayapiv1.Gateway) (*kuadrantgatewayapi.Topology, error) {
+	gatewayNode, ok := lo.Find(topology.Gateways(), func(g kuadrantgatewayapi.GatewayNode) bool {
+		return g.ObjectKey() == client.ObjectKeyFromObject(gateway)
+	})
+	if !ok || len(gatewayNode.AttachedPolicies()) == 0 {
+		return topology, nil
+	}
+
+	overridePolicies := lo.FilterMap(gatewayNode.AttachedPolicies(), func(policy kuadrantgatewayapi.Policy, _ int) (*kuadrantv1beta2.RateLimitPolicy, bool) {
+		rlp, ok := policy.(*kuadrantv1beta2.RateLimitPolicy)
+		if !ok || rlp.Spec.Overrides == nil {
+			return nil, false
+		}
+		return rlp, true
+	})
+
+	if len(overridePolicies) == 0 {
+		return topology, nil
+	}
+
+	overriddenPolicies := lo.Map(overridePolicies, func(p *kuadrantv1beta2.RateLimitPolicy, _ int) kuadrantgatewayapi.Policy { return p })
+
+	for _, route := range topology.Routes() {
+		if !slices.Contains(kuadrantgatewayapi.GetRouteAcceptedGatewayParentKeys(route.HTTPRoute), client.ObjectKeyFromObject(gateway)) {
+			overriddenPolicies = append(overriddenPolicies, route.AttachedPolicies()...)
+			continue
+		}
+
+		for _, policy := range route.AttachedPolicies() {
+			overriddenPolicy := policy.DeepCopyObject().(*kuadrantv1beta2.RateLimitPolicy)
+			overriddenPolicy.Spec.CommonSpec().Limits = overridePolicies[0].Spec.Overrides.Limits
+			overriddenPolicies = append(overriddenPolicies, overriddenPolicy)
+		}
+	}
+
+	return kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithGateways(lo.Map(topology.Gateways(), func(g kuadrantgatewayapi.GatewayNode, _ int) *gatewayapiv1.Gateway { return g.Gateway })),
+		kuadrantgatewayapi.WithRoutes(lo.Map(topology.Routes(), func(r kuadrantgatewayapi.RouteNode, _ int) *gatewayapiv1.HTTPRoute { return r.HTTPRoute })),
+		kuadrantgatewayapi.WithPolicies(overriddenPolicies),
+		kuadrantgatewayapi.WithLogger(topology.Logger),
+	)
+}

--- a/pkg/rlptools/rate_limit_index.go
+++ b/pkg/rlptools/rate_limit_index.go
@@ -7,12 +7,15 @@ import (
 
 	"github.com/elliotchance/orderedmap/v2"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
 
-type RateLimitIndexKey = client.ObjectKey
+type RateLimitIndexKey struct {
+	RateLimitPolicyKey types.NamespacedName
+	GatewayKey         types.NamespacedName
+}
 
 // NewRateLimitIndex builds an index to manage sets of rate limits, organized by key
 func NewRateLimitIndex() *RateLimitIndex {

--- a/pkg/rlptools/rate_limit_index_test.go
+++ b/pkg/rlptools/rate_limit_index_test.go
@@ -14,7 +14,8 @@ func TestRateLimitIndexSet(t *testing.T) {
 	t.Run("index rate limits to a key", func(subT *testing.T) {
 		index := NewRateLimitIndex()
 
-		index.Set(client.ObjectKey{Name: "rlp-1", Namespace: "ns"}, []limitadorv1alpha1.RateLimit{
+		key := RateLimitIndexKey{RateLimitPolicyKey: client.ObjectKey{Name: "rlp-1", Namespace: "ns"}}
+		index.Set(key, []limitadorv1alpha1.RateLimit{
 			{Namespace: "ns/rlp-1", MaxValue: 10, Seconds: 1},
 			{Namespace: "ns/rlp-1", MaxValue: 100, Seconds: 60},
 			{Namespace: "ns/rlp-1", MaxValue: 1000, Seconds: 1},
@@ -30,17 +31,17 @@ func TestRateLimitIndexSet(t *testing.T) {
 	t.Run("index rate limits to different keys", func(subT *testing.T) {
 		index := NewRateLimitIndex()
 
-		index.Set(client.ObjectKey{Name: "rlp-1", Namespace: "ns"}, []limitadorv1alpha1.RateLimit{
+		index.Set(RateLimitIndexKey{RateLimitPolicyKey: client.ObjectKey{Name: "rlp-1", Namespace: "ns"}}, []limitadorv1alpha1.RateLimit{
 			{Namespace: "ns/rlp-1", MaxValue: 10, Seconds: 1},
 			{Namespace: "ns/rlp-1", MaxValue: 100, Seconds: 60},
 			{Namespace: "ns/rlp-1", MaxValue: 1000, Seconds: 1},
 		})
 
-		index.Set(client.ObjectKey{Name: "rlp-2", Namespace: "ns"}, []limitadorv1alpha1.RateLimit{
+		index.Set(RateLimitIndexKey{RateLimitPolicyKey: client.ObjectKey{Name: "rlp-2", Namespace: "ns"}}, []limitadorv1alpha1.RateLimit{
 			{Namespace: "ns/rlp-2", MaxValue: 50, Seconds: 1},
 		})
 
-		key := client.ObjectKey{Name: "rlp-1", Namespace: "ns"}
+		key := RateLimitIndexKey{RateLimitPolicyKey: client.ObjectKey{Name: "rlp-1", Namespace: "ns"}}
 		rateLimits, found := index.Get(key)
 		if !found {
 			subT.Fatal("expected rate limits to be indexed to key but none found:", key)
@@ -50,7 +51,7 @@ func TestRateLimitIndexSet(t *testing.T) {
 			subT.Fatal("expected:", expectedCount, "rate limits for key", key, ", returned:", len(rateLimits))
 		}
 
-		key = client.ObjectKey{Name: "rlp-2", Namespace: "ns"}
+		key = RateLimitIndexKey{RateLimitPolicyKey: client.ObjectKey{Name: "rlp-2", Namespace: "ns"}}
 		rateLimits, found = index.Get(key)
 		if !found {
 			subT.Fatal("expected rate limits to be indexed to key but none found:", key)
@@ -70,13 +71,13 @@ func TestRateLimitIndexSet(t *testing.T) {
 	t.Run("reset rate limits for an existing key", func(subT *testing.T) {
 		index := NewRateLimitIndex()
 
-		index.Set(client.ObjectKey{Name: "rlp-1", Namespace: "ns"}, []limitadorv1alpha1.RateLimit{
+		index.Set(RateLimitIndexKey{RateLimitPolicyKey: client.ObjectKey{Name: "rlp-1", Namespace: "ns"}}, []limitadorv1alpha1.RateLimit{
 			{Namespace: "ns/rlp-1", MaxValue: 10, Seconds: 1},
 			{Namespace: "ns/rlp-1", MaxValue: 100, Seconds: 60},
 			{Namespace: "ns/rlp-1", MaxValue: 1000, Seconds: 1},
 		})
 
-		index.Set(client.ObjectKey{Name: "rlp-1", Namespace: "ns"}, []limitadorv1alpha1.RateLimit{
+		index.Set(RateLimitIndexKey{RateLimitPolicyKey: client.ObjectKey{Name: "rlp-1", Namespace: "ns"}}, []limitadorv1alpha1.RateLimit{
 			{Namespace: "ns/rlp-1", MaxValue: 500, Seconds: 3600},
 		})
 
@@ -93,7 +94,7 @@ func TestRateLimitIndexSet(t *testing.T) {
 	t.Run("add an empty list of limits if a noop", func(subT *testing.T) {
 		idx := NewRateLimitIndex()
 
-		idx.Set(client.ObjectKey{Name: "gwA", Namespace: "nsA"}, []limitadorv1alpha1.RateLimit{})
+		idx.Set(RateLimitIndexKey{GatewayKey: client.ObjectKey{Name: "gwA", Namespace: "nsA"}}, []limitadorv1alpha1.RateLimit{})
 
 		aggregatedRateLimits := idx.ToRateLimits()
 		if len(aggregatedRateLimits) != 0 {
@@ -104,7 +105,7 @@ func TestRateLimitIndexSet(t *testing.T) {
 	t.Run("add nil list of limits if a noop", func(subT *testing.T) {
 		idx := NewRateLimitIndex()
 
-		idx.Set(client.ObjectKey{Name: "gwA", Namespace: "nsA"}, []limitadorv1alpha1.RateLimit{})
+		idx.Set(RateLimitIndexKey{GatewayKey: client.ObjectKey{Name: "gwA", Namespace: "nsA"}}, []limitadorv1alpha1.RateLimit{})
 
 		aggregatedRateLimits := idx.ToRateLimits()
 		if len(aggregatedRateLimits) != 0 {

--- a/pkg/rlptools/wasm_utils_test.go
+++ b/pkg/rlptools/wasm_utils_test.go
@@ -100,7 +100,7 @@ func TestWasmRules(t *testing.T) {
 					Data: []wasm.DataItem{
 						{
 							Static: &wasm.StaticSpec{
-								Key:   "limit.50rps__770adfd9",
+								Key:   "limit.50rps__36e9aa4c",
 								Value: "1",
 							},
 						},
@@ -150,7 +150,7 @@ func TestWasmRules(t *testing.T) {
 					Data: []wasm.DataItem{
 						{
 							Static: &wasm.StaticSpec{
-								Key:   "limit.50rps_for_selected_hostnames__5af2c820",
+								Key:   "limit.50rps_for_selected_hostnames__ac4044ab",
 								Value: "1",
 							},
 						},
@@ -200,7 +200,7 @@ func TestWasmRules(t *testing.T) {
 					Data: []wasm.DataItem{
 						{
 							Static: &wasm.StaticSpec{
-								Key:   "limit.50rps_for_selected_route__b6640119",
+								Key:   "limit.50rps_for_selected_route__db289136",
 								Value: "1",
 							},
 						},
@@ -249,7 +249,7 @@ func TestWasmRules(t *testing.T) {
 					Data: []wasm.DataItem{
 						{
 							Static: &wasm.StaticSpec{
-								Key:   "limit.50rps_for_selected_path__4088dcf9",
+								Key:   "limit.50rps_for_selected_path__38eb97a4",
 								Value: "1",
 							},
 						},
@@ -290,7 +290,7 @@ func TestWasmRules(t *testing.T) {
 					Data: []wasm.DataItem{
 						{
 							Static: &wasm.StaticSpec{
-								Key:   "limit.50rps__770adfd9",
+								Key:   "limit.50rps__783b9343",
 								Value: "1",
 							},
 						},
@@ -313,7 +313,7 @@ func TestWasmRules(t *testing.T) {
 					Data: []wasm.DataItem{
 						{
 							Static: &wasm.StaticSpec{
-								Key:   "limit.50rps_per_username__f5bebfb8",
+								Key:   "limit.50rps_per_username__d681f6c3",
 								Value: "1",
 							},
 						},

--- a/tests/commons.go
+++ b/tests/commons.go
@@ -128,8 +128,8 @@ func GatewayIsReady(ctx context.Context, cl client.Client, gateway *gatewayapiv1
 	}
 }
 
-func BuildBasicHttpRoute(routeName, gwName, ns string, hostnames []string) *gatewayapiv1.HTTPRoute {
-	return &gatewayapiv1.HTTPRoute{
+func BuildBasicHttpRoute(routeName, gwName, ns string, hostnames []string, mutateFns ...func(*gatewayapiv1.HTTPRoute)) *gatewayapiv1.HTTPRoute {
+	route := &gatewayapiv1.HTTPRoute{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "HTTPRoute",
 			APIVersion: gatewayapiv1.GroupVersion.String(),
@@ -164,6 +164,10 @@ func BuildBasicHttpRoute(routeName, gwName, ns string, hostnames []string) *gate
 			},
 		},
 	}
+	for _, mutateFn := range mutateFns {
+		mutateFn(route)
+	}
+	return route
 }
 
 func RouteIsAccepted(ctx context.Context, cl client.Client, routeKey client.ObjectKey) func() bool {

--- a/tests/istio/rate_limiting_wasmplugin_controller_test.go
+++ b/tests/istio/rate_limiting_wasmplugin_controller_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 								Data: []wasm.DataItem{
 									{
 										Static: &wasm.StaticSpec{
-											Key:   `limit.l1__2804bad6`,
+											Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"),
 											Value: "1",
 										},
 									},
@@ -354,7 +354,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 				Data: []wasm.DataItem{
 					{
 						Static: &wasm.StaticSpec{
-							Key:   "limit.toys__3bfcbeee",
+							Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "toys"),
 							Value: "1",
 						},
 					},
@@ -380,7 +380,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 				Data: []wasm.DataItem{
 					{
 						Static: &wasm.StaticSpec{
-							Key:   "limit.assets__8bf729ff",
+							Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "assets"),
 							Value: "1",
 						},
 					},
@@ -465,7 +465,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 								Data: []wasm.DataItem{
 									{
 										Static: &wasm.StaticSpec{
-											Key:   `limit.l1__2804bad6`,
+											Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"),
 											Value: "1",
 										},
 									},
@@ -780,7 +780,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.l1__2804bad6`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlpAKey, "l1"),
 												Value: "1",
 											},
 										},
@@ -928,7 +928,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.l1__2804bad6`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"),
 												Value: "1",
 											},
 										},
@@ -1123,7 +1123,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.l1__2804bad6`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"),
 												Value: "1",
 											},
 										},
@@ -1239,7 +1239,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.l1__2804bad6`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"),
 												Value: "1",
 											},
 										},
@@ -1420,7 +1420,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.l1__2804bad6`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"),
 												Value: "1",
 											},
 										},
@@ -1499,7 +1499,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.l1__2804bad6`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"),
 												Value: "1",
 											},
 										},
@@ -1655,7 +1655,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.gatewaylimit__b95fa83b`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlp1Key, "gatewaylimit"),
 												Value: "1",
 											},
 										},
@@ -1759,7 +1759,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.routelimit__efc5113c`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlp2Key, "routelimit"),
 												Value: "1",
 											},
 										},
@@ -1949,7 +1949,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.routelimit__efc5113c`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlp2Key, "routelimit"),
 												Value: "1",
 											},
 										},
@@ -2043,7 +2043,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.gatewaylimit__b95fa83b`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlp1Key, "gatewaylimit"),
 												Value: "1",
 											},
 										},
@@ -2077,7 +2077,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 									Data: []wasm.DataItem{
 										{
 											Static: &wasm.StaticSpec{
-												Key:   `limit.routelimit__efc5113c`,
+												Key:   rlptools.LimitNameToLimitadorIdentifier(rlp2Key, "routelimit"),
 												Value: "1",
 											},
 										},
@@ -2205,7 +2205,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 								Data: []wasm.DataItem{
 									{
 										Static: &wasm.StaticSpec{
-											Key:   `limit.l1__2804bad6`,
+											Key:   rlptools.LimitNameToLimitadorIdentifier(rlpKey, "l1"),
 											Value: "1",
 										},
 									},
@@ -2325,7 +2325,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			Expect(testClient().Get(ctx, wasmPluginKey, existingWasmPlugin)).To(Succeed())
 			existingWASMConfig, err := rlptools.WASMPluginFromStruct(existingWasmPlugin.Spec.PluginConfig)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(existingWASMConfig).To(Equal(expectedWasmPluginConfig(gwRLPKey, gwRLP, "limit.gateway__4ea5ee68", "*")))
+			Expect(existingWASMConfig).To(Equal(expectedWasmPluginConfig(gwRLPKey, gwRLP, rlptools.LimitNameToLimitadorIdentifier(gwRLPKey, "gateway"), "*")))
 
 			// Create Route RLP
 			routeRLP := &kuadrantv1beta2.RateLimitPolicy{
@@ -2361,7 +2361,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 				g.Expect(testClient().Get(ctx, wasmPluginKey, existingWasmPlugin)).To(Succeed())
 				existingWASMConfig, err = rlptools.WASMPluginFromStruct(existingWasmPlugin.Spec.PluginConfig)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(existingWASMConfig).To(Equal(expectedWasmPluginConfig(routeRLPKey, routeRLP, "limit.route__8a84e406", "*.example.com")))
+				g.Expect(existingWASMConfig).To(Equal(expectedWasmPluginConfig(routeRLPKey, routeRLP, rlptools.LimitNameToLimitadorIdentifier(routeRLPKey, "route"), "*.example.com")))
 			}).WithContext(ctx).Should(Succeed())
 
 			// Update GW RLP to overrides
@@ -2378,7 +2378,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 				g.Expect(testClient().Get(ctx, wasmPluginKey, existingWasmPlugin)).To(Succeed())
 				existingWASMConfig, err = rlptools.WASMPluginFromStruct(existingWasmPlugin.Spec.PluginConfig)
 				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(existingWASMConfig).To(Equal(expectedWasmPluginConfig(routeRLPKey, routeRLP, "limit.gateway__4ea5ee68", "*.example.com")))
+				g.Expect(existingWASMConfig).To(Equal(expectedWasmPluginConfig(routeRLPKey, routeRLP, rlptools.LimitNameToLimitadorIdentifier(routeRLPKey, "gateway"), "*.example.com")))
 			}).WithContext(ctx).Should(Succeed())
 
 		}, testTimeOut)


### PR DESCRIPTION
**Before:**

We are currently wrongly generating the wasm configs for cases of multiple gateway parents linked to routes, having override RateLimitPolicies targeting the gateways and an overridden route policy.

The overridden policy config ends up in the WasmPlugin and in the Limitador CR with mismatching `domain/namespace`, causing the override policy to never be enforced – in spite of the status reporting otherwise.

**After:**

This PR simplifies the configuration of overridden RateLimitPolicies.

A route RateLimitPolicy overridden at a particular gateway will no longer be added to the gateway's WasmPlugin config; rather, the override gateway policy will, with its `domain` value kept unchanged, as if all routes under the gateway were not targeted by policies.

In the Limitador CR, all RateLimitPolicies (override and overridden) will be added, even when some never get triggered (due to been overridden.)

## Verification

#### Setup

```sh
make local-setup
```

```sh
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: external-gw
  namespace: kuadrant-system
spec:
  gatewayClassName: istio
  addresses:
  - type: IPAddress
    value: "172.18.0.10"
  listeners:
  - allowedRoutes:
      namespaces:
        from: All
    name: api
    hostname: "*.external"
    port: 80
    protocol: HTTP
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: internal-gw
  namespace: kuadrant-system
spec:
  gatewayClassName: istio
  addresses:
  - type: IPAddress
    value: "172.18.0.11"
  listeners:
  - allowedRoutes:
      namespaces:
        from: All
    name: api
    hostname: "*.internal"
    port: 80
    protocol: HTTP
EOF
```

```sh
kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/main/examples/toystore/toystore.yaml

kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: toystore-api
spec:
  parentRefs:
  - name: external-gw
    namespace: kuadrant-system
  - name: internal-gw
    namespace: kuadrant-system
  hostnames:
  - api.external
  - api.internal
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: "/cars"
    - path:
        type: PathPrefix
        value: "/dolls"
    backendRefs:
    - name: toystore
      port: 80
  - matches:
    - path:
        type: PathPrefix
        value: "/admin"
    backendRefs:
    - name: toystore
      port: 80
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: toystore-www
spec:
  parentRefs:
  - name: external-gw
    namespace: kuadrant-system
  - name: internal-gw
    namespace: kuadrant-system
  hostnames:
  - www.external
  - www.internal
  rules:
  - backendRefs:
    - name: toystore
      port: 80
EOF
```

#### Send requests

Repeat the following requests as many times as needed after each state transition between creating and updating policies:

```sh
curl --resolve api.external:80:172.18.0.10 "http://api.external/cars"
```

```sh
curl --resolve api.internal:80:172.18.0.11 "http://api.internal/cars"
```

```sh
curl --resolve www.external:80:172.18.0.10 "http://www.external/cars"
```

```sh
curl --resolve www.internal:80:172.18.0.11 "http://www.internal/cars"
```

What to look at in the responses:

- _Without any policies_ → all requests should go through without any header modification or limits
- _After creating AuthPolicies_ → a special request header `authpolicy` is injected containing the name of the policy that was enforced
- _After creating RateLimitPolicies_ → both gateway policies (external: 3rp10s, internal: 5rp10s) must be enforced at both routes respectively for `*.external` and `*.internal` traffic
- _After modifying the external override gateway RateLimitPolicy to defaults_ → internal override gateway policy (5rp10s) must continue to be enforced at both routes for `*.internal` traffic; toystore api specific policy (1rp10s) must be enforced at `api.external` traffic, while external gateway override (3rp10s) continues to be enforced at the rest of `*.external` (i.e. `www.external`)

#### Create policies

```sh
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```

```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: external-gw-auth
  namespace: kuadrant-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: external-gw
  overrides:
    rules:
      response:
        success:
          headers:
            "authpolicy":
              plain:
                value: external-gw-auth
---
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: internal-gw-auth
  namespace: kuadrant-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: internal-gw
  overrides:
    rules:
      response:
        success:
          headers:
            "authpolicy":
              plain:
                value: internal-gw-auth
---
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: toystore-api-auth
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore-api
  rules:
    response:
      success:
        headers:
          "authpolicy":
            plain:
              value: toystore-api-auth
EOF
```

```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: external-gw-rl
  namespace: kuadrant-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: external-gw
  overrides:
    limits:
      "external-gw-3rp10s":
        rates:
        - limit: 3
          duration: 10
          unit: second
---
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: internal-gw-rl
  namespace: kuadrant-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: internal-gw
  overrides:
    limits:
      "internal-gw-5rp10s":
        rates:
        - limit: 5
          duration: 10
          unit: second
---
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: toystore-api-rl
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore-api
  limits:
    "toystore-api-1rp10s":
      rates:
      - limit: 1
        duration: 10
        unit: second
EOF
```

#### Change a gateway policy from `overrides` → `defaults`

```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: external-gw-rl
  namespace: kuadrant-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: external-gw
  defaults:
    limits:
      "external-gw-3rp10s":
        rates:
        - limit: 3
          duration: 10
          unit: second
EOF
```

