### PR TITLE
tests: Fix flaky dnspolicy test

### DIFF
--- a/tests/common/dnspolicy/dnspolicy_controller_test.go
+++ b/tests/common/dnspolicy/dnspolicy_controller_test.go
@@ -763,7 +763,7 @@ var _ = Describe("DNSPolicy controller", func() {
 				)
 				currentRec = newRec
 				currentWildcardRec = newWildcardRec
-			}, tests.TimeoutMedium, time.Second).Should(BeNil())
+			}, tests.TimeoutLong, time.Second).Should(BeNil())
 		}, testTimeOut)
 
 		It("should remove gateway back reference on policy deletion", func(ctx SpecContext) {


### PR DESCRIPTION
Flaky test:
```
 Summarizing 1 Failure:
  [FAIL] DNSPolicy controller valid target and valid gateway status [It] should re-create dns record when listener hostname changes
  /home/runner/work/kuadrant-operator/kuadrant-operator/tests/common/dnspolicy/dnspolicy_controller_test.go:766
```
Failed on the scheduled nightly job: https://github.com/Kuadrant/kuadrant-operator/actions/runs/10822642839/job/30026825858

Caused by not waiting long enough for the records to become ready again, increased the timeout on the check.