### PR TITLE
🔥 "replaces" from bundle

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -27,10 +27,6 @@ on:
         description: WASM Shim version
         default: latest
         type: string
-      replacesVersion:
-        description: Kuadrant Operator replaced version
-        default: 0.0.0-alpha
-        type: string
       channels:
         description: Bundle and catalog channels, comma separated
         default: preview
@@ -68,10 +64,6 @@ on:
       wasmShimVersion:
         description: WASM Shim version
         default: latest
-        type: string
-      replacesVersion:
-        description: Kuadrant Operator replaced version
-        default: 0.0.0-alpha
         type: string
       channels:
         description: Bundle and catalog channels, comma separated
@@ -155,7 +147,6 @@ jobs:
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
             DNS_OPERATOR_VERSION=${{ inputs.dnsOperatorVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
-            REPLACES_VERSION=${{ inputs.replacesVersion }} \
             DEFAULT_CHANNEL=${{ inputs.defaultChannel }} \
             CHANNELS=${{ inputs.channels }}
       - name: Set up Docker Buildx
@@ -204,7 +195,6 @@ jobs:
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
             DNS_OPERATOR_VERSION=${{ inputs.dnsOperatorVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
-            REPLACES_VERSION=${{ inputs.replacesVersion }} \
             DEFAULT_CHANNEL=${{ inputs.defaultChannel }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,10 +26,6 @@ on:
         description: WASM Shim version
         default: latest
         type: string
-      replacesVersion:
-        description: Kuadrant Operator replaced version
-        default: 0.0.0-alpha
-        type: string
       prerelease:
         description: Is the release a pre-release?
         required: false
@@ -64,7 +60,6 @@ jobs:
           LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
           DNS_OPERATOR_VERSION=${{ inputs.dnsOperatorVersion }} \
           WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
-          REPLACES_VERSION=${{ inputs.replacesVersion }}
           make prepare-release
       - name: Commit and push
         run: |

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,6 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 DEFAULT_IMAGE_TAG = latest
-DEFAULT_REPLACES_VERSION = 0.0.0-alpha
-
-REPLACES_VERSION ?= $(DEFAULT_REPLACES_VERSION)
 
 # Semantic versioning (i.e. Major.Minor.Patch)
 is_semantic_version = $(shell [[ $(1) =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$$ ]] && echo "true")
@@ -397,7 +394,6 @@ bundle: $(OPM) $(YQ) manifests dependencies-manifests kustomize operator-sdk ## 
 	$(call update-csv-config,kuadrant-operator.v$(BUNDLE_VERSION),config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml,.metadata.name)
 	$(call update-csv-config,$(BUNDLE_VERSION),config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml,.spec.version)
 	$(call update-csv-config,$(IMG),config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml,.metadata.annotations.containerImage)
-	$(call update-csv-config,kuadrant-operator.v$(REPLACES_VERSION),config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml,.spec.replaces)
 	# Generate bundle
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --version $(BUNDLE_VERSION) $(BUNDLE_METADATA_OPTS)
 	# Update operator dependencies
@@ -435,7 +431,6 @@ prepare-release: ## Prepare the manifests for OLM and Helm Chart for a release.
 		LIMITADOR_OPERATOR_VERSION=$(LIMITADOR_OPERATOR_VERSION) \
 		DNS_OPERATOR_VERSION=$(DNS_OPERATOR_VERSION) \
 		WASM_SHIM_VERSION=$(WASM_SHIM_VERSION) \
-		REPLACES_VERSION=$(REPLACES_VERSION)
 	$(MAKE) helm-build VERSION=$(VERSION) \
 		AUTHORINO_OPERATOR_VERSION=$(AUTHORINO_OPERATOR_VERSION) \
 		LIMITADOR_OPERATOR_VERSION=$(LIMITADOR_OPERATOR_VERSION) \

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-09-17T13:54:51Z"
+    createdAt: "2024-10-01T07:44:08Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/Kuadrant/kuadrant-operator
@@ -755,5 +755,4 @@ spec:
   relatedImages:
   - image: oci://quay.io/kuadrant/wasm-shim:latest
     name: wasmshim
-  replaces: kuadrant-operator.v0.0.0-alpha
   version: 0.0.0

--- a/catalog/kuadrant-operator-channel-entry.yaml
+++ b/catalog/kuadrant-operator-channel-entry.yaml
@@ -4,4 +4,3 @@ package: kuadrant-operator
 name: preview
 entries:
   - name: kuadrant-operator.v0.0.0
-    replaces: kuadrant-operator.v0.0.0-alpha

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -96,5 +96,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  replaces: kuadrant-operator.v0.0.0-alpha
   version: 0.0.0

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -32,7 +32,6 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo Build kuadrant operator catalog
 	@echo
 	@echo BUNDLE_IMG                     = $(BUNDLE_IMG)
-	@echo REPLACES_VERSION               = $(REPLACES_VERSION)
 	@echo LIMITADOR_OPERATOR_BUNDLE_IMG  = $(LIMITADOR_OPERATOR_BUNDLE_IMG)
 	@echo AUTHORINO_OPERATOR_BUNDLE_IMG  = $(AUTHORINO_OPERATOR_BUNDLE_IMG)
 	@echo DNS_OPERATOR_BUNDLE_IMG        = $(DNS_OPERATOR_BUNDLE_IMG)
@@ -42,8 +41,8 @@ $(CATALOG_FILE): $(OPM) $(YQ)
 	@echo
 	@echo Please check this matches your expectations and override variables if needed.
 	@echo
-	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) $(REPLACES_VERSION)\
-			$(LIMITADOR_OPERATOR_BUNDLE_IMG) $(AUTHORINO_OPERATOR_BUNDLE_IMG)\
+	$(PROJECT_PATH)/utils/generate-catalog.sh $(OPM) $(YQ) $(BUNDLE_IMG) \
+			$(LIMITADOR_OPERATOR_BUNDLE_IMG) $(AUTHORINO_OPERATOR_BUNDLE_IMG) \
 			$(DNS_OPERATOR_BUNDLE_IMG) $(DEFAULT_CHANNEL) $@
 
 .PHONY: catalog
@@ -54,8 +53,7 @@ catalog: $(OPM) ## Generate catalog content and validate.
 	$(MAKE) $(CATALOG_DOCKERFILE)
 	$(MAKE) $(CATALOG_FILE) LIMITADOR_OPERATOR_BUNDLE_IMG=$(LIMITADOR_OPERATOR_BUNDLE_IMG) \
 		AUTHORINO_OPERATOR_BUNDLE_IMG=$(AUTHORINO_OPERATOR_BUNDLE_IMG) \
-		BUNDLE_IMG=$(BUNDLE_IMG) \
-		REPLACES_VERSION=$(REPLACES_VERSION)
+		BUNDLE_IMG=$(BUNDLE_IMG)
 	cd $(PROJECT_PATH)/catalog && $(OPM) validate kuadrant-operator-catalog
 
 # Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.

--- a/utils/generate-catalog.sh
+++ b/utils/generate-catalog.sh
@@ -7,12 +7,11 @@ set -euo pipefail
 OPM="${1?:Error \$OPM not set. Bye}"
 YQ="${2?:Error \$YQ not set. Bye}"
 BUNDLE_IMG="${3?:Error \$BUNDLE_IMG not set. Bye}"
-REPLACES_VERSION="${4?:Error \$REPLACES_VERSION not set. Bye}"
-LIMITADOR_OPERATOR_BUNDLE_IMG="${5?:Error \$LIMITADOR_OPERATOR_BUNDLE_IMG not set. Bye}"
-AUTHORINO_OPERATOR_BUNDLE_IMG="${6?:Error \$AUTHORINO_OPERATOR_BUNDLE_IMG not set. Bye}"
-DNS_OPERATOR_BUNDLE_IMG="${7?:Error \$DNS_OPERATOR_BUNDLE_IMG not set. Bye}"
-CHANNEL="${8?:Error \$CHANNEL not set. Bye}"
-CATALOG_FILE="${9?:Error \$CATALOG_FILE not set. Bye}"
+LIMITADOR_OPERATOR_BUNDLE_IMG="${4?:Error \$LIMITADOR_OPERATOR_BUNDLE_IMG not set. Bye}"
+AUTHORINO_OPERATOR_BUNDLE_IMG="${5?:Error \$AUTHORINO_OPERATOR_BUNDLE_IMG not set. Bye}"
+DNS_OPERATOR_BUNDLE_IMG="${6?:Error \$DNS_OPERATOR_BUNDLE_IMG not set. Bye}"
+CHANNEL="${7?:Error \$CHANNEL not set. Bye}"
+CATALOG_FILE="${8?:Error \$CATALOG_FILE not set. Bye}"
 
 CATALOG_FILE_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE})" )" && pwd )"
 CATALOG_BASEDIR="$( cd "$( dirname "$(realpath ${CATALOG_FILE_BASEDIR})" )" && pwd )"
@@ -99,8 +98,7 @@ ${OPM} init kuadrant-operator --default-channel=${CHANNEL} --output yaml >> ${CA
 cat ${TMP_DIR}/kuadrant-operator-bundle.yaml >> ${CATALOG_FILE}
 # Add a channel entry for the bundle
 NAME=`${YQ} eval '.name' ${TMP_DIR}/kuadrant-operator-bundle.yaml` \
-REPLACES=kuadrant-operator.v${REPLACES_VERSION} \
 CHANNEL=${CHANNEL} \
-    ${YQ} eval '(.entries[0].name = strenv(NAME)) | (.entries[0].replaces = strenv(REPLACES)) | (.name = strenv(CHANNEL))' ${CATALOG_BASEDIR}/kuadrant-operator-channel-entry.yaml >> ${CATALOG_FILE}
+    ${YQ} eval '(.entries[0].name = strenv(NAME)) | (.name = strenv(CHANNEL))' ${CATALOG_BASEDIR}/kuadrant-operator-channel-entry.yaml >> ${CATALOG_FILE}
 
 rm -rf $TMP_DIR


### PR DESCRIPTION
For OLM from custom catalogs, replaces does not make sense as the catalog has only one bundle.

For OLM  from public catalogs, we switched recently to `semver-mode`, so the "replaces" are automatically computed by OLM https://github.com/k8s-operatorhub/community-operators/pull/5074/files#diff-065802dd933715bcbb9102cf0ec632f16e00b47c9aafda66865c08e3c00fbda2R1

Helm charts not affected (AFAICT)

In conclusion, no need for `replaces` field. 🔥 to it.