### PR TITLE
chore: Remove DNSRecord ownerID generation

### DIFF
--- a/controllers/dnspolicy_dnsrecords.go
+++ b/controllers/dnspolicy_dnsrecords.go
@@ -15,7 +15,6 @@ import (
 	kuadrantdnsv1alpha1 "github.com/kuadrant/dns-operator/api/v1alpha1"
 
 	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
-	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	reconcilerutils "github.com/kuadrant/kuadrant-operator/pkg/library/reconcilers"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 	"github.com/kuadrant/kuadrant-operator/pkg/multicluster"
@@ -113,7 +112,6 @@ func (r *DNSPolicyReconciler) reconcileGatewayDNSRecords(ctx context.Context, gw
 }
 
 func (r *DNSPolicyReconciler) desiredDNSRecord(gateway *multicluster.GatewayWrapper, dnsPolicy *v1alpha1.DNSPolicy, targetListener gatewayapiv1.Listener, clusterGateways []multicluster.ClusterGateway, managedZone *kuadrantdnsv1alpha1.ManagedZone) (*kuadrantdnsv1alpha1.DNSRecord, error) {
-	ownerID := common.ToBase36HashLen(fmt.Sprintf("%s-%s-%s", gateway.ClusterID, gateway.Name, gateway.Namespace), utils.ClusterIDLength)
 	rootHost := string(*targetListener.Hostname)
 	var healthProtocol *string
 	var healthCheckSpec *kuadrantdnsv1alpha1.HealthCheckSpec
@@ -134,8 +132,7 @@ func (r *DNSPolicyReconciler) desiredDNSRecord(gateway *multicluster.GatewayWrap
 			Labels:    commonDNSRecordLabels(client.ObjectKeyFromObject(gateway), dnsPolicy),
 		},
 		Spec: kuadrantdnsv1alpha1.DNSRecordSpec{
-			OwnerID:  &ownerID,
-			RootHost: &rootHost,
+			RootHost: rootHost,
 			ManagedZoneRef: &kuadrantdnsv1alpha1.ManagedZoneReference{
 				Name: managedZone.Name,
 			},

--- a/controllers/dnspolicy_status.go
+++ b/controllers/dnspolicy_status.go
@@ -162,8 +162,8 @@ func propagateRecordConditions(records *kuadrantdnsv1alpha1.DNSRecordList, polic
 				continue
 			}
 
-			policyStatus.RecordConditions[*record.Spec.RootHost] = append(
-				policyStatus.RecordConditions[*record.Spec.RootHost],
+			policyStatus.RecordConditions[record.Spec.RootHost] = append(
+				policyStatus.RecordConditions[record.Spec.RootHost],
 				condition)
 		}
 	}

--- a/controllers/dnspolicy_status_test.go
+++ b/controllers/dnspolicy_status_test.go
@@ -75,7 +75,7 @@ func TestPropagateRecordConditions(t *testing.T) {
 			Records: &kuadrantdnsv1alpha1.DNSRecordList{
 				Items: []kuadrantdnsv1alpha1.DNSRecord{
 					{
-						Spec: kuadrantdnsv1alpha1.DNSRecordSpec{RootHost: &rootHost},
+						Spec: kuadrantdnsv1alpha1.DNSRecordSpec{RootHost: rootHost},
 						Status: kuadrantdnsv1alpha1.DNSRecordStatus{
 							Conditions: []metav1.Condition{
 								healthyProviderCondition,
@@ -108,7 +108,7 @@ func TestPropagateRecordConditions(t *testing.T) {
 			Records: &kuadrantdnsv1alpha1.DNSRecordList{
 				Items: []kuadrantdnsv1alpha1.DNSRecord{
 					{
-						Spec: kuadrantdnsv1alpha1.DNSRecordSpec{RootHost: &rootHost},
+						Spec: kuadrantdnsv1alpha1.DNSRecordSpec{RootHost: rootHost},
 						Status: kuadrantdnsv1alpha1.DNSRecordStatus{
 							Conditions: []metav1.Condition{
 								healthyProviderCondition,

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.4.0
 	github.com/kuadrant/authorino v0.17.2
 	github.com/kuadrant/authorino-operator v0.11.1
-	github.com/kuadrant/dns-operator v0.0.0-20240426081919-e328d819392b
+	github.com/kuadrant/dns-operator v0.0.0-20240627145308-8a571eaae927
 	github.com/kuadrant/limitador-operator v0.7.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/onsi/ginkgo/v2 v2.13.2
@@ -46,7 +46,6 @@ require (
 	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/Microsoft/hcsshim v0.11.4 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/aws/aws-sdk-go v1.44.311 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
@@ -94,7 +93,6 @@ require (
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
-github.com/aws/aws-sdk-go v1.44.311 h1:60i8hyVMOXqabKJQPCq4qKRBQ6hRafI/WOcDxGM+J7Q=
-github.com/aws/aws-sdk-go v1.44.311/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -223,10 +221,6 @@ github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -256,8 +250,8 @@ github.com/kuadrant/authorino v0.17.2 h1:UgWH4NY/n36IhoaU+ELUkoujaly1/9sx5mHY5vU
 github.com/kuadrant/authorino v0.17.2/go.mod h1:al71fN0FX6c9Orrhk9GR4CtjtC+CD/lUHJCs7drlRNM=
 github.com/kuadrant/authorino-operator v0.11.1 h1:jndTZhiHMU+2Dk0NU+KP2+MUSfvclrn+YtTCQDJj+1s=
 github.com/kuadrant/authorino-operator v0.11.1/go.mod h1:TeFFdX477vUTMushCojaHpvwPLga4DpErGI2oQbqFIs=
-github.com/kuadrant/dns-operator v0.0.0-20240426081919-e328d819392b h1:xQNP+EMa9/FniWCAfQEKNR1cPLANAEcWGNAcY1CIx0E=
-github.com/kuadrant/dns-operator v0.0.0-20240426081919-e328d819392b/go.mod h1:5UhTSjazSNW/eW+pn1ZIeuvuPDnRMwiFkYgAlCoC9zI=
+github.com/kuadrant/dns-operator v0.0.0-20240627145308-8a571eaae927 h1:T/pEIu+l13ecaJhCKNBlVu8YELcye4qM6m8b0u9rTbA=
+github.com/kuadrant/dns-operator v0.0.0-20240627145308-8a571eaae927/go.mod h1:XquyzShT4VAew+2Kfg7zuQ1SrhbohyGgXIFZh2udTa0=
 github.com/kuadrant/limitador-operator v0.7.0 h1:pLIpM6vUxAY/Jn6ny61IGpqS7Oti786duBzJ67DJOuA=
 github.com/kuadrant/limitador-operator v0.7.0/go.mod h1:tg+G+3eTzUUfvUmdbiqH3FnScEPSWZ3DmorD1ZAx1bo=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
@@ -510,7 +504,6 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
@@ -540,14 +533,12 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
-golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
 golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=

--- a/tests/common/dnspolicy/dnspolicy_controller_single_cluster_test.go
+++ b/tests/common/dnspolicy/dnspolicy_controller_single_cluster_test.go
@@ -41,7 +41,7 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 	var testNamespace string
 	var gateway *gatewayapiv1.Gateway
 	var dnsPolicy *v1alpha1.DNSPolicy
-	var ownerID, clusterHash, gwHash, recordName, wildcardRecordName string
+	var clusterHash, gwHash, recordName, wildcardRecordName string
 	var domain = fmt.Sprintf("example-%s.com", rand.String(6))
 
 	BeforeEach(func(ctx SpecContext) {
@@ -78,7 +78,6 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 		Expect(k8sClient.Create(ctx, gateway)).To(Succeed())
 
 		clusterHash = common.ToBase36HashLen(clusterUID, utils.ClusterIDLength)
-		ownerID = common.ToBase36HashLen(fmt.Sprintf("%s-%s-%s", clusterUID, gateway.Name, gateway.Namespace), utils.ClusterIDLength)
 
 		gwHash = common.ToBase36HashLen(gateway.Name+"-"+gateway.Namespace, 6)
 
@@ -200,43 +199,34 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Name: wildcardRecordName, Namespace: testNamespace}, wildcardDnsRecord)
 				g.Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(*dnsRecord).To(
-					MatchFields(IgnoreExtras, Fields{
-						"ObjectMeta": HaveField("Name", recordName),
-						"Spec": MatchFields(IgnoreExtras, Fields{
-							"OwnerID":        Equal(&ownerID),
-							"ManagedZoneRef": HaveField("Name", "mz-example-com"),
-							"Endpoints": ConsistOf(
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":       Equal(tests.HostOne(domain)),
-									"Targets":       ContainElements(tests.IPAddressOne, tests.IPAddressTwo),
-									"RecordType":    Equal("A"),
-									"SetIdentifier": Equal(""),
-									"RecordTTL":     Equal(externaldns.TTL(60)),
-								})),
-							),
-						}),
-					}),
-				)
+				g.Expect(dnsRecord.Name).To(Equal(recordName))
+				g.Expect(dnsRecord.Spec.ManagedZoneRef.Name).To(Equal("mz-example-com"))
+				g.Expect(dnsRecord.Spec.Endpoints).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(tests.HostOne(domain)),
+						"Targets":       ContainElements(tests.IPAddressOne, tests.IPAddressTwo),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldns.TTL(60)),
+					})),
+				))
+				g.Expect(dnsRecord.Status.OwnerID).ToNot(BeEmpty())
+				g.Expect(dnsRecord.Status.OwnerID).To(Equal(dnsRecord.GetUIDHash()))
 				g.Expect(tests.EndpointsTraversable(dnsRecord.Spec.Endpoints, tests.HostOne(domain), []string{tests.IPAddressOne, tests.IPAddressTwo})).To(BeTrue())
-				g.Expect(*wildcardDnsRecord).To(
-					MatchFields(IgnoreExtras, Fields{
-						"ObjectMeta": HaveField("Name", wildcardRecordName),
-						"Spec": MatchFields(IgnoreExtras, Fields{
-							"OwnerID":        Equal(&ownerID),
-							"ManagedZoneRef": HaveField("Name", "mz-example-com"),
-							"Endpoints": ConsistOf(
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":       Equal(tests.HostWildcard(domain)),
-									"Targets":       ContainElements(tests.IPAddressOne, tests.IPAddressTwo),
-									"RecordType":    Equal("A"),
-									"SetIdentifier": Equal(""),
-									"RecordTTL":     Equal(externaldns.TTL(60)),
-								})),
-							),
-						}),
-					}),
-				)
+
+				g.Expect(wildcardDnsRecord.Name).To(Equal(wildcardRecordName))
+				g.Expect(wildcardDnsRecord.Spec.ManagedZoneRef.Name).To(Equal("mz-example-com"))
+				g.Expect(wildcardDnsRecord.Spec.Endpoints).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(tests.HostWildcard(domain)),
+						"Targets":       ContainElements(tests.IPAddressOne, tests.IPAddressTwo),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldns.TTL(60)),
+					})),
+				))
+				g.Expect(wildcardDnsRecord.Status.OwnerID).ToNot(BeEmpty())
+				g.Expect(wildcardDnsRecord.Status.OwnerID).To(Equal(wildcardDnsRecord.GetUIDHash()))
 				g.Expect(tests.EndpointsTraversable(wildcardDnsRecord.Spec.Endpoints, tests.HostWildcard(domain), []string{tests.IPAddressOne, tests.IPAddressTwo})).To(BeTrue())
 			}, tests.TimeoutMedium, tests.RetryIntervalMedium, ctx).Should(Succeed())
 		}, testTimeOut)
@@ -268,105 +258,96 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Name: wildcardRecordName, Namespace: testNamespace}, wildcardDnsRecord)
 				g.Expect(err).NotTo(HaveOccurred())
 
-				g.Expect(*dnsRecord).To(
-					MatchFields(IgnoreExtras, Fields{
-						"ObjectMeta": HaveField("Name", recordName),
-						"Spec": MatchFields(IgnoreExtras, Fields{
-							"OwnerID":        Equal(&ownerID),
-							"ManagedZoneRef": HaveField("Name", "mz-example-com"),
-							"Endpoints": ConsistOf(
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":       Equal(clusterHash + "-" + gwHash + "." + "klb.test." + domain),
-									"Targets":       ConsistOf(tests.IPAddressOne, tests.IPAddressTwo),
-									"RecordType":    Equal("A"),
-									"SetIdentifier": Equal(""),
-									"RecordTTL":     Equal(externaldns.TTL(60)),
-								})),
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":          Equal("ie.klb.test." + domain),
-									"Targets":          ConsistOf(clusterHash + "-" + gwHash + "." + "klb.test." + domain),
-									"RecordType":       Equal("CNAME"),
-									"SetIdentifier":    Equal(clusterHash + "-" + gwHash + "." + "klb.test." + domain),
-									"RecordTTL":        Equal(externaldns.TTL(60)),
-									"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "weight", Value: "120"}}),
-								})),
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":          Equal("klb.test." + domain),
-									"Targets":          ConsistOf("ie.klb.test." + domain),
-									"RecordType":       Equal("CNAME"),
-									"SetIdentifier":    Equal("IE"),
-									"RecordTTL":        Equal(externaldns.TTL(300)),
-									"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "IE"}}),
-								})),
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":          Equal("klb.test." + domain),
-									"Targets":          ConsistOf("ie.klb.test." + domain),
-									"RecordType":       Equal("CNAME"),
-									"SetIdentifier":    Equal("default"),
-									"RecordTTL":        Equal(externaldns.TTL(300)),
-									"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
-								})),
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":       Equal(tests.HostOne(domain)),
-									"Targets":       ConsistOf("klb.test." + domain),
-									"RecordType":    Equal("CNAME"),
-									"SetIdentifier": Equal(""),
-									"RecordTTL":     Equal(externaldns.TTL(300)),
-								})),
-							),
-						}),
-					}),
-				)
+				g.Expect(dnsRecord.Name).To(Equal(recordName))
+				g.Expect(dnsRecord.Spec.ManagedZoneRef.Name).To(Equal("mz-example-com"))
+				g.Expect(dnsRecord.Spec.Endpoints).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(clusterHash + "-" + gwHash + "." + "klb.test." + domain),
+						"Targets":       ConsistOf(tests.IPAddressOne, tests.IPAddressTwo),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldns.TTL(60)),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":          Equal("ie.klb.test." + domain),
+						"Targets":          ConsistOf(clusterHash + "-" + gwHash + "." + "klb.test." + domain),
+						"RecordType":       Equal("CNAME"),
+						"SetIdentifier":    Equal(clusterHash + "-" + gwHash + "." + "klb.test." + domain),
+						"RecordTTL":        Equal(externaldns.TTL(60)),
+						"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "weight", Value: "120"}}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":          Equal("klb.test." + domain),
+						"Targets":          ConsistOf("ie.klb.test." + domain),
+						"RecordType":       Equal("CNAME"),
+						"SetIdentifier":    Equal("IE"),
+						"RecordTTL":        Equal(externaldns.TTL(300)),
+						"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "IE"}}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":          Equal("klb.test." + domain),
+						"Targets":          ConsistOf("ie.klb.test." + domain),
+						"RecordType":       Equal("CNAME"),
+						"SetIdentifier":    Equal("default"),
+						"RecordTTL":        Equal(externaldns.TTL(300)),
+						"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(tests.HostOne(domain)),
+						"Targets":       ConsistOf("klb.test." + domain),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldns.TTL(300)),
+					})),
+				))
+				g.Expect(dnsRecord.Status.OwnerID).ToNot(BeEmpty())
+				g.Expect(dnsRecord.Status.OwnerID).To(Equal(dnsRecord.GetUIDHash()))
 				g.Expect(tests.EndpointsTraversable(dnsRecord.Spec.Endpoints, tests.HostOne(domain), []string{tests.IPAddressOne, tests.IPAddressTwo})).To(BeTrue())
-				g.Expect(*wildcardDnsRecord).To(
-					MatchFields(IgnoreExtras, Fields{
-						"ObjectMeta": HaveField("Name", wildcardRecordName),
-						"Spec": MatchFields(IgnoreExtras, Fields{
-							"OwnerID":        Equal(&ownerID),
-							"ManagedZoneRef": HaveField("Name", "mz-example-com"),
-							"Endpoints": ContainElements(
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":       Equal(clusterHash + "-" + gwHash + "." + "klb." + domain),
-									"Targets":       ConsistOf(tests.IPAddressOne, tests.IPAddressTwo),
-									"RecordType":    Equal("A"),
-									"SetIdentifier": Equal(""),
-									"RecordTTL":     Equal(externaldns.TTL(60)),
-								})),
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":          Equal("ie.klb." + domain),
-									"Targets":          ConsistOf(clusterHash + "-" + gwHash + "." + "klb." + domain),
-									"RecordType":       Equal("CNAME"),
-									"SetIdentifier":    Equal(clusterHash + "-" + gwHash + "." + "klb." + domain),
-									"RecordTTL":        Equal(externaldns.TTL(60)),
-									"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "weight", Value: "120"}}),
-								})),
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":          Equal("klb." + domain),
-									"Targets":          ConsistOf("ie.klb." + domain),
-									"RecordType":       Equal("CNAME"),
-									"SetIdentifier":    Equal("default"),
-									"RecordTTL":        Equal(externaldns.TTL(300)),
-									"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
-								})),
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":          Equal("klb." + domain),
-									"Targets":          ConsistOf("ie.klb." + domain),
-									"RecordType":       Equal("CNAME"),
-									"SetIdentifier":    Equal("IE"),
-									"RecordTTL":        Equal(externaldns.TTL(300)),
-									"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "IE"}}),
-								})),
-								PointTo(MatchFields(IgnoreExtras, Fields{
-									"DNSName":       Equal(tests.HostWildcard(domain)),
-									"Targets":       ConsistOf("klb." + domain),
-									"RecordType":    Equal("CNAME"),
-									"SetIdentifier": Equal(""),
-									"RecordTTL":     Equal(externaldns.TTL(300)),
-								})),
-							),
-						}),
-					}),
-				)
+
+				g.Expect(wildcardDnsRecord.Name).To(Equal(wildcardRecordName))
+				g.Expect(wildcardDnsRecord.Spec.ManagedZoneRef.Name).To(Equal("mz-example-com"))
+				g.Expect(wildcardDnsRecord.Spec.Endpoints).To(ContainElements(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(clusterHash + "-" + gwHash + "." + "klb." + domain),
+						"Targets":       ConsistOf(tests.IPAddressOne, tests.IPAddressTwo),
+						"RecordType":    Equal("A"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldns.TTL(60)),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":          Equal("ie.klb." + domain),
+						"Targets":          ConsistOf(clusterHash + "-" + gwHash + "." + "klb." + domain),
+						"RecordType":       Equal("CNAME"),
+						"SetIdentifier":    Equal(clusterHash + "-" + gwHash + "." + "klb." + domain),
+						"RecordTTL":        Equal(externaldns.TTL(60)),
+						"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "weight", Value: "120"}}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":          Equal("klb." + domain),
+						"Targets":          ConsistOf("ie.klb." + domain),
+						"RecordType":       Equal("CNAME"),
+						"SetIdentifier":    Equal("default"),
+						"RecordTTL":        Equal(externaldns.TTL(300)),
+						"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "*"}}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":          Equal("klb." + domain),
+						"Targets":          ConsistOf("ie.klb." + domain),
+						"RecordType":       Equal("CNAME"),
+						"SetIdentifier":    Equal("IE"),
+						"RecordTTL":        Equal(externaldns.TTL(300)),
+						"ProviderSpecific": Equal(externaldns.ProviderSpecific{{Name: "geo-code", Value: "IE"}}),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"DNSName":       Equal(tests.HostWildcard(domain)),
+						"Targets":       ConsistOf("klb." + domain),
+						"RecordType":    Equal("CNAME"),
+						"SetIdentifier": Equal(""),
+						"RecordTTL":     Equal(externaldns.TTL(300)),
+					})),
+				))
+				g.Expect(wildcardDnsRecord.Status.OwnerID).ToNot(BeEmpty())
+				g.Expect(wildcardDnsRecord.Status.OwnerID).To(Equal(wildcardDnsRecord.GetUIDHash()))
 				g.Expect(tests.EndpointsTraversable(wildcardDnsRecord.Spec.Endpoints, tests.HostWildcard(domain), []string{tests.IPAddressOne, tests.IPAddressTwo})).To(BeTrue())
 			}, tests.TimeoutMedium, tests.RetryIntervalMedium, ctx).Should(Succeed())
 		}, testTimeOut)

--- a/tests/common/dnspolicy/dnspolicy_controller_test.go
+++ b/tests/common/dnspolicy/dnspolicy_controller_test.go
@@ -541,10 +541,10 @@ var _ = Describe("DNSPolicy controller", func() {
 							"Type":    Equal(string(kuadrant.PolicyConditionEnforced)),
 							"Status":  Equal(metav1.ConditionTrue),
 							"Reason":  Equal(string(kuadrant.PolicyReasonEnforced)),
-							"Message": Equal("DNSPolicy has been partially enforced"),
+							"Message": Equal("DNSPolicy has been successfully enforced"),
 						})),
 				)
-			}, tests.TimeoutMedium, time.Second).Should(Succeed())
+			}, tests.TimeoutLong, time.Second).Should(Succeed())
 
 			// ensure there are no policies with not accepted condition
 			// in this case the "enforced" on the policy should be false


### PR DESCRIPTION
The `ownerID` field on DNSRecord is now optional, the dns operator will ensure a valid unique ownerID for all DNSRecords if none is explicitly set.

Requires: https://github.com/Kuadrant/dns-operator/pull/170