### PR TITLE
REMOVE: kuadrant controller management of limitador

### DIFF
--- a/controllers/kuadrant_controller.go
+++ b/controllers/kuadrant_controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 
 	"github.com/go-logr/logr"
-	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +35,6 @@ import (
 	maistrav1 "github.com/kuadrant/kuadrant-operator/api/external/maistra/v1"
 	maistrav2 "github.com/kuadrant/kuadrant-operator/api/external/maistra/v2"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
-	"github.com/kuadrant/kuadrant-operator/pkg/common"
 	"github.com/kuadrant/kuadrant-operator/pkg/istio"
 	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/library/gatewayapi"
 	"github.com/kuadrant/kuadrant-operator/pkg/library/reconcilers"
@@ -394,32 +392,7 @@ func (r *KuadrantReconciler) registerServiceMeshMember(ctx context.Context, kObj
 }
 
 func (r *KuadrantReconciler) reconcileSpec(ctx context.Context, kObj *kuadrantv1beta1.Kuadrant) error {
-	if err := r.registerExternalAuthorizer(ctx, kObj); err != nil {
-		return err
-	}
-
-	return r.reconcileLimitador(ctx, kObj)
-}
-
-func (r *KuadrantReconciler) reconcileLimitador(ctx context.Context, kObj *kuadrantv1beta1.Kuadrant) error {
-	limitador := &limitadorv1alpha1.Limitador{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Limitador",
-			APIVersion: "limitador.kuadrant.io/v1alpha1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      common.LimitadorName,
-			Namespace: kObj.Namespace,
-		},
-		Spec: limitadorv1alpha1.LimitadorSpec{},
-	}
-
-	err := r.SetOwnerReference(kObj, limitador)
-	if err != nil {
-		return err
-	}
-
-	return r.ReconcileResource(ctx, &limitadorv1alpha1.Limitador{}, limitador, reconcilers.CreateOnlyMutator)
+	return r.registerExternalAuthorizer(ctx, kObj)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -435,6 +408,5 @@ func (r *KuadrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kuadrantv1beta1.Kuadrant{}).
-		Owns(&limitadorv1alpha1.Limitador{}).
 		Complete(r)
 }

--- a/controllers/kuadrant_controller.go
+++ b/controllers/kuadrant_controller.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 
 	"github.com/go-logr/logr"
+	authorinov1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	iopv1alpha1 "istio.io/istio/operator/pkg/apis/istio/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -408,5 +410,7 @@ func (r *KuadrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kuadrantv1beta1.Kuadrant{}).
+		Owns(&limitadorv1alpha1.Limitador{}).
+		Owns(&authorinov1beta1.Authorino{}).
 		Complete(r)
 }


### PR DESCRIPTION
With the move to the state of the world reconcile the kuadrant controller no longer needs to reconcile the creation of the limitador resource.

This change is independent but will introduce a breaking change if merged before https://github.com/Kuadrant/kuadrant-operator/pull/883 and https://github.com/Kuadrant/kuadrant-operator/pull/887

Required PRs:
- [x] #883 
- [x] #887