### PR TITLE
Set gateway-api-state-metrics version to 0.4.0 (latest at this time) …

### DIFF
--- a/config/observability/kustomization.yaml
+++ b/config/observability/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 
 resources:
   - github.com/prometheus-operator/kube-prometheus?ref=release-0.13
-  - github.com/Kuadrant/gateway-api-state-metrics?ref=main
-  - github.com/Kuadrant/gateway-api-state-metrics/config/examples/dashboards?ref=main
+  - github.com/Kuadrant/gateway-api-state-metrics?ref=0.4.0
+  - github.com/Kuadrant/gateway-api-state-metrics/config/examples/dashboards?ref=0.4.0
 # To scrape istio metrics, 3 configurations are required:
 # 1. Envoy metrics directly from the istio ingress gateway pod
   - podmonitor-envoy.yaml

--- a/examples/dashboards/platform_engineer.json
+++ b/examples/dashboards/platform_engineer.json
@@ -146,6 +146,71 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
+      "description": "Total number of Gateway API gateways",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 8
+      },
+      "id": 146,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"})",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Total",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
       "description": "List of all Gateways, their class and status.",
       "fieldConfig": {
         "defaults": {
@@ -203,8 +268,8 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 11,
-        "x": 0,
+        "w": 21,
+        "x": 3,
         "y": 8
       },
       "id": 115,
@@ -391,11 +456,11 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Total number of Gateway API gateways",
+      "description": "Total Gateways with an [Accepted and Programmed](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.GatewayConditionType) state of True",
       "fieldConfig": {
         "defaults": {
           "color": {
-            "fixedColor": "blue",
+            "fixedColor": "light-green",
             "mode": "fixed"
           },
           "mappings": [],
@@ -414,11 +479,11 @@
       },
       "gridPos": {
         "h": 3,
-        "w": 2,
-        "x": 11,
-        "y": 8
+        "w": 3,
+        "x": 0,
+        "y": 11
       },
-      "id": 146,
+      "id": 147,
       "options": {
         "colorMode": "value",
         "graphMode": "none",
@@ -442,14 +507,223 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "count(gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"})",
+          "expr": "count(gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Accepted\"} > 0 and ignoring(type) gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Programmed\"} > 0)",
           "instant": true,
           "range": false,
           "refId": "A"
         }
       ],
-      "title": "Total",
+      "title": "Healthy",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Total Gateways with a False or missing [Accepted or Programmed](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.GatewayConditionType) state.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "light-yellow",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 0,
+        "y": 14
+      },
+      "id": 148,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "count(\n(gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"} * on(name, exported_namespace, instance) group_left gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Programmed\"} < 1)\nor ignoring(type) \n(gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"} * on(name, exported_namespace, instance) group_left gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Accepted\"} < 1)\n)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Unhealthy",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "List of all listeners in Gateways",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 154,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "gatewayapi_gateway_listener_info{exported_namespace=~\"${gateway_namespace}\"}",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Listeners",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "Value #A": true,
+              "Value #B": true,
+              "Value #C": true,
+              "Value #D": true,
+              "__name__": true,
+              "container": true,
+              "customresource_group": true,
+              "customresource_kind": true,
+              "customresource_version": true,
+              "instance": true,
+              "job": true,
+              "namespace": false,
+              "prometheus": true,
+              "receive": true,
+              "replica": true,
+              "target_group": true,
+              "tenant_id": true
+            },
+            "indexByName": {
+              "Time": 0,
+              "Value": 21,
+              "__name__": 1,
+              "allowed_routes_namespaces_from": 19,
+              "cluster_id": 20,
+              "container": 2,
+              "customresource_group": 3,
+              "customresource_kind": 4,
+              "customresource_version": 5,
+              "hostname": 11,
+              "instance": 7,
+              "job": 8,
+              "listener_name": 12,
+              "name": 6,
+              "namespace": 9,
+              "port": 13,
+              "prometheus": 10,
+              "protocol": 14,
+              "receive": 15,
+              "replica": 16,
+              "tenant_id": 17,
+              "tls_mode": 18
+            },
+            "renameByName": {
+              "Value #A": "",
+              "allowed_routes_namespaces_from": "Allowed Routes NS",
+              "cluster_id": "Cluster ID",
+              "customresource_kind": "Kind",
+              "exported_namespace": "Namespace",
+              "hostname": "Hostname",
+              "listener_name": "Listener",
+              "name": "Gateway",
+              "namespace": "Gateway NS",
+              "port": "Port",
+              "protocol": "Protocol",
+              "receive": "",
+              "target_kind": "Target Kind",
+              "target_name": "Target Name",
+              "tls_mode": "TLS Mode"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "datasource": {
@@ -488,9 +762,9 @@
       },
       "gridPos": {
         "h": 9,
-        "w": 11,
-        "x": 13,
-        "y": 8
+        "w": 12,
+        "x": 12,
+        "y": 17
       },
       "id": 117,
       "options": {
@@ -630,142 +904,12 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Total Gateways with an [Accepted and Programmed](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.GatewayConditionType) state of True",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "light-green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 11,
-        "y": 11
-      },
-      "id": 147,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Accepted\"} > 0 and ignoring(type) gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Programmed\"} > 0)",
-          "instant": true,
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Healthy",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "description": "Total Gateways with a False or missing [Accepted or Programmed](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.GatewayConditionType) state.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "light-yellow",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 11,
-        "y": 14
-      },
-      "id": 148,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "pluginVersion": "9.5.3",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(\n(gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"} * on(name, exported_namespace, instance) group_left gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Programmed\"} < 1)\nor ignoring(type) \n(gatewayapi_gateway_info{exported_namespace=~\"${gateway_namespace}\"} * on(name, exported_namespace, instance) group_left gatewayapi_gateway_status{exported_namespace=~\"${gateway_namespace}\",type=\"Accepted\"} < 1)\n)",
-          "instant": true,
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Unhealthy",
-      "type": "stat"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 26
       },
       "id": 145,
       "panels": [],
@@ -811,7 +955,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 27
       },
       "id": 97,
       "options": {
@@ -989,7 +1133,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 27
       },
       "id": 118,
       "options": {
@@ -1193,7 +1337,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 24
+        "y": 33
       },
       "id": 120,
       "options": {
@@ -1289,7 +1433,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 24
+        "y": 33
       },
       "id": 153,
       "options": {
@@ -1384,7 +1528,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 24
+        "y": 33
       },
       "id": 137,
       "options": {
@@ -1573,7 +1717,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 31
+        "y": 40
       },
       "id": 141,
       "interval": "1m",
@@ -1754,7 +1898,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 31
+        "y": 40
       },
       "id": 143,
       "interval": "1m",
@@ -1851,7 +1995,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 31
+        "y": 40
       },
       "id": 139,
       "options": {


### PR DESCRIPTION
…to pickup new field introduced in https://github.com/Kuadrant/gateway-api-state-metrics/pull/43

Fixes #667

To show this new field, I think it makes sense to have a new panel to show Gateway Listeners, including all the fields of a listener that are available via state metrics.
Here's where the new panel fits in, with a slight change to the layout of the PE dashbaord. (lot of fields, so needs scrolling)
![image](https://github.com/Kuadrant/kuadrant-operator/assets/878251/3b660702-67b6-41ab-9366-3604b8224630)


And here's the panel showing all the fields when stretched out to accomodate them without scrolling (including the new 'allowed_routes_namespaces_from' field)
![image](https://github.com/Kuadrant/kuadrant-operator/assets/878251/1c893756-d334-4b16-8328-56f7c808fdf3)

