### PR TITLE
allow for a listener with no hostname set

### DIFF
--- a/controllers/dnspolicy_dnsrecords.go
+++ b/controllers/dnspolicy_dnsrecords.go
@@ -55,13 +55,12 @@ func (r *DNSPolicyReconciler) reconcileGatewayDNSRecords(ctx context.Context, ga
 	}
 
 	log.V(3).Info("checking gateway for attached routes ", "gateway", gateway.Name)
-
 	for _, listener := range gateway.Spec.Listeners {
-		listenerHost := *listener.Hostname
-		if listenerHost == "" {
-			log.Info("skipping listener no hostname assigned", listener.Name, "in ns ", gateway.Namespace)
+		if listener.Hostname == nil || *listener.Hostname == "" {
+			log.Info("skipping listener no hostname assigned", "listener", listener.Name, "in ns ", gateway.Namespace)
 			continue
 		}
+
 		hasAttachedRoute := false
 		for _, statusListener := range gateway.Status.Listeners {
 			if string(listener.Name) == string(statusListener.Name) {

--- a/tests/common/dnspolicy/dnspolicy_controller_test.go
+++ b/tests/common/dnspolicy/dnspolicy_controller_test.go
@@ -80,6 +80,7 @@ var _ = Describe("DNSPolicy controller", func() {
 
 	It("should validate loadBalancing field correctly", func(ctx SpecContext) {
 		gateway = tests.NewGatewayBuilder("test-gateway", gatewayClass.Name, testNamespace).
+			WithHTTPListener(tests.ListenerNameOne, "").
 			WithHTTPListener(tests.ListenerNameOne, tests.HostTwo(domain)).Gateway
 
 		// simple should succeed
@@ -140,6 +141,7 @@ var _ = Describe("DNSPolicy controller", func() {
 	It("should validate provider ref field correctly", func(ctx SpecContext) {
 
 		gateway = tests.NewGatewayBuilder("test-gateway", gatewayClass.Name, testNamespace).
+			WithHTTPListener(tests.ListenerNameOne, "").
 			WithHTTPListener(tests.ListenerNameOne, tests.HostTwo(domain)).Gateway
 
 		// should not allow an empty providerRef list

--- a/tests/common/tlspolicy/tlspolicy_controller_test.go
+++ b/tests/common/tlspolicy/tlspolicy_controller_test.go
@@ -115,6 +115,7 @@ var _ = Describe("TLSPolicy controller", func() {
 
 			By("creating a valid Gateway")
 			gateway = tests.NewGatewayBuilder("test-gateway", gatewayClass.Name, testNamespace).
+				WithHTTPListener("no-host", "").
 				WithHTTPListener("test-listener", "test.example.com").Gateway
 			Expect(k8sClient.Create(ctx, gateway)).To(Succeed())
 

--- a/tests/commons.go
+++ b/tests/commons.go
@@ -548,14 +548,20 @@ func (t *GatewayBuilder) WithLabels(labels map[string]string) *GatewayBuilder {
 	return t
 }
 
-func (t *GatewayBuilder) WithHTTPListener(name, hostname string) *GatewayBuilder {
-	typedHostname := gatewayapiv1.Hostname(hostname)
-	t.WithListener(gatewayapiv1.Listener{
+func (t *GatewayBuilder) WithHTTPListener(name string, hostname string) *GatewayBuilder {
+
+	var typedHostname gatewayapiv1.Hostname
+	gl := gatewayapiv1.Listener{
 		Name:     gatewayapiv1.SectionName(name),
-		Hostname: &typedHostname,
 		Port:     gatewayapiv1.PortNumber(80),
 		Protocol: gatewayapiv1.HTTPProtocolType,
-	})
+	}
+	if hostname != "" {
+		typedHostname = gatewayapiv1.Hostname(hostname)
+		gl.Hostname = &typedHostname
+	}
+
+	t.WithListener(gl)
 	return t
 }
 


### PR DESCRIPTION
fixes #905 

Signed-off-by: craig <cbrookes@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED

@mikenairn 