### PR TITLE
Script

### DIFF
--- a/config/observability/README.md
+++ b/config/observability/README.md
@@ -9,6 +9,7 @@ If however you have run `make local-setup` and would like to install the observa
 ```bash
 ./bin/kustomize build ./config/observability/| docker run --rm -i docker.io/ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
 ./bin/kustomize build ./config/observability/| docker run --rm -i docker.io/ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -
+./bin/kustomize build ./config/observability/prometheus/monitors/envoy | kubectl apply -f -
 ./bin/kustomize build ./config/thanos | kubectl apply -f -
 ./bin/kustomize build ./examples/dashboards | kubectl apply -f -
 ./bin/kustomize build ./examples/alerts | kubectl apply -f -

--- a/config/observability/kustomization.yaml
+++ b/config/observability/kustomization.yaml
@@ -4,12 +4,6 @@ kind: Kustomization
 resources:
   - github.com/prometheus-operator/kube-prometheus?ref=release-0.13
   - github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.5.0
-# To scrape istio metrics, 3 configurations are required:
-# 1. Envoy metrics directly from the istio ingress gateway pod
-  - prometheus/monitors/pod-monitor-envoy.yaml
-# 2. Istiod metrics via the istiod service
-  - prometheus/monitors/service-monitor-istiod.yaml
-# 3. Istio metrics exposed via envoy on 15020 in each application.
 # We're using the additionalScrapeConfigs field of the Prometheus CR
 # here to read existing prometheus scrape annotations on pods.
 # Ideally this would be done via another PodMonitor or ServicMonitor,
@@ -24,7 +18,6 @@ resources:
   - prometheus/monitors/service-monitor-authorino-operator.yaml
   - prometheus/monitors/service-monitor-dns-operator.yaml
 
-  - prometheus/telemetry.yaml
 
 patchesStrategicMerge:
   - rbac/cluster_role.yaml

--- a/config/observability/openshift/telemetry.yaml
+++ b/config/observability/openshift/telemetry.yaml
@@ -2,7 +2,7 @@ apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
   name: namespace-metrics
-  namespace: gateway-system
+  namespace: istio-system
 spec:
   metrics:
   - providers:

--- a/config/observability/prometheus/monitors/envoy/kustomization.yaml
+++ b/config/observability/prometheus/monitors/envoy/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- pod-monitor-envoy.yaml
+- service-monitor.yaml
+

--- a/config/observability/prometheus/monitors/envoy/pod-monitor-envoy.yaml
+++ b/config/observability/prometheus/monitors/envoy/pod-monitor-envoy.yaml
@@ -2,13 +2,15 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: envoy-stats
+  namespace: envoy-gateway-system 
 spec:
   namespaceSelector:
     matchNames:
-    - gateway-system
+      - gateway-system
   selector:
     matchLabels:
       app: kuadrant-ingressgateway
   podMetricsEndpoints:
-  - port: http-envoy-prom
-    path: /stats/prometheus
+    - port: http-envoy-prom
+      path: /stats/prometheus
+

--- a/config/observability/prometheus/monitors/envoy/service-monitor.yaml
+++ b/config/observability/prometheus/monitors/envoy/service-monitor.yaml
@@ -1,13 +1,15 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: istiod
+  name: envoy-gateway
+  namespace: envoy-gateway-system
 spec:
   namespaceSelector:
     matchNames:
-    - gateway-system
+      - envoy-gateway-system
   selector:
     matchLabels:
-      app: istiod
+      control-plane: envoy-gateway
   endpoints:
-  - port: http-monitoring
+    - port: metrics
+

--- a/config/observability/prometheus/monitors/istio/kustomization.yaml
+++ b/config/observability/prometheus/monitors/istio/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:  
+  - service-monitor-istiod.yaml
+  - telemetry.yaml
+

--- a/config/observability/prometheus/monitors/istio/service-monitor-istiod.yaml
+++ b/config/observability/prometheus/monitors/istio/service-monitor-istiod.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  namespaceSelector:
+    matchNames:
+    - istio-system
+  selector:
+    matchLabels:
+      app: istiod
+  endpoints:
+  - port: http-monitoring
+

--- a/config/observability/prometheus/monitors/istio/telemetry.yaml
+++ b/config/observability/prometheus/monitors/istio/telemetry.yaml
@@ -2,7 +2,7 @@ apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
   name: namespace-metrics
-  namespace: gateway-system
+  namespace: istio-system
 spec:
   metrics:
   - providers:
@@ -26,3 +26,4 @@ spec:
           value: "request.host"
         request_url_path:
           value: "request.url_path"
+

--- a/hack/quickstart-setup.sh
+++ b/hack/quickstart-setup.sh
@@ -84,6 +84,7 @@ KUADRANT_CERT_MANAGER_KUSTOMIZATION="${KUADRANT_REPO}/config/dependencies/cert-m
 KUADRANT_METALLB_KUSTOMIZATION="${KUADRANT_REPO}/config/metallb?ref=${KUADRANT_REF}"
 KUADARNT_THANOS_KUSTOMIZATION="${KUADRANT_REPO}/config/thanos?ref=${KUADRANT_REF}"
 KUADARNT_OBSERVABILITY_KUSTOMIZATION="${KUADRANT_REPO}/config/observability?ref=${KUADRANT_REF}"
+KUADARNT_OBSERVABILITY_ISTIO_KUSTOMIZATION="${KUADRANT_REPO}/config/observability/prometheus/monitors/istio?ref=${KUADRANT_REF}"
 KUADRANT_DASHBOARDS_KUSTOMIZATION="${KUADRANT_REPO}/examples/dashboards?ref=${KUADRANT_REF}"
 KUADRANT_ALERTS_KUSTOMIZATION="${KUADRANT_REPO}/examples/alerts?ref=${KUADRANT_REF}"
 MGC_REPO="github.com/${KUADRANT_ORG}/multicluster-gateway-controller.git"
@@ -462,6 +463,7 @@ fi
 info "Installing observability stack in ${KUADRANT_CLUSTER_NAME}..."
 kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | $CONTAINER_RUNTIME_BIN run --rm -i docker.io/ryane/kfilt -i kind=CustomResourceDefinition | kubectl apply --server-side -f -
 kubectl kustomize ${KUADARNT_OBSERVABILITY_KUSTOMIZATION} | $CONTAINER_RUNTIME_BIN run --rm -i docker.io/ryane/kfilt -x kind=CustomResourceDefinition | kubectl apply -f -
+kubectl kustomize ${KUADARNT_OBSERVABILITY_ISTIO_KUSTOMIZATION} |  kubectl apply --server-side -f -
 kubectl kustomize ${KUADRANT_DASHBOARDS_KUSTOMIZATION} | kubectl apply --server-side -f -
 kubectl kustomize ${KUADRANT_ALERTS_KUSTOMIZATION} | kubectl apply --server-side -f -
 success "observability stack installed successfully."


### PR DESCRIPTION
The quickstart script was failing as a namespace was missing. The namespace no longer gets installed with the preferred documented method of installing istio via sail.  The script should finish properly now and the observability piece should install without issues

KUADRANT_REF=script ./hack/quickstart-setup.sh 