### PR TITLE
Start subnet offset at 1 to avoid overlap with kind cluster ips

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ deploy-dependencies: kustomize dependencies-manifests ## Deploy dependencies to 
 	kubectl -n "$(KUADRANT_NAMESPACE)" wait --timeout=300s --for=condition=Available deployments --all
 
 .PHONY: install-metallb
-install-metallb: SUBNET_OFFSET=0
+install-metallb: SUBNET_OFFSET=1
 install-metallb: kustomize yq ## Installs the metallb load balancer allowing use of an LoadBalancer type with a gateway
 	$(KUSTOMIZE) build config/metallb | kubectl apply -f -
 	kubectl -n metallb-system wait --for=condition=Available deployments controller --timeout=300s

--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -70,7 +70,7 @@ export CONTAINER_RUNTIME_BIN=$(containerRuntime)
 export KIND_BIN=kind
 export HELM_BIN=helm
 export KUSTOMIZE_BIN=$(dockerBinCmd "kustomize")
-export SUBNET_OFFSET=0
+export SUBNET_OFFSET=1
 export HUB=1
 
 YQ_BIN=$(dockerBinCmd "yq")
@@ -402,7 +402,7 @@ if cluster_exists "${KUADRANT_CLUSTER_NAME}"; then
             next_cluster_number=$((last_number + 1))
         fi
         KUADRANT_CLUSTER_NAME="${KUADRANT_CLUSTER_NAME}-${next_cluster_number}"
-        SUBNET_OFFSET=${next_cluster_number}
+        SUBNET_OFFSET=$((SUBNET_OFFSET + 1))
         HUB=0
         echo "Next cluster number will be ${KUADRANT_CLUSTER_NAME}."
         read -r -p "Is it okay to create the cluster '${KUADRANT_CLUSTER_NAME}'? (y/N): " confirm </dev/tty


### PR DESCRIPTION
This fixes an issue where the service loadbalancer cluster ip can collide with other ip address used by local kind clusters or the network gateway ip.

I've seen this happen locally with podman (on macos) where the first kind cluster ip when using the quickstart script is 10.89.0.3, with a network gateway (not gateway api) ip of 10.89.0.1.

```
podman inspect $(podman ps -q --filter "name=kuadrant-local-control-plane") | grep -i "10."
...
                         "Gateway": "10.89.0.1",
                         "IPAddress": "10.89.0.3",
```

The first service loadbalancer ip assigned by metallb will be 10.89.0.0, but the next one will be 10.89.0.1 (and so on), which can collide.
This causes connection issues to that service loadbalancer ip.
```
kubectl --context kind-kuadrant-local get svc -A|grep -i loadbalancer
kuadrant-system   api-gateway-istio                                       LoadBalancer   10.96.85.153    10.89.0.2     15021:30253/TCP,443:30654/TCP                     27m
monitoring        prometheus-k8s-lb                                       LoadBalancer   10.96.190.210   10.89.0.1     9090:32689/TCP,8080:30109/TCP                     28m
monitoring        thanos-receive-router-lb                                LoadBalancer   10.96.190.231   10.89.0.0     10901:32399/TCP,10902:32451/TCP,19291:30993/TCP   58m
```

If you bring up a 2nd kind cluster using the quickstart script, the ip address of it will be 10.89.0.4
```
podman inspect $(podman ps -q --filter "name=kuadrant-local-1-control-plane") | grep -i "10."
...
                         "Gateway": "10.89.0.1",
                         "IPAddress": "10.89.0.4",
```
Similarly, this can clash with service loadbalancer ips on the first cluster.

The fix starts the subnet offset for metallb assigned service loadbalancer IPs at .16.

e.g.
1st cluster .16-.31
```shell
kubectl --context kind-kuadrant-local get svc -A|grep -i loadbalancer
kuadrant-system   api-gateway-istio                                       LoadBalancer   10.96.194.138   10.89.0.18    15021:30452/TCP,443:31978/TCP                     18m
monitoring        prometheus-k8s-lb                                       LoadBalancer   10.96.251.8     10.89.0.17    9090:30172/TCP,8080:31329/TCP                     18m
monitoring        thanos-receive-router-lb                                LoadBalancer   10.96.13.245    10.89.0.16    10901:31777/TCP,10902:30359/TCP,19291:32405/TCP   35m
```
2nd cluster .32-47
```shell
kubectl --context $KUBECTL_CONTEXT get svc -A|grep -i loadbalancer
kuadrant-system   api-gateway-istio                                       LoadBalancer   10.96.131.15    10.89.0.33    15021:32203/TCP,443:30664/TCP           15m
monitoring        prometheus-k8s-lb                                       LoadBalancer   10.96.219.216   10.89.0.32    9090:31146/TCP,8080:30621/TCP           15m
```

@ehearneRedHat may have seen this issue as well on linux with docker. To be confirmed.