### PR TITLE
Workflow: PR Conditional Build and Push Image to Quay.io Repo

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -208,3 +208,4 @@ jobs:
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
       - name: Print Image URL
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        

--- a/.github/workflows/build-images-pr.yaml
+++ b/.github/workflows/build-images-pr.yaml
@@ -1,0 +1,29 @@
+name: PR Conditional Build and Push Image to Quay.io Repo
+
+on:
+  pull_request_target:
+    types: [labeled, opened, synchronize, reopened]
+
+concurrency:
+  group: pr-conditional-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  workflow-build:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'forked_image_approved') }}
+    name: Calls build-images-base workflow
+    uses: ./.github/workflows/build-images-base.yaml
+    secrets: inherit
+    with:
+      kuadrantOperatorVersion: ${{ github.event.pull_request.user.login }}-${{ github.event.pull_request.number }}
+      kuadrantOperatorTag: ${{ github.event.pull_request.user.login }}-${{ github.event.pull_request.number }}
+
+  remove-label:
+    runs-on: ubuntu-latest
+    needs: workflow-build
+    steps:
+      - name: Remove forked_image_approved label after workflow is triggered
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: forked_image_approved
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
 Closes: [#241]([https://github.com/Kuadrant/kuadrant-operator/issues/241])

## To solve the issue of pull requests (PRs) coming from forks not being able to trigger the build and push of images, a new workflow has been implemented.

## Summary:

This workflow leverages the pull_request_target event and performs the build and push only if the forked_image_approved label is applied to the PR. This ensures that only approved changes can trigger the image build and push process, maintaining security for secrets.


```
name: PR Conditional Build and Push Image to Quay.io Repo

on:
  pull_request_target:
    types: [labeled, opened, synchronize, reopened]

jobs:
  workflow-build:
    if: ${{ github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'forked_image_approved') }}
    name: Calls build-images-base workflow
    uses: ./.github/workflows/build-images-base.yaml
    secrets: inherit
    with:
      kuadrantOperatorVersion: ${{ github.event.pull_request.user.login }}-${{ github.event.pull_request.number }}
      kuadrantOperatorTag: ${{ github.event.pull_request.user.login }}-${{ github.event.pull_request.number }} 
```

## Verification Steps

1. Create a Pull Request from a Fork:
+ Fork the repository and make changes that affect the Docker image build.
+ Create a pull request (PR) from the forked repository to the base repository.

2. Apply the forked_image_approved Label:
+ As a maintainer, review the incoming PR.
+ If the changes are approved, apply the forked_image_approved label to the PR.

3. Check Workflow Execution:
+ Verify that the PR Conditional Build and Push Image to Quay.io Repo workflow is triggered upon applying the label.
+ Ensure the workflow runs successfully, building and pushing the Docker images.

4. Verify Image Push:
+ After the workflow completes, check the Quay.io repository.
+ Confirm that the image is built and pushed with the tags corresponding to the PR (e.g., username-PRnumber).

# Should look like this:
(https://github.com/user-attachments/assets/563717f2-9442-47fb-afbe-e0a83333e8cd)

