### PR TITLE
Update makefile to support standalone Podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ SHELL = /usr/bin/env bash -o pipefail
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
+# Container Engine to be used for building image and with kind
+CONTAINER_ENGINE ?= docker
+
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
@@ -314,16 +317,22 @@ run: generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: ## Build docker image with the manager.
-	docker build -t $(IMG) .
+	$(CONTAINER_ENGINE) build -t $(IMG) .
 
 docker-push: ## Push docker image with the manager.
-	docker push $(IMG)
+	$(CONTAINER_ENGINE) push $(IMG)
 
 kind-load-image: ## Load image to local cluster
-	$(KIND) load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)
+	@mkdir -p ./tmp
+	@if [ -f ./tmp/image.tar ]; then rm ./tmp/image.tar; fi
+	$(CONTAINER_ENGINE) save -o ./tmp/image.tar $(IMG)
+	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) load image-archive ./tmp/image.tar $(IMG) --name $(KIND_CLUSTER_NAME)
 
 kind-load-bundle: ## Load image to local cluster
-	$(KIND) load docker-image $(BUNDLE_IMG) --name $(KIND_CLUSTER_NAME)
+	@mkdir -p ./tmp
+	@if [ -f ./tmp/bundle_image.tar ]; then rm ./tmp/bundle_image.tar; fi
+	$(CONTAINER_ENGINE) save -o ./tmp/bundle_image.tar $(BUNDLE_IMG)
+	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) load image-archive ./tmp/bundle_image.tar $(BUNDLE_IMG) --name $(KIND_CLUSTER_NAME)
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -374,7 +383,7 @@ bundle-ignore-createdAt:
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_ENGINE) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/Makefile
+++ b/Makefile
@@ -323,16 +323,13 @@ docker-push: ## Push docker image with the manager.
 	$(CONTAINER_ENGINE) push $(IMG)
 
 kind-load-image: ## Load image to local cluster
-	@mkdir -p ./tmp
-	@if [ -f ./tmp/image.tar ]; then rm ./tmp/image.tar; fi
-	$(CONTAINER_ENGINE) save -o ./tmp/image.tar $(IMG)
-	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) load image-archive ./tmp/image.tar $(IMG) --name $(KIND_CLUSTER_NAME)
+	$(eval TMP_DIR := $(shell mktemp -d))
+	$(CONTAINER_ENGINE) save -o $(TMP_DIR)/image.tar $(IMG) \
+	   && KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) load image-archive $(TMP_DIR)/image.tar $(IMG) --name $(KIND_CLUSTER_NAME) ; \
+	   EXITVAL=$$? ; \
+	   rm -rf $(TMP_DIR) ;\
+	   exit $${EXITVAL}
 
-kind-load-bundle: ## Load image to local cluster
-	@mkdir -p ./tmp
-	@if [ -f ./tmp/bundle_image.tar ]; then rm ./tmp/bundle_image.tar; fi
-	$(CONTAINER_ENGINE) save -o ./tmp/bundle_image.tar $(BUNDLE_IMG)
-	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) load image-archive ./tmp/bundle_image.tar $(BUNDLE_IMG) --name $(KIND_CLUSTER_NAME)
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/make/development-environments.mk
+++ b/make/development-environments.mk
@@ -49,7 +49,12 @@ namespace: ## Creates a namespace where to deploy Kuadrant Operator
 .PHONY: local-deploy
 local-deploy: ## Deploy Kuadrant Operator from the current code
 	$(MAKE) docker-build IMG=$(IMAGE_TAG_BASE):dev
-	$(KIND) load docker-image $(IMAGE_TAG_BASE):dev --name $(KIND_CLUSTER_NAME)
+
+	@mkdir -p ./tmp
+	@if [ -f ./tmp/image.tar ]; then rm ./tmp/image.tar; fi
+	$(CONTAINER_ENGINE) save -o ./tmp/image.tar $(IMAGE_TAG_BASE):dev
+	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) load image-archive ./tmp/image.tar $(IMAGE_TAG_BASE):dev --name $(KIND_CLUSTER_NAME)
+
 	$(MAKE) deploy IMG=$(IMAGE_TAG_BASE):dev
 	kubectl -n $(KUADRANT_NAMESPACE) wait --timeout=300s --for=condition=Available deployments --all
 

--- a/make/development-environments.mk
+++ b/make/development-environments.mk
@@ -49,11 +49,7 @@ namespace: ## Creates a namespace where to deploy Kuadrant Operator
 .PHONY: local-deploy
 local-deploy: ## Deploy Kuadrant Operator from the current code
 	$(MAKE) docker-build IMG=$(IMAGE_TAG_BASE):dev
-
-	@mkdir -p ./tmp
-	@if [ -f ./tmp/image.tar ]; then rm ./tmp/image.tar; fi
-	$(CONTAINER_ENGINE) save -o ./tmp/image.tar $(IMAGE_TAG_BASE):dev
-	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) load image-archive ./tmp/image.tar $(IMAGE_TAG_BASE):dev --name $(KIND_CLUSTER_NAME)
+	$(MAKE) kind-load-image IMG=$(IMAGE_TAG_BASE):dev
 
 	$(MAKE) deploy IMG=$(IMAGE_TAG_BASE):dev
 	kubectl -n $(KUADRANT_NAMESPACE) wait --timeout=300s --for=condition=Available deployments --all

--- a/make/kind.mk
+++ b/make/kind.mk
@@ -7,8 +7,8 @@ KIND_CLUSTER_NAME ?= kuadrant-local
 
 .PHONY: kind-create-cluster
 kind-create-cluster: kind ## Create the "kuadrant-local" kind cluster.
-	$(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config utils/kind-cluster.yaml
+	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) create cluster --name $(KIND_CLUSTER_NAME) --config utils/kind-cluster.yaml
 
 .PHONY: kind-delete-cluster
 kind-delete-cluster: kind ## Delete the "kuadrant-local" kind cluster.
-	- $(KIND) delete cluster --name $(KIND_CLUSTER_NAME)
+	- KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) delete cluster --name $(KIND_CLUSTER_NAME)


### PR DESCRIPTION
Changes allow podman to be used as the standalone container engine. 

This PR introduces a new environment variable call `CONTAINER_ENGINE` which defaults to docker. The variable is used in the building of images and tells kind what engine to use.

Loading images to the kind clusters has being changed from `kind load docker-image ...` to `kind load image-archive ...` which allows supporting both docker and podman.  This does have the extra step of creating the archives for the images.