### PR TITLE
Target ref

### DIFF
--- a/controllers/authpolicy_istio_authorizationpolicy.go
+++ b/controllers/authpolicy_istio_authorizationpolicy.go
@@ -94,8 +94,8 @@ func (r *AuthPolicyReconciler) istioAuthorizationPolicy(ctx context.Context, ap 
 			Labels:    istioAuthorizationPolicyLabels(client.ObjectKeyFromObject(gateway), client.ObjectKeyFromObject(ap)),
 		},
 		Spec: istiosecurity.AuthorizationPolicy{
-			Action:   istiosecurity.AuthorizationPolicy_CUSTOM,
-			Selector: kuadrantistioutils.WorkloadSelectorFromGateway(ctx, r.Client(), gateway),
+			Action:    istiosecurity.AuthorizationPolicy_CUSTOM,
+			TargetRef: kuadrantistioutils.PolicyTargetRefFromGateway(gateway),
 			ActionDetail: &istiosecurity.AuthorizationPolicy_Provider{
 				Provider: &istiosecurity.AuthorizationPolicy_ExtensionProvider{
 					Name: KuadrantExtAuthProviderName,

--- a/tests/istio/authpolicy_controller_authorizationpolicy_test.go
+++ b/tests/istio/authpolicy_controller_authorizationpolicy_test.go
@@ -121,6 +121,11 @@ var _ = Describe("AuthPolicy controller managing authorization policy", Ordered,
 				logf.Log.V(1).Info("Fetching Istio's AuthorizationPolicy", "key", iapKey.String(), "error", err)
 				return err == nil
 			}).WithContext(ctx).Should(BeTrue())
+
+			// has the correct target ref
+			Expect(iap.Spec.TargetRef.Group).To(Equal("gateway.networking.k8s.io"))
+			Expect(iap.Spec.TargetRef.Kind).To(Equal("Gateway"))
+			Expect(iap.Spec.TargetRef.Name).To(Equal(TestGatewayName))
 			Expect(iap.Spec.Rules).To(HaveLen(1))
 			Expect(iap.Spec.Rules[0].To).To(HaveLen(1))
 			Expect(iap.Spec.Rules[0].To[0].Operation).ShouldNot(BeNil())
@@ -164,6 +169,11 @@ var _ = Describe("AuthPolicy controller managing authorization policy", Ordered,
 				logf.Log.V(1).Info("Fetching Istio's AuthorizationPolicy", "key", iapKey.String(), "error", err)
 				return err == nil
 			}).WithContext(ctx).Should(BeTrue())
+
+			// has the correct target ref
+			Expect(iap.Spec.TargetRef.Group).To(Equal("gateway.networking.k8s.io"))
+			Expect(iap.Spec.TargetRef.Kind).To(Equal("Gateway"))
+			Expect(iap.Spec.TargetRef.Name).To(Equal(TestGatewayName))
 			Expect(iap.Spec.Rules).To(HaveLen(1))
 			Expect(iap.Spec.Rules[0].To).To(HaveLen(1))
 			Expect(iap.Spec.Rules[0].To[0].Operation).ShouldNot(BeNil())
@@ -365,7 +375,6 @@ var _ = Describe("AuthPolicy controller managing authorization policy", Ordered,
 				condition := meta.FindStatusCondition(existingPolicy.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted))
 				return condition != nil && condition.Reason == string(kuadrant.PolicyReasonUnknown) && strings.Contains(condition.Message, "cannot match any route rules, check for invalid route selectors in the policy")
 			}).WithContext(ctx).Should(BeTrue())
-
 			// check istio authorizationpolicy
 			iapKey := types.NamespacedName{Name: controllers.IstioAuthorizationPolicyName(TestGatewayName, routePolicy.Spec.TargetRef), Namespace: testNamespace}
 			iap := &secv1beta1resources.AuthorizationPolicy{}

--- a/tests/istio/authpolicy_controller_authorizationpolicy_test.go
+++ b/tests/istio/authpolicy_controller_authorizationpolicy_test.go
@@ -375,6 +375,7 @@ var _ = Describe("AuthPolicy controller managing authorization policy", Ordered,
 				condition := meta.FindStatusCondition(existingPolicy.Status.Conditions, string(gatewayapiv1alpha2.PolicyConditionAccepted))
 				return condition != nil && condition.Reason == string(kuadrant.PolicyReasonUnknown) && strings.Contains(condition.Message, "cannot match any route rules, check for invalid route selectors in the policy")
 			}).WithContext(ctx).Should(BeTrue())
+
 			// check istio authorizationpolicy
 			iapKey := types.NamespacedName{Name: controllers.IstioAuthorizationPolicyName(TestGatewayName, routePolicy.Spec.TargetRef), Namespace: testNamespace}
 			iap := &secv1beta1resources.AuthorizationPolicy{}


### PR DESCRIPTION
### Using PolicyTargetReference instead of Selector for authpolicy_controller
 
closes issue : #302

### Verification Steps

- Set up an instance of kuadrant and the toystore.

`make local-setup`
`kubectl apply -f examples/toystore/kuadrant.yaml`
`kubectl apply -f examples/toystore/toystore.yaml`

- Create and Apply AuthPolicies
  
```sh
echo "
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: gw-1
  namespace: istio-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: gw-1
  rules:
    authentication:
      api-key-users:
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: APIKEY
    response:
      success:
        dynamicMetadata:
          identity:
            json:
              properties:
                userid:
                  selector: auth.identity.metadata.annotations.secret\\.kuadrant\\.io/user-id
---
apiVersion: kuadrant.io/v1beta2
kind: AuthPolicy
metadata:
  name: toystore
  namespace: default
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  rules:
    authentication:
      api-key-users:
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: TOYSTORE
    response:
      success:
        dynamicMetadata:
          identity:
            json:
              properties:
                userid:
                  selector: auth.identity.metadata.annotations.secret\\.kuadrant\\.io/user-id
" | kubectl apply -f -
```
- Deploy the Gateway:
``` echo "
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: gw-1
  namespace: istio-system
  annotations:
    kuadrant.io/namespace: kuadrant-system
    networking.istio.io/service-type: ClusterIP
spec:
  gatewayClassName: istio
  listeners:
    - name: apis
      port: 80
      protocol: HTTP
      hostname: '*.io'
      allowedRoutes:
        namespaces:
          from: All
" | kubectl apply -f -
```
- Create and Apply the Route:
```echo "
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
  namespace: default
spec:
  parentRefs:
  - name: gw-1
    namespace: istio-system
  hostnames:
  - api.toystore.io
  rules:
  - matches:
    - path:
        type: Exact
        value: /toy
      method: GET
    backendRefs:
    - name: toystore
      port: 80
" | kubectl apply -f -
```
- Check the Status of 'AuthPolicy' resources:
 `kubectl get authpolicy -A`

- Detailed status Verification:
`kubectl get authpolicy -n istio-system gw-1 -o yaml`
`kubectl get authpolicy -n default toystore -o yaml`

- Check events for AuthPolicies:
 `kubectl describe authpolicy -n istio-system gw-1`
  `kubectl describe authpolicy -n default toystore`

- Should output both of these for each auth-policy
```
    Target Ref:
    Group:  gateway.networking.k8s.io
    Kind:   Gateway
    Name:   gw-1
```

```
    Target Ref:
    Group:  gateway.networking.k8s.io
    Kind:   HTTPRoute
    Name:   toystore
```