### PR TITLE
rate limit policy: header match support in wasm configuration

### DIFF
--- a/pkg/rlptools/wasm/utils.go
+++ b/pkg/rlptools/wasm/utils.go
@@ -244,7 +244,7 @@ func patternExpresionFromHeader(headerMatch gatewayapiv1.HTTPHeaderMatch) Patter
 	// As for gateway api v1, the only operation type with core support is Exact match.
 	// https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPHeaderMatch
 
-	return wasm.PatternExpression{
+	return PatternExpression{
 		Selector: kuadrantv1beta2.ContextSelector(fmt.Sprintf("request.headers.%s", headerMatch.Name)),
 		Operator: PatternOperator(kuadrantv1beta2.EqualOperator),
 		Value:    headerMatch.Value,

--- a/pkg/rlptools/wasm/utils_test.go
+++ b/pkg/rlptools/wasm/utils_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"k8s.io/apimachinery/pkg/types"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -322,6 +323,77 @@ func TestRules(t *testing.T) {
 							Selector: &SelectorSpec{
 								Selector: "auth.identity.username",
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Route with header match",
+			rlp: rlp("my-rlp", map[string]kuadrantv1beta2.Limit{
+				"50rps": {
+					Rates: []kuadrantv1beta2.Rate{counter50rps},
+				},
+			}),
+			route: &gatewayapiv1.HTTPRoute{
+				Spec: gatewayapiv1.HTTPRouteSpec{
+					Hostnames: []gatewayapiv1.Hostname{"*.example.com"},
+					Rules: []gatewayapiv1.HTTPRouteRule{
+						{
+							Matches: []gatewayapiv1.HTTPRouteMatch{
+								{
+									Path: &gatewayapiv1.HTTPPathMatch{
+										Type:  ptr.To(gatewayapiv1.PathMatchPathPrefix),
+										Value: ptr.To("/v1"),
+									},
+									Method: ptr.To(gatewayapiv1.HTTPMethodGet),
+									Headers: []gatewayapiv1.HTTPHeaderMatch{
+										{
+											Name:  gatewayapiv1.HTTPHeaderName("X-kuadrant-a"),
+											Value: "1",
+										},
+										{
+											Name:  gatewayapiv1.HTTPHeaderName("X-kuadrant-b"),
+											Value: "1",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedRules: []wasm.Rule{
+				{
+					Conditions: []wasm.Condition{
+						{
+							AllOf: []wasm.PatternExpression{
+								{
+									Selector: "request.url_path",
+									Operator: wasm.PatternOperator(kuadrantv1beta2.StartsWithOperator),
+									Value:    "/v1",
+								},
+								{
+									Selector: "request.method",
+									Operator: wasm.PatternOperator(kuadrantv1beta2.EqualOperator),
+									Value:    "GET",
+								},
+								{
+									Selector: "request.headers.X-kuadrant-a",
+									Operator: wasm.PatternOperator(kuadrantv1beta2.EqualOperator),
+									Value:    "1",
+								},
+								{
+									Selector: "request.headers.X-kuadrant-b",
+									Operator: wasm.PatternOperator(kuadrantv1beta2.EqualOperator),
+									Value:    "1",
+								},
+							},
+						},
+					},
+					Data: []wasm.DataItem{
+						{
+							Static: &wasm.StaticSpec{Key: "limit.50rps__783b9343", Value: "1"},
 						},
 					},
 				},

--- a/pkg/rlptools/wasm/utils_test.go
+++ b/pkg/rlptools/wasm/utils_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
@@ -363,37 +363,37 @@ func TestRules(t *testing.T) {
 					},
 				},
 			},
-			expectedRules: []wasm.Rule{
+			expectedRules: []Rule{
 				{
-					Conditions: []wasm.Condition{
+					Conditions: []Condition{
 						{
-							AllOf: []wasm.PatternExpression{
+							AllOf: []PatternExpression{
 								{
 									Selector: "request.url_path",
-									Operator: wasm.PatternOperator(kuadrantv1beta2.StartsWithOperator),
+									Operator: PatternOperator(kuadrantv1beta2.StartsWithOperator),
 									Value:    "/v1",
 								},
 								{
 									Selector: "request.method",
-									Operator: wasm.PatternOperator(kuadrantv1beta2.EqualOperator),
+									Operator: PatternOperator(kuadrantv1beta2.EqualOperator),
 									Value:    "GET",
 								},
 								{
 									Selector: "request.headers.X-kuadrant-a",
-									Operator: wasm.PatternOperator(kuadrantv1beta2.EqualOperator),
+									Operator: PatternOperator(kuadrantv1beta2.EqualOperator),
 									Value:    "1",
 								},
 								{
 									Selector: "request.headers.X-kuadrant-b",
-									Operator: wasm.PatternOperator(kuadrantv1beta2.EqualOperator),
+									Operator: PatternOperator(kuadrantv1beta2.EqualOperator),
 									Value:    "1",
 								},
 							},
 						},
 					},
-					Data: []wasm.DataItem{
+					Data: []DataItem{
 						{
-							Static: &wasm.StaticSpec{Key: "limit.50rps__783b9343", Value: "1"},
+							Static: &StaticSpec{Key: "limit.50rps__783b9343", Value: "1"},
 						},
 					},
 				},


### PR DESCRIPTION
### What 

Header match support in route selectors (applies to rate limit policy wasm configuration).

As an example: rate limit policy to rate limit traffic of the toystore service when the request has "X-kuadrant" header with the value `yes`. 

```yaml
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - headers:
      - name: "X-kuadrant"
        value: "yes"
    backendRefs:
    - name: toystore
      port: 80
---
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:
    "get-resource":
      rates:
      - limit: 5
        duration: 10
        unit: second
      routeSelectors:
      - matches:
        - headers:
          - name: "X-kuadrant"
            value: "yes"
```

### Verification Steps

* Checkout this branch
* Deploy
```
make local-setup
```
* Deploy kuadrant
```
kubectl apply  -f - <<EOF               
---                                     
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
spec: {}
EOF
```
* Deploy toystore
```sh
kubectl apply -f examples/toystore/toystore.yaml
kubectl wait --timeout=300s --for=condition=Available deployment toystore
```

* Create  HTTP Route with two rules with header matching.
```yaml
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: istio-ingressgateway
    namespace: istio-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - headers:
      - name: "X-kuadrant-class"
        value: "a"
    backendRefs:
    - name: toystore
      port: 80
  - matches:
    - headers:
      - name: "X-kuadrant-class"
        value: "b"
    backendRefs:
    - name: toystore
      port: 80
EOF
```

* Create  Rate limit policy

```yaml
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta2
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:
    "kuadrant-class-a":
      rates:
      - limit: 5
        duration: 10
        unit: second
      routeSelectors:
      - matches:
        - headers:
          - name: "X-kuadrant-class"
            value: "a"
EOF
```
* Ensure HTTP Route is rate limits at 5 requests every 10 seconds only when the header is present to qualify traffic as "class a"

Export the gateway hostname and port:
```
export INGRESS_HOST=$(kubectl get gtw istio-ingressgateway -n istio-system -o jsonpath='{.status.addresses[0].value}')
export INGRESS_PORT=$(kubectl get gtw istio-ingressgateway -n istio-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
```

```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "X-kuadrant-class: a" -H 'Host: api.toystore.com' http://$GATEWAY_URL/ | grep -E --color "\b(429)\b|$"; sleep 1; done
```

* Ensure HTTP Route is **not** rate limited when the header is present to qualify traffic as "class b"

```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "X-kuadrant-class: b" -H 'Host: api.toystore.com' http://$GATEWAY_URL/ | grep -E --color "\b(429)\b|$"; sleep 1; done
```


