### PR TITLE
wasm configuration types refactor

### DIFF
--- a/config/dependencies/envoy-gateway/gateway/envoyproxy.yaml
+++ b/config/dependencies/envoy-gateway/gateway/envoyproxy.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: custom-loglevel
+spec:
+  logging:
+    level:
+      default: debug

--- a/config/dependencies/envoy-gateway/gateway/gateway-class.yaml
+++ b/config/dependencies/envoy-gateway/gateway/gateway-class.yaml
@@ -5,3 +5,8 @@ metadata:
   name: envoygateway
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: custom-loglevel
+    namespace: gateway-system

--- a/config/dependencies/envoy-gateway/gateway/kustomization.yaml
+++ b/config/dependencies/envoy-gateway/gateway/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - namespace.yaml
 - gateway-class.yaml
 - gateway.yaml
+- envoyproxy.yaml

--- a/controllers/envoygateway_wasm_controller.go
+++ b/controllers/envoygateway_wasm_controller.go
@@ -135,7 +135,7 @@ func (r *EnvoyGatewayWasmReconciler) desiredEnvoyExtensionPolicy(
 		return nil, err
 	}
 
-	if config == nil || len(config.RateLimitPolicies) == 0 {
+	if config == nil || len(config.Policies) == 0 {
 		logger.V(1).Info("config is empty. EnvoyExtensionPolicy will be deleted if it exists")
 		utils.TagObjectToDelete(envoyPolicy)
 		return envoyPolicy, nil

--- a/controllers/rate_limiting_istio_wasmplugin_controller.go
+++ b/controllers/rate_limiting_istio_wasmplugin_controller.go
@@ -132,7 +132,7 @@ func (r *RateLimitingIstioWASMPluginReconciler) desiredRateLimitingWASMPlugin(ct
 		return nil, err
 	}
 
-	if pluginConfig == nil || len(pluginConfig.RateLimitPolicies) == 0 {
+	if pluginConfig == nil || len(pluginConfig.Policies) == 0 {
 		logger.V(1).Info("pluginConfig is empty. Wasmplugin will be deleted if it exists")
 		utils.TagObjectToDelete(wasmPlugin)
 		return wasmPlugin, nil

--- a/doc/development.md
+++ b/doc/development.md
@@ -248,6 +248,7 @@ Multiple controller integration tests are defined
 | `github.com/kuadrant/kuadrant-operator/tests/gatewayapi` | no gateway provider. GatewayAPI CRDs, Kuadrant API and Kuadrant dependencies. | `make local-gatewayapi-env-setup` | `make test-gatewayapi-env-integration` |
 | `github.com/kuadrant/kuadrant-operator/controllers` | at least one gatewayapi provider. It can be any: istio, envoygateway, ...  | `make local-env-setup GATEWAYAPI_PROVIDER=[istio \| envoygateway]` (Default *istio*) | `make test-integration GATEWAYAPI_PROVIDER=[istio \| envoygateway]` (Default *istio*) |
 | `github.com/kuadrant/kuadrant-operator/tests/istio` | GatewayAPI CRDs, Istio, Kuadrant API and Kuadrant dependencies.  | `make local-env-setup GATEWAYAPI_PROVIDER=istio` | `make test-istio-env-integration` |
+| `github.com/kuadrant/kuadrant-operator/tests/envoygateway` | GatewayAPI CRDs, EnvoyGateway, Kuadrant API and Kuadrant dependencies.  | `make local-env-setup GATEWAYAPI_PROVIDER=envoygateway` | `make test-envoygateway-env-integration` |
 
 ### Lint tests
 

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.18.4
 	sigs.k8s.io/external-dns v0.14.0
 	sigs.k8s.io/gateway-api v1.1.0
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -183,7 +184,6 @@ require (
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.17.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
 replace maistra.io/istio-operator => github.com/maistra/istio-operator v0.0.0-20240217080932-98753cb28cd7

--- a/pkg/rlptools/wasm/types.go
+++ b/pkg/rlptools/wasm/types.go
@@ -107,8 +107,6 @@ type Condition struct {
 	AllOf []PatternExpression `json:"allOf,omitempty"`
 }
 
-// Rule defines conditions that are evaluated using patter expressions.
-// The rule evaluates to true when all the pattern expressions are evaluated to true.
 type Rule struct {
 	// Top level conditions for the rule. At least one of the conditions must be met.
 	// Empty conditions evaluate to true, so actions will be invoked.

--- a/pkg/rlptools/wasm/types_test.go
+++ b/pkg/rlptools/wasm/types_test.go
@@ -1,0 +1,221 @@
+//go:build unit
+
+package wasm
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/yaml"
+
+	kuadrantv1beta2 "github.com/kuadrant/kuadrant-operator/api/v1beta2"
+	"github.com/kuadrant/kuadrant-operator/pkg/common"
+)
+
+func TestConfig(t *testing.T) {
+	testCases := []struct {
+		name           string
+		expectedConfig *Config
+		yaml           string
+	}{
+		{
+			name:           "basic example",
+			expectedConfig: testBasicConfigExample(),
+			yaml: `
+extensions:
+  limitador:
+    type: ratelimit
+    endpoint: kuadrant-rate-limiting-service
+    failureMode: allow
+policies:
+- name: rlp-ns-A/rlp-name-A
+  hostnames:
+  - '*.toystore.com'
+  - example.com
+  rules:
+  - conditions:
+    - allOf:
+      - selector: request.host
+        operator: eq
+        value: cars.toystore.com
+    actions:
+    - extension: limitador
+      scope: rlp-ns-A/rlp-name-A
+      data:
+      - static:
+          key: rlp-ns-A/rlp-name-A
+          value: "1"
+      - selector:
+          selector: auth.metadata.username
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			var conf Config
+			if err := yaml.Unmarshal([]byte(tc.yaml), &conf); err != nil {
+				subT.Fatal(err)
+			}
+
+			if !cmp.Equal(tc.expectedConfig, &conf) {
+				diff := cmp.Diff(tc.expectedConfig, &conf)
+				subT.Fatalf("unexpected config (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConfigMarshallUnmarshalling(t *testing.T) {
+	conf := testBasicConfigExample()
+	serializedConfig, err := json.Marshal(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(string(serializedConfig))
+
+	var unMarshalledConf Config
+	if err := json.Unmarshal(serializedConfig, &unMarshalledConf); err != nil {
+		t.Fatal(err)
+	}
+
+	if !cmp.Equal(conf, &unMarshalledConf) {
+		diff := cmp.Diff(conf, &unMarshalledConf)
+		t.Fatalf("unexpected wasm rules (-want +got):\n%s", diff)
+	}
+}
+
+func TestValidActionConfig(t *testing.T) {
+	testCases := []struct {
+		name           string
+		yaml           string
+		expectedAction *Action
+	}{
+		{
+			name: "valid empty data",
+			expectedAction: &Action{
+				Scope:         "some-scope",
+				ExtensionName: "limitador",
+				Data:          nil,
+			},
+			yaml: `
+scope: some-scope
+extension: limitador
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			var action Action
+			if err := yaml.Unmarshal([]byte(tc.yaml), &action); err != nil {
+				subT.Fatal(err)
+			}
+			if !cmp.Equal(tc.expectedAction, &action) {
+				diff := cmp.Diff(tc.expectedAction, &action)
+				subT.Fatalf("unexpected wasm action (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestInValidActionConfig(t *testing.T) {
+	testCases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "unknown data type",
+			yaml: `
+scope: some-scope
+extension: limitador
+data:
+- other: 
+    key: keyA
+`,
+		},
+		{
+			name: "both data types at the same time",
+			yaml: `
+scope: some-scope
+extension: limitador
+data:
+- static: 
+    key: keyA
+  selector:
+    selector: selectorA
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			var action Action
+			if err := yaml.Unmarshal([]byte(tc.yaml), &action); err == nil {
+				subT.Fatal("unmashall should fail")
+			}
+		})
+	}
+}
+
+func testBasicConfigExample() *Config {
+	return &Config{
+		Extensions: map[string]Extension{
+			RateLimitPolicyExtensionName: {
+				Endpoint:    common.KuadrantRateLimitClusterName,
+				FailureMode: FailureModeAllow,
+				Type:        RateLimitExtensionType,
+			},
+		},
+		Policies: []Policy{
+			{
+				Name: "rlp-ns-A/rlp-name-A",
+				Hostnames: []string{
+					"*.toystore.com",
+					"example.com",
+				},
+				Rules: []Rule{
+					{
+						Conditions: []Condition{
+							{
+								AllOf: []PatternExpression{
+									{
+										Selector: "request.host",
+										Operator: PatternOperator(kuadrantv1beta2.EqualOperator),
+										Value:    "cars.toystore.com",
+									},
+								},
+							},
+						},
+						Actions: []Action{
+							{
+								Scope:         "rlp-ns-A/rlp-name-A",
+								ExtensionName: RateLimitPolicyExtensionName,
+								Data: []DataType{
+									{
+										Value: &Static{
+											Static: StaticSpec{
+												Key:   "rlp-ns-A/rlp-name-A",
+												Value: "1",
+											},
+										},
+									},
+									{
+										Value: &Selector{
+											Selector: SelectorSpec{
+												Selector: "auth.metadata.username",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/rlptools/wasm/utils.go
+++ b/pkg/rlptools/wasm/utils.go
@@ -420,7 +420,7 @@ func ConfigForGateway(
 
 	config := &Config{
 		Extensions: map[string]Extension{
-			RateLimitPolicyExtensionName: Extension{
+			RateLimitPolicyExtensionName: {
 				Endpoint:    common.KuadrantRateLimitClusterName,
 				FailureMode: FailureModeAllow,
 				Type:        RateLimitExtensionType,

--- a/pkg/rlptools/wasm/utils_test.go
+++ b/pkg/rlptools/wasm/utils_test.go
@@ -99,11 +99,19 @@ func TestRules(t *testing.T) {
 							},
 						},
 					},
-					Data: []DataItem{
+					Actions: []Action{
 						{
-							Static: &StaticSpec{
-								Key:   "limit.50rps__36e9aa4c",
-								Value: "1",
+							Scope:         "my-app/minimal",
+							ExtensionName: RateLimitPolicyExtensionName,
+							Data: []DataType{
+								{
+									Value: &Static{
+										Static: StaticSpec{
+											Key:   "limit.50rps__36e9aa4c",
+											Value: "1",
+										},
+									},
+								},
 							},
 						},
 					},
@@ -149,11 +157,19 @@ func TestRules(t *testing.T) {
 							},
 						},
 					},
-					Data: []DataItem{
+					Actions: []Action{
 						{
-							Static: &StaticSpec{
-								Key:   "limit.50rps_for_selected_hostnames__ac4044ab",
-								Value: "1",
+							Scope:         "my-app/my-rlp",
+							ExtensionName: RateLimitPolicyExtensionName,
+							Data: []DataType{
+								{
+									Value: &Static{
+										Static: StaticSpec{
+											Key:   "limit.50rps_for_selected_hostnames__ac4044ab",
+											Value: "1",
+										},
+									},
+								},
 							},
 						},
 					},
@@ -199,11 +215,19 @@ func TestRules(t *testing.T) {
 							},
 						},
 					},
-					Data: []DataItem{
+					Actions: []Action{
 						{
-							Static: &StaticSpec{
-								Key:   "limit.50rps_for_selected_route__db289136",
-								Value: "1",
+							Scope:         "my-app/my-rlp",
+							ExtensionName: RateLimitPolicyExtensionName,
+							Data: []DataType{
+								{
+									Value: &Static{
+										Static: StaticSpec{
+											Key:   "limit.50rps_for_selected_route__db289136",
+											Value: "1",
+										},
+									},
+								},
 							},
 						},
 					},
@@ -248,11 +272,19 @@ func TestRules(t *testing.T) {
 							},
 						},
 					},
-					Data: []DataItem{
+					Actions: []Action{
 						{
-							Static: &StaticSpec{
-								Key:   "limit.50rps_for_selected_path__38eb97a4",
-								Value: "1",
+							Scope:         "my-app/my-rlp",
+							ExtensionName: RateLimitPolicyExtensionName,
+							Data: []DataType{
+								{
+									Value: &Static{
+										Static: StaticSpec{
+											Key:   "limit.50rps_for_selected_path__38eb97a4",
+											Value: "1",
+										},
+									},
+								},
 							},
 						},
 					},
@@ -289,11 +321,19 @@ func TestRules(t *testing.T) {
 			expectedRules: []Rule{
 				{
 					Conditions: nil,
-					Data: []DataItem{
+					Actions: []Action{
 						{
-							Static: &StaticSpec{
-								Key:   "limit.50rps__783b9343",
-								Value: "1",
+							Scope:         "my-app/my-rlp",
+							ExtensionName: RateLimitPolicyExtensionName,
+							Data: []DataType{
+								{
+									Value: &Static{
+										Static: StaticSpec{
+											Key:   "limit.50rps__783b9343",
+											Value: "1",
+										},
+									},
+								},
 							},
 						},
 					},
@@ -312,16 +352,26 @@ func TestRules(t *testing.T) {
 			expectedRules: []Rule{
 				{
 					Conditions: nil,
-					Data: []DataItem{
+					Actions: []Action{
 						{
-							Static: &StaticSpec{
-								Key:   "limit.50rps_per_username__d681f6c3",
-								Value: "1",
-							},
-						},
-						{
-							Selector: &SelectorSpec{
-								Selector: "auth.identity.username",
+							Scope:         "my-app/my-rlp",
+							ExtensionName: RateLimitPolicyExtensionName,
+							Data: []DataType{
+								{
+									Value: &Static{
+										Static: StaticSpec{
+											Key:   "limit.50rps_per_username__d681f6c3",
+											Value: "1",
+										},
+									},
+								},
+								{
+									Value: &Selector{
+										Selector: SelectorSpec{
+											Selector: "auth.identity.username",
+										},
+									},
+								},
 							},
 						},
 					},
@@ -391,9 +441,20 @@ func TestRules(t *testing.T) {
 							},
 						},
 					},
-					Data: []DataItem{
+					Actions: []Action{
 						{
-							Static: &StaticSpec{Key: "limit.50rps__783b9343", Value: "1"},
+							Scope:         "my-app/my-rlp",
+							ExtensionName: RateLimitPolicyExtensionName,
+							Data: []DataType{
+								{
+									Value: &Static{
+										Static: StaticSpec{
+											Key:   "limit.50rps__783b9343",
+											Value: "1",
+										},
+									},
+								},
+							},
 						},
 					},
 				},

--- a/tests/envoygateway/wasm_controller_test.go
+++ b/tests/envoygateway/wasm_controller_test.go
@@ -146,11 +146,17 @@ var _ = Describe("wasm controller", func() {
 			existingWASMConfig, err := wasm.ConfigFromJSON(ext.Spec.Wasm[0].Config)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(existingWASMConfig).To(Equal(&wasm.Config{
-				FailureMode: wasm.FailureModeDeny,
-				RateLimitPolicies: []wasm.RateLimitPolicy{
+				Extensions: map[string]wasm.Extension{
+					wasm.RateLimitPolicyExtensionName: {
+						Endpoint:    common.KuadrantRateLimitClusterName,
+						FailureMode: wasm.FailureModeAllow,
+						Type:        wasm.RateLimitExtensionType,
+					},
+				},
+				Policies: []wasm.Policy{
 					{
-						Name:   gwPolicyKey.String(),
-						Domain: wasm.LimitsNamespaceFromRLP(gwPolicy),
+						Name:      gwPolicyKey.String(),
+						Hostnames: []string{gwHost},
 						Rules: []wasm.Rule{
 							{
 								Conditions: []wasm.Condition{
@@ -169,18 +175,24 @@ var _ = Describe("wasm controller", func() {
 										},
 									},
 								},
-								Data: []wasm.DataItem{
+								Actions: []wasm.Action{
 									{
-										Static: &wasm.StaticSpec{
-											Key:   wasm.LimitNameToLimitadorIdentifier(gwPolicyKey, "l1"),
-											Value: "1",
+										Scope:         wasm.LimitsNamespaceFromRLP(gwPolicy),
+										ExtensionName: wasm.RateLimitPolicyExtensionName,
+										Data: []wasm.DataType{
+											{
+												Value: &wasm.Static{
+													Static: wasm.StaticSpec{
+														Key:   wasm.LimitNameToLimitadorIdentifier(gwPolicyKey, "l1"),
+														Value: "1",
+													},
+												},
+											},
 										},
 									},
 								},
 							},
 						},
-						Hostnames: []string{gwHost},
-						Service:   common.KuadrantRateLimitClusterName,
 					},
 				},
 			}))
@@ -293,11 +305,17 @@ var _ = Describe("wasm controller", func() {
 			existingWASMConfig, err := wasm.ConfigFromJSON(ext.Spec.Wasm[0].Config)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(existingWASMConfig).To(Equal(&wasm.Config{
-				FailureMode: wasm.FailureModeDeny,
-				RateLimitPolicies: []wasm.RateLimitPolicy{
+				Extensions: map[string]wasm.Extension{
+					wasm.RateLimitPolicyExtensionName: {
+						Endpoint:    common.KuadrantRateLimitClusterName,
+						FailureMode: wasm.FailureModeAllow,
+						Type:        wasm.RateLimitExtensionType,
+					},
+				},
+				Policies: []wasm.Policy{
 					{
-						Name:   routePolicyKey.String(),
-						Domain: wasm.LimitsNamespaceFromRLP(routePolicy),
+						Name:      routePolicyKey.String(),
+						Hostnames: []string{string(gwRoute.Spec.Hostnames[0])},
 						Rules: []wasm.Rule{
 							{
 								Conditions: []wasm.Condition{
@@ -316,18 +334,24 @@ var _ = Describe("wasm controller", func() {
 										},
 									},
 								},
-								Data: []wasm.DataItem{
+								Actions: []wasm.Action{
 									{
-										Static: &wasm.StaticSpec{
-											Key:   wasm.LimitNameToLimitadorIdentifier(routePolicyKey, "l1"),
-											Value: "1",
+										Scope:         wasm.LimitsNamespaceFromRLP(routePolicy),
+										ExtensionName: wasm.RateLimitPolicyExtensionName,
+										Data: []wasm.DataType{
+											{
+												Value: &wasm.Static{
+													Static: wasm.StaticSpec{
+														Key:   wasm.LimitNameToLimitadorIdentifier(routePolicyKey, "l1"),
+														Value: "1",
+													},
+												},
+											},
 										},
 									},
 								},
 							},
 						},
-						Hostnames: []string{string(gwRoute.Spec.Hostnames[0])},
-						Service:   common.KuadrantRateLimitClusterName,
 					},
 				},
 			}))


### PR DESCRIPTION
### What

https://github.com/Kuadrant/wasm-shim/pull/87 introduced a new kuadrant's Wasm configuration. It is based on extensions. It's basically the same, but more extensible, which allows to include auth in the future. The wasm controllers (istio and envoygateway based ones) are updated to generate the new configuration scheme expected by the wasm module. 

The scope of this issue is limited to rate limiting. External auth using wasm will be covered in following up tasks.

Example of the new wasm configuration:

```yaml
---
extensions:
  limitador:
    type: ratelimit
    endpoint: limitador-cluster
    failureMode: deny
policies:
  - name: rlp-ns-A/rlp-name-A
    hostnames:
      - '*.toystore.com'
      - example.com
    rules:
      - conditions:
          - allOf:
              - selector: request.path
                operator: eq
                value: /admin/toy
              - selector: request.method
                operator: eq
                value: POST
              - selector: request.host
                operator: eq
                value: cars.toystore.com
        actions:
          - extension: limitador
            scope: rlp-ns-A/rlp-name-A
            data:
              - static:
                  key: rlp-ns-A/rlp-name-A
                  value: "1"
              - selector:
                  selector: auth.metadata.username
```

Related work: https://github.com/Kuadrant/wasm-shim/pull/87

TODO:

- [x] verification steps
- [x] wasm config schema documentation
- [x] tests

### Verification steps

###  Setup (Persona: _Cluster admin_)

```sh
make local-env-setup GATEWAYAPI_PROVIDER=envoygateway
```

Run the operator with a custom wasm build (right now it is not being merged in `main`)
```sh
RELATED_IMAGE_WASMSHIM=oci://quay.io/kuadrant/wasm-shim:external-auth make run
```

Now follow the guide named [Authenticated Rate Limiting for Application Developers](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/authenticated-rl-for-app-developers.md#authenticated-rate-limiting-for-application-developers) and start requesting an instance of Kuadrant. The guide should take you to authenticated rate limiting configuration and the traffic should be rate limiting as expected.


Once you go through all the steps successfully, let's inspect the resources and new configuration. 

:warning: do not cleanup the environment after going through all the steps of the guide.

###  Verification of kuadrant managed EnvoyGateway resources

#### EnvoyExtensionPolicy

Check *EnvoyExtensionPolicy* resource defined by kuadrant

```sh
kubectl get envoyextensionpolicy -n gateway-system kuadrant-wasm-for-kuadrant-ingressgateway -o yaml | yq e -P
```

```yaml
apiVersion: gateway.envoyproxy.io/v1alpha1
kind: EnvoyExtensionPolicy
metadata:
  annotations:
    kuadrant.io/namespace: kuadrant-system
  creationTimestamp: "2024-10-01T16:13:37Z"
  generation: 1
  name: kuadrant-wasm-for-kuadrant-ingressgateway
  namespace: gateway-system
  ownerReferences:
    - apiVersion: gateway.networking.k8s.io/v1
      blockOwnerDeletion: true
      controller: true
      kind: Gateway
      name: kuadrant-ingressgateway
      uid: 44c78246-8334-4e41-b19c-606a2b3d3714
  resourceVersion: "3592"
  uid: 4c0a7ad8-4fbc-4f6f-93b8-d5140086d3d4
spec:
  targetRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: kuadrant-ingressgateway
  wasm:
    - code:
        image:
          url: oci://quay.io/kuadrant/wasm-shim:external-auth
        type: Image
      config:
        extensions:
          limitador:
            endpoint: kuadrant-rate-limiting-service
            failureMode: allow
            type: ratelimit
        policies:
          - hostnames:
              - api.toystore.com
            name: default/toystore
            rules:
              - actions:
                  - data:
                      - static:
                          key: limit.alice_limit__bfdf2c38
                          value: "1"
                    extension: limitador
                    scope: default/toystore
                conditions:
                  - allOf:
                      - operator: eq
                        selector: request.url_path
                        value: /toy
                      - operator: eq
                        selector: request.method
                        value: GET
                      - operator: eq
                        selector: metadata.filter_metadata.envoy\.filters\.http\.ext_authz.identity.userid
                        value: alice
              - actions:
                  - data:
                      - static:
                          key: limit.bob_limit__58541558
                          value: "1"
                    extension: limitador
                    scope: default/toystore
                conditions:
                  - allOf:
                      - operator: eq
                        selector: request.url_path
                        value: /toy
                      - operator: eq
                        selector: request.method
                        value: GET
                      - operator: eq
                        selector: metadata.filter_metadata.envoy\.filters\.http\.ext_authz.identity.userid
                        value: bob
      failOpen: false
      name: kuadrant-wasm-shim
      rootID: kuadrant_wasm_shim
status:
  ancestors:
    - ancestorRef:
        group: gateway.networking.k8s.io
        kind: Gateway
        name: kuadrant-ingressgateway
        namespace: gateway-system
      conditions:
        - lastTransitionTime: "2024-10-01T16:13:39Z"
          message: Policy has been accepted.
          reason: Accepted
          status: "True"
          type: Accepted
      controllerName: gateway.envoyproxy.io/gatewayclass-controller
```

Few things to highlight:

* Wasm module defined with a reference to the kuadrant's wasm-shim OCI image `oci://quay.io/kuadrant/wasm-shim:external-auth`. 
* The wasm configuration follows the new schema based on extensions. There is only one extension for limitador.