### PR TITLE
fix: helm chart image refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ endif
 LIMITADOR_OPERATOR_BUNDLE_IMG ?= quay.io/kuadrant/limitador-operator-bundle:$(LIMITADOR_OPERATOR_BUNDLE_IMG_TAG)
 
 ## dns
-DNS_OPERATOR_VERSION ?= main
+DNS_OPERATOR_VERSION ?= latest
 
 kuadrantdns_bundle_is_semantic := $(call is_semantic_version,$(DNS_OPERATOR_VERSION))
 ifeq (latest,$(DNS_OPERATOR_VERSION))

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -13380,7 +13380,8 @@ spec:
                 - weighted
                 type: object
               providerRefs:
-                description: providerRefS is a list of references to provider secrets.
+                description: providerRefs is a list of references to provider secrets.
+                  Max is one but intention is to allow this to be more in the future
                 items:
                   properties:
                     name:
@@ -16193,7 +16194,7 @@ spec:
         env:
         - name: RELATED_IMAGE_WASMSHIM
           value: oci://quay.io/kuadrant/wasm-shim:latest
-        image: quay.io/kuadrant/kuadrant-operator:remove_managed_zone_api
+        image: quay.io/kuadrant/kuadrant-operator:latest
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
* Set correct image ref in helm chart for main branch
* Set DNS_OPERATOR_VERSION to latest, consistent with Authorino and Limitador

should have been reverted before merging https://github.com/Kuadrant/kuadrant-operator/pull/793