### PR TITLE
added dashboard id's and linked to Grafana Docs for more info.

### DIFF
--- a/doc/observability/examples.md
+++ b/doc/observability/examples.md
@@ -2,11 +2,23 @@
 
 Explore a variety of starting points for monitoring your Kuadrant installation with our [examples](https://github.com/Kuadrant/kuadrant-operator/tree/main/examples) folder. These dashboards and alerts are ready-to-use and easily customizable to fit your environment.
 
+There are some example dashboards uploaded to [Grafana.com](https://grafana.com/grafana/dashboards/) . You can use the ID's listed below to import these dashboards into Grafana:
+
+| Name     | ID |
+| ----------- | ----------- |
+| [App Developer Dashboard](https://grafana.com/grafana/dashboards/20970)      | `20970`       |
+| [Business User Dashboard](https://grafana.com/grafana/dashboards/20981)   | `20981`        |
+| [Platform Engineer Dashboard](https://grafana.com/grafana/dashboards/20982) | `20982` |
+
 ## Dashboards
 
 ### Importing Dashboards into Grafana
 
-- **UI Method:** Use the 'Import' feature in the Grafana UI to upload dashboard JSON files directly.
+For more details on how to import dashboards into Grafana, visit the [import dashboards](https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/import-dashboards/) page. 
+
+- **UI Method:**
+    - **JSON** -  Use the 'Import' feature in the Grafana UI to upload dashboard JSON files directly.
+    - **ID** - Use the 'Import' feature in the Grafana UI to import via [Grafana.com](https://grafana.com/grafana/dashboards/) using a Dashboard ID. 
 - **ConfigMap Method:** Automate dashboard provisioning by adding files to a ConfigMap, which should be mounted at `/etc/grafana/provisioning/dashboards`.
 
 Datasources are configured as template variables, automatically integrating with your existing data sources. Metrics for these dashboards are sourced from [Prometheus](https://github.com/prometheus/prometheus). For more details on the metrics used, visit the [metrics](https://docs.kuadrant.io/kuadrant-operator/doc/observability/metrics/) documentation page.


### PR DESCRIPTION
### What:
 - Added dashboard id's and linked to Grafana Docs for more info in `doc/observability/examples.md` . 

### Why: 
- This change is needed to update the information in https://docs.kuadrant.io/0.7.0/kuadrant-operator/doc/observability/examples/ to reflect new ways to use dashboards (i.e. importing using IDs) .

### Verify: 
- Check `doc/observability/examples.md` and ensure all added links work. 
- Follow the instructions in `config/observability/README.md` to access Grafana instance, and import the dashboards using the ID's listed in `doc/observability/examples.md` . They should import with no issues.