### PR TITLE
changed app developer dashboard to new dashboard id

### DIFF
--- a/.github/workflows/upload-dashboards.yaml
+++ b/.github/workflows/upload-dashboards.yaml
@@ -32,7 +32,7 @@ jobs:
           # Check and upload each dashboard if it has changed
           if [[ "$changed_files" == *"examples/dashboards/app_developer.json"* ]]; then
             echo "Uploading App Developer Dashboard"
-            curl -X POST -F "json=@./examples/dashboards/app_developer.json" -H 'Content-Type: multipart/form-data' -H "Authorization: Basic $auth" "https://www.grafana.com/api/dashboards/20970/revisions"
+            curl -X POST -F "json=@./examples/dashboards/app_developer.json" -H 'Content-Type: multipart/form-data' -H "Authorization: Basic $auth" "https://www.grafana.com/api/dashboards/21538/revisions"
           fi
 
           if [[ "$changed_files" == *"examples/dashboards/business_user.json"* ]]; then

--- a/doc/observability/examples.md
+++ b/doc/observability/examples.md
@@ -6,7 +6,7 @@ There are some example dashboards uploaded to [Grafana.com](https://grafana.com/
 
 | Name     | ID |
 | ----------- | ----------- |
-| [App Developer Dashboard](https://grafana.com/grafana/dashboards/20970)      | `20970`       |
+| [App Developer Dashboard](https://grafana.com/grafana/dashboards/20970)      | `21538`       |
 | [Business User Dashboard](https://grafana.com/grafana/dashboards/20981)   | `20981`        |
 | [Platform Engineer Dashboard](https://grafana.com/grafana/dashboards/20982) | `20982` |
 

--- a/doc/observability/examples.md
+++ b/doc/observability/examples.md
@@ -6,7 +6,7 @@ There are some example dashboards uploaded to [Grafana.com](https://grafana.com/
 
 | Name     | ID |
 | ----------- | ----------- |
-| [App Developer Dashboard](https://grafana.com/grafana/dashboards/20970)      | `21538`       |
+| [App Developer Dashboard](https://grafana.com/grafana/dashboards/21538)      | `21538`       |
 | [Business User Dashboard](https://grafana.com/grafana/dashboards/20981)   | `20981`        |
 | [Platform Engineer Dashboard](https://grafana.com/grafana/dashboards/20982) | `20982` |
 


### PR DESCRIPTION
### What:

Previous App Developer Dashboard Page on Grafana was faulty, not allowing users to use the Download JSON button due to a double upload of a revision. 

New App Developer Dashboard Page has since been uploaded to Grafana, therefore the new ID has been amended in docs and workflow that deal with App Developer Dashboard Page on Grafana.

A follow up to this PR would be to update the docs 0.7.0, 0.8.0 and latest . 