### PR TITLE
envoygateway dev environment install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,13 @@ $(GINKGO):
 .PHONY: ginkgo
 ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
 
+HELM = $(PROJECT_PATH)/bin/helm
+$(HELM):
+	curl -sSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | PATH=$(PROJECT_PATH)/bin:$(PATH) USE_SUDO=false HELM_INSTALL_DIR=$(PROJECT_PATH)/bin bash
+
+.PHONY: helm
+helm: $(HELM) ## Download helm locally if necessary.
+
 ##@ Development
 define patch-config
 	envsubst \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ SHELL = /usr/bin/env bash -o pipefail
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
+OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m | tr '[:upper:]' '[:lower:]')
+
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:

--- a/config/dependencies/envoy-gateway/gateway/gateway-class.yaml
+++ b/config/dependencies/envoy-gateway/gateway/gateway-class.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller

--- a/config/dependencies/envoy-gateway/gateway/gateway.yaml
+++ b/config/dependencies/envoy-gateway/gateway/gateway.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: eg
+spec:
+  gatewayClassName: eg
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/config/dependencies/envoy-gateway/gateway/kustomization.yaml
+++ b/config/dependencies/envoy-gateway/gateway/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# Adds namespace to all resources.
+namespace: envoy-gateway-system
+resources:
+- gateway-class.yaml
+- gateway.yaml

--- a/doc/development.md
+++ b/doc/development.md
@@ -27,7 +27,7 @@ The `make local-setup` target accepts the following variables:
 
 | **Makefile Variable** | **Description** | **Default value** |
 | --- | --- |--- |
-| `GATEWAYAPI_PROVIDER` | GatewayAPI provider name. Accepted values: [*istio*] | *istio* |
+| `GATEWAYAPI_PROVIDER` | GatewayAPI provider name. Accepted values: [*istio* \| *envoygateway*] | *istio* |
 
 ## Run as a local process
 
@@ -41,7 +41,7 @@ The `make local-env-setup` target accepts the following variables:
 
 | **Makefile Variable** | **Description** | **Default value** |
 | --- | --- |--- |
-| `GATEWAYAPI_PROVIDER` | GatewayAPI provider name. Accepted values: [*istio*] | *istio* |
+| `GATEWAYAPI_PROVIDER` | GatewayAPI provider name. Accepted values: [*istio* \| *envoygateway*] | *istio* |
 
 Then, run the operator locally
 
@@ -54,12 +54,12 @@ make run
 **Requirements**:
 * Active session open to the kubernetes cluster.
 * GatewayAPI installed
-* GatewayAPI provider installed. Currently only Istio supported.
+* GatewayAPI provider installed. Currently only [Istio](https://istio.io/) and [EnvoyGateway](https://gateway.envoyproxy.io/) supported.
 * [Cert Manager](https://cert-manager.io/) installed
 
 Before running the kuadrant operator, some dependencies needs to be deployed.
 
-```
+```sh
 make install
 make deploy-dependencies
 ```
@@ -246,7 +246,7 @@ Multiple controller integration tests are defined
 | --- | --- | --- | --- |
 | `github.com/kuadrant/kuadrant-operator/tests/bare_k8s` | no gateway provider, no GatewayAPI CRDs. Just Kuadrant API and Kuadrant dependencies. | `make local-k8s-env-setup` | `make test-bare-k8s-integration` |
 | `github.com/kuadrant/kuadrant-operator/tests/gatewayapi` | no gateway provider. GatewayAPI CRDs, Kuadrant API and Kuadrant dependencies. | `make local-gatewayapi-env-setup` | `make test-gatewayapi-env-integration` |
-| `github.com/kuadrant/kuadrant-operator/controllers` | at least one gatewayapi provider. It can be any: istio, envoygateway, ...  | `make local-env-setup GATEWAYAPI_PROVIDER=[istio]` (Default *istio*) | `make test-integration` |
+| `github.com/kuadrant/kuadrant-operator/controllers` | at least one gatewayapi provider. It can be any: istio, envoygateway, ...  | `make local-env-setup GATEWAYAPI_PROVIDER=[istio \| envoygateway]` (Default *istio*) | `make test-integration` |
 | `github.com/kuadrant/kuadrant-operator/tests/istio` | GatewayAPI CRDs, Istio, Kuadrant API and Kuadrant dependencies.  | `make local-env-setup GATEWAYAPI_PROVIDER=istio` | `make test-istio-env-integration` |
 
 ### Lint tests

--- a/make/alerts.mk
+++ b/make/alerts.mk
@@ -1,12 +1,9 @@
 ##@ Alerts
-export WORKDIR ?= $(shell pwd)
 export IMAGE ?= quay.io/prometheus/prometheus
-export AVAILABILITY_SLO_RULES ?= $(WORKDIR)/examples/alerts/slo-availability.yaml
-export LATENCY_SLO_RULES ?= $(WORKDIR)/examples/alerts/slo-latency.yaml
-export UNIT_TEST_DIR ?= $(WORKDIR)/examples/alerts/tests
-export OS = $(shell uname | tr '[:upper:]' '[:lower:]')
-export ARCH = $(shell uname -m | tr '[:upper:]' '[:lower:]')
-export SLOTH = $(WORKDIR)/bin/sloth
+export AVAILABILITY_SLO_RULES ?= $(PROJECT_PATH)/examples/alerts/slo-availability.yaml
+export LATENCY_SLO_RULES ?= $(PROJECT_PATH)/examples/alerts/slo-latency.yaml
+export UNIT_TEST_DIR ?= $(PROJECT_PATH)/examples/alerts/tests
+export SLOTH = $(PROJECT_PATH)/bin/sloth
 export ALERTS_SLOTH_INPUT_DIR = /examples/alerts/sloth
 export ALERTS_SLOTH_OUTPUT_DIR = /examples/alerts
 
@@ -30,7 +27,7 @@ alerts-tests: container-runtime-tool ## Test alerts using promtool
 
 sloth: $(SLOTH) ## Install Sloth
 $(SLOTH):
-	cd $(WORKDIR)/bin && curl -L https://github.com/slok/sloth/releases/download/v0.11.0/sloth-$(OS)-$(ARCH) > sloth && chmod +x sloth
+	cd $(PROJECT_PATH)/bin && curl -L https://github.com/slok/sloth/releases/download/v0.11.0/sloth-$(OS)-$(ARCH) > sloth && chmod +x sloth
     
 sloth-generate: sloth ## Generate alerts using Sloth templates
-	$(SLOTH) generate -i $(WORKDIR)$(ALERTS_SLOTH_INPUT_DIR) -o $(WORKDIR)$(ALERTS_SLOTH_OUTPUT_DIR) --default-slo-period=28d
+	$(SLOTH) generate -i $(PROJECT_PATH)$(ALERTS_SLOTH_INPUT_DIR) -o $(PROJECT_PATH)$(ALERTS_SLOTH_OUTPUT_DIR) --default-slo-period=28d

--- a/make/development-environments.mk
+++ b/make/development-environments.mk
@@ -119,3 +119,11 @@ istio-env-setup: ## Install Istio, istio gateway and gatewayapi-env-setup
 	@echo "export GATEWAY_URL=\$$INGRESS_HOST:\$$INGRESS_PORT"
 	@echo "curl -H \"Host: myhost.com\" \$$GATEWAY_URL"
 	@echo
+
+##@ Development Environment: Kubernetes with GatewayAPI and EnvoyGateway installed
+
+.PHONY: envoygateway-env-setup
+envoygateway-env-setup: ## Install Envoy Gateway and one gateway
+	$(MAKE) k8s-env-setup
+	$(MAKE) envoy-gateway-install # envoy gateway k8s manifests include gateway API CRDs
+	$(MAKE) deploy-eg-gateway

--- a/make/envoy-gateway.mk
+++ b/make/envoy-gateway.mk
@@ -9,22 +9,21 @@ EG_NAMESPACE = envoy-gateway-system
 # egctl tool
 EGCTL=$(PROJECT_PATH)/bin/egctl
 EGCTL_VERSION ?= v1.0.0
-OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-UNAME_P := $(shell uname -p)
-ifeq ($(UNAME_P),x86_64)
-	ARCH = amd64
+
+ifeq ($(ARCH),x86_64)
+	EG_ARCH = amd64
 endif
-ifeq ($(UNAME_P),aarch64)
-	ARCH = arm64
+ifeq ($(ARCH),aarch64)
+	EG_ARCH = arm64
 endif
-ifneq ($(filter armv5%,$(UNAME_P)),)
-    ARCH = armv5
+ifneq ($(filter armv5%,$(ARCH)),)
+	EG_ARCH = armv5
 endif
-ifneq ($(filter armv6%,$(UNAME_P)),)
-    ARCH = armv6
+ifneq ($(filter armv6%,$(ARCH)),)
+	EG_ARCH = armv6
 endif
-ifneq ($(filter armv7%,$(UNAME_P)),)
-    ARCH = arm
+ifneq ($(filter armv7%,$(ARCH)),)
+	EG_ARCH = arm
 endif
 
 $(EGCTL):
@@ -32,9 +31,9 @@ $(EGCTL):
 	## get-egctl.sh requires sudo and does not allow installing in a custom location. Fails if not in the PATH as well
 	# curl -sSL https://gateway.envoyproxy.io/get-egctl.sh | EGCTL_INSTALL_DIR=$(PROJECT_PATH)/bin  VERSION=$(EGCTL_VERSION) bash
 	$(eval TMP := $(shell mktemp -d))
-	cd $(TMP); curl -sSL https://github.com/envoyproxy/gateway/releases/download/$(EGCTL_VERSION)/egctl_$(EGCTL_VERSION)_$(OS)_$(ARCH).tar.gz -o egctl.tar.gz
+	cd $(TMP); curl -sSL https://github.com/envoyproxy/gateway/releases/download/$(EGCTL_VERSION)/egctl_$(EGCTL_VERSION)_$(OS)_$(EG_ARCH).tar.gz -o egctl.tar.gz
 	tar xf $(TMP)/egctl.tar.gz -C $(TMP)
-	cp $(TMP)/bin/$(OS)/$(ARCH)/egctl $(EGCTL)
+	cp $(TMP)/bin/$(OS)/$(EG_ARCH)/egctl $(EGCTL)
 	-rm -rf $(TMP)
 
 .PHONY: egctl

--- a/make/envoy-gateway.mk
+++ b/make/envoy-gateway.mk
@@ -1,0 +1,42 @@
+
+##@ Envoy Gateway
+
+## Targets to help install and configure EG
+
+EG_CONFIG_DIR = config/dependencies/envoy-gateway
+EG_NAMESPACE = envoy-gateway-system
+
+# egctl tool
+EGCTL=$(PROJECT_PATH)/bin/egctl
+EGCTL_VERSION ?= v1.0.0
+OS = linux
+ARCH = amd64
+$(EGCTL):
+	mkdir -p $(PROJECT_PATH)/bin
+	## get-egctl.sh requires sudo and does not allow installing in a custom location. Fails if not in the PATH as well
+	# curl -sSL https://gateway.envoyproxy.io/get-egctl.sh | EGCTL_INSTALL_DIR=$(PROJECT_PATH)/bin  VERSION=$(EGCTL_VERSION) bash
+	$(eval TMP := $(shell mktemp -d))
+	cd $(TMP); curl -sSL https://github.com/envoyproxy/gateway/releases/download/$(EGCTL_VERSION)/egctl_$(EGCTL_VERSION)_$(OS)_$(ARCH).tar.gz -o egctl.tar.gz
+	tar xf $(TMP)/egctl.tar.gz -C $(TMP)
+	cp $(TMP)/bin/$(OS)/$(ARCH)/egctl $(EGCTL)
+	-rm -rf $(TMP)
+
+.PHONY: egctl
+egctl: $(EGCTL) ## Download egctl locally if necessary.
+
+EG_VERSION ?= v1.0.1
+.PHONY: envoy-gateway-install
+envoy-gateway-install: kustomize $(HELM)
+	$(HELM) install eg oci://docker.io/envoyproxy/gateway-helm --version $(EG_VERSION) -n envoy-gateway-system --create-namespace
+	kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
+
+.PHONY: deploy-eg-gateway
+deploy-eg-gateway: kustomize ## Deploy Gateway API gateway
+	$(KUSTOMIZE) build $(EG_CONFIG_DIR)/gateway | kubectl apply -f -
+	kubectl wait --timeout=5m -n envoy-gateway-system gateway/eg --for=condition=Programmed
+	@echo
+	@echo "-- Linux only -- Ingress gateway is exported using loadbalancer service in port 80"
+	@echo "export INGRESS_HOST=\$$(kubectl get gtw eg -n envoy-gateway-system -o jsonpath='{.status.addresses[0].value}')"
+	@echo "export INGRESS_PORT=\$$(kubectl get gtw eg -n envoy-gateway-system -o jsonpath='{.spec.listeners[?(@.name==\"http\")].port}')"
+	@echo "Now you can hit the gateway:"
+	@echo "curl --verbose --resolve www.example.com:\$${INGRESS_PORT}:\$${INGRESS_HOST} http://www.example.com:\$${INGRESS_PORT}/get"

--- a/make/envoy-gateway.mk
+++ b/make/envoy-gateway.mk
@@ -9,8 +9,24 @@ EG_NAMESPACE = envoy-gateway-system
 # egctl tool
 EGCTL=$(PROJECT_PATH)/bin/egctl
 EGCTL_VERSION ?= v1.0.0
-OS = linux
-ARCH = amd64
+OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+UNAME_P := $(shell uname -p)
+ifeq ($(UNAME_P),x86_64)
+	ARCH = amd64
+endif
+ifeq ($(UNAME_P),aarch64)
+	ARCH = arm64
+endif
+ifneq ($(filter armv5%,$(UNAME_P)),)
+    ARCH = armv5
+endif
+ifneq ($(filter armv6%,$(UNAME_P)),)
+    ARCH = armv6
+endif
+ifneq ($(filter armv7%,$(UNAME_P)),)
+    ARCH = arm
+endif
+
 $(EGCTL):
 	mkdir -p $(PROJECT_PATH)/bin
 	## get-egctl.sh requires sudo and does not allow installing in a custom location. Fails if not in the PATH as well


### PR DESCRIPTION
### What

Epic issue https://github.com/Kuadrant/kuadrant-operator/issues/325

Deploy kuadrant on k8s cluster powered by EnvoyGateway

```
make local-setup GATEWAYAPI_PROVIDER=envoygateway
```

Let's hit that gateway (the steps only work on linux)

```sh
INGRESS_HOST=$(kubectl get gtw eg -n envoy-gateway-system -o jsonpath='{.status.addresses[0].value}')
INGRESS_PORT=$(kubectl get gtw eg -n envoy-gateway-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
```

```sh
curl --verbose --resolve www.example.com:${INGRESS_PORT}:${INGRESS_HOST} http://www.example.com:${INGRESS_PORT}/get
```
The expected response is 404 (no route yet)

```
* Added www.example.com:80:172.18.0.252 to DNS cache
* Hostname www.example.com was found in DNS cache
*   Trying 172.18.0.252:80...
* Connected to www.example.com (172.18.0.252) port 80 (#0)
> GET /get HTTP/1.1
> Host: www.example.com
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 Not Found
< date: Fri, 12 Apr 2024 09:28:19 GMT
< content-length: 0
< 
* Connection #0 to host www.example.com left intact
```

> Note that the target branch of this PR is not `main`, instead, it is `envoygateway` to collect all required changes to support entirely envoygateway gatewayapi provider