### PR TITLE
Quiet flag for uninterrupted single cluster run of quickstart script

### DIFF
--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -351,7 +351,7 @@ postSetup() {
   esac
 }
 
-if [[ -z "$QUIET" ]]; then
+if [[ -z "$KUADRANT_QUIET" ]]; then
   info "📘 Welcome to the Kuadrant Quick Start setup process"
 
   info "This script will guide you through setting up a local Kubernetes cluster with the following components:"
@@ -368,7 +368,7 @@ if [[ -z "$QUIET" ]]; then
   read -r -p "Are you ready to begin? (y/n) " yn </dev/tty
 else 
   yn="y"
-  info "QUIET flag detected. Proceeding without prompts in single cluster mode and without DNS Provider..."
+  info "KUADRANT_QUIET flag detected. Proceeding without prompts in single cluster mode and without DNS Provider..."
 fi
 
 case $yn in
@@ -392,7 +392,7 @@ check_dependencies
 
 info "Checking for existing Kubernetes clusters..."
 if cluster_exists "${KUADRANT_CLUSTER_NAME}"; then
-    if [[ -z "$QUIET" ]]; then
+    if [[ -z "$KUADRANT_QUIET" ]]; then
       echo "A cluster named '${KUADRANT_CLUSTER_NAME}' already exists."
       echo "This will be treated as a 'hub' cluster, with any new clusters being workers."
       read -r -p "Proceed with multi-cluster setup? (y/N): " proceed </dev/tty
@@ -422,14 +422,14 @@ if cluster_exists "${KUADRANT_CLUSTER_NAME}"; then
           exit 0
       fi
     else 
-      error "Aborting as single cluster already exists. Please delete the cluster first before running quickstart with QUIET flag."
+      error "Aborting as single cluster already exists. Please delete the cluster first before running quickstart with KUADRANT_QUIET flag."
       exit 0
     fi
 else
     info "No existing cluster named '${KUADRANT_CLUSTER_NAME}' found. Proceeding with initial setup."
 fi
 
-if [[ -z "$QUIET" ]]; then
+if [[ -z "$KUADRANT_QUIET" ]]; then
   echo "Do you want to set up a DNS provider for use with Kuadrant's DNSPolicy API? (y/n)"
   read -r SETUP_PROVIDER </dev/tty
 else

--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -154,12 +154,16 @@ generate_ip_address_pool() {
 }
 
 requiredENV() {
-  info "Configuring DNS provider environment variables... 🛰️"
-  info "You have chosen to set up a DNS provider, which is required for using Kuadrant's DNSPolicy API."
-  info "Supported DNS providers are AWS Route 53 and Google Cloud DNS."
+  if [[ -z "$KUADRANT_QUIET" ]]; then
+    info "Configuring DNS provider environment variables... 🛰️"
+    info "You have chosen to set up a DNS provider, which is required for using Kuadrant's DNSPolicy API."
+    info "Supported DNS providers are AWS Route 53 and Google Cloud DNS."
+  fi
 
-  # Read directly from the terminal, ensuring it can handle piped script execution
-  read -r -p "Please enter 'aws' for AWS Route 53, or 'gcp' for Google Cloud DNS: " DNS_PROVIDER </dev/tty
+  if [[ -z "$DNS_PROVIDER" ]]; then
+    # Read directly from the terminal, ensuring it can handle piped script execution
+    read -r -p "Please enter 'aws' for AWS Route 53, or 'gcp' for Google Cloud DNS: " DNS_PROVIDER </dev/tty
+  fi
 
   if [[ "$DNS_PROVIDER" =~ ^(aws|gcp)$ ]]; then
     info "You have selected the $DNS_PROVIDER DNS provider."
@@ -167,8 +171,12 @@ requiredENV() {
     error "Invalid input. Supported providers are 'aws' and 'gcp' only. Exiting."
     exit 1
   fi
-  export DNS_PROVIDER
 
+  if [[ -z "$DNS_PROVIDER" ]]; then
+    export DNS_PROVIDER
+  fi
+
+  # Opting to keep this part as is with QUIET mode as a friendly reminder to users who wish to run entirely in QUIET mode. If this is you, set the below env vars before running the script. :) 
   if [[ "$DNS_PROVIDER" == "aws" ]]; then
     if [[ -z "${KUADRANT_AWS_ACCESS_KEY_ID}" ]]; then
       echo "Enter an AWS access key ID for an account where you have access to AWS Route 53:"
@@ -368,7 +376,7 @@ if [[ -z "$KUADRANT_QUIET" ]]; then
   read -r -p "Are you ready to begin? (y/n) " yn </dev/tty
 else 
   yn="y"
-  info "KUADRANT_QUIET flag detected. Proceeding without prompts in single cluster mode and without DNS Provider..."
+  info "KUADRANT_QUIET flag detected. Proceeding without prompts..."
 fi
 
 case $yn in
@@ -433,7 +441,11 @@ if [[ -z "$KUADRANT_QUIET" ]]; then
   echo "Do you want to set up a DNS provider for use with Kuadrant's DNSPolicy API? (y/n)"
   read -r SETUP_PROVIDER </dev/tty
 else
-  SETUP_PROVIDER="n"
+  if [[ -z "$DNS_PROVIDER" ]]; then
+    SETUP_PROVIDER="n"
+  else
+    SETUP_PROVIDER="y"
+  fi
 fi
 
 case $SETUP_PROVIDER in

--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -501,6 +501,16 @@ info "Installing cert-manager... 🛡️"
 kubectl apply -k ${KUADRANT_CERT_MANAGER_KUSTOMIZATION}
 info "Waiting for cert-manager deployments to be ready"
 kubectl -n cert-manager wait --for=condition=Available deployments --all --timeout=300s
+# Check to see if endpoint is available for cert-manager-webhook before setting up cluster issuer.
+while true; do
+  ENDPOINTS=$(kubectl get endpoints cert-manager-webhook -n cert-manager -o jsonpath='{.subsets[0].addresses}')
+  if [ "$ENDPOINTS" != "[]" ]; then
+    echo "cert-manager-webhook has endpoints available."
+    break
+  fi
+  echo "Waiting for endpoints to become available for cert-manager-webhook..."
+  sleep 2
+done
 setupClusterIssuer
 success "cert-manager installed successfully."
 


### PR DESCRIPTION
### What: 
`KUADRANT_QUIET`, `DNS_PROVIDER` and `MULTICLUSTER` flag detection for running quickstart script uninterrupted has been added.

### How: 
It checks for whether `KUADRANT_QUIET` exists and if so, will run an uninterrupted run of quickstart in single cluster and no DNS provider mode. 

If `DNS_PROVIDER` is set alongside `KUADRANT_QUIET`, then it will run the quickstart script in single cluster mode, with dns provider. 

If `MULTICLUSTER` is set alongside `KUADRANT_QUIET` or `DNS_PROVIDER`, or both, it will run in multicluster mode with or without dns provider . 

### Why: 
Developers or System Administrators may find this useful so they do not need to use prompts to spin up Kuadrant quickly, such as for testing purposes in CI/CD pipelines. 

### Verify:

Run:
- `KUADRANT_QUIET=<whatever> ./hack/quickstart-setup.sh` 
- `KUADRANT_QUIET=<whatever> DNS_PROVIDER=<whatever> ./hack/quickstart-setup.sh`
- `KUADRANT_QUIET=<whatever> DNS_PROVIDER=<whatever> MULTICLUSTER=<whatever> ./hack/quickstart-setup.sh`
- `KUADRANT_QUIET=<whatever> MULTICLUSTER=<whatever> ./hack/quickstart-setup.sh`

Of course, other combinations exist for those env vars. The idea is that all these combinations run successfully and without error to make the script more automated. 