### PR TITLE
enhanced gateway api topology

### DIFF
--- a/controllers/authpolicy_status.go
+++ b/controllers/authpolicy_status.go
@@ -169,6 +169,8 @@ func (r *AuthPolicyReconciler) generateTopology(ctx context.Context) (*kuadrantg
 	})
 
 	return kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
 		kuadrantgatewayapi.WithGateways(utils.Map(gwList.Items, ptr.To[gatewayapiv1.Gateway])),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(policies),

--- a/controllers/authpolicy_status.go
+++ b/controllers/authpolicy_status.go
@@ -170,7 +170,7 @@ func (r *AuthPolicyReconciler) generateTopology(ctx context.Context) (*kuadrantg
 
 	return kuadrantgatewayapi.NewTopology(
 		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
-		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(),
 		kuadrantgatewayapi.WithGateways(utils.Map(gwList.Items, ptr.To[gatewayapiv1.Gateway])),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(policies),

--- a/controllers/ratelimitpolicy_enforced_status_controller.go
+++ b/controllers/ratelimitpolicy_enforced_status_controller.go
@@ -200,6 +200,8 @@ func (r *RateLimitPolicyEnforcedStatusReconciler) buildTopology(ctx context.Cont
 	}
 
 	return kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
 		kuadrantgatewayapi.WithGateways(utils.Map(gatewayList.Items, ptr.To[gatewayapiv1.Gateway])),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(utils.Map(policyList.Items, func(p kuadrantv1beta2.RateLimitPolicy) kuadrantgatewayapi.Policy { return &p })),

--- a/controllers/ratelimitpolicy_enforced_status_controller.go
+++ b/controllers/ratelimitpolicy_enforced_status_controller.go
@@ -201,7 +201,6 @@ func (r *RateLimitPolicyEnforcedStatusReconciler) buildTopology(ctx context.Cont
 
 	return kuadrantgatewayapi.NewTopology(
 		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
-		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
 		kuadrantgatewayapi.WithGateways(utils.Map(gatewayList.Items, ptr.To[gatewayapiv1.Gateway])),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(utils.Map(policyList.Items, func(p kuadrantv1beta2.RateLimitPolicy) kuadrantgatewayapi.Policy { return &p })),

--- a/controllers/ratelimitpolicy_limits.go
+++ b/controllers/ratelimitpolicy_limits.go
@@ -141,7 +141,7 @@ func (r *RateLimitPolicyReconciler) buildTopology(ctx context.Context, policies 
 
 	return kuadrantgatewayapi.NewTopology(
 		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
-		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(),
 		kuadrantgatewayapi.WithGateways(utils.Map(gwList.Items, ptr.To[gatewayapiv1.Gateway])),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(policies),

--- a/controllers/ratelimitpolicy_limits.go
+++ b/controllers/ratelimitpolicy_limits.go
@@ -140,6 +140,8 @@ func (r *RateLimitPolicyReconciler) buildTopology(ctx context.Context, policies 
 	}
 
 	return kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
 		kuadrantgatewayapi.WithGateways(utils.Map(gwList.Items, ptr.To[gatewayapiv1.Gateway])),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(policies),

--- a/controllers/target_status_controller.go
+++ b/controllers/target_status_controller.go
@@ -220,7 +220,7 @@ func (r *TargetStatusReconciler) buildTopology(ctx context.Context, gw *gatewaya
 
 	t, err := kuadrantgatewayapi.NewTopology(
 		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
-		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(),
 		kuadrantgatewayapi.WithGateways([]*gatewayapiv1.Gateway{gw}),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(policies),

--- a/controllers/target_status_controller.go
+++ b/controllers/target_status_controller.go
@@ -219,6 +219,8 @@ func (r *TargetStatusReconciler) buildTopology(ctx context.Context, gw *gatewaya
 	}
 
 	t, err := kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
 		kuadrantgatewayapi.WithGateways([]*gatewayapiv1.Gateway{gw}),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(policies),

--- a/pkg/library/gatewayapi/helper_test.go
+++ b/pkg/library/gatewayapi/helper_test.go
@@ -122,3 +122,22 @@ func testBasicRoutePolicy(name, namespace string, route *gatewayapiv1.HTTPRoute)
 		},
 	}
 }
+
+func testStandalonePolicy(name, namespace string) Policy {
+	return &TestPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "example.com/v1",
+			Kind:       "TestPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		TargetRef: gatewayapiv1alpha2.PolicyTargetReference{
+			Group:     gatewayapiv1.Group(gatewayapiv1.GroupName),
+			Kind:      gatewayapiv1.Kind("Gateway"),
+			Namespace: ptr.To(gatewayapiv1.Namespace("unknown")),
+			Name:      gatewayapiv1.ObjectName("unknown"),
+		},
+	}
+}

--- a/pkg/library/gatewayapi/topology.go
+++ b/pkg/library/gatewayapi/topology.go
@@ -222,9 +222,9 @@ func WithPolicies(policies []Policy) TopologyOpts {
 	}
 }
 
-func WithProgrammedGatewaysOnly(programmedGatewaysOnly bool) TopologyOpts {
+func WithProgrammedGatewaysOnly() TopologyOpts {
 	return func(o *topologyOptions) {
-		o.programmedGatewaysOnly = programmedGatewaysOnly
+		o.programmedGatewaysOnly = true
 	}
 }
 

--- a/pkg/library/gatewayapi/topology.go
+++ b/pkg/library/gatewayapi/topology.go
@@ -328,7 +328,6 @@ func buildDAGEdges(opts *topologyOptions, gateways []gatewayDAGNode, routes []ht
 	edges := make([]edge, 0)
 
 	for _, route := range routes {
-
 		gatewayParentKeys := GetGatewayParentKeys(route.HTTPRoute)
 
 		if opts.linkAcceptedRoutesOnly {
@@ -359,7 +358,6 @@ func buildDAGEdges(opts *topologyOptions, gateways []gatewayDAGNode, routes []ht
 		for _, attachedPolicy := range attachedPolicies {
 			edges = append(edges, edge{parent: route, child: attachedPolicy})
 		}
-
 	}
 
 	for _, g := range effectiveGatewys {

--- a/pkg/library/gatewayapi/topology.go
+++ b/pkg/library/gatewayapi/topology.go
@@ -18,42 +18,135 @@ const (
 	typeField      dag.Field     = dag.Field("type")
 	gatewayLabel   dag.NodeLabel = dag.NodeLabel("gateway")
 	httprouteLabel dag.NodeLabel = dag.NodeLabel("httproute")
+	policyLabel    dag.NodeLabel = dag.NodeLabel("policy")
 )
 
-type RouteNode struct {
-	*gatewayapiv1.HTTPRoute
-
-	attachedPolicies []Policy
+type PolicyTargetNode interface {
+	GetGatewayNode() *GatewayNode
+	GetRouteNode() *RouteNode
 }
 
-func (r *RouteNode) AttachedPolicies() []Policy {
-	return r.attachedPolicies
+type PolicyNode struct {
+	policyDAGNode
+
+	graph *dag.DAG
+}
+
+func (p *PolicyNode) GetPolicy() Policy {
+	return p.Policy
+}
+
+func (p *PolicyNode) TargetRef() PolicyTargetNode {
+	targetNodes := p.graph.Parents(p.ID())
+
+	if len(targetNodes) == 0 {
+		return nil
+	}
+
+	// there should be only one
+	switch typedNode := targetNodes[0].(type) {
+	case gatewayDAGNode:
+		return &GatewayNode{typedNode, p.graph}
+	case httpRouteDAGNode:
+		return &RouteNode{typedNode, p.graph}
+	}
+
+	return nil
+}
+
+type RouteNode struct {
+	httpRouteDAGNode
+
+	graph *dag.DAG
+}
+
+var _ PolicyTargetNode = &RouteNode{}
+
+func (r *RouteNode) AttachedPolicies() []PolicyNode {
+	// get children of Policy kind
+	policyNodeList := utils.Filter(r.graph.Children(r.ID()), func(n dag.Node) bool {
+		_, ok := n.(policyDAGNode)
+		return ok
+	})
+
+	return utils.Map(policyNodeList, func(n dag.Node) PolicyNode {
+		return PolicyNode{n.(policyDAGNode), r.graph}
+	})
 }
 
 func (r *RouteNode) Route() *gatewayapiv1.HTTPRoute {
 	return r.HTTPRoute
 }
 
-type GatewayNode struct {
-	*gatewayapiv1.Gateway
-
-	attachedPolicies []Policy
-
-	routes []RouteNode
+func (r *RouteNode) ObjectKey() client.ObjectKey {
+	return client.ObjectKeyFromObject(r.HTTPRoute)
 }
 
-func (g *GatewayNode) AttachedPolicies() []Policy {
-	return g.attachedPolicies
+func (r *RouteNode) GetGatewayNode() *GatewayNode {
+	return nil
+}
+
+func (r *RouteNode) GetRouteNode() *RouteNode {
+	return r
+}
+
+type GatewayNode struct {
+	gatewayDAGNode
+
+	graph *dag.DAG
+}
+
+var _ PolicyTargetNode = &GatewayNode{}
+
+func (g *GatewayNode) AttachedPolicies() []PolicyNode {
+	// get children of Policy kind
+	policyNodeList := utils.Filter(g.graph.Children(g.ID()), func(n dag.Node) bool {
+		_, ok := n.(policyDAGNode)
+		return ok
+	})
+
+	return utils.Map(policyNodeList, func(n dag.Node) PolicyNode {
+		return PolicyNode{n.(policyDAGNode), g.graph}
+	})
+}
+
+func (g *GatewayNode) GetGateway() *gatewayapiv1.Gateway {
+	return g.Gateway
 }
 
 func (g *GatewayNode) Routes() []RouteNode {
-	return g.routes
+	// get children of httproute kind
+	routeNodeList := utils.Filter(g.graph.Children(g.ID()), func(n dag.Node) bool {
+		_, ok := n.(httpRouteDAGNode)
+		return ok
+	})
+
+	return utils.Map(routeNodeList, func(n dag.Node) RouteNode {
+		routeDAGNode := n.(httpRouteDAGNode)
+		return RouteNode{routeDAGNode, g.graph}
+	})
 }
 
 func (g *GatewayNode) ObjectKey() client.ObjectKey {
 	return client.ObjectKeyFromObject(g.Gateway)
 }
 
+func (g *GatewayNode) GetGatewayNode() *GatewayNode {
+	return g
+}
+
+func (g *GatewayNode) GetRouteNode() *RouteNode {
+	return nil
+}
+
+// Topology defines a graph with Gateway API entities.
+// Contains GatewayNodes (Gateway API gateways)
+// Contains RouteNodes (Gateway API httproutes)
+// Contains PolicyNodes (Gateway API policy attachment objects)
+// Hierarchy is as follows.
+// GatewayNode children can be either RouteNode or PolicyNode nodes
+// RouteNode children are PolicyNode nodes
+// PolicyNode parents can be either RouteNode or GatewayNode nodes
 type Topology struct {
 	graph  *dag.DAG
 	Logger logr.Logger
@@ -61,26 +154,30 @@ type Topology struct {
 
 type gatewayDAGNode struct {
 	*gatewayapiv1.Gateway
-
-	attachedPolicies []Policy
 }
 
 func dagNodeIDFromObject(obj client.Object) dag.NodeID {
 	return fmt.Sprintf("%s#%s", obj.GetObjectKind().GroupVersionKind().String(), client.ObjectKeyFromObject(obj).String())
 }
 
-func (g gatewayDAGNode) ID() string {
+func (g gatewayDAGNode) ID() dag.NodeID {
 	return dagNodeIDFromObject(g.Gateway)
 }
 
 type httpRouteDAGNode struct {
 	*gatewayapiv1.HTTPRoute
-
-	attachedPolicies []Policy
 }
 
-func (h httpRouteDAGNode) ID() string {
+func (h httpRouteDAGNode) ID() dag.NodeID {
 	return dagNodeIDFromObject(h.HTTPRoute)
+}
+
+type policyDAGNode struct {
+	Policy
+}
+
+func (p policyDAGNode) ID() dag.NodeID {
+	return dagNodeIDFromObject(p.Policy)
 }
 
 type topologyOptions struct {
@@ -89,10 +186,17 @@ type topologyOptions struct {
 	policies               []Policy
 	logger                 logr.Logger
 	programmedGatewaysOnly bool
+	linkAcceptedRoutesOnly bool
 }
 
 // TopologyOpts allows to manipulate topologyOptions.
 type TopologyOpts func(*topologyOptions)
+
+func WithAcceptedRoutesLinkedOnly() TopologyOpts {
+	return func(o *topologyOptions) {
+		o.linkAcceptedRoutesOnly = true
+	}
+}
 
 func WithLogger(logger logr.Logger) TopologyOpts {
 	return func(o *topologyOptions) {
@@ -128,7 +232,8 @@ func NewTopology(opts ...TopologyOpts) (*Topology, error) {
 	// defaults
 	o := &topologyOptions{
 		logger:                 logr.Discard(),
-		programmedGatewaysOnly: true,
+		programmedGatewaysOnly: false,
+		linkAcceptedRoutesOnly: false,
 	}
 
 	for _, opt := range opts {
@@ -141,6 +246,8 @@ func NewTopology(opts ...TopologyOpts) (*Topology, error) {
 			return []dag.NodeLabel{gatewayLabel}
 		case httpRouteDAGNode:
 			return []dag.NodeLabel{httprouteLabel}
+		case policyDAGNode:
+			return []dag.NodeLabel{policyLabel}
 		default:
 			return nil
 		}
@@ -148,9 +255,17 @@ func NewTopology(opts ...TopologyOpts) (*Topology, error) {
 
 	graph := dag.NewDAG(typeIndexer)
 
-	gatewayDAGNodes := buildGatewayDAGNodes(o.gateways, o.policies, o.programmedGatewaysOnly)
+	gatewayDAGNodes := utils.Map(o.gateways, func(g *gatewayapiv1.Gateway) gatewayDAGNode {
+		return gatewayDAGNode{Gateway: g}
+	})
 
-	routeDAGNodes := buildHTTPRouteDAGNodes(o.routes, o.policies)
+	routeDAGNodes := utils.Map(o.routes, func(route *gatewayapiv1.HTTPRoute) httpRouteDAGNode {
+		return httpRouteDAGNode{HTTPRoute: route}
+	})
+
+	policyDAGNodes := utils.Map(o.policies, func(policy Policy) policyDAGNode {
+		return policyDAGNode{Policy: policy}
+	})
 
 	for _, node := range gatewayDAGNodes {
 		err := graph.AddNode(node)
@@ -158,6 +273,7 @@ func NewTopology(opts ...TopologyOpts) (*Topology, error) {
 			return nil, err
 		}
 	}
+
 	for _, node := range routeDAGNodes {
 		err := graph.AddNode(node)
 		if err != nil {
@@ -165,7 +281,14 @@ func NewTopology(opts ...TopologyOpts) (*Topology, error) {
 		}
 	}
 
-	edges := buildDAGEdges(gatewayDAGNodes, routeDAGNodes)
+	for _, node := range policyDAGNodes {
+		err := graph.AddNode(node)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	edges := buildDAGEdges(o, gatewayDAGNodes, routeDAGNodes, policyDAGNodes)
 
 	for _, edge := range edges {
 		err := graph.AddEdge(edge.parent.ID(), edge.child.ID())
@@ -186,56 +309,42 @@ type edge struct {
 	child  dag.Node
 }
 
-func buildDAGEdges(gateways []gatewayDAGNode, routes []httpRouteDAGNode) []edge {
+func buildDAGEdges(opts *topologyOptions, gateways []gatewayDAGNode, routes []httpRouteDAGNode, policies []policyDAGNode) []edge {
+	effectiveGatewys := gateways
+
+	if opts.programmedGatewaysOnly {
+		// filter out not programmed gateways
+		effectiveGatewys = utils.Filter(gateways, func(g gatewayDAGNode) bool {
+			return meta.IsStatusConditionTrue(g.Status.Conditions, string(gatewayapiv1.GatewayConditionProgrammed))
+		})
+	}
+
 	// internal index: key -> gateway for reference
-	gatewaysIndex := make(map[client.ObjectKey]gatewayDAGNode, len(gateways))
-	for _, gateway := range gateways {
+	gatewaysIndex := make(map[client.ObjectKey]gatewayDAGNode, len(effectiveGatewys))
+	for _, gateway := range effectiveGatewys {
 		gatewaysIndex[client.ObjectKeyFromObject(gateway.Gateway)] = gateway
 	}
 
 	edges := make([]edge, 0)
+
 	for _, route := range routes {
-		for _, parentKey := range GetRouteAcceptedGatewayParentKeys(route.HTTPRoute) {
+
+		gatewayParentKeys := GetGatewayParentKeys(route.HTTPRoute)
+
+		if opts.linkAcceptedRoutesOnly {
+			gatewayParentKeys = GetRouteAcceptedGatewayParentKeys(route.HTTPRoute)
+		}
+
+		for _, parentKey := range gatewayParentKeys {
 			// the parent gateway may not be in the available list of gateways
 			// or the gateway may not be valid
 			if gateway, ok := gatewaysIndex[parentKey]; ok {
 				edges = append(edges, edge{parent: gateway, child: route})
 			}
 		}
-	}
 
-	return edges
-}
-
-func buildGatewayDAGNodes(gateways []*gatewayapiv1.Gateway, policies []Policy, programmedGatewaysOnly bool) []gatewayDAGNode {
-	targetedGateways := gateways
-	if programmedGatewaysOnly {
-		targetedGateways = utils.Filter(gateways, func(g *gatewayapiv1.Gateway) bool {
-			return meta.IsStatusConditionTrue(g.Status.Conditions, string(gatewayapiv1.GatewayConditionProgrammed))
-		})
-	}
-
-	return utils.Map(targetedGateways, func(g *gatewayapiv1.Gateway) gatewayDAGNode {
-		// Compute attached policies
-		attachedPolicies := utils.Filter(policies, func(p Policy) bool {
-			group := p.GetTargetRef().Group
-			kind := p.GetTargetRef().Kind
-			name := p.GetTargetRef().Name
-			namespace := ptr.Deref(p.GetTargetRef().Namespace, gatewayapiv1.Namespace(p.GetNamespace()))
-
-			return group == gatewayapiv1.GroupName &&
-				kind == "Gateway" &&
-				name == gatewayapiv1.ObjectName(g.Name) &&
-				namespace == gatewayapiv1.Namespace(g.Namespace)
-		})
-		return gatewayDAGNode{Gateway: g, attachedPolicies: attachedPolicies}
-	})
-}
-
-func buildHTTPRouteDAGNodes(routes []*gatewayapiv1.HTTPRoute, policies []Policy) []httpRouteDAGNode {
-	return utils.Map(routes, func(route *gatewayapiv1.HTTPRoute) httpRouteDAGNode {
-		// Compute attached policies
-		attachedPolicies := utils.Filter(policies, func(p Policy) bool {
+		// Compute route's child (attached) policies
+		attachedPolicies := utils.Filter(policies, func(p policyDAGNode) bool {
 			group := p.GetTargetRef().Group
 			kind := p.GetTargetRef().Kind
 			name := p.GetTargetRef().Name
@@ -246,8 +355,33 @@ func buildHTTPRouteDAGNodes(routes []*gatewayapiv1.HTTPRoute, policies []Policy)
 				name == gatewayapiv1.ObjectName(route.Name) &&
 				namespace == gatewayapiv1.Namespace(route.Namespace)
 		})
-		return httpRouteDAGNode{HTTPRoute: route, attachedPolicies: attachedPolicies}
-	})
+
+		for _, attachedPolicy := range attachedPolicies {
+			edges = append(edges, edge{parent: route, child: attachedPolicy})
+		}
+
+	}
+
+	for _, g := range effectiveGatewys {
+		// Compute gateway's child (attached) policies
+		attachedPolicies := utils.Filter(policies, func(p policyDAGNode) bool {
+			group := p.GetTargetRef().Group
+			kind := p.GetTargetRef().Kind
+			name := p.GetTargetRef().Name
+			namespace := ptr.Deref(p.GetTargetRef().Namespace, gatewayapiv1.Namespace(p.GetNamespace()))
+
+			return group == gatewayapiv1.GroupName &&
+				kind == "Gateway" &&
+				name == gatewayapiv1.ObjectName(g.Name) &&
+				namespace == gatewayapiv1.Namespace(g.Namespace)
+		})
+
+		for _, attachedPolicy := range attachedPolicies {
+			edges = append(edges, edge{parent: g, child: attachedPolicy})
+		}
+	}
+
+	return edges
 }
 
 func (g *Topology) Gateways() []GatewayNode {
@@ -263,25 +397,7 @@ func (g *Topology) Gateways() []GatewayNode {
 			return GatewayNode{}
 		}
 
-		routeNodes := g.graph.Children(gNode.ID())
-		// convert to "RouteNode" from httpRouteDAGNode
-		routes := utils.Map(routeNodes, func(r dag.Node) RouteNode {
-			rDAGNode, ok := r.(httpRouteDAGNode)
-			if !ok { // should not happen
-				g.Logger.Error(
-					fmt.Errorf("node ID %s type %T", n.ID(), n),
-					"DAG index returns gateway children that are not routes",
-				)
-				return RouteNode{}
-			}
-			return RouteNode(rDAGNode)
-		})
-
-		return GatewayNode{
-			Gateway:          gNode.Gateway,
-			attachedPolicies: gNode.attachedPolicies,
-			routes:           routes,
-		}
+		return GatewayNode{gNode, g.graph}
 	})
 }
 
@@ -297,6 +413,40 @@ func (g *Topology) Routes() []RouteNode {
 			)
 			return RouteNode{}
 		}
-		return RouteNode(rNode)
+		return RouteNode{rNode, g.graph}
 	})
+}
+
+func (g *Topology) Policies() []PolicyNode {
+	policyNodes := g.graph.GetNodes(typeField, policyLabel)
+
+	return utils.Map(policyNodes, func(r dag.Node) PolicyNode {
+		pNode, ok := r.(policyDAGNode)
+		if !ok { // should not happen
+			g.Logger.Error(
+				fmt.Errorf("node ID %s type %T", r.ID(), r),
+				"DAG policy index returns nodes that are not policies",
+			)
+			return PolicyNode{}
+		}
+		return PolicyNode{pNode, g.graph}
+	})
+}
+
+func (g *Topology) GetPolicy(policy Policy) (PolicyNode, bool) {
+	dagNode, err := g.graph.GetNode(policyDAGNode{policy}.ID())
+	if err != nil {
+		return PolicyNode{}, false
+	}
+
+	pNode, ok := dagNode.(policyDAGNode)
+	if !ok {
+		g.Logger.Error(
+			fmt.Errorf("policy key %s with node ID %s type %T",
+				client.ObjectKeyFromObject(policy), dagNode.ID(), dagNode),
+			"the policy ID conflicts with another graph node type",
+		)
+		return PolicyNode{}, false
+	}
+	return PolicyNode{pNode, g.graph}, true
 }

--- a/pkg/library/gatewayapi/topology_indexes.go
+++ b/pkg/library/gatewayapi/topology_indexes.go
@@ -129,7 +129,7 @@ func buildGatewayPoliciesIndex(t *Topology) map[client.ObjectKey][]Policy {
 		// Consisting of:
 		// - Policy targeting directly the gateway
 		// - Policies targeting the descendant routes of the gateway
-		policies := make([]Policy, 0)
+		policies := make([]PolicyNode, 0)
 
 		policies = append(policies, gatewayNode.AttachedPolicies()...)
 
@@ -137,7 +137,9 @@ func buildGatewayPoliciesIndex(t *Topology) map[client.ObjectKey][]Policy {
 			policies = append(policies, routeNode.AttachedPolicies()...)
 		}
 
-		index[gatewayNode.ObjectKey()] = policies
+		index[gatewayNode.ObjectKey()] = utils.Map(policies, func(pNode PolicyNode) Policy {
+			return pNode.Policy
+		})
 	}
 
 	return index

--- a/pkg/library/gatewayapi/topology_indexes_test.go
+++ b/pkg/library/gatewayapi/topology_indexes_test.go
@@ -53,7 +53,7 @@ func TestTopologyIndexes_PoliciesFromGateway(t *testing.T) {
 		policies := []Policy{gwPolicy, routePolicy}
 
 		t, err := NewTopology(
-			WithProgrammedGatewaysOnly(true),
+			WithProgrammedGatewaysOnly(),
 			WithGateways(gateways),
 			WithRoutes(routes),
 			WithPolicies(policies),

--- a/pkg/library/gatewayapi/topology_indexes_test.go
+++ b/pkg/library/gatewayapi/topology_indexes_test.go
@@ -53,6 +53,7 @@ func TestTopologyIndexes_PoliciesFromGateway(t *testing.T) {
 		policies := []Policy{gwPolicy, routePolicy}
 
 		t, err := NewTopology(
+			WithProgrammedGatewaysOnly(true),
 			WithGateways(gateways),
 			WithRoutes(routes),
 			WithPolicies(policies),

--- a/pkg/library/gatewayapi/topology_test.go
+++ b/pkg/library/gatewayapi/topology_test.go
@@ -149,7 +149,7 @@ func TestGatewayAPITopology_GatewayNode_Routes(t *testing.T) {
 		assert.Equal(subT, len(gw2Node.Routes()), 0)
 	})
 
-	t.Run("routes targetting unprogrammed gateway are not linked", func(subT *testing.T) {
+	t.Run("routes targeting unprogrammed gateway are not linked", func(subT *testing.T) {
 		// routeA -> gw1 (unprogrammed)
 		invalidGateway := testInvalidGateway("gw1", NS)
 		gateways := []*gatewayapiv1.Gateway{invalidGateway}
@@ -166,7 +166,7 @@ func TestGatewayAPITopology_GatewayNode_Routes(t *testing.T) {
 
 		gws := topology.Gateways()
 		assert.Equal(subT, len(gws), 1, "not ready gateways should be added")
-		assert.Equal(subT, len(gws[0].Routes()), 0, "routes targetting invalid gateways should not be linked")
+		assert.Equal(subT, len(gws[0].Routes()), 0, "routes targeting invalid gateways should not be linked")
 	})
 }
 
@@ -268,7 +268,7 @@ func TestGatewayAPITopology_Policies(t *testing.T) {
 		assert.Assert(subT, len(topology.Policies()) == 0, "topology should not return any policy")
 	})
 
-	t.Run("policy targetting missing network objet is added as a topology node", func(subT *testing.T) {
+	t.Run("policy targeting missing network objet is added as a topology node", func(subT *testing.T) {
 		policies := make([]Policy, 0)
 		for _, pName := range []string{"p1", "p2", "p3"} {
 			policies = append(policies, testStandalonePolicy(pName, NS))
@@ -299,7 +299,7 @@ func TestGatewayAPITopology_Policies(t *testing.T) {
 }
 
 func TestGatewayAPITopology_Policies_TargetRef(t *testing.T) {
-	t.Run("policy targetting missing network objet does not return TargetRef", func(subT *testing.T) {
+	t.Run("policy targeting missing network objet does not return TargetRef", func(subT *testing.T) {
 		topology, err := NewTopology(
 			WithPolicies([]Policy{testStandalonePolicy("p", NS)}),
 			WithLogger(log.NewLogger()),
@@ -311,7 +311,7 @@ func TestGatewayAPITopology_Policies_TargetRef(t *testing.T) {
 		assert.Assert(subT, policyNodes[0].TargetRef() == nil, "standalone policies should not have target ref")
 	})
 
-	t.Run("targetting a httproute should return routenode", func(subT *testing.T) {
+	t.Run("targeting a httproute should return routenode", func(subT *testing.T) {
 		route := testBasicRoute("route", NS)
 		routes := []*gatewayapiv1.HTTPRoute{route}
 
@@ -333,7 +333,7 @@ func TestGatewayAPITopology_Policies_TargetRef(t *testing.T) {
 		assert.Equal(subT, targetRouteNode.ObjectKey(), client.ObjectKeyFromObject(route), "policy's target ref has unexpected key")
 	})
 
-	t.Run("targetting a gateway should return gatewaynode", func(subT *testing.T) {
+	t.Run("targeting a gateway should return gatewaynode", func(subT *testing.T) {
 		gw := testBasicGateway("gw", NS)
 		gateways := []*gatewayapiv1.Gateway{gw}
 

--- a/pkg/library/gatewayapi/topology_test.go
+++ b/pkg/library/gatewayapi/topology_test.go
@@ -21,14 +21,14 @@ func TestGatewayAPITopology_Gateways(t *testing.T) {
 		assert.Assert(subT, len(topology.Gateways()) == 0, "topology should not return any gateway")
 	})
 
-	t.Run("invalid gateway is skipped", func(subT *testing.T) {
+	t.Run("invalid gateway is added as a topology node", func(subT *testing.T) {
 		invalidGateway := testInvalidGateway("gw1", NS)
 		gateways := []*gatewayapiv1.Gateway{invalidGateway}
 
 		topology, err := NewTopology(WithGateways(gateways), WithLogger(log.NewLogger()))
 		assert.NilError(subT, err)
 
-		assert.Assert(subT, len(topology.Gateways()) == 0, "not ready gateways should not be added")
+		assert.Equal(subT, len(topology.Gateways()), 1, "not ready gateways should be added")
 	})
 
 	t.Run("valid gateways are included", func(subT *testing.T) {
@@ -119,6 +119,7 @@ func TestGatewayAPITopology_GatewayNode_Routes(t *testing.T) {
 		routes := []*gatewayapiv1.HTTPRoute{routeA, routeB}
 
 		topology, err := NewTopology(
+			WithAcceptedRoutesLinkedOnly(),
 			WithGateways(gateways),
 			WithRoutes(routes),
 			WithLogger(log.NewLogger()),
@@ -146,6 +147,26 @@ func TestGatewayAPITopology_GatewayNode_Routes(t *testing.T) {
 		gw2Node, ok := gwIndex[client.ObjectKeyFromObject(gw2)]
 		assert.Assert(subT, ok, "expected gateway not found")
 		assert.Equal(subT, len(gw2Node.Routes()), 0)
+	})
+
+	t.Run("routes targetting unprogrammed gateway are not linked", func(subT *testing.T) {
+		// routeA -> gw1 (unprogrammed)
+		invalidGateway := testInvalidGateway("gw1", NS)
+		gateways := []*gatewayapiv1.Gateway{invalidGateway}
+		route := testBasicRoute("route", NS, invalidGateway)
+		routes := []*gatewayapiv1.HTTPRoute{route}
+
+		topology, err := NewTopology(
+			WithProgrammedGatewaysOnly(true),
+			WithGateways(gateways),
+			WithRoutes(routes),
+			WithLogger(log.NewLogger()),
+		)
+		assert.NilError(subT, err)
+
+		gws := topology.Gateways()
+		assert.Equal(subT, len(gws), 1, "not ready gateways should be added")
+		assert.Equal(subT, len(gws[0].Routes()), 0, "routes targetting invalid gateways should not be linked")
 	})
 }
 
@@ -238,4 +259,129 @@ func TestGatewayAPITopology_RouteNode_AttachedPolicies(t *testing.T) {
 	route2Node, ok := routeIndex[client.ObjectKeyFromObject(route2)]
 	assert.Assert(t, ok, "expected route not found")
 	assert.Equal(t, len(route2Node.AttachedPolicies()), 0)
+}
+
+func TestGatewayAPITopology_Policies(t *testing.T) {
+	t.Run("no policies", func(subT *testing.T) {
+		topology, err := NewTopology(WithLogger(log.NewLogger()))
+		assert.NilError(subT, err)
+		assert.Assert(subT, len(topology.Policies()) == 0, "topology should not return any policy")
+	})
+
+	t.Run("policy targetting missing network objet is added as a topology node", func(subT *testing.T) {
+		policies := make([]Policy, 0)
+		for _, pName := range []string{"p1", "p2", "p3"} {
+			policies = append(policies, testStandalonePolicy(pName, NS))
+		}
+
+		topology, err := NewTopology(WithPolicies(policies), WithLogger(log.NewLogger()))
+		assert.NilError(subT, err)
+
+		assert.Equal(subT, len(topology.Policies()), 3, "standalone policies should be added")
+	})
+
+	t.Run("happy path", func(subT *testing.T) {
+		route := testBasicRoute("route", NS)
+		routes := []*gatewayapiv1.HTTPRoute{route}
+
+		routePolicy := testBasicRoutePolicy("policy", NS, route)
+		policies := []Policy{routePolicy}
+
+		topology, err := NewTopology(
+			WithRoutes(routes),
+			WithPolicies(policies),
+			WithLogger(log.NewLogger()),
+		)
+		assert.NilError(subT, err)
+
+		assert.Equal(subT, len(topology.Policies()), 1, "expected policies not returned")
+	})
+}
+
+func TestGatewayAPITopology_Policies_TargetRef(t *testing.T) {
+	t.Run("policy targetting missing network objet does not return TargetRef", func(subT *testing.T) {
+		topology, err := NewTopology(
+			WithPolicies([]Policy{testStandalonePolicy("p", NS)}),
+			WithLogger(log.NewLogger()),
+		)
+		assert.NilError(subT, err)
+
+		policyNodes := topology.Policies()
+		assert.Equal(subT, len(policyNodes), 1, "standalone policies should be added")
+		assert.Assert(subT, policyNodes[0].TargetRef() == nil, "standalone policies should not have target ref")
+	})
+
+	t.Run("targetting a httproute should return routenode", func(subT *testing.T) {
+		route := testBasicRoute("route", NS)
+		routes := []*gatewayapiv1.HTTPRoute{route}
+
+		routePolicy := testBasicRoutePolicy("policy", NS, route)
+		policies := []Policy{routePolicy}
+
+		topology, err := NewTopology(
+			WithRoutes(routes),
+			WithPolicies(policies),
+			WithLogger(log.NewLogger()),
+		)
+		assert.NilError(subT, err)
+
+		policyNodes := topology.Policies()
+		assert.Equal(subT, len(policyNodes), 1, "expected policies not returned")
+		targetRefNode := policyNodes[0].TargetRef()
+		targetRouteNode, ok := targetRefNode.(*RouteNode)
+		assert.Assert(subT, ok, "policy's target ref is not routenode")
+		assert.Equal(subT, targetRouteNode.ObjectKey(), client.ObjectKeyFromObject(route), "policy's target ref has unexpected key")
+	})
+
+	t.Run("targetting a gateway should return gatewaynode", func(subT *testing.T) {
+		gw := testBasicGateway("gw", NS)
+		gateways := []*gatewayapiv1.Gateway{gw}
+
+		gwPolicy := testBasicGatewayPolicy("policy", NS, gw)
+		policies := []Policy{gwPolicy}
+
+		topology, err := NewTopology(
+			WithGateways(gateways),
+			WithPolicies(policies),
+			WithLogger(log.NewLogger()),
+		)
+		assert.NilError(subT, err)
+
+		policyNodes := topology.Policies()
+		assert.Equal(subT, len(policyNodes), 1, "expected policies not returned")
+		targetRefNode := policyNodes[0].TargetRef()
+		targetGatewayNode, ok := targetRefNode.(*GatewayNode)
+		assert.Assert(subT, ok, "policy's target ref is not gatewaynode")
+		assert.Equal(subT, targetGatewayNode.ObjectKey(), client.ObjectKeyFromObject(gw), "policy's target ref has unexpected key")
+	})
+}
+
+func TestGatewayAPITopology_GetPolicy(t *testing.T) {
+	t.Run("when ID is not found, returns not found", func(subT *testing.T) {
+		topology, err := NewTopology(
+			WithPolicies([]Policy{testStandalonePolicy("p", NS)}),
+			WithLogger(log.NewLogger()),
+		)
+		assert.NilError(subT, err)
+
+		_, ok := topology.GetPolicy(testStandalonePolicy("other", NS))
+		assert.Assert(subT, !ok, "'other' policy should not be found")
+	})
+
+	t.Run("when ID is found, returns the policy", func(subT *testing.T) {
+		policies := make([]Policy, 0)
+		for _, pName := range []string{"p1", "p2", "p3"} {
+			policies = append(policies, testStandalonePolicy(pName, NS))
+		}
+
+		topology, err := NewTopology(WithPolicies(policies), WithLogger(log.NewLogger()))
+		assert.NilError(subT, err)
+
+		policyNode, ok := topology.GetPolicy(testStandalonePolicy("p1", NS))
+		assert.Assert(subT, ok, "policy should be found")
+
+		assert.Equal(subT, client.ObjectKeyFromObject(policyNode), client.ObjectKey{
+			Name: "p1", Namespace: NS,
+		})
+	})
 }

--- a/pkg/library/gatewayapi/topology_test.go
+++ b/pkg/library/gatewayapi/topology_test.go
@@ -157,7 +157,7 @@ func TestGatewayAPITopology_GatewayNode_Routes(t *testing.T) {
 		routes := []*gatewayapiv1.HTTPRoute{route}
 
 		topology, err := NewTopology(
-			WithProgrammedGatewaysOnly(true),
+			WithProgrammedGatewaysOnly(),
 			WithGateways(gateways),
 			WithRoutes(routes),
 			WithLogger(log.NewLogger()),

--- a/pkg/library/gatewayapi/utils.go
+++ b/pkg/library/gatewayapi/utils.go
@@ -191,3 +191,23 @@ func isCRDInstalled(restMapper meta.RESTMapper, group, kind, version string) (bo
 
 	return false, err
 }
+
+// GetGatewayParentRefsFromRoute returns the list of parentRefs that are Gateway typed
+func GetGatewayParentRefsFromRoute(route *gatewayapiv1.HTTPRoute) []gatewayapiv1.ParentReference {
+	if route == nil {
+		return nil
+	}
+	return utils.Filter(route.Spec.ParentRefs, IsParentGateway)
+}
+
+// GetGatewayParentKeys returns the object keys of all parent gateways
+func GetGatewayParentKeys(route *gatewayapiv1.HTTPRoute) []client.ObjectKey {
+	gatewayParentRefs := GetGatewayParentRefsFromRoute(route)
+
+	return utils.Map(gatewayParentRefs, func(p gatewayapiv1.ParentReference) client.ObjectKey {
+		return client.ObjectKey{
+			Name:      string(p.Name),
+			Namespace: string(ptr.Deref(p.Namespace, gatewayapiv1.Namespace(route.Namespace))),
+		}
+	})
+}

--- a/pkg/library/mappers/gateway.go
+++ b/pkg/library/mappers/gateway.go
@@ -49,7 +49,6 @@ func (m *gatewayEventMapper) MapToPolicy(ctx context.Context, obj client.Object,
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To[gatewayapiv1.HTTPRoute])),
 		kuadrantgatewayapi.WithPolicies(policies),
 		kuadrantgatewayapi.WithLogger(logger),
-		kuadrantgatewayapi.WithProgrammedGatewaysOnly(false),
 	)
 	if err != nil {
 		logger.V(1).Error(err, "unable to build topology for gateway")

--- a/pkg/rlptools/overrides.go
+++ b/pkg/rlptools/overrides.go
@@ -53,7 +53,7 @@ func ApplyOverrides(topology *kuadrantgatewayapi.Topology, gateway *gatewayapiv1
 
 	return kuadrantgatewayapi.NewTopology(
 		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
-		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(),
 		kuadrantgatewayapi.WithGateways(lo.Map(topology.Gateways(), func(g kuadrantgatewayapi.GatewayNode, _ int) *gatewayapiv1.Gateway { return g.Gateway })),
 		kuadrantgatewayapi.WithRoutes(lo.Map(topology.Routes(), func(r kuadrantgatewayapi.RouteNode, _ int) *gatewayapiv1.HTTPRoute { return r.HTTPRoute })),
 		kuadrantgatewayapi.WithPolicies(overriddenPolicies),

--- a/pkg/rlptools/topology_index.go
+++ b/pkg/rlptools/topology_index.go
@@ -50,7 +50,7 @@ func TopologyIndexesFromGateway(ctx context.Context, cl client.Client, gw *gatew
 
 	topology, err := kuadrantgatewayapi.NewTopology(
 		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
-		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(),
 		kuadrantgatewayapi.WithGateways([]*gatewayapiv1.Gateway{gw}),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To)),
 		kuadrantgatewayapi.WithPolicies(policies),

--- a/pkg/rlptools/topology_index.go
+++ b/pkg/rlptools/topology_index.go
@@ -49,6 +49,8 @@ func TopologyIndexesFromGateway(ctx context.Context, cl client.Client, gw *gatew
 	policies := utils.Map(rlpList.Items, func(p kuadrantv1beta2.RateLimitPolicy) kuadrantgatewayapi.Policy { return &p })
 
 	topology, err := kuadrantgatewayapi.NewTopology(
+		kuadrantgatewayapi.WithAcceptedRoutesLinkedOnly(),
+		kuadrantgatewayapi.WithProgrammedGatewaysOnly(true),
 		kuadrantgatewayapi.WithGateways([]*gatewayapiv1.Gateway{gw}),
 		kuadrantgatewayapi.WithRoutes(utils.Map(routeList.Items, ptr.To)),
 		kuadrantgatewayapi.WithPolicies(policies),


### PR DESCRIPTION
### What

* new topology option `WithAcceptedRoutesLinkedOnly()`: only accepted routes will be linked to the gateway
* new topology option `WithProgrammedGatewaysOnly()`: only programmed (valid) gateways can have routes and attached policies. Not programmed gateways will be isolated nodes in the topology.
* new public method `Policies()` that returns all policies included in the topology. Returned objects are `PolicyNodes` that allow to jump to topology nodes targeted by the policy (aka `PolicyTargetNode`).

Work being done as part of https://github.com/Kuadrant/kuadrant-operator/issues/530

This is part of a series of PR's that will end with a new controller that will only reconcile limitador limits configuration. 
