### PR TITLE
fix: observability setup guide

### DIFF
--- a/config/observability/README.md
+++ b/config/observability/README.md
@@ -5,6 +5,7 @@
 ```bash
 ./bin/kustomize build ./config/observability/| docker run --rm -i ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
 ./bin/kustomize build ./config/observability/| docker run --rm -i ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -
+./bin/kustomize build ./examples/dashboards | kubectl apply -f -
 ```
 
 This will deploy prometheus, alertmanager and grafana into the `monitoring` namespace,


### PR DESCRIPTION
Add examples/dashboards to the list of required kustomizations that must be included to have grafana function.

Currently, if you do not apply the example dashboards kustomization the grafana deployment will never start as there are configmaps missing that are being mounted by the deployment causing the pod to never initialize with various errors like `MountVolume.SetUp failed for volume "grafana-business-user" : configmap "grafana-business-user" not found`.

```
Events:                                                                                                                                                                                                                                                                                                                       
  Type     Reason       Age                   From               Message                                                                                       
  ----     ------       ----                  ----               -------                                                                                                                                                                                                                                                      
  Normal   Scheduled    16m                   default-scheduler  Successfully assigned monitoring/grafana-6bcdcb4b5d-t27lh to kuadrant-local-control-plane     
  Warning  FailedMount  16m (x5 over 16m)     kubelet            MountVolume.SetUp failed for volume "grafana-business-user" : configmap "grafana-business-user" not found                                                                                                                                                    
  Warning  FailedMount  16m (x5 over 16m)     kubelet            MountVolume.SetUp failed for volume "grafana-app-developer" : configmap "grafana-app-developer" not found                                                                                                                                                    
  Warning  FailedMount  16m (x5 over 16m)     kubelet            MountVolume.SetUp failed for volume "grafana-controller-resources" : configmap "grafana-controller-resources" not found                                                                                                                                      
  Warning  FailedMount  10m (x11 over 16m)    kubelet            MountVolume.SetUp failed for volume "grafana-platform-engineer" : configmap "grafana-platform-engineer" not found                                                                                                                                            
  Warning  FailedMount  6m13s (x13 over 16m)  kubelet            MountVolume.SetUp failed for volume "grafana-controller-runtime" : configmap "grafana-controller-runtime" not found                                                                                                                                          
  Normal   Pulling      7s                    kubelet            Pulling image "grafana/grafana:9.5.3"  
```

Note: I do not believe this to be the correct long term fix, if grafana requires those configmaps it should be part of the grafana kustomization to create them.