### PR TITLE
Revert "use correct status type when enforcing policy"

### DIFF
--- a/controllers/dnspolicy_controller_single_cluster_test.go
+++ b/controllers/dnspolicy_controller_single_cluster_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 )
 
@@ -130,20 +129,6 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 		})
 
 		It("should create dns records", func() {
-
-			Eventually(func(g Gomega, ctx context.Context) {
-
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsPolicy), dnsPolicy)).To(Succeed())
-				g.Expect(dnsPolicy.Status.Conditions).To(
-					ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(string(kuadrant.PolicyConditionEnforced)),
-						"Status":  Equal(metav1.ConditionFalse),
-						"Reason":  Equal(string(kuadrant.PolicyReasonEnforced)),
-						"Message": Equal("DNSPolicy has been partially enforced"),
-					})),
-				)
-
-			}, TestTimeoutMedium, TestRetryIntervalMedium, ctx).Should(Succeed())
 
 			Eventually(func(g Gomega, ctx context.Context) {
 				recordList := &kuadrantdnsv1alpha1.DNSRecordList{}

--- a/controllers/dnspolicy_controller_test.go
+++ b/controllers/dnspolicy_controller_test.go
@@ -344,9 +344,9 @@ var _ = Describe("DNSPolicy controller", func() {
 						}),
 						MatchFields(IgnoreExtras, Fields{
 							"Type":    Equal(string(kuadrant.PolicyConditionEnforced)),
-							"Status":  Equal(metav1.ConditionFalse),
+							"Status":  Equal(metav1.ConditionTrue),
 							"Reason":  Equal(string(kuadrant.PolicyReasonEnforced)),
-							"Message": Equal("DNSPolicy has been partially enforced"),
+							"Message": Equal("DNSPolicy has been successfully enforced"),
 						})),
 				)
 			}, TestTimeoutMedium, time.Second).Should(Succeed())

--- a/controllers/dnspolicy_status.go
+++ b/controllers/dnspolicy_status.go
@@ -115,7 +115,7 @@ func (r *DNSPolicyReconciler) enforcedCondition(recordsList *kuadrantdnsv1alpha1
 				controlled = true
 				// if at least one record not ready the policy is not enforced
 				for _, condition := range record.Status.Conditions {
-					if condition.Type == string(kuadrantdnsv1alpha1.ConditionTypeReady) && condition.Status == metav1.ConditionFalse {
+					if condition.Type == string(v1alpha2.PolicyConditionAccepted) && condition.Status == metav1.ConditionFalse {
 						return kuadrant.EnforcedCondition(dnsPolicy, nil, false)
 					}
 				}

--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -55,7 +55,6 @@ const (
 	TestListenerNameTwo      = "test-listener-2"
 	TestIPAddressOne         = "172.0.0.1"
 	TestIPAddressTwo         = "172.0.0.2"
-	TestHTTPRouteName        = "toystore-route"
 )
 
 func ApplyKuadrantCR(namespace string) {

--- a/controllers/limitador_cluster_envoyfilter_controller_test.go
+++ b/controllers/limitador_cluster_envoyfilter_controller_test.go
@@ -31,8 +31,9 @@ var _ = Describe("Limitador Cluster EnvoyFilter controller", Ordered, func() {
 	var (
 		testNamespace          string
 		kuadrantInstallationNS string
+		gwName                 = "toystore-gw"
 		rlpName                = "toystore-rlp"
-		efName                 = fmt.Sprintf("kuadrant-ratelimiting-cluster-%s", TestGatewayName)
+		efName                 = fmt.Sprintf("kuadrant-ratelimiting-cluster-%s", gwName)
 	)
 
 	BeforeAll(func(ctx SpecContext) {
@@ -46,7 +47,7 @@ var _ = Describe("Limitador Cluster EnvoyFilter controller", Ordered, func() {
 
 	beforeEachCallback := func(ctx SpecContext) {
 		testNamespace = CreateNamespaceWithContext(ctx)
-		gateway := testBuildBasicGateway(TestGatewayName, testNamespace)
+		gateway := testBuildBasicGateway(gwName, testNamespace)
 		err := k8sClient.Create(ctx, gateway)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -101,7 +102,7 @@ var _ = Describe("Limitador Cluster EnvoyFilter controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(TestGatewayName),
+						Name:  gatewayapiv1.ObjectName(gwName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{

--- a/controllers/rate_limiting_wasmplugin_controller_test.go
+++ b/controllers/rate_limiting_wasmplugin_controller_test.go
@@ -70,11 +70,12 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		var (
 			routeName = "toystore-route"
 			rlpName   = "toystore-rlp"
+			gwName    = "toystore-gw"
 			gateway   *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+			gateway = testBuildBasicGateway(gwName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -84,7 +85,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("Simple RLP targeting HTTPRoute creates wasmplugin", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -177,7 +178,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("Full featured RLP targeting HTTPRoute creates wasmplugin", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.toystore.acme.com", "api.toystore.io"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.toystore.acme.com", "api.toystore.io"})
 			httpRoute.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
 					Matches: []gatewayapiv1.HTTPRouteMatch{
@@ -391,7 +392,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("Simple RLP targeting Gateway parented by one HTTPRoute creates wasmplugin", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -406,7 +407,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(TestGatewayName),
+						Name:  gatewayapiv1.ObjectName(gwName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -482,11 +483,12 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 	Context("RLP targeting HTTPRoute-less Gateway", func() {
 		var (
 			rlpName = "toystore-rlp"
+			gwName  = "toystore-gw"
 			gateway *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+			gateway = testBuildBasicGateway(gwName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -505,7 +507,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(TestGatewayName),
+						Name:  gatewayapiv1.ObjectName(gwName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -543,11 +545,12 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		var (
 			routeName = "toystore-route"
 			rlpName   = "toystore-rlp"
+			gwName    = "toystore-gw"
 			gateway   *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+			gateway = testBuildBasicGateway(gwName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -557,7 +560,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("When the gateway does not have more policies, the wasmplugin resource is not created", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -631,7 +634,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			)
 
 			// create httproute B
-			httpRouteB := testBuildBasicHttpRoute(routeBName, TestGatewayName, testNamespace, []string{"*.b.example.com"})
+			httpRouteB := testBuildBasicHttpRoute(routeBName, gwName, testNamespace, []string{"*.b.example.com"})
 			err := k8sClient.Create(ctx, httpRouteB)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRouteB))).WithContext(ctx).Should(BeTrue())
@@ -646,7 +649,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(TestGatewayName),
+						Name:  gatewayapiv1.ObjectName(gwName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -669,7 +672,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			Eventually(assertPolicyIsAcceptedAndEnforced(ctx, rlpAKey)).WithContext(ctx).Should(BeTrue())
 
 			// create httproute C
-			httpRouteC := testBuildBasicHttpRoute(routeCName, TestGatewayName, testNamespace, []string{"*.c.example.com"})
+			httpRouteC := testBuildBasicHttpRoute(routeCName, gwName, testNamespace, []string{"*.c.example.com"})
 			httpRouteC.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
 					Matches: []gatewayapiv1.HTTPRouteMatch{
@@ -805,12 +808,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		var (
 			routeName = "route-a"
 			rlpName   = "rlp-a"
+			gwName    = "toystore-gw"
 			gateway   *gatewayapiv1.Gateway
 			gwBName   = "gw-b"
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+			gateway = testBuildBasicGateway(gwName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -843,7 +847,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(TestGatewayName),
+						Name:  gatewayapiv1.ObjectName(gwName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -866,7 +870,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			Expect(testRLPEnforcedCondition(ctx, rlpKey, kuadrant.PolicyReasonUnknown, "RateLimitPolicy has encountered some issues: no free routes to enforce policy"))
 
 			// create Route A -> Gw A
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			err = k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -1037,7 +1041,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			Eventually(testGatewayIsReady(gwB)).WithContext(ctx).Should(BeTrue())
 
 			// create Route A -> Gw A
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			err = k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -1261,11 +1265,12 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 	Context("RLP switches targetRef from one route A to another route B", func() {
 		var (
+			gwName  = "toystore-gw"
 			gateway *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+			gateway = testBuildBasicGateway(gwName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -1295,7 +1300,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route A -> Gw A on *.a.example.com
 			//
-			httpRouteA := testBuildBasicHttpRoute(routeAName, TestGatewayName, testNamespace, []string{"*.a.example.com"})
+			httpRouteA := testBuildBasicHttpRoute(routeAName, gwName, testNamespace, []string{"*.a.example.com"})
 			// GET /routeA
 			httpRouteA.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -1317,7 +1322,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route B -> Gw A on *.b.example.com
 			//
-			httpRouteB := testBuildBasicHttpRoute(routeBName, TestGatewayName, testNamespace, []string{"*.b.example.com"})
+			httpRouteB := testBuildBasicHttpRoute(routeBName, gwName, testNamespace, []string{"*.b.example.com"})
 			// GET /routeB
 			httpRouteB.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -1520,11 +1525,12 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 	Context("Free Route gets dedicated RLP", func() {
 		var (
+			gwName  = "toystore-gw"
 			gateway *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+			gateway = testBuildBasicGateway(gwName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -1553,7 +1559,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route A -> Gw A on *.a.example.com
 			//
-			httpRouteA := testBuildBasicHttpRoute(routeAName, TestGatewayName, testNamespace, []string{"*.a.example.com"})
+			httpRouteA := testBuildBasicHttpRoute(routeAName, gwName, testNamespace, []string{"*.a.example.com"})
 			// GET /routeA
 			httpRouteA.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -1582,7 +1588,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(TestGatewayName),
+						Name:  gatewayapiv1.ObjectName(gwName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -1779,11 +1785,12 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 	Context("New free route on a Gateway with RLP", func() {
 		var (
+			gwName  = "toystore-gw"
 			gateway *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+			gateway = testBuildBasicGateway(gwName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -1815,7 +1822,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route A -> Gw A on *.a.example.com
 			//
-			httpRouteA := testBuildBasicHttpRoute(routeAName, TestGatewayName, testNamespace, []string{"*.a.example.com"})
+			httpRouteA := testBuildBasicHttpRoute(routeAName, gwName, testNamespace, []string{"*.a.example.com"})
 			// GET /routeA
 			httpRouteA.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -1844,7 +1851,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(TestGatewayName),
+						Name:  gatewayapiv1.ObjectName(gwName),
 					},
 					RateLimitPolicyCommonSpec: kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -1970,7 +1977,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			//
 			// create Route B -> Gw A on *.b.example.com
 			//
-			httpRouteB := testBuildBasicHttpRoute(routeBName, TestGatewayName, testNamespace, []string{"*.b.example.com"})
+			httpRouteB := testBuildBasicHttpRoute(routeBName, gwName, testNamespace, []string{"*.b.example.com"})
 			// GET /routeB
 			httpRouteB.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
@@ -2097,6 +2104,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 	Context("Gateway with hostname in listener", func() {
 		var (
+			gwName     = "toystore-gw"
 			routeName  = "toystore-route"
 			rlpName    = "rlp-a"
 			gateway    *gatewayapiv1.Gateway
@@ -2104,7 +2112,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+			gateway = testBuildBasicGateway(gwName, testNamespace)
 			gateway.Spec.Listeners[0].Hostname = ptr.To(gatewayapiv1.Hostname(gwHostname))
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
@@ -2116,7 +2124,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 		It("RLP with hostnames in route selector targeting hostname less HTTPRoute creates wasmplugin", func(ctx SpecContext) {
 			// create httproute
 			var emptyRouteHostnames []string
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, emptyRouteHostnames)
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, emptyRouteHostnames)
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -2217,11 +2225,12 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 			routeName    = "toystore-route"
 			gwRLPName    = "gw-rlp"
 			routeRLPName = "route-rlp"
+			gwName       = "toystore-gw"
 			gateway      *gatewayapiv1.Gateway
 		)
 
 		beforeEachCallback := func(ctx SpecContext) {
-			gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+			gateway = testBuildBasicGateway(gwName, testNamespace)
 			err := k8sClient.Create(ctx, gateway)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -2273,7 +2282,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 
 		It("Limit key shifts correctly from Gateway RLP default -> Route RLP -> Gateway RLP overrides", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			Expect(k8sClient.Create(ctx, httpRoute)).To(Succeed())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
 
@@ -2287,7 +2296,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(TestGatewayName),
+						Name:  gatewayapiv1.ObjectName(gwName),
 					},
 					Defaults: &kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{

--- a/controllers/ratelimitpolicy_controller_test.go
+++ b/controllers/ratelimitpolicy_controller_test.go
@@ -35,6 +35,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 		testNamespace          string
 		kuadrantInstallationNS string
 		routeName              = "toystore-route"
+		gwName                 = "toystore-gw"
 		rlpName                = "toystore-rlp"
 		gateway                *gatewayapiv1.Gateway
 	)
@@ -98,7 +99,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 
 	beforeEachCallback := func(ctx SpecContext) {
 		testNamespace = CreateNamespaceWithContext(ctx)
-		gateway = testBuildBasicGateway(TestGatewayName, testNamespace)
+		gateway = testBuildBasicGateway(gwName, testNamespace)
 
 		Expect(k8sClient.Create(ctx, gateway)).To(Succeed())
 		Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
@@ -121,7 +122,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 	Context("RLP targeting HTTPRoute", func() {
 		It("Creates all the resources for a basic HTTPRoute and RateLimitPolicy", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -162,7 +163,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			}))
 
 			// Check gateway back references
-			gwKey := client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}
+			gwKey := client.ObjectKey{Name: gwName, Namespace: testNamespace}
 			existingGateway := &gatewayapiv1.Gateway{}
 			Eventually(func(g Gomega) {
 				err = k8sClient.Get(ctx, gwKey, existingGateway)
@@ -180,7 +181,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 	Context("RLP targeting Gateway", func() {
 		It("Creates all the resources for a basic Gateway and RateLimitPolicy", func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -199,7 +200,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.Group("gateway.networking.k8s.io"),
 						Kind:  "Gateway",
-						Name:  gatewayapiv1.ObjectName(TestGatewayName),
+						Name:  gatewayapiv1.ObjectName(gwName),
 					},
 					Defaults: &kuadrantv1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]kuadrantv1beta2.Limit{
@@ -263,7 +264,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			// create ratelimitpolicy
 			rlp := policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
 				policy.Spec.TargetRef.Kind = "Gateway"
-				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(TestGatewayName)
+				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(gwName)
 			})
 			err := k8sClient.Create(ctx, rlp)
 			Expect(err).ToNot(HaveOccurred())
@@ -322,14 +323,14 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 				// GW policy defaults are overridden and not enforced when Route has their own policy attached
 
 				// create httproute
-				httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+				httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 				Expect(k8sClient.Create(ctx, httpRoute)).To(Succeed())
 				Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
 
 				// create GW RLP
 				gwRLP = policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
 					policy.Spec.TargetRef.Kind = "Gateway"
-					policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(TestGatewayName)
+					policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(gwName)
 				})
 				Expect(k8sClient.Create(ctx, gwRLP)).To(Succeed())
 				gwRLPKey := client.ObjectKey{Name: gwRLP.Name, Namespace: testNamespace}
@@ -384,7 +385,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 
 			When("Free route is created", func() {
 				It("Gateway policy should now be enforced", func(ctx SpecContext) {
-					route2 := testBuildBasicHttpRoute("route2", TestGatewayName, testNamespace, []string{"*.car.com"})
+					route2 := testBuildBasicHttpRoute("route2", gwName, testNamespace, []string{"*.car.com"})
 					Expect(k8sClient.Create(ctx, route2)).To(Succeed())
 					Eventually(testRLPIsEnforced(ctx, client.ObjectKeyFromObject(gwRLP))).WithContext(ctx).Should(BeTrue())
 				}, testTimeOut)
@@ -401,7 +402,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 		It("Explicit defaults - no underlying routes to enforce policy", func(ctx SpecContext) {
 			gwRLP := policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
 				policy.Spec.TargetRef.Kind = "Gateway"
-				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(TestGatewayName)
+				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(gwName)
 			})
 
 			Expect(k8sClient.Create(ctx, gwRLP)).To(Succeed())
@@ -413,7 +414,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 		It("Implicit defaults - no underlying routes to enforce policy", func(ctx SpecContext) {
 			gwRLP := policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
 				policy.Spec.TargetRef.Kind = "Gateway"
-				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(TestGatewayName)
+				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(gwName)
 				policy.Spec.RateLimitPolicyCommonSpec = *policy.Spec.Defaults.DeepCopy()
 				policy.Spec.Defaults = nil
 			})
@@ -431,13 +432,13 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 
 		BeforeEach(func(ctx SpecContext) {
 			// create httproute
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			Expect(k8sClient.Create(ctx, httpRoute)).To(Succeed())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
 
 			gwRLP = policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
 				policy.Spec.TargetRef.Kind = "Gateway"
-				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(TestGatewayName)
+				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(gwName)
 				policy.Spec.Overrides = policy.Spec.Defaults.DeepCopy()
 				policy.Spec.Defaults = nil
 			})
@@ -563,7 +564,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			// Create GW RLP with defaults
 			gwRLP = policyFactory(func(policy *kuadrantv1beta2.RateLimitPolicy) {
 				policy.Spec.TargetRef.Kind = "Gateway"
-				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(TestGatewayName)
+				policy.Spec.TargetRef.Name = gatewayapiv1.ObjectName(gwName)
 			})
 			Expect(k8sClient.Create(ctx, gwRLP)).To(Succeed())
 			gwRLPKey := client.ObjectKeyFromObject(gwRLP)
@@ -706,7 +707,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 		}, testTimeOut)
 
 		It("Conflict reason", func(ctx SpecContext) {
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			Expect(k8sClient.Create(ctx, httpRoute)).To(Succeed())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
 
@@ -763,7 +764,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 		}
 
 		BeforeEach(func(ctx SpecContext) {
-			route := testBuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
+			route := testBuildBasicHttpRoute(testHTTPRouteName, testGatewayName, testNamespace, []string{"*.toystore.com"})
 			Expect(k8sClient.Create(ctx, route)).To(Succeed())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
 		})
@@ -816,7 +817,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			// RLP A -> Route B
 
 			// create httproute A
-			httpRouteA := testBuildBasicHttpRoute(routeAName, TestGatewayName, testNamespace, []string{"*.a.example.com"})
+			httpRouteA := testBuildBasicHttpRoute(routeAName, gwName, testNamespace, []string{"*.a.example.com"})
 			err := k8sClient.Create(ctx, httpRouteA)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRouteA))).WithContext(ctx).Should(BeTrue())
@@ -846,7 +847,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			// To RLP A -> Route B
 
 			// create httproute B
-			httpRouteB := testBuildBasicHttpRoute(routeBName, TestGatewayName, testNamespace, []string{"*.b.example.com"})
+			httpRouteB := testBuildBasicHttpRoute(routeBName, gwName, testNamespace, []string{"*.b.example.com"})
 			err = k8sClient.Create(ctx, httpRouteB)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRouteB))).WithContext(ctx).Should(BeTrue())
@@ -973,13 +974,13 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			// RLP B -> Route B
 
 			// create httproute A
-			httpRouteA := testBuildBasicHttpRoute(routeAName, TestGatewayName, testNamespace, []string{"*.a.example.com"})
+			httpRouteA := testBuildBasicHttpRoute(routeAName, gwName, testNamespace, []string{"*.a.example.com"})
 			err := k8sClient.Create(ctx, httpRouteA)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRouteA))).WithContext(ctx).Should(BeTrue())
 
 			// create httproute B
-			httpRouteB := testBuildBasicHttpRoute(routeBName, TestGatewayName, testNamespace, []string{"*.b.example.com"})
+			httpRouteB := testBuildBasicHttpRoute(routeBName, gwName, testNamespace, []string{"*.b.example.com"})
 			err = k8sClient.Create(ctx, httpRouteB)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRouteB))).WithContext(ctx).Should(BeTrue())
@@ -1067,7 +1068,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			// RLP A
 
 			// create httproute A
-			httpRoute := testBuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			httpRoute := testBuildBasicHttpRoute(routeName, gwName, testNamespace, []string{"*.example.com"})
 			err := k8sClient.Create(ctx, httpRoute)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
@@ -1127,7 +1128,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			// RLP B -> Route A
 
 			// create httproute A
-			httpRouteA := testBuildBasicHttpRoute(routeAName, TestGatewayName, testNamespace, []string{"*.a.example.com"})
+			httpRouteA := testBuildBasicHttpRoute(routeAName, gwName, testNamespace, []string{"*.a.example.com"})
 			err := k8sClient.Create(ctx, httpRouteA)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRouteA))).WithContext(ctx).Should(BeTrue())
@@ -1174,7 +1175,7 @@ var _ = Describe("RateLimitPolicy controller", Ordered, func() {
 			// RLP A was the older owner of route A, and wiil be the new owner of route B
 
 			// create httproute B
-			httpRouteB := testBuildBasicHttpRoute(routeBName, TestGatewayName, testNamespace, []string{"*.b.example.com"})
+			httpRouteB := testBuildBasicHttpRoute(routeBName, gwName, testNamespace, []string{"*.b.example.com"})
 			err = k8sClient.Create(ctx, httpRouteB)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(httpRouteB))).WithContext(ctx).Should(BeTrue())

--- a/controllers/ratelimitpolicy_status_test.go
+++ b/controllers/ratelimitpolicy_status_test.go
@@ -1,5 +1,3 @@
-//go:build unit
-
 package controllers
 
 import (

--- a/controllers/target_status_controller_test.go
+++ b/controllers/target_status_controller_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		testNamespace = CreateNamespaceWithContext(ctx)
 
 		// create gateway
-		gateway := testBuildBasicGateway(TestGatewayName, testNamespace, func(gateway *gatewayapiv1.Gateway) {
+		gateway := testBuildBasicGateway(testGatewayName, testNamespace, func(gateway *gatewayapiv1.Gateway) {
 			gateway.Spec.Listeners = []gatewayapiv1.Listener{{
 				Name:     gatewayapiv1.SectionName("test-listener-toystore-com"),
 				Hostname: ptr.To(gatewayapiv1.Hostname("*.toystore.com")),
@@ -65,7 +65,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		Eventually(testGatewayIsReady(gateway)).WithContext(ctx).Should(BeTrue())
 
 		// create application
-		route := testBuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
+		route := testBuildBasicHttpRoute(testHTTPRouteName, testGatewayName, testNamespace, []string{"*.toystore.com"})
 		err = k8sClient.Create(ctx, route)
 		Expect(err).ToNot(HaveOccurred())
 		Eventually(testRouteIsAccepted(client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
@@ -91,7 +91,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		if err != nil {
 			return false
 		}
-		routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+		routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 		if !found {
 			return false
 		}
@@ -105,7 +105,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		if err != nil {
 			return false
 		}
-		routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+		routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 		if !found {
 			return false
 		}
@@ -150,7 +150,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group:     gatewayapiv1.GroupName,
 						Kind:      "HTTPRoute",
-						Name:      TestHTTPRouteName,
+						Name:      testHTTPRouteName,
 						Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 					},
 					Defaults: &v1beta2.AuthPolicyCommonSpec{
@@ -206,7 +206,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool {
 				return policyAcceptedAndTargetsAffected(ctx, routePolicy1)() &&
-					!isAuthPolicyAccepted(ctx, routePolicy2)() && !routeAffected(ctx, TestHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy2))
+					!isAuthPolicyAccepted(ctx, routePolicy2)() && !routeAffected(ctx, testHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy2))
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -224,8 +224,8 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 			Expect(k8sClient.Create(ctx, routePolicy2)).To(Succeed())
 
 			Eventually(func() bool {
-				return !isAuthPolicyAccepted(ctx, routePolicy1)() && routeNotAffected(ctx, TestHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy1)) &&
-					!isAuthPolicyAccepted(ctx, routePolicy2)() && !routeAffected(ctx, TestHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy2))
+				return !isAuthPolicyAccepted(ctx, routePolicy1)() && routeNotAffected(ctx, testHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy1)) &&
+					!isAuthPolicyAccepted(ctx, routePolicy2)() && !routeAffected(ctx, testHTTPRouteName, policyAffectedCondition, client.ObjectKeyFromObject(routePolicy2))
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -238,11 +238,11 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool { // route is not affected by the policy
 				route := &gatewayapiv1.HTTPRoute{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestHTTPRouteName, Namespace: testNamespace}, route)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: testHTTPRouteName, Namespace: testNamespace}, route)
 				if err != nil {
 					return false
 				}
-				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 				return !found || meta.IsStatusConditionFalse(routeParentStatus.Conditions, policyAffectedCondition)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
@@ -253,12 +253,12 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      TestGatewayName,
+					Name:      testGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
-			Eventually(policyAcceptedAndTargetsAffected(ctx, policy, TestHTTPRouteName)).WithContext(ctx).Should(BeTrue())
+			Eventually(policyAcceptedAndTargetsAffected(ctx, policy, testHTTPRouteName)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
 		It("removes PolicyAffected status condition from the targeted gateway and routes when the policy is deleted", func(ctx SpecContext) {
@@ -267,7 +267,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      TestGatewayName,
+					Name:      testGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
@@ -278,17 +278,17 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool { // gateway and route not affected by the policy
 				gateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, gateway)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, gateway)
 				if err != nil || meta.IsStatusConditionTrue(gateway.Status.Conditions, policyAffectedCondition) {
 					return false
 				}
 
 				route := &gatewayapiv1.HTTPRoute{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Name: TestHTTPRouteName, Namespace: testNamespace}, route)
+				err = k8sClient.Get(ctx, client.ObjectKey{Name: testHTTPRouteName, Namespace: testNamespace}, route)
 				if err != nil {
 					return false
 				}
-				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 				return !found || meta.IsStatusConditionFalse(routeParentStatus.Conditions, policyAffectedCondition)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
@@ -298,8 +298,8 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 			Expect(k8sClient.Create(ctx, routePolicy)).To(Succeed())
 			Eventually(policyAcceptedAndTargetsAffected(ctx, routePolicy)).WithContext(ctx).Should(BeTrue())
 
-			otherRouteName := TestHTTPRouteName + "-other"
-			otherRoute := testBuildBasicHttpRoute(otherRouteName, TestGatewayName, testNamespace, []string{"other.toystore.com"})
+			otherRouteName := testHTTPRouteName + "-other"
+			otherRoute := testBuildBasicHttpRoute(otherRouteName, testGatewayName, testNamespace, []string{"other.toystore.com"})
 			Expect(k8sClient.Create(ctx, otherRoute)).To(Succeed())
 
 			gatewayPolicy := policyFactory(func(policy *v1beta2.AuthPolicy) {
@@ -307,7 +307,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      TestGatewayName,
+					Name:      testGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
@@ -321,7 +321,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			// remove route policy and check if the gateway policy has been rolled out to the status of the newly non-targeted route
 			Expect(k8sClient.Delete(ctx, routePolicy)).To(Succeed())
-			Eventually(policyAcceptedAndTargetsAffected(ctx, gatewayPolicy, otherRouteName, TestHTTPRouteName)).WithContext(ctx).Should(BeTrue())
+			Eventually(policyAcceptedAndTargetsAffected(ctx, gatewayPolicy, otherRouteName, testHTTPRouteName)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 	})
 
@@ -343,7 +343,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 					TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
 						Group: gatewayapiv1.GroupName,
 						Kind:  "HTTPRoute",
-						Name:  gatewayapiv1.ObjectName(TestHTTPRouteName),
+						Name:  gatewayapiv1.ObjectName(testHTTPRouteName),
 					},
 					Defaults: &v1beta2.RateLimitPolicyCommonSpec{
 						Limits: map[string]v1beta2.Limit{
@@ -391,11 +391,11 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool { // route is not affected by the policy
 				route := &gatewayapiv1.HTTPRoute{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestHTTPRouteName, Namespace: testNamespace}, route)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: testHTTPRouteName, Namespace: testNamespace}, route)
 				if err != nil {
 					return false
 				}
-				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 				return !found || meta.IsStatusConditionFalse(routeParentStatus.Conditions, policyAffectedCondition)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
@@ -406,12 +406,12 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      TestGatewayName,
+					Name:      testGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
-			Eventually(policyAcceptedAndTargetsAffected(ctx, policy, TestHTTPRouteName)).WithContext(ctx).Should(BeTrue())
+			Eventually(policyAcceptedAndTargetsAffected(ctx, policy, testHTTPRouteName)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
 		It("removes PolicyAffected status condition from the targeted gateway and routes when the policy is deleted", func(ctx SpecContext) {
@@ -420,7 +420,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      TestGatewayName,
+					Name:      testGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
@@ -431,17 +431,17 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool { // gateway and route not affected by the policy
 				gateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, gateway)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, gateway)
 				if err != nil || meta.IsStatusConditionTrue(gateway.Status.Conditions, policyAffectedCondition) {
 					return false
 				}
 
 				route := &gatewayapiv1.HTTPRoute{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Name: TestHTTPRouteName, Namespace: testNamespace}, route)
+				err = k8sClient.Get(ctx, client.ObjectKey{Name: testHTTPRouteName, Namespace: testNamespace}, route)
 				if err != nil {
 					return false
 				}
-				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
+				routeParentStatus, found := utils.Find(route.Status.RouteStatus.Parents, findRouteParentStatusFunc(route, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, kuadrant.ControllerName))
 				return !found || meta.IsStatusConditionFalse(routeParentStatus.Conditions, policyAffectedCondition)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
@@ -451,8 +451,8 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 			Expect(k8sClient.Create(ctx, routePolicy)).To(Succeed())
 			Eventually(policyAcceptedAndTargetsAffected(ctx, routePolicy)).WithContext(ctx).Should(BeTrue())
 
-			otherRouteName := TestHTTPRouteName + "-other"
-			otherRoute := testBuildBasicHttpRoute(otherRouteName, TestGatewayName, testNamespace, []string{"other.toystore.com"})
+			otherRouteName := testHTTPRouteName + "-other"
+			otherRoute := testBuildBasicHttpRoute(otherRouteName, testGatewayName, testNamespace, []string{"other.toystore.com"})
 			Expect(k8sClient.Create(ctx, otherRoute)).To(Succeed())
 
 			gatewayPolicy := policyFactory(func(policy *v1beta2.RateLimitPolicy) {
@@ -460,7 +460,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 				policy.Spec.TargetRef = gatewayapiv1alpha2.PolicyTargetReference{
 					Group:     gatewayapiv1.GroupName,
 					Kind:      "Gateway",
-					Name:      TestGatewayName,
+					Name:      testGatewayName,
 					Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
 				}
 			})
@@ -474,7 +474,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			// remove route policy and check if the gateway policy has been rolled out to the status of the newly non-targeted route
 			Expect(k8sClient.Delete(ctx, routePolicy)).To(Succeed())
-			Eventually(policyAcceptedAndTargetsAffected(ctx, gatewayPolicy, otherRouteName, TestHTTPRouteName)).WithContext(ctx).Should(BeTrue())
+			Eventually(policyAcceptedAndTargetsAffected(ctx, gatewayPolicy, otherRouteName, testHTTPRouteName)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 	})
 
@@ -483,7 +483,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 		// policyFactory builds a standards DNSPolicy object that targets the test gateway by default, with the given mutate functions applied
 		policyFactory := func(mutateFns ...func(policy *v1alpha1.DNSPolicy)) *v1alpha1.DNSPolicy {
-			policy := v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).WithTargetGateway(TestGatewayName).WithRoutingStrategy(v1alpha1.SimpleRoutingStrategy)
+			policy := v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).WithTargetGateway(testGatewayName).WithRoutingStrategy(v1alpha1.SimpleRoutingStrategy)
 			for _, mutateFn := range mutateFns {
 				mutateFn(policy)
 			}
@@ -499,21 +499,15 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 			return meta.IsStatusConditionTrue(policy.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted))
 		}
 
-		isDNSPolicyEnforced := func(ctx context.Context, policyKey client.ObjectKey) bool {
-			policy := &v1alpha1.DNSPolicy{}
-			err := k8sClient.Get(ctx, policyKey, policy)
-			if err != nil {
-				return false
-			}
-			return meta.IsStatusConditionTrue(policy.Status.Conditions, string(kuadrant.PolicyConditionEnforced))
-		}
-
 		// policyAcceptedAndTargetsAffected returns an assertion function that checks if a DNSPolicy is accepted
 		// and the statuses of its target object has been all updated as affected by the policy
 		policyAcceptedAndTargetsAffected := func(ctx context.Context, policy *v1alpha1.DNSPolicy) func() bool {
 			return func() bool {
 				policyKey := client.ObjectKeyFromObject(policy)
-				return isDNSPolicyAccepted(ctx, policyKey) && targetsAffected(ctx, policyKey, policyAffectedCondition, policy.Spec.TargetRef)
+				if !isDNSPolicyAccepted(ctx, policyKey) {
+					return false
+				}
+				return targetsAffected(ctx, policyKey, policyAffectedCondition, policy.Spec.TargetRef)
 			}
 		}
 
@@ -531,8 +525,6 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 		It("adds PolicyAffected status condition to the targeted gateway", func(ctx SpecContext) {
 			policy := policyFactory()
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
-			// policy should not be enforced since DNS Record is not ready because of the missing secret on the MZ
-			Eventually(isDNSPolicyEnforced(ctx, client.ObjectKeyFromObject(policy))).ShouldNot(BeTrue())
 			Eventually(policyAcceptedAndTargetsAffected(ctx, policy)).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -546,11 +538,11 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool {
 				gateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, gateway)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, gateway)
 				if err != nil {
 					return false
 				}
-				condition := meta.FindStatusCondition(gateway.Status.Conditions, TestGatewayName)
+				condition := meta.FindStatusCondition(gateway.Status.Conditions, testGatewayName)
 				return condition == nil || !strings.Contains(condition.Message, policyKey.String()) || condition.Status == metav1.ConditionFalse
 			})
 		}, testTimeOut)
@@ -564,7 +556,7 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 		// policyFactory builds a standards TLSPolicy object that targets the test gateway by default, with the given mutate functions applied
 		policyFactory := func(mutateFns ...func(policy *v1alpha1.TLSPolicy)) *v1alpha1.TLSPolicy {
-			policy := v1alpha1.NewTLSPolicy("test-tls-policy", testNamespace).WithTargetGateway(TestGatewayName).WithIssuerRef(*issuerRef)
+			policy := v1alpha1.NewTLSPolicy("test-tls-policy", testNamespace).WithTargetGateway(testGatewayName).WithIssuerRef(*issuerRef)
 			for _, mutateFn := range mutateFns {
 				mutateFn(policy)
 			}
@@ -620,11 +612,11 @@ var _ = Describe("Target status reconciler", Ordered, func() {
 
 			Eventually(func() bool {
 				gateway := &gatewayapiv1.Gateway{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: TestGatewayName, Namespace: testNamespace}, gateway)
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: testGatewayName, Namespace: testNamespace}, gateway)
 				if err != nil {
 					return false
 				}
-				condition := meta.FindStatusCondition(gateway.Status.Conditions, TestGatewayName)
+				condition := meta.FindStatusCondition(gateway.Status.Conditions, testGatewayName)
 				return condition == nil || !strings.Contains(condition.Message, policyKey.String()) || condition.Status == metav1.ConditionFalse
 			})
 		}, testTimeOut)

--- a/controllers/tlspolicy_status_test.go
+++ b/controllers/tlspolicy_status_test.go
@@ -1,5 +1,3 @@
-//go:build unit
-
 package controllers
 
 import (
@@ -30,8 +28,8 @@ func TestTLSPolicyReconciler_enforcedCondition(t *testing.T) {
 		ns              = "default"
 		tlsPolicyName   = "kuadrant-tls-policy"
 		issuerName      = "kuadrant-issuer"
-		certificateName = "kuadrant-certifcate"
 		gwName          = "kuadrant-gateway"
+		certificateName = "kuadrant-certifcate"
 	)
 
 	scheme := runtime.NewScheme()

--- a/pkg/library/kuadrant/apimachinery_status_conditions.go
+++ b/pkg/library/kuadrant/apimachinery_status_conditions.go
@@ -107,14 +107,12 @@ func AcceptedCondition(p Policy, err error) *metav1.Condition {
 func EnforcedCondition(policy Policy, err PolicyError, allSubresourcesReady bool) *metav1.Condition {
 	// Enforced
 	message := fmt.Sprintf("%s has been successfully enforced", policy.Kind())
-	status := metav1.ConditionTrue
 	if !allSubresourcesReady {
 		message = fmt.Sprintf("%s has been partially enforced", policy.Kind())
-		status = metav1.ConditionFalse
 	}
 	cond := &metav1.Condition{
 		Type:    string(PolicyConditionEnforced),
-		Status:  status,
+		Status:  metav1.ConditionTrue,
 		Reason:  string(PolicyReasonEnforced),
 		Message: message,
 	}


### PR DESCRIPTION
Reverts Kuadrant/kuadrant-operator#594

The Enforced status of policies that are _partially_ enforced should be `True`, not `False`.