### PR TITLE
Update kind to v0.23.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
-          version: v0.22.0
+          version: v0.23.0
           config: utils/kind-cluster.yaml
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s
@@ -122,7 +122,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
-          version: v0.22.0
+          version: v0.23.0
           config: utils/kind-cluster.yaml
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s
@@ -167,7 +167,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
-          version: v0.22.0
+          version: v0.23.0
           config: utils/kind-cluster.yaml
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s
@@ -212,7 +212,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1.2.0
         with:
-          version: v0.22.0
+          version: v0.23.0
           config: utils/kind-cluster.yaml
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ $(OPM):
 opm: $(OPM) ## Download opm locally if necessary.
 
 KIND = $(PROJECT_PATH)/bin/kind
-KIND_VERSION = v0.22.0
+KIND_VERSION = v0.23.0
 $(KIND):
 	$(call go-install-tool,$(KIND),sigs.k8s.io/kind@$(KIND_VERSION))
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -3,7 +3,7 @@
 ## Technology stack required for development
 
 * [operator-sdk] version v1.28.1
-* [kind] version v0.22.0
+* [kind] version v0.23.0
 * [git][git_tool]
 * [go] version 1.21+
 * [kubernetes] version v1.19+

--- a/doc/development.md
+++ b/doc/development.md
@@ -2,7 +2,7 @@
 
 ## Technology stack required for development
 
-* [operator-sdk] version v1.28.1
+* [operator-sdk] version v1.32.0
 * [kind] version v0.23.0
 * [git][git_tool]
 * [go] version 1.21+

--- a/utils/kind-cluster.yaml
+++ b/utils/kind-cluster.yaml
@@ -3,4 +3,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.29.2
+  image: kindest/node:v1.30.0


### PR DESCRIPTION
### Update Kind to v0.23.0 and Node Image to v1.30.0

#### Description
This PR updates the Kind version used in the Makefile and GitHub workflows from v0.22.0 to v0.23.0. Additionally, the node image is updated to v1.30.0.

#### Changes Made
- Updated Kind version to v0.23.0 in the Makefile.
  - Reference: [Makefile#L232](https://github.com/Kuadrant/kuadrant-operator/blob/ce588820287c17e6a1726ef098b79a8b536d5901/Makefile#L232)
- Updated Kind version to v0.23.0 in GitHub workflows.
  - Reference: [test.yaml#L80](https://github.com/Kuadrant/kuadrant-operator/blob/ce588820287c17e6a1726ef098b79a8b536d5901/.github/workflows/test.yaml#L80)
- Updated the node image to v1.30.0.
  - Reference: [kind-cluster.yaml#L6](https://github.com/Kuadrant/kuadrant-operator/blob/ce588820287c17e6a1726ef098b79a8b536d5901/utils/kind-cluster.yaml#L6)
- Updated the development readme to reflect these changes.
  - Reference: [development.md](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/development.md#technology-stack-required-for-development)
