### PR TITLE
topology CM lookup, inject into console-plugin deployment

### DIFF
--- a/controllers/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin_reconciler.go
@@ -89,7 +89,7 @@ func (r *ConsolePluginReconciler) Run(eventCtx context.Context, _ []controller.R
 	}
 
 	// Deployment
-	deployment := consoleplugin.Deployment(r.namespace, ConsolePluginImageURL)
+	deployment := consoleplugin.Deployment(r.namespace, ConsolePluginImageURL, TopologyConfigMapName)
 	deploymentMutators := make([]reconcilers.DeploymentMutateFn, 0)
 	deploymentMutators = append(deploymentMutators, reconcilers.DeploymentImageMutator)
 	if !topologyExists {

--- a/pkg/openshift/consoleplugin/deployment.go
+++ b/pkg/openshift/consoleplugin/deployment.go
@@ -7,7 +7,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/env"
 	"k8s.io/utils/ptr"
 )
 
@@ -81,7 +80,7 @@ func DeploymentLabels(namespace string) map[string]string {
 	return result
 }
 
-func Deployment(ns, image string) *appsv1.Deployment {
+func Deployment(ns, image, topologyName string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -110,14 +109,8 @@ func Deployment(ns, image string) *appsv1.Deployment {
 							ImagePullPolicy: corev1.PullAlways,
 							VolumeMounts:    DeploymentVolumeMounts(),
 							Env: []corev1.EnvVar{
-								{
-									Name:  "TOPOLOGY_CONFIGMAP_NAME",
-									Value: "topology",
-								},
-								{
-									Name:  "TOPOLOGY_CONFIGMAP_NAMESPACE",
-									Value: env.GetString("OPERATOR_NAMESPACE", "kuadrant-system"),
-								},
+								{Name: "TOPOLOGY_CONFIGMAP_NAME", Value: topologyName},
+								{Name: "TOPOLOGY_CONFIGMAP_NAMESPACE", Value: ns},
 							},
 						},
 					},

--- a/pkg/openshift/consoleplugin/deployment.go
+++ b/pkg/openshift/consoleplugin/deployment.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/env"
 	"k8s.io/utils/ptr"
 )
 
@@ -108,6 +109,16 @@ func Deployment(ns, image string) *appsv1.Deployment {
 							},
 							ImagePullPolicy: corev1.PullAlways,
 							VolumeMounts:    DeploymentVolumeMounts(),
+							Env: []corev1.EnvVar{
+								{
+									Name:  "TOPOLOGY_CONFIGMAP_NAME",
+									Value: "topology",
+								},
+								{
+									Name:  "TOPOLOGY_CONFIGMAP_NAMESPACE",
+									Value: env.GetString("OPERATOR_NAMESPACE", "kuadrant-system"),
+								},
+							},
 						},
 					},
 					Volumes:       DeploymentVolumes(),

--- a/pkg/openshift/consoleplugin/nginx_configmap.go
+++ b/pkg/openshift/consoleplugin/nginx_configmap.go
@@ -34,6 +34,9 @@ http {
 		location / {
 			root                /usr/share/nginx/html;
 		}
+		location /config.js {
+			root /tmp;
+		}
 	}
 }
 `,


### PR DESCRIPTION
### What

Load the location of the `topology` ConfigMap dynamically. An update to the kuadrant-operator now sets some env-vars on the ConsolePlugin deployment, which the plugin uses to discover the topology resource. 

Resolves: https://github.com/Kuadrant/kuadrant-console-plugin/issues/48

### Verification

Verified on OpenShift v4.15

* Install Gateway API

```shell
make gateway-api-install
```

* Install Istio

Follow [user guide](https://docs.kuadrant.io/0.11.0/kuadrant-operator/doc/install/install-openshift/#step-4-install-and-configure-istio-with-the-sail-operator)

* Deploy the kuadrant operator to a NS other than `kuadrant-system`

```
kubectl create ns quadrant-system
```

Install the operator from this branch (`dynamic-topology`):

```yaml
kubectl apply -f - <<EOF
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: kuadrant-operator-catalog
  namespace: quadrant-system
spec:
  sourceType: grpc
  image: quay.io/kuadrant/kuadrant-operator-catalog:dynamic-topology
  displayName: Kuadrant Operators
  publisher: grpc
  updateStrategy:
    registryPoll:
      interval: 45m
---
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: kuadrant-operator
  namespace: quadrant-system
spec:
  channel: preview
  installPlanApproval: Automatic
  name: kuadrant-operator
  source: kuadrant-operator-catalog
  sourceNamespace: quadrant-system
---
kind: OperatorGroup
apiVersion: operators.coreos.com/v1
metadata:
  name: kuadrant
  namespace: quadrant-system
spec:
  upgradeStrategy: Default
EOF
```
Wait for the Kuadrant Operators to be installed as follows:

```
kubectl get installplan -n quadrant-system -o=jsonpath='{.items[0].status.phase}'
```

After some time, this command should return `complete`.

* Enable Kuadrant's dynamic plugin: https://docs.kuadrant.io/dev/kuadrant-operator/doc/install/install-openshift/#step-10-configure-the-kuadrant-console-plugin

* Deploy resources

Apply the Kuadrant custom resource

```yaml
kubectl -n quadrant-system apply -f - <<EOF
---
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: quadrant-sample
spec: {}
EOF
```

Note: a patched version of the `kuadrant-console-plugin` has already been published as `:latest`, because I like to live dangerously.

Ensure the topology is loaded OK on the Kuadrant > Policy Topology view

Verify the two env vars are set in the kuadrant-console deployment:

```bash
kubectl get deployment kuadrant-console -n quadrant-system -o jsonpath='{.spec.template.spec.containers}' | yq e -P
```
```yaml
- env:
    - name: TOPOLOGY_CONFIGMAP_NAME
      value: topology
    - name: TOPOLOGY_CONFIGMAP_NAMESPACE
      value: quadrant-system
  image: quay.io/kuadrant/console-plugin:latest
  imagePullPolicy: Always
  name: kuadrant-console
  ports:
    - containerPort: 9443
      protocol: TCP
  resources: {}
  terminationMessagePath: /dev/termination-log
  terminationMessagePolicy: File
  volumeMounts:
    - mountPath: /var/serving-cert
      name: plugin-serving-cert
      readOnly: true
    - mountPath: /etc/nginx/nginx.conf
      name: nginx-conf
      readOnly: true
      subPath: nginx.conf
```