### PR TITLE
dns: Pin DNS Operator version to v0.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ endif
 LIMITADOR_OPERATOR_BUNDLE_IMG ?= quay.io/kuadrant/limitador-operator-bundle:$(LIMITADOR_OPERATOR_BUNDLE_IMG_TAG)
 
 ## dns
-DNS_OPERATOR_VERSION ?= main
+DNS_OPERATOR_VERSION ?= 0.4.1
 
 kuadrantdns_bundle_is_semantic := $(call is_semantic_version,$(DNS_OPERATOR_VERSION))
 ifeq (latest,$(DNS_OPERATOR_VERSION))

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-07-30T12:48:29Z"
+    createdAt: "2024-08-14T15:45:59Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -10,4 +10,4 @@ dependencies:
   - type: olm.package
     value:
       packageName: dns-operator
-      version: "0.0.0"
+      version: "0.4.1"

--- a/config/dependencies/dns/kustomization.yaml
+++ b/config/dependencies/dns/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- github.com/kuadrant/dns-operator/config/default?ref=main
+- github.com/kuadrant/dns-operator/config/default?ref=v0.4.1
 
 patches:
   - path: deployment_patch.yaml


### PR DESCRIPTION
In order to avoid breaking test/dev environments we will pin this again for a short period of time.

1. Merge this PR
2. Merge DNS Operator PR https://github.com/Kuadrant/dns-operator/pull/203
3. Merge updated kuadrant operator PR https://github.com/Kuadrant/kuadrant-operator/pull/793 

Note: I have no idea what will happen with the OLM bundle/catalogs that are built using the github workflows. This change will only prevent dev/test environments that are using the manifests from breaking when we merge the dns operator PR.