### PR TITLE
refactor: integration tests for dns & tls policy target ref CEL validation

### DIFF
--- a/api/v1alpha1/dnspolicy_types.go
+++ b/api/v1alpha1/dnspolicy_types.go
@@ -214,14 +214,6 @@ func (p *DNSPolicy) DirectReferenceAnnotationName() string {
 // Validate ensures the resource is valid. Compatible with the validating interface
 // used by webhooks
 func (p *DNSPolicy) Validate() error {
-	if p.Spec.TargetRef.Group != gatewayapiv1.GroupName {
-		return fmt.Errorf("invalid targetRef.Group %s. The only supported group is %s", p.Spec.TargetRef.Group, gatewayapiv1.GroupName)
-	}
-
-	if p.Spec.TargetRef.Kind != ("Gateway") {
-		return fmt.Errorf("invalid targetRef.Kind %s. The only supported kind is Gateway", p.Spec.TargetRef.Kind)
-	}
-
 	if p.Spec.TargetRef.Namespace != nil && string(*p.Spec.TargetRef.Namespace) != p.Namespace {
 		return fmt.Errorf("invalid targetRef.Namespace %s. Currently only supporting references to the same namespace", *p.Spec.TargetRef.Namespace)
 	}

--- a/api/v1alpha1/tlspolicy_types.go
+++ b/api/v1alpha1/tlspolicy_types.go
@@ -196,14 +196,6 @@ func (p *TLSPolicy) DirectReferenceAnnotationName() string {
 }
 
 func (p *TLSPolicy) Validate() error {
-	if p.Spec.TargetRef.Group != (gatewayapiv1.GroupName) {
-		return fmt.Errorf("invalid targetRef.Group %s. The only supported group is %s", p.Spec.TargetRef.Group, gatewayapiv1.GroupName)
-	}
-
-	if p.Spec.TargetRef.Kind != ("Gateway") {
-		return fmt.Errorf("invalid targetRef.Kind %s. The only supported kind is Gateway", p.Spec.TargetRef.Kind)
-	}
-
 	if p.Spec.TargetRef.Namespace != nil && string(*p.Spec.TargetRef.Namespace) != p.Namespace {
 		return fmt.Errorf("invalid targetRef.Namespace %s. Currently only supporting references to the same namespace", *p.Spec.TargetRef.Namespace)
 	}

--- a/tests/common/dnspolicy/dnspolicy_controller_test.go
+++ b/tests/common/dnspolicy/dnspolicy_controller_test.go
@@ -648,7 +648,27 @@ var _ = Describe("DNSPolicy controller", func() {
 			//}, tests.TimeoutMedium, tests.RetryIntervalMedium).Should(MatchError(ContainSubstring("not found")))
 
 		}, testTimeOut)
-
 	})
 
+	Context("cel validation", func() {
+		It("should error targeting invalid group", func(ctx SpecContext) {
+			p := v1alpha1.NewTLSPolicy("test-tls-policy", testNamespace).
+				WithTargetGateway("gateway")
+			p.Spec.TargetRef.Group = "not-gateway.networking.k8s.io"
+
+			err := k8sClient.Create(ctx, p)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'"))
+		}, testTimeOut)
+
+		It("should error targeting invalid kind", func(ctx SpecContext) {
+			p := v1alpha1.NewTLSPolicy("test-tls-policy", testNamespace).
+				WithTargetGateway("gateway")
+			p.Spec.TargetRef.Kind = "TCPRoute"
+
+			err := k8sClient.Create(ctx, p)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Invalid targetRef.kind. The only supported values are 'Gateway'"))
+		}, testTimeOut)
+	})
 })

--- a/tests/common/tlspolicy/tlspolicy_controller_test.go
+++ b/tests/common/tlspolicy/tlspolicy_controller_test.go
@@ -513,4 +513,26 @@ var _ = Describe("TLSPolicy controller", func() {
 		})
 
 	})
+
+	Context("cel validation", func() {
+		It("should error targeting invalid group", func() {
+			p := v1alpha1.NewTLSPolicy("test-tls-policy", testNamespace).
+				WithTargetGateway("gateway")
+			p.Spec.TargetRef.Group = "not-gateway.networking.k8s.io"
+
+			err := k8sClient.Create(ctx, p)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'"))
+		})
+
+		It("should error targeting invalid kind", func() {
+			p := v1alpha1.NewTLSPolicy("test-tls-policy", testNamespace).
+				WithTargetGateway("gateway")
+			p.Spec.TargetRef.Kind = "TCPRoute"
+
+			err := k8sClient.Create(ctx, p)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Invalid targetRef.kind. The only supported values are 'Gateway'"))
+		})
+	})
 })


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/428

TLSPolicy & DNSPolicy already have CEL validation for targetRef `kind` and `group`. The same validation in `Validate()` function is redundant so it is now removed. Additionally added integration tests to test this CEL validation is working as expected.

# Validation
* Passing workflows is sufficient as it includes the integrations test to test the CEL validation and that there is no regression issue 