### PR TITLE
feat: set quay image expiry to prevent overflow of images

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -35,6 +35,10 @@ on:
         description: Bundle and catalog channels, comma separated
         default: preview
         type: string
+      quayImageExpiry:
+        description: When to expire the built quay images. The time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively, from the time the image is built.
+        default: never
+        type: string
   workflow_dispatch:
     inputs:
       kuadrantOperatorTag:
@@ -69,6 +73,10 @@ on:
         description: Bundle and catalog channels, comma separated
         default: preview
         type: string
+      quayImageExpiry:
+        description: When to expire the built quay images. The time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively, from the time the image is built.
+        default: never
+        type: string
 
 env:
   IMG_TAGS: ${{ inputs.kuadrantOperatorTag }}
@@ -77,6 +85,7 @@ env:
   IMG_REGISTRY_ORG: kuadrant
   MAIN_BRANCH_NAME: main
   OPERATOR_NAME: kuadrant-operator
+  QUAY_IMAGE_EXPIRY: ${{ inputs.quayImageExpiry }}
 
 jobs:
   build:
@@ -107,6 +116,7 @@ jobs:
           provenance: false
           tags: |
             ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}:${{ env.IMG_TAGS }}
+          build-args: QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
       - name: Print Image URL
         run: echo "Image pushed to ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}:${{ env.IMG_TAGS }}"
 
@@ -155,6 +165,7 @@ jobs:
           provenance: false
           tags: |
             ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle:${{ env.IMG_TAGS }}
+          build-args: QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
       - name: Print Bundle Image URL
         run: echo "Bundle image pushed to ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle:${{ env.IMG_TAGS }}"
 
@@ -202,5 +213,6 @@ jobs:
           provenance: false
           tags: |
             ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog:${{ env.IMG_TAGS }}
+          # The Quay image expiry label for the generated catalog Dockerfile is set via opm, using the value set in the QUAY_IMAGE_EXPIRY environment variable
       - name: Print Catalog Image URL
         run: echo "Catalog image pushed to ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog:${{ env.IMG_TAGS }}"

--- a/.github/workflows/build-images-branches.yaml
+++ b/.github/workflows/build-images-branches.yaml
@@ -13,3 +13,5 @@ jobs:
     with:
       kuadrantOperatorVersion: ${{ github.ref_name }}
       kuadrantOperatorTag: ${{ github.ref_name }}
+      # Conditionally set quayImageExpiry to expire quay images only for non-release branches
+      quayImageExpiry: ${{ startsWith(github.ref_name, 'release') && 'never' || '1w' }}

--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -25,3 +25,4 @@ jobs:
       limitadorOperatorVersion: ${{ vars.LIMITADOR_OPERATOR_SHA }}
       dnsOperatorVersion: ${{ vars.DNS_OPERATOR_SHA }}
       wasmShimVersion: ${{ vars.WASM_SHIM_SHA }}
+      quayImageExpiry: 2w

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -27,5 +27,10 @@ FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
+
+# Quay image expiry
+ARG QUAY_IMAGE_EXPIRY
+ENV QUAY_IMAGE_EXPIRY=${QUAY_IMAGE_EXPIRY:-never}
+LABEL quay.expires-after=$QUAY_IMAGE_EXPIRY
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -390,7 +390,7 @@ bundle: $(OPM) $(YQ) manifests dependencies-manifests kustomize operator-sdk ## 
 	$(call update-operator-dependencies,dns-operator,$(DNS_OPERATOR_BUNDLE_IMG))
 	$(OPERATOR_SDK) bundle validate ./bundle
 	$(MAKE) bundle-ignore-createdAt
-	echo "$$QUAY_DOCKERFILE_LABEL" >> bundle.Dockerfile
+	echo "$$QUAY_EXPIRY_TIME_LABEL" >> bundle.Dockerfile
 
 .PHONY: bundle-ignore-createdAt
 bundle-ignore-createdAt:

--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ run: generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: ## Build docker image with the manager.
-	$(CONTAINER_ENGINE) build -t $(IMG) .
+	$(CONTAINER_ENGINE) build --build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) -t $(IMG) .
 
 docker-push: ## Push docker image with the manager.
 	$(CONTAINER_ENGINE) push $(IMG)
@@ -390,6 +390,7 @@ bundle: $(OPM) $(YQ) manifests dependencies-manifests kustomize operator-sdk ## 
 	$(call update-operator-dependencies,dns-operator,$(DNS_OPERATOR_BUNDLE_IMG))
 	$(OPERATOR_SDK) bundle validate ./bundle
 	$(MAKE) bundle-ignore-createdAt
+	echo "$$QUAY_DOCKERFILE_LABEL" >> bundle.Dockerfile
 
 .PHONY: bundle-ignore-createdAt
 bundle-ignore-createdAt:
@@ -404,7 +405,7 @@ bundle-ignore-createdAt:
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	$(CONTAINER_ENGINE) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(CONTAINER_ENGINE) build --build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -19,3 +19,8 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
+
+# Quay image expiry
+ARG QUAY_IMAGE_EXPIRY
+ENV QUAY_IMAGE_EXPIRY=${QUAY_IMAGE_EXPIRY:-never}
+LABEL quay.expires-after=${QUAY_IMAGE_EXPIRY}

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -7,9 +7,22 @@ CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
 CATALOG_FILE = $(PROJECT_PATH)/catalog/kuadrant-operator-catalog/operator.yaml
 CATALOG_DOCKERFILE = $(PROJECT_PATH)/catalog/kuadrant-operator-catalog.Dockerfile
 
+# Quay image default expiry
+QUAY_IMAGE_EXPIRY ?= never
+
+# A LABEL that can be appended to a generated Dockerfile to set the Quay image expiration through Docker arguments.
+define QUAY_DOCKERFILE_LABEL
+
+# Quay image expiry
+ARG QUAY_IMAGE_EXPIRY
+ENV QUAY_IMAGE_EXPIRY=$${QUAY_IMAGE_EXPIRY:-never}
+LABEL quay.expires-after=$${QUAY_IMAGE_EXPIRY}
+endef
+export QUAY_DOCKERFILE_LABEL
+
 $(CATALOG_DOCKERFILE): $(OPM)
 	-mkdir -p $(PROJECT_PATH)/catalog/kuadrant-operator-catalog
-	cd $(PROJECT_PATH)/catalog && $(OPM) generate dockerfile kuadrant-operator-catalog
+	cd $(PROJECT_PATH)/catalog && $(OPM) generate dockerfile kuadrant-operator-catalog -l quay.expires-after=$(QUAY_IMAGE_EXPIRY)
 catalog-dockerfile: $(CATALOG_DOCKERFILE) ## Generate catalog dockerfile.
 
 CHANNELS ?= preview

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -11,14 +11,14 @@ CATALOG_DOCKERFILE = $(PROJECT_PATH)/catalog/kuadrant-operator-catalog.Dockerfil
 QUAY_IMAGE_EXPIRY ?= never
 
 # A LABEL that can be appended to a generated Dockerfile to set the Quay image expiration through Docker arguments.
-define QUAY_DOCKERFILE_LABEL
+define QUAY_EXPIRY_TIME_LABEL
 
 # Quay image expiry
 ARG QUAY_IMAGE_EXPIRY
 ENV QUAY_IMAGE_EXPIRY=$${QUAY_IMAGE_EXPIRY:-never}
 LABEL quay.expires-after=$${QUAY_IMAGE_EXPIRY}
 endef
-export QUAY_DOCKERFILE_LABEL
+export QUAY_EXPIRY_TIME_LABEL
 
 $(CATALOG_DOCKERFILE): $(OPM)
 	-mkdir -p $(PROJECT_PATH)/catalog/kuadrant-operator-catalog


### PR DESCRIPTION
# Description
Part of: https://github.com/Kuadrant/kuadrant-operator/issues/769
Associated with: https://github.com/Kuadrant/kuadrant-operator/pull/843

Currently, all built Quay images never expire and are consuming unnecessary quota on Quay.io. Quay provides a way to [set tag expiration from a Dockerfile](https://docs.redhat.com/en/documentation/red_hat_quay/3.4/html/use_red_hat_quay/working_with_tags#setting_tag_expiration_from_a_dockerfile) to prevent this issue for images that don't need to be kept indefinitely, such as development branches and nightly builds. This can help prevent the problem from escalating over time.

# Verification
* You can check that the `expire_images` tag has an expiry at the following quay repos which was build by the CI for this branch:
  * https://quay.io/repository/kuadrant/kuadrant-operator?tab=tags
  * https://quay.io/repository/kuadrant/kuadrant-operator-bundle?tab=tags
  * https://quay.io/repository/kuadrant/kuadrant-operator-catalog?tab=tags
* If you want to verify manually locally that the image label is set:
  *  Remove local image
     ```
     docker rmi quay.io/kuadrant/kuadrant-operator:latest
     docker rmi quay.io/kuadrant/kuadrant-operator-bundle:latest
     docker rmi quay.io/kuadrant/kuadrant-operator-catalog:latest
     ```
  * Build image
    ```
    make docker-build bundle-build catalog-dockerfile catalog-build
    ```
  * Inspect image labels 
    ```
    docker inspect quay.io/kuadrant/kuadrant-operator:latest --format='{{json .Config.Labels}}'
    docker inspect quay.io/kuadrant/kuadrant-operator-bundle:latest --format='{{json .Config.Labels}}'
    docker inspect quay.io/kuadrant/kuadrant-operator-catalog:latest --format='{{json .Config.Labels}}'
    ```
  * The `quay.expires-after` label should be set to `never`
     
    <img width="1625" alt="image" src="https://github.com/user-attachments/assets/a0848f31-73a8-4d8b-ac07-6819d109e804">

  * Remove local image again
     ```
     docker rmi quay.io/kuadrant/kuadrant-operator:latest
     docker rmi quay.io/kuadrant/kuadrant-operator-bundle:latest
     docker rmi quay.io/kuadrant/kuadrant-operator-catalog:latest
     ```
  * Build image with a set expiry
    ```
     # Delete the generated catalog Dockerfile as it won't regenerate again with the correct label if it's already present
     rm catalog/kuadrant-operator-catalog.Dockerfile 
     QUAY_IMAGE_EXPIRY=3d make docker-build bundle-build catalog-dockerfile catalog-build
    ```
  * Inspect image labels 
    ```
    docker inspect quay.io/kuadrant/kuadrant-operator:latest --format='{{json .Config.Labels}}'
    docker inspect quay.io/kuadrant/kuadrant-operator-bundle:latest --format='{{json .Config.Labels}}'
    docker inspect quay.io/kuadrant/kuadrant-operator-catalog:latest --format='{{json .Config.Labels}}'
    ```
  * The `quay.expires-after` label should be set to `3d`
    
    <img width="1634" alt="image" src="https://github.com/user-attachments/assets/6635f57d-ec88-498d-b61d-0a453218a448">
