### PR TITLE
ratelimitpolicy_controller_test.go: explicit namespce in parentref

### DIFF
--- a/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
+++ b/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
@@ -1295,8 +1295,14 @@ var _ = Describe("RateLimitPolicy controller", func() {
 
 			gatewayParentsFunc := func(r *gatewayapiv1.HTTPRoute) {
 				r.Spec.ParentRefs = []gatewayapiv1.ParentReference{
-					{Name: gatewayapiv1.ObjectName(gatewayAName)},
-					{Name: gatewayapiv1.ObjectName(gatewayBName)},
+					{
+						Name:      gatewayapiv1.ObjectName(gatewayAName),
+						Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
+					},
+					{
+						Name:      gatewayapiv1.ObjectName(gatewayBName),
+						Namespace: ptr.To(gatewayapiv1.Namespace(testNamespace)),
+					},
 				}
 			}
 


### PR DESCRIPTION
Without explicit namespace in parentref, for some unknown reason we are still investigating, envoygateway sets the namespace to `default` in the `status` section

```yaml
    status:
      parents:
        - conditions:
            - lastTransitionTime: "2024-08-28T13:33:34Z"
              message: Route is accepted
              observedGeneration: 1
              reason: Accepted
              status: "True"
              type: Accepted
            - lastTransitionTime: "2024-08-28T13:33:34Z"
              message: Resolved all the Object references for the Route
              observedGeneration: 1
              reason: ResolvedRefs
              status: "True"
              type: ResolvedRefs
          controllerName: gateway.envoyproxy.io/gatewayclass-controller
          parentRef:
            group: gateway.networking.k8s.io
            kind: Gateway
            name: gateway-a
        - conditions:
            - lastTransitionTime: "2024-08-28T13:33:34Z"
              message: Route is accepted
              observedGeneration: 1
              reason: Accepted
              status: "True"
              type: Accepted
            - lastTransitionTime: "2024-08-28T13:33:34Z"
              message: Resolved all the Object references for the Route
              observedGeneration: 1
              reason: ResolvedRefs
              status: "True"
              type: ResolvedRefs
          controllerName: gateway.envoyproxy.io/gatewayclass-controller
          parentRef:
            group: gateway.networking.k8s.io
            kind: Gateway
            name: gateway-b
            namespace: default
```

Note that it does not happen for all the gateways. 

That forces us to set the namespace explicitly even though, it is not required as the default namespace of the parentref is the namespace of the resource. 