### PR TITLE
Refactor patrially enforced condition for dnspolicy

### DIFF
--- a/tests/common/dnspolicy/dnspolicy_controller_single_cluster_test.go
+++ b/tests/common/dnspolicy/dnspolicy_controller_single_cluster_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
-	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/utils"
 	"github.com/kuadrant/kuadrant-operator/tests"
 )
@@ -170,21 +169,6 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 		})
 
 		It("should create dns records", func(ctx SpecContext) {
-
-			Eventually(func(g Gomega, ctx context.Context) {
-
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsPolicy), dnsPolicy)).To(Succeed())
-				g.Expect(dnsPolicy.Status.Conditions).To(
-					ContainElement(MatchFields(IgnoreExtras, Fields{
-						"Type":    Equal(string(kuadrant.PolicyConditionEnforced)),
-						"Status":  Equal(metav1.ConditionTrue),
-						"Reason":  Equal(string(kuadrant.PolicyReasonEnforced)),
-						"Message": Equal("DNSPolicy has been partially enforced"),
-					})),
-				)
-
-			}, tests.TimeoutMedium, tests.RetryIntervalMedium, ctx).Should(Succeed())
-
 			Eventually(func(g Gomega, ctx context.Context) {
 				recordList := &kuadrantdnsv1alpha1.DNSRecordList{}
 				err := k8sClient.List(ctx, recordList, &client.ListOptions{Namespace: testNamespace})


### PR DESCRIPTION
closes #586 
fixes #685  

Changing the enforced logic around DNSPolicy. 
Now it works as one would expect. Also updated relevant integration tests. 
Added a new test to cover all possible `Enforced` conditions. It is arguable if we need such a hefty test, that is, more-less, a copy of an already existent one. My reasoning is that unexpected `Enforced` behaviour caused a few bugs and I'd rather have tests run an extra 20-ish seconds but be confident in the scope of the test. 
 