### PR TITLE
Bump go version to 1.22 🚀

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -116,10 +116,10 @@ jobs:
     name: Build Bundle
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v3
@@ -165,10 +165,10 @@ jobs:
     needs: [build, build-bundle]
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -40,10 +40,10 @@ jobs:
             importpath: golang.org/x/tools/cmd/goimports@latest
 
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
 
       - name: Check out code
@@ -90,10 +90,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
 
       - name: Check out code

--- a/.github/workflows/test-alerts.yaml
+++ b/.github/workflows/test-alerts.yaml
@@ -19,10 +19,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Unit Tests
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     defaults:
@@ -67,10 +67,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -112,10 +112,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -157,10 +157,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -202,10 +202,10 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -241,10 +241,10 @@ jobs:
     name: Verify manifests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -256,10 +256,10 @@ jobs:
     name: Verify bundle
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -271,10 +271,10 @@ jobs:
     name: Verify fmt
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -286,7 +286,7 @@ jobs:
     name: Test Scripts
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     defaults:
@@ -308,10 +308,10 @@ jobs:
     name: Verify generate
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4
@@ -323,10 +323,10 @@ jobs:
     name: Verify go.mod
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.21.x
+      - name: Set up Go 1.22.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
         id: go
       - name: Check out code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/doc/development.md
+++ b/doc/development.md
@@ -5,7 +5,7 @@
 * [operator-sdk] version v1.32.0
 * [kind] version v0.23.0
 * [git][git_tool]
-* [go] version 1.21+
+* [go] version 1.22+
 * [kubernetes] version v1.19+
 * [kubectl] version v1.19+
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/kuadrant-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/cert-manager/cert-manager v1.12.1


### PR DESCRIPTION
### What

Bump Go to [1.22](https://go.dev/blog/go1.22)

PS: This upgrade was motivated by the latest EnvoyGateway release [v1.1.0](https://github.com/envoyproxy/gateway/releases/tag/v1.1.0) which requires Golang 1.22