### PR TITLE
Object types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,9 +302,12 @@ clean-cov: ## Remove coverage reports
 ifdef TEST_NAME
 test-unit: TEST_PATTERN := --run $(TEST_NAME)
 endif
+ifdef VERBOSE
+test-unit: VERBOSE_FLAG = -v
+endif
 test-unit: clean-cov generate fmt vet ## Run Unit tests.
 	mkdir -p $(PROJECT_PATH)/coverage/unit
-	go test $(UNIT_DIRS) -coverprofile $(PROJECT_PATH)/coverage/unit/cover.out -tags unit -v -timeout 0 $(TEST_PATTERN)
+	go test $(UNIT_DIRS) -coverprofile $(PROJECT_PATH)/coverage/unit/cover.out -tags unit $(VERBOSE_FLAG) -timeout 0 $(TEST_PATTERN)
 
 ##@ Build
 

--- a/pkg/library/kuadrant/gateway_wrapper.go
+++ b/pkg/library/kuadrant/gateway_wrapper.go
@@ -36,7 +36,7 @@ func (g GatewayWrapper) PolicyRefs() []client.ObjectKey {
 		return make([]client.ObjectKey, 0)
 	}
 
-	refs := BackReferencesFromObject(g.Gateway, g.Referrer)
+	refs := BackReferencesFromObject(g.Gateway, g.BackReferenceAnnotationName())
 
 	err := json.Unmarshal([]byte(val), &refs)
 	if err != nil {
@@ -50,7 +50,7 @@ func (g GatewayWrapper) ContainsPolicy(policyKey client.ObjectKey) bool {
 	if g.Gateway == nil {
 		return false
 	}
-	refs := BackReferencesFromObject(g.Gateway, g.Referrer)
+	refs := BackReferencesFromObject(g.Gateway, g.BackReferenceAnnotationName())
 	return slices.Contains(refs, policyKey)
 }
 
@@ -82,7 +82,7 @@ func (g GatewayWrapper) AddPolicy(policyKey client.ObjectKey) bool {
 	}
 
 	// annotation exists and does not contain a back reference to the policy → add the policy to it
-	refs := append(BackReferencesFromObject(g.Gateway, g.Referrer), policyKey)
+	refs := append(BackReferencesFromObject(g.Gateway, g.BackReferenceAnnotationName()), policyKey)
 	serialized, err := json.Marshal(refs)
 	if err != nil {
 		return false

--- a/pkg/library/kuadrant/gateway_wrapper_test.go
+++ b/pkg/library/kuadrant/gateway_wrapper_test.go
@@ -162,7 +162,7 @@ func TestBackReferencesFromGatewayWrapper(t *testing.T) {
 		},
 		Referrer: &PolicyKindStub{},
 	}
-	refs := utils.Map(BackReferencesFromObject(gw.Gateway, gw.Referrer), func(ref client.ObjectKey) string { return ref.String() })
+	refs := utils.Map(BackReferencesFromObject(gw.Gateway, gw.BackReferenceAnnotationName()), func(ref client.ObjectKey) string { return ref.String() })
 	if !slices.Contains(refs, "app-ns/policy-1") {
 		t.Error("GatewayWrapper.PolicyRefs() should contain app-ns/policy-1")
 	}

--- a/pkg/library/kuadrant/referrer.go
+++ b/pkg/library/kuadrant/referrer.go
@@ -20,8 +20,8 @@ type Referrer interface {
 }
 
 // BackReferencesFromObject returns the names of the policies listed in the annotations of a target ref object.
-func BackReferencesFromObject(obj client.Object, referrer Referrer) []client.ObjectKey {
-	backRefs, found := utils.ReadAnnotationsFromObject(obj)[referrer.BackReferenceAnnotationName()]
+func BackReferencesFromObject(obj client.Object, backrefAnnotation string) []client.ObjectKey {
+	backRefs, found := utils.ReadAnnotationsFromObject(obj)[backrefAnnotation]
 	if !found {
 		return make([]client.ObjectKey, 0)
 	}
@@ -36,12 +36,11 @@ func BackReferencesFromObject(obj client.Object, referrer Referrer) []client.Obj
 	return refs
 }
 
-func DirectReferencesFromObject(obj client.Object, referrer Referrer) (client.ObjectKey, error) {
+func DirectReferencesFromObject(obj client.Object, directAnnotation string) (client.ObjectKey, error) {
 	annotations := utils.ReadAnnotationsFromObject(obj)
-	key := referrer.DirectReferenceAnnotationName()
-	directRefs, found := annotations[key]
+	directRefs, found := annotations[directAnnotation]
 	if !found {
-		return client.ObjectKey{}, fmt.Errorf("annotation %s not found", key)
+		return client.ObjectKey{}, fmt.Errorf("annotation %s not found", directAnnotation)
 	}
 
 	parts := strings.Split(directRefs, "/")

--- a/pkg/library/kuadrant/referrer_test.go
+++ b/pkg/library/kuadrant/referrer_test.go
@@ -25,7 +25,7 @@ func TestBackReferencesFromObject(t *testing.T) {
 
 	policyKind := &PolicyKindStub{}
 
-	refs := utils.Map(BackReferencesFromObject(obj, policyKind), func(ref client.ObjectKey) string { return ref.String() })
+	refs := utils.Map(BackReferencesFromObject(obj, policyKind.BackReferenceAnnotationName()), func(ref client.ObjectKey) string { return ref.String() })
 	if !slices.Contains(refs, "app-ns/policy-1") {
 		t.Error("GatewayWrapper.PolicyRefs() should contain app-ns/policy-1")
 	}

--- a/pkg/library/mappers/event_mapper.go
+++ b/pkg/library/mappers/event_mapper.go
@@ -1,19 +1,10 @@
 package mappers
 
 import (
-	"context"
-
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 )
-
-type EventMapper interface {
-	MapToPolicy(context.Context, client.Object, kuadrantgatewayapi.Policy) []reconcile.Request
-}
 
 // options
 

--- a/pkg/library/mappers/utils_test.go
+++ b/pkg/library/mappers/utils_test.go
@@ -1,0 +1,39 @@
+//go:build unit
+
+package mappers
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+)
+
+func gatewayFactory(ns, name string) *gatewayapiv1.Gateway {
+	return &gatewayapiv1.Gateway{
+		TypeMeta:   metav1.TypeMeta{Kind: "Gateway", APIVersion: gatewayapiv1.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       gatewayapiv1.GatewaySpec{},
+	}
+}
+
+func routeFactory(ns, name string, parentRef gatewayapiv1.ParentReference) *gatewayapiv1.HTTPRoute {
+	return &gatewayapiv1.HTTPRoute{
+		TypeMeta:   metav1.TypeMeta{Kind: "HTTPRoute", APIVersion: gatewayapiv1.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+				ParentRefs: []gatewayapiv1.ParentReference{parentRef},
+			},
+		},
+	}
+}
+
+func policyFactory(ns, name string, targetRef gatewayapiv1alpha2.LocalPolicyTargetReference) *kuadrantv1beta2.RateLimitPolicy {
+	return &kuadrantv1beta2.RateLimitPolicy{
+		TypeMeta:   metav1.TypeMeta{Kind: "RateLimitPolicy", APIVersion: kuadrantv1beta2.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec:       kuadrantv1beta2.RateLimitPolicySpec{TargetRef: targetRef},
+	}
+}


### PR DESCRIPTION
### What

* Policy types

```go
type PolicyType interface {
	GetGVK() schema.GroupVersionKind
	GetInstance() client.Object
	GetList(context.Context, client.Client, ...client.ListOption) ([]Policy, error)
	BackReferenceAnnotationName() string
	DirectReferenceAnnotationName() string
}
```

* `Type` interface for all Gateway API types

```go
type Type interface {
	GetGVK() schema.GroupVersionKind
	GetInstance() client.Object
}
```

* Simplified the `Policy` interface: it should not have anything related to kuadrant.

Useful types to write common controller mappers and controllers that can be used by any policy type. 


Work being done as part of https://github.com/Kuadrant/kuadrant-operator/issues/530

This is part of a series of PR's that will end up with a new controller that will only reconcile limitador limits configuration. 