### PR TITLE
envoygateway kuadrant status controller check added

### DIFF
--- a/controllers/kuadrant_status.go
+++ b/controllers/kuadrant_status.go
@@ -20,6 +20,7 @@ import (
 
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	"github.com/kuadrant/kuadrant-operator/pkg/common"
+	kuadrantenvoygateway "github.com/kuadrant/kuadrant-operator/pkg/envoygateway"
 	kuadrantistioutils "github.com/kuadrant/kuadrant-operator/pkg/istio"
 )
 
@@ -203,6 +204,7 @@ func (r *KuadrantReconciler) checkGatewayProviders() (*string, error) {
 
 	anyProvider, err := anyProviderFunc([]func(restMapper meta.RESTMapper) (bool, error){
 		kuadrantistioutils.IsIstioInstalled,
+		kuadrantenvoygateway.IsEnvoyGatewayInstalled,
 	})
 
 	if err != nil {

--- a/pkg/envoygateway/utils.go
+++ b/pkg/envoygateway/utils.go
@@ -6,9 +6,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func IsEnvoyGatewaySecurityPolicyInstalled(restMapper meta.RESTMapper) (bool, error) {
+func IsEnvoyExtensionPolicyInstalled(restMapper meta.RESTMapper) (bool, error) {
 	_, err := restMapper.RESTMapping(
-		schema.GroupKind{Group: egv1alpha1.GroupName, Kind: "SecurityPolicy"},
+		schema.GroupKind{Group: egv1alpha1.GroupName, Kind: egv1alpha1.KindEnvoyExtensionPolicy},
 		egv1alpha1.GroupVersion.Version)
 
 	if err == nil {
@@ -20,4 +20,41 @@ func IsEnvoyGatewaySecurityPolicyInstalled(restMapper meta.RESTMapper) (bool, er
 	}
 
 	return false, err
+}
+
+func IsEnvoyGatewaySecurityPolicyInstalled(restMapper meta.RESTMapper) (bool, error) {
+	_, err := restMapper.RESTMapping(
+		schema.GroupKind{Group: egv1alpha1.GroupName, Kind: egv1alpha1.KindSecurityPolicy},
+		egv1alpha1.GroupVersion.Version)
+
+	if err == nil {
+		return true, nil
+	}
+
+	if meta.IsNoMatchError(err) {
+		return false, nil
+	}
+
+	return false, err
+}
+
+func IsEnvoyGatewayInstalled(restMapper meta.RESTMapper) (bool, error) {
+	ok, err := IsEnvoyGatewaySecurityPolicyInstalled(restMapper)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+
+	ok, err = IsEnvoyExtensionPolicyInstalled(restMapper)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+
+	// EnvoyGateway found
+	return true, nil
 }


### PR DESCRIPTION
### What

Kuadrant status was reporting error as Istio gateway provider was not found. Added EnvoyGateway provider check. 

### Verification steps

### ①  Setup

```sh
make local-setup GATEWAYAPI_PROVIDER=envoygateway
```

Request an instance of Kuadrant in the `kuadrant-system` namespace:

```sh
kubectl -n kuadrant-system apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```

### ② Check kuadrant CR status

```sh
kubectl wait --for=condition=ready kuadrant/kuadrant -n kuadrant-system
```
It should return
```sh
kuadrant.kuadrant.io/kuadrant condition met
```

## Cleanup

```sh
make local-cleanup
```