### PR TITLE
Build information log with version, hash and dirty attributes 

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -116,7 +116,10 @@ jobs:
           provenance: false
           tags: |
             ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}:${{ env.IMG_TAGS }}
-          build-args: QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
+          build-args: |
+            QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
+            GIT_SHA=${{ github.sha }}
+            DIRTY=false
       - name: Print Image URL
         run: echo "Image pushed to ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}:${{ env.IMG_TAGS }}"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,19 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
+COPY version/ version/
 
 # Set environment variables for cross-compilation
 ARG TARGETARCH
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager main.go
+
+ARG GIT_SHA
+ARG DIRTY
+
+ENV GIT_SHA=${GIT_SHA:-unknown}
+ENV DIRTY=${DIRTY:-unknown}
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -436,6 +436,7 @@ prepare-release: ## Prepare the manifests for OLM and Helm Chart for a release.
 		LIMITADOR_OPERATOR_VERSION=$(LIMITADOR_OPERATOR_VERSION) \
 		DNS_OPERATOR_VERSION=$(DNS_OPERATOR_VERSION) \
 		WASM_SHIM_VERSION=$(WASM_SHIM_VERSION)
+	sed -i -e 's/Version = ".*"/Version = "$(VERSION)"/' $(PROJECT_PATH)/version/version.go
 
 ##@ Code Style
 

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/kuadrant/kuadrant-operator/pkg/library/kuadrant"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/reconcilers"
 	"github.com/kuadrant/kuadrant-operator/pkg/log"
+	"github.com/kuadrant/kuadrant-operator/version"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -62,6 +63,8 @@ var (
 	scheme   = k8sruntime.NewScheme()
 	logLevel = env.GetString("LOG_LEVEL", "info")
 	logMode  = env.GetString("LOG_MODE", "production")
+	gitSHA   string // value injected in compilation-time
+	dirty    string // value injected in compilation-time
 )
 
 func init() {
@@ -100,6 +103,7 @@ func printControllerMetaInfo() {
 	setupLog.Info(fmt.Sprintf("go version: %s", runtime.Version()))
 	setupLog.Info(fmt.Sprintf("go os/arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	setupLog.Info("base logger", "log level", logLevel, "log mode", logMode)
+	setupLog.Info("build information", "version", version.Version, "commit", gitSHA, "dirty", dirty)
 }
 
 func main() {

--- a/utils/check-git-dirty.sh
+++ b/utils/check-git-dirty.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if ! command -v git &>/dev/null 
+then
+    echo "git not found..." >&2
+    exit 1
+fi
+
+if output=$(git diff --stat 2>/dev/null)
+then
+[ -n "$output" ] && echo "true" || echo "false"
+else
+    # Not a git repository
+    exit 1
+fi

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2021 Red Hat, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package version
+
+var (
+	// This variable is dependent on what the current release is e.g. if it is v0.10.0 then this variable, outside of releases, will be v0.10.1-dev .
+	Version = "0.10.0-dev"
+)


### PR DESCRIPTION
### What

Generates log line with traceable version for custom builds as well as release builds. Consistent with other kuadrant components.

```
{"level":"info","ts":"2024-09-17T09:39:59Z","logger":"kuadrant-operator","msg":"build information","version":"0.10.0-dev","commit":"774fd571d2ff2533041ae13b858790ce620944eb","dirty":"false"}
```

In yaml format

```yaml
level: info
ts: "2024-09-17T09:39:59Z"
logger: kuadrant-operator
msg: build information
version: 0.10.0-dev
commit: 774fd571d2ff2533041ae13b858790ce620944eb
dirty: "false"
```

| Attribute  | Description |
| ------------- | ------------- |
| version |  release number vX.Y.Z[-dev]   |
| commit  | git sha  |
| dirty  | *true* when not git committed files used in the build  |

For releases, the *VERSION* attributes provides high level overview of the release number. Useful to determine included features. The *COMMIT* attribute provides git reference. Useful for engineering reporting.

Additionally, the `prepare-release` make target also updates `version/version.go` value with the desired version. 

### Verification Steps

* `make local-setup`
* Read logs from the kuadrant operator
```
kubectl logs deployment/kuadrant-operator-controller-manager -n kuadrant-system | grep "build information"
```
You should see a log line like above