### PR TITLE
Delete dns records when listener hostname changes

### DIFF
--- a/controllers/dns_helper.go
+++ b/controllers/dns_helper.go
@@ -254,13 +254,15 @@ func (dh *dnsHelper) removeDNSForDeletedListeners(ctx context.Context, upstreamG
 
 	for i, dnsRecord := range dnsList.Items {
 		listenerExists := false
+		rootHostMatches := false
 		for _, listener := range upstreamGateway.Spec.Listeners {
 			if listener.Name == gatewayapiv1.SectionName(dnsRecord.Labels[LabelListenerReference]) {
 				listenerExists = true
+				rootHostMatches = string(*listener.Hostname) == dnsRecord.Spec.RootHost
 				break
 			}
 		}
-		if !listenerExists {
+		if !listenerExists || !rootHostMatches {
 			if err := dh.Delete(ctx, &dnsList.Items[i], &client.DeleteOptions{}); client.IgnoreNotFound(err) != nil {
 				return err
 			}


### PR DESCRIPTION
fixes: #794 

The DNSRecord resource does not handle changes made to the `rootHost` which can cause things to be left around in the provider if it's modified after initial record creation. This change modifies the logic detecting if existing records should be removed to take into account possible hostname changes, removing any that no longer match (qw.listener.hostname != record.spec.rootHost).

related: https://github.com/Kuadrant/dns-operator/pull/219