### PR TITLE
remove cert-manager as dependency

### DIFF
--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -11,18 +11,3 @@ dependencies:
     value:
       packageName: dns-operator
       version: "0.0.0"
-  - type: olm.gvk
-    value:
-      group: cert-manager.io
-      kind: Certificate
-      version: v1
-  - type: olm.gvk
-    value:
-      group: cert-manager.io
-      kind: ClusterIssuer
-      version: v1
-  - type: olm.gvk
-    value:
-      group: cert-manager.io
-      kind: Issuer
-      version: v1

--- a/doc/install/install-openshift.md
+++ b/doc/install/install-openshift.md
@@ -5,7 +5,7 @@ NOTE: You must perform these steps on each OpenShift cluster that you want to us
 ## Prerequisites
 
 - OpenShift Container Platform 4.14.x or later with community Operator catalog available.
-- AWS account with Route 53 and zone. 
+- AWS account with Route 53 and zone.
 - Accessible Redis instance.
 
 
@@ -27,9 +27,27 @@ Before you can use Kuadrant, you must install Gateway API v1 as follows:
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
 ```
 
-### Step 3 - Install and configure Istio with the Sail Operator
+### Step 3 - Install cert-manager
 
-Kuadrant integrates with Istio as a Gateway API provider. You can set up an Istio-based Gateway API provider by using the Sail Operator. 
+Before you can use Kuadrant, you must install cert-manager.
+
+Install one of the different flavours of the Cert-Manager.
+
+#### Install community version of the cert-manager
+
+Consider [installing cert-manager via OperatorHub](https://cert-manager.io/docs/installation/operator-lifecycle-manager/),
+which you can do from the OpenShift web console.
+
+More installation options at [cert-manager.io](https://cert-manager.io/docs/installation/)
+
+#### Install cert-manager Operator for Red Hat OpenShift
+
+You can install the [cert-manager Operator for Red Hat OpenShift](https://docs.openshift.com/container-platform/4.16/security/cert_manager_operator/cert-manager-operator-install.html)
+by using the web console.
+
+### Step 4 - Install and configure Istio with the Sail Operator
+
+Kuadrant integrates with Istio as a Gateway API provider. You can set up an Istio-based Gateway API provider by using the Sail Operator.
 
 #### Install Istio
 
@@ -46,9 +64,9 @@ apiVersion: operators.coreos.com/v1
 metadata:
   name: sail
   namespace: istio-system
-spec: 
-  upgradeStrategy: Default  
----  
+spec:
+  upgradeStrategy: Default
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -97,11 +115,11 @@ Wait for Istio to be ready as follows:
 kubectl wait istio/default -n istio-system --for="condition=Ready=true"
 ```
 
-### Step 4 - Optional: Configure observability and metrics
+### Step 5 - Optional: Configure observability and metrics
 
 Kuadrant provides a set of example dashboards that use known metrics exported by Kuadrant and Gateway components to provide insight into different components of your APIs and Gateways. While not essential, it is best to set up an OpenShift monitoring stack. This section provides links to OpenShift and Thanos documentation on configuring monitoring and metrics storage.
 
-You can set up user-facing monitoring by following the steps in the OpenShift documentation on [configuring the monitoring stack](https://docs.openshift.com/container-platform/latest/observability/monitoring/configuring-the-monitoring-stack.html). 
+You can set up user-facing monitoring by following the steps in the OpenShift documentation on [configuring the monitoring stack](https://docs.openshift.com/container-platform/latest/observability/monitoring/configuring-the-monitoring-stack.html).
 
 If you have user workload monitoring enabled, it is best to configure remote writes to a central storage system such as Thanos:
 
@@ -128,7 +146,7 @@ If you have Grafana installed in your cluster, you can import the [example dashb
 For example installation details, see [installing Grafana on OpenShift](https://cloud.redhat.com/experts/o11y/ocp-grafana/). When installed, you must add your Thanos instance as a data source to Grafana. Alternatively, if you are using only the user workload monitoring stack in your OpenShift cluster, and not writing metrics to an external Thanos instance, you can [set up a data source to the thanos-querier route in the OpenShift cluster](https://docs.openshift.com/container-platform/4.15/observability/monitoring/accessing-third-party-monitoring-apis.html#accessing-metrics-from-outside-cluster_accessing-monitoring-apis-by-using-the-cli).
 
 
-### Step 5 - Create secrets for your credentials 
+### Step 6 - Create secrets for your credentials
 
 Before installing the Kuadrant Operator, you must enter the following commands to set up secrets that you will use later:
 
@@ -153,8 +171,8 @@ spec:
   updateStrategy:
     registryPoll:
       interval: 45m
-EOF      
-```      
+EOF
+```
 
 #### AWS Route 53 credentials for TLS
 
@@ -173,8 +191,8 @@ Set the Redis credentials for shared multicluster counters for the Kuadrant Limi
 
 ```bash
 kubectl -n kuadrant-system create secret generic redis-config \
-  --from-literal=URL=$REDIS_URL  
-```  
+  --from-literal=URL=$REDIS_URL
+```
 
 #### AWS Route 53 credentials for DNS
 
@@ -189,9 +207,9 @@ kubectl -n ingress-gateway create secret generic aws-credentials \
   --type=kuadrant.io/aws \
   --from-literal=AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
   --from-literal=AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
-```  
+```
 
-### Step 6 - Install the Kuadrant Operator 
+### Step 7 - Install the Kuadrant Operator
 
 To install the Kuadrant Operator, enter the following command:
 
@@ -214,10 +232,10 @@ apiVersion: operators.coreos.com/v1
 metadata:
   name: kuadrant
   namespace: kuadrant-system
-spec: 
+spec:
   upgradeStrategy: Default
 EOF
-```  
+```
 
 Wait for the Kuadrant Operators to be installed as follows:
 
@@ -227,7 +245,7 @@ kubectl get installplan -n kuadrant-system -o=jsonpath='{.items[0].status.phase}
 
 After some time, this command should return `complete`.
 
-### Step 7 - Configure Kuadrant
+### Step 8 - Configure Kuadrant
 
 To configure your Kuadrant deployment, enter the following command:
 
@@ -243,9 +261,9 @@ spec:
     storage:
       redis-cached:
         configSecretRef:
-          name: redis-config 
-EOF          
-```      
+          name: redis-config
+EOF
+```
 
 Wait for Kuadrant to be ready as follows:
 
@@ -255,5 +273,5 @@ kubectl wait kuadrant/kuadrant --for="condition=Ready=true" -n kuadrant-system -
 
 Kuadrant is now ready to use.
 
-## Next steps 
+## Next steps
 - [Secure, protect, and connect APIs with Kuadrant on OpenShift](../user-guides/secure-protect-connect-single-multi-cluster.md)

--- a/doc/install/install-openshift.md
+++ b/doc/install/install-openshift.md
@@ -31,6 +31,8 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 
 Before you can use Kuadrant, you must install cert-manager.
 
+> The minimum supported version of cert-manager is v1.12.1.
+
 Install one of the different flavours of the Cert-Manager.
 
 #### Install community version of the cert-manager


### PR DESCRIPTION
### What

While this older https://github.com/Kuadrant/kuadrant-operator/pull/680 change was removing cert-manager operator as dependency and, instead, add cert-manager API as dependency, this PR is completely removing cert-manager as dependency for the operator. 

Additionally, TLS policy status reports with some understandable error when the cert-manager is not available in the cluster.

### Why

The cert-manager is, in fact, a direct dependency of the kuadrant controller (regarding the TLS policy) and indirectly for authorino (required for the webhook deployment). Unfortunately, the dependency declaration of the cert-manager, either as operator or as API, creates unsolvable (from our side) issues in Openshift. 

And the issue comes from the [RH build of the cert-manager operator ](https://github.com/openshift/cert-manager-operator). This operator, only available for openshift, provides the same APIs as the upstream community version of the [cert-manager operator](https://github.com/cert-manager/cert-manager). That overlapping APIs, was an issue when kuadrant had dependency on the operator. When the openshift cluster had the RH build of the cert-manager operator installed, the kuadrant requirement could not be met as upstream cert-manager was unable to install. On https://github.com/Kuadrant/kuadrant-operator/pull/680 we fixed this issue changing the dependency type from operator to API level. Unfortunately, there are still issues. And the main issue is that The RH build of the cert-manager cannot be installed in the same namespace as the kuadrant operator. The reason being that the kuadrant operator is cluster wide and the RH cert-manager is namespace scoped operator. The [OperatorGroup](https://olm.operatorframework.io/docs/concepts/crds/operatorgroup/) does not enable installing different scoped operators in the same namespace. 

Even if the RH cert manager is installed in another NS A, when installing kuadrant in some NS K, OLM tries to install yet another RH cert-manager operator instance in the NS K. Which fails for the reasons explained above. 

Extracted from the installplan resource:

```yaml
clusterServiceVersionNames:             
- dns-operator.v0.0.0                   
- limitador-operator.v0.9.0             
- cert-manager-operator.v1.13.1         
- authorino-operator.v0.11.1            
- kuadrant-operator.v0.8.0 
```

My guess (just a guess) is that OLM thinks that even if the GVK exists, nobody is watching for it in the specified namespace, hence it tries to install an operator that fulfill the needs in the specified namespace. 

Interesting to note that even if the community cert-manager is installed before Kuadrant, the RH cert-manager will still try to be installed in the same namespace as kuadrant. Not sure OLM is behaving as it should. We might have found a bug here. If we re-add cert-manager APIs as dependencies, we need to verify that when the upstream operator is pre-installed, the RH build operator is not being installed  in openshift.


> read public slack channel discussion about this topic [here](https://kubernetes.slack.com/archives/C05J0D0V525/p1718604400142519)

### The Plan

The plan now is to have the cert-manager API as documentation requirement. The pre-requisite for kuadrant to work as expected is that the cert-manager APIs are in place in the cluster. 

The RH build of the cert-manager is planning cluster wide scope feature. Tracked here: https://github.com/openshift/cert-manager-operator/pull/188. 

Once a release of RH cert-manager that supports all namespaces is available, we can move back to having it as a dependency. One test we will need to do after bringing the cert-manager dependency back: verify that when the upstream operator is pre-installed, the RH build operator is not being installed  in openshift. Created issue for this https://github.com/Kuadrant/kuadrant-operator/issues/729

### Verification steps

* Create kind cluster
```
make kind-create-cluster
```

* Deploy OLM system
```
make install-olm
```

* Deploy Gateway API CRDs (for these verification steps no need to install istio)
```
make gateway-api-install
```
* Deploy kuadrant operator using OLM. The catalog has already been created for you out of the changes of this branch. But feel free to [create your own catalog](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/development.md#build-custom-olm-catalog).
```
make deploy-catalog CATALOG_IMG=quay.io/kuadrant/kuadrant-operator-catalog:fix-cert-manager-deps
```

The operators should be installed correctly. Wait until the CSV reports all the operators succeeded.
```
❯ kubectl get clusterserviceversions.operators.coreos.com 
NAME                        DISPLAY              VERSION   REPLACES                         PHASE
authorino-operator.v0.0.0   Authorino Operator   0.0.0                                      Succeeded
dns-operator.v0.0.0         DNS Operator         0.0.0                                      Succeeded
kuadrant-operator.v0.0.0    Kuadrant Operator    0.0.0     kuadrant-operator.v0.0.0-alpha   Succeeded
limitador-operator.v0.0.0   Limitador            0.0.0                                      Succeeded
```

This is the key change of this PR: the **cert-manager** has **NOT** been installed

Let's test the TLSPolicy on this cert-manager-less scenario:

* Create a namespace:
```shell
kubectl create namespace my-gateways
```

* Create an ingress gateway

```sh
kubectl -n my-gateways apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: prod-web
spec:
  gatewayClassName: istio
  listeners:
    - allowedRoutes:
        namespaces:
          from: All
      name: api
      hostname: "*.toystore.local"
      port: 443
      protocol: HTTPS
      tls:
        mode: Terminate
        certificateRefs:
          - name: toystore-local-tls
            kind: Secret
EOF
```
* Create a Kuadrant `TLSPolicy` to configure TLS:
```sh
kubectl apply -n my-gateways -f - <<EOF
apiVersion: kuadrant.io/v1alpha1
kind: TLSPolicy
metadata:
  name: prod-web
spec:
  targetRef:
    name: prod-web
    group: gateway.networking.k8s.io
    kind: Gateway
  issuerRef:
    group: cert-manager.io
    kind: Issuer
    name: selfsigned-issuer
EOF
```

The TLSPolicy controller should be disabled with the following error log

```
❯ k logs deployment/kuadrant-operator-controller-manager -n kuadrant-system | grep TLSPolicy
{"level":"error","ts":"2024-07-15T09:38:19Z","logger":"kuadrant-operator.tlspolicy","msg":"CertManager CRD was not installed","group":"cert-manager.io","kind":"Certificate","version":"v1","stacktrace":"github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi.IsCertManagerInstalled\n\t/workspace/pkg/library/gatewayapi/utils.go:162\ngithub.com/kuadrant/kuadrant-operator/controllers.(*TLSPolicyReconciler).SetupWithManager\n\t/workspace/controllers/tlspolicy_controller.go:205\nmain.main\n\t/workspace/main.go:212\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:267"}
{"level":"info","ts":"2024-07-15T09:38:19Z","logger":"kuadrant-operator.tlspolicy","msg":"TLSPolicy controller disabled. CertManager was not found"}
```

The TLSPolicy instance status should be empty as the controller is not enabled. There is an open issue https://github.com/Kuadrant/kuadrant-operator/issues/730 for adding some understandable error when the cert-manager is not available in the cluster.

