### PR TITLE
Transition to Cross-Compilation for faster Docker Build Times

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -85,31 +85,27 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to container registry
+        uses: docker/login-action@v2
         with:
-          image: ${{ env.OPERATOR_NAME }}
-          tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64
-          dockerfiles: |
-            ./Dockerfile
-      - name: Push Image
-        if: ${{ !env.ACT }}
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Build and Push Image
+        id: build-image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}:${{ env.IMG_TAGS }}
       - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: echo "Image pushed to ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}:${{ env.IMG_TAGS }}"
 
   build-bundle:
     needs: build
@@ -123,10 +119,6 @@ jobs:
         id: go
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
       - name: Run make bundle
         id: make-bundle
         run: |
@@ -138,27 +130,27 @@ jobs:
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
             REPLACES_VERSION=${{ inputs.replacesVersion }} \
             CHANNELS=${{ inputs.channels }}
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to container registry
+        uses: docker/login-action@v2
         with:
-          image: ${{ env.OPERATOR_NAME }}-bundle
-          tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64
-          dockerfiles: |
-            ./bundle.Dockerfile
-      - name: Push Image
-        if: ${{ !env.ACT }}
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-      - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Build and Push Bundle Image
+        id: build-bundle-image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./bundle.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle:${{ env.IMG_TAGS }}
+      - name: Print Bundle Image URL
+        run: echo "Bundle image pushed to ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle:${{ env.IMG_TAGS }}"
 
   build-catalog:
     name: Build Catalog
@@ -182,29 +174,24 @@ jobs:
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
             REPLACES_VERSION=${{ inputs.replacesVersion }} \
             CHANNELS=${{ inputs.channels }}
-      - name: Install qemu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user-static
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to container registry
+        uses: docker/login-action@v2
         with:
-          image: ${{ env.OPERATOR_NAME }}-catalog
-          tags: ${{ env.IMG_TAGS }}
-          platforms: linux/amd64,linux/arm64
-          context: ./catalog
-          dockerfiles: |
-            ./catalog/kuadrant-operator-catalog.Dockerfile
-      - name: Push Image
-        if: ${{ !env.ACT }}
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-      - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Build and Push Catalog Image
+        id: build-catalog-image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./catalog
+          file: ./catalog/kuadrant-operator-catalog.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: false
+          tags: |
+            ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog:${{ env.IMG_TAGS }}
+      - name: Print Catalog Image URL
+        run: echo "Catalog image pushed to ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog:${{ env.IMG_TAGS }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -15,8 +15,11 @@ COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
 
+# Set environment variables for cross-compilation
+ARG TARGETARCH
+
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
closes #787 

## This pull request introduces significant improvements to the Docker build process by implementing cross-compilation.

Building arm64 image via QEMU takes over 15 mins on github actions, making it slow to build for development.

![image](https://github.com/user-attachments/assets/e01c83d1-278c-4e51-aeba-ecb3a366e008)

Building the image via cross compile dropped this build time to 2 min 30

![image](https://github.com/user-attachments/assets/6eedff38-217e-49af-af28-bd51e9ceea21)

## Changes Made 

1. **Dockerfile Updates**:
    - Introduced cross-compilation support by using `ARG TARGETARCH`.
    - Utilized `--platform=$BUILDPLATFORM` for multi-platform builds with Docker Buildx.
    
2. **Workflow File**:
    - Updated the workflow to leverage Docker Buildx for building and pushing images to multiple platforms (linux/amd64, linux/arm64).
    - Removed reliance on QEMU emulation, significantly speeding up the build process.

## Benefits

- **Faster Build Times**: The new build process reduces the time from approximately 16 minutes to just 2 minutes and 30 seconds, representing an almost 8x improvement.
- **Optimised Build Efficiency**: Reduces overhead and simplifies the build process by eliminating the need for emulation.
