### PR TITLE
Add OpenSSF Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Testing](https://github.com/Kuadrant/kuadrant-operator/actions/workflows/test.yaml/badge.svg)](https://github.com/Kuadrant/kuadrant-operator/actions/workflows/test.yaml)
 [![codecov](https://codecov.io/gh/Kuadrant/kuadrant-operator/branch/main/graph/badge.svg?token=4Z16KPS3HT)](https://codecov.io/gh/Kuadrant/kuadrant-operator)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9242/badge)](https://www.bestpractices.dev/projects/9242)
 
 The Operator to install and manage the lifecycle of the [Kuadrant](https://github.com/Kuadrant/) components deployments.
 


### PR DESCRIPTION
First pass of adding the Kuadrant project to https://www.bestpractices.dev/en/projects/9242 to show progress.

Part of onboarding to CNCF. https://github.com/cncf/toc/issues/1372