### PR TITLE
ADD: Warning doc on labels

### DIFF
--- a/doc/install/install-kubernetes.md
+++ b/doc/install/install-kubernetes.md
@@ -8,7 +8,7 @@
 
     Kuadrant uses a number of labels to search and filter resources on the cluster.
     All required labels are formatted as `kuadrant.io/*`.
-    Removal of any labels with the prefix may cause unexpected behaviour and degradstion of the product.
+    Removal of any labels with the prefix may cause unexpected behaviour and degradation of the product.
 
 ## Prerequisites
 

--- a/doc/install/install-kubernetes.md
+++ b/doc/install/install-kubernetes.md
@@ -4,6 +4,12 @@
 
     You must perform these steps on each Kubernetes cluster where you want to use Kuadrant.
 
+!!! warning
+
+    Kuadrant uses a number of labels to search and filter resources on the cluster.
+    All required labels are formatted as `kuadrant.io/*`.
+    Removal of any labels with the prefix may cause unexpected behaviour and degradstion of the product.
+
 ## Prerequisites
 
 - Access to a Kubernetes cluster, with `kubeadmin` or an account with similar permissions

--- a/doc/install/install-openshift.md
+++ b/doc/install/install-openshift.md
@@ -4,6 +4,12 @@
 
     You must perform these steps on each OpenShift cluster that you want to use Kuadrant on.
 
+!!! warning
+    
+    Kuadrant uses a number of labels to search and filter resources on the cluster.
+    All required labels are formatted as `kuadrant.io/*`.
+    Removal of any labels with the prefix may cause unexpected behaviour and degradstion of the product.
+
 ## Prerequisites
 
 - OpenShift Container Platform 4.14.x or later with community Operator catalog available.

--- a/doc/install/install-openshift.md
+++ b/doc/install/install-openshift.md
@@ -8,7 +8,7 @@
     
     Kuadrant uses a number of labels to search and filter resources on the cluster.
     All required labels are formatted as `kuadrant.io/*`.
-    Removal of any labels with the prefix may cause unexpected behaviour and degradstion of the product.
+    Removal of any labels with the prefix may cause unexpected behaviour and degradation of the product.
 
 ## Prerequisites
 


### PR DESCRIPTION
The state of the world reconcile takes advantage of labels and the removal of such labels will cause issue. This is to warn the user not to mess with the labels.