### PR TITLE
tests: Add test suite common resource labels and fix dnsrecord cleanup

### DIFF
--- a/make/integration-tests.mk
+++ b/make/integration-tests.mk
@@ -2,6 +2,7 @@ INTEGRATION_COVER_PKGS = ./pkg/...,./controllers/...,./api/...
 INTEGRATION_TESTS_EXTRA_ARGS ?=
 INTEGRATION_TEST_NUM_CORES ?= 4
 INTEGRATION_TEST_NUM_PROCESSES ?= 10
+INTEGRATION_TEST_PACKAGES ?= tests/common/...
 
 ##@ Integration tests
 
@@ -92,4 +93,4 @@ test-integration: clean-cov generate fmt vet ginkgo ## Requires kubernetes clust
 		--fail-on-pending \
 		--keep-going \
 		--trace \
-		$(INTEGRATION_TESTS_EXTRA_ARGS) tests/common/...
+		$(INTEGRATION_TESTS_EXTRA_ARGS) $(INTEGRATION_TEST_PACKAGES)

--- a/tests/common/dnspolicy/dnspolicy_controller_single_cluster_test.go
+++ b/tests/common/dnspolicy/dnspolicy_controller_single_cluster_test.go
@@ -138,7 +138,7 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 	Context("simple routing strategy", func() {
 
 		BeforeEach(func(ctx SpecContext) {
-			dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway(tests.GatewayName)
 			Expect(k8sClient.Create(ctx, dnsPolicy)).To(Succeed())
@@ -197,7 +197,7 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 
 		Context("with default geo", func() {
 			BeforeEach(func(ctx SpecContext) {
-				dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+				dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 					WithProviderSecret(*dnsProviderSecret).
 					WithTargetGateway(tests.GatewayName).
 					WithLoadBalancingFor(120, "IE", true)
@@ -317,7 +317,7 @@ var _ = Describe("DNSPolicy Single Cluster", func() {
 
 		Context("without default geo", func() {
 			BeforeEach(func(ctx SpecContext) {
-				dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+				dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 					WithProviderSecret(*dnsProviderSecret).
 					WithTargetGateway(tests.GatewayName).
 					WithLoadBalancingFor(120, "IE", false)

--- a/tests/common/dnspolicy/dnspolicy_controller_test.go
+++ b/tests/common/dnspolicy/dnspolicy_controller_test.go
@@ -84,7 +84,7 @@ var _ = Describe("DNSPolicy controller", func() {
 			WithHTTPListener(tests.ListenerNameOne, tests.HostTwo(domain)).Gateway
 
 		// simple should succeed
-		dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+		dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 			WithProviderSecret(*dnsProviderSecret).
 			WithTargetGateway("test-gateway")
 		Expect(k8sClient.Create(ctx, dnsPolicy)).To(Succeed())
@@ -105,7 +105,7 @@ var _ = Describe("DNSPolicy controller", func() {
 		Expect(k8sClient.Delete(ctx, dnsPolicy)).ToNot(HaveOccurred())
 
 		// loadbalanced should succeed
-		dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+		dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 			WithProviderSecret(*dnsProviderSecret).
 			WithTargetGateway("test-gateway").
 			WithLoadBalancingFor(100, "foo", false)
@@ -145,12 +145,12 @@ var _ = Describe("DNSPolicy controller", func() {
 			WithHTTPListener(tests.ListenerNameOne, tests.HostTwo(domain)).Gateway
 
 		// should not allow an empty providerRef list
-		dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+		dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 			WithTargetGateway("test-gateway")
 		Expect(k8sClient.Create(ctx, dnsPolicy)).To(MatchError(ContainSubstring("spec.providerRefs: Required value")))
 
 		// should create with a single providerRef
-		dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+		dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 			WithProviderSecret(*dnsProviderSecret).
 			WithTargetGateway("test-gateway")
 		Expect(k8sClient.Create(ctx, dnsPolicy)).To(Succeed())
@@ -217,7 +217,7 @@ var _ = Describe("DNSPolicy controller", func() {
 		}, tests.TimeoutMedium, tests.RetryIntervalMedium).Should(Succeed())
 
 		// Create policy1 targeting gateway1 with simple routing strategy
-		dnsPolicy1 := v1alpha1.NewDNSPolicy("test-dns-policy1", testNamespace).
+		dnsPolicy1 := tests.NewDNSPolicy("test-dns-policy1", testNamespace).
 			WithProviderSecret(*dnsProviderSecret).
 			WithTargetGateway("test-gateway1")
 		Expect(k8sClient.Create(ctx, dnsPolicy1)).To(Succeed())
@@ -265,7 +265,7 @@ var _ = Describe("DNSPolicy controller", func() {
 		}, tests.TimeoutLong, tests.RetryIntervalMedium).Should(Succeed())
 
 		// create policy2 targeting gateway2 with the load-balanced strategy
-		dnsPolicy2 := v1alpha1.NewDNSPolicy("test-dns-policy2", testNamespace).
+		dnsPolicy2 := tests.NewDNSPolicy("test-dns-policy2", testNamespace).
 			WithProviderSecret(*dnsProviderSecret).
 			WithTargetGateway("test-gateway2").
 			WithLoadBalancingFor(100, "foo", false)
@@ -336,7 +336,7 @@ var _ = Describe("DNSPolicy controller", func() {
 
 	Context("invalid target", func() {
 		It("should have accepted condition with status false and correct reason", func(ctx SpecContext) {
-			dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway("test-gateway")
 			Expect(k8sClient.Create(ctx, dnsPolicy)).To(Succeed())
@@ -411,13 +411,13 @@ var _ = Describe("DNSPolicy controller", func() {
 			}, tests.TimeoutMedium, tests.RetryIntervalMedium).Should(Succeed())
 
 			// Create policy1 targeting gateway1 with simple routing strategy
-			dnsPolicy1 := v1alpha1.NewDNSPolicy("test-dns-policy1", testNamespace).
+			dnsPolicy1 := tests.NewDNSPolicy("test-dns-policy1", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway("test-gateway1")
 			Expect(k8sClient.Create(ctx, dnsPolicy1)).To(Succeed())
 
 			// create policy2 targeting gateway2 with the load-balanced strategy
-			dnsPolicy2 := v1alpha1.NewDNSPolicy("test-dns-policy2", testNamespace).
+			dnsPolicy2 := tests.NewDNSPolicy("test-dns-policy2", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway("test-gateway2").
 				WithLoadBalancingFor(100, "foo", false)
@@ -464,7 +464,7 @@ var _ = Describe("DNSPolicy controller", func() {
 			gateway = tests.NewGatewayBuilder(testGatewayName, gatewayClass.Name, testNamespace).
 				WithHTTPListener(tests.ListenerNameOne, tests.HostTwo(domain)).
 				Gateway
-			dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway(testGatewayName)
 
@@ -512,7 +512,7 @@ var _ = Describe("DNSPolicy controller", func() {
 				WithHTTPListener(tests.ListenerNameOne, tests.HostOne(domain)).
 				WithHTTPListener(tests.ListenerNameWildcard, tests.HostWildcard(domain)).
 				Gateway
-			dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway(tests.GatewayName)
 
@@ -802,7 +802,7 @@ var _ = Describe("DNSPolicy controller", func() {
 
 	Context("cel validation", func() {
 		It("should error targeting invalid group", func(ctx SpecContext) {
-			p := v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			p := tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway("gateway")
 			p.Spec.TargetRef.Group = "not-gateway.networking.k8s.io"
@@ -813,7 +813,7 @@ var _ = Describe("DNSPolicy controller", func() {
 		}, testTimeOut)
 
 		It("should error targeting invalid kind", func(ctx SpecContext) {
-			p := v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			p := tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway("gateway")
 			p.Spec.TargetRef.Kind = "TCPRoute"
@@ -830,7 +830,7 @@ var _ = Describe("DNSPolicy controller", func() {
 				WithHTTPListener(tests.ListenerNameOne, tests.HostOne(domain)).
 				WithHTTPListener(tests.ListenerNameWildcard, tests.HostWildcard(domain)).
 				Gateway
-			dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway(tests.GatewayName)
 			Expect(k8sClient.Create(ctx, gateway)).To(Succeed())
@@ -866,7 +866,7 @@ var _ = Describe("DNSPolicy controller", func() {
 
 		})
 
-		It("should have an accpeterd and enforced policy with additional context", func(ctx SpecContext) {
+		It("should have an accepted and enforced policy with additional context", func(ctx SpecContext) {
 			Eventually(func(g Gomega) {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(dnsPolicy), dnsPolicy)
 				g.Expect(err).NotTo(HaveOccurred())
@@ -899,7 +899,7 @@ var _ = Describe("DNSPolicy controller", func() {
 			Expect(k8sClient.Create(ctx, gateway)).To(Succeed())
 		})
 		It("should create a DNSPolicy with an invalid CIDR", func(ctx SpecContext) {
-			dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway(gateway.Name).
 				WithExcludeAddresses([]string{"1.1.1.1/345"})
@@ -948,7 +948,7 @@ var _ = Describe("DNSPolicy controller", func() {
 		})
 
 		It("should create a DNSPolicy valid exclude addresses", func(ctx SpecContext) {
-			dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway(gateway.Name).
 				WithExcludeAddresses([]string{tests.IPAddressOne})
@@ -1022,7 +1022,7 @@ var _ = Describe("DNSPolicy controller", func() {
 
 		})
 		It("should not create a DNSRecords if no endpoints due to DNSPolicy exclude addresses", func(ctx SpecContext) {
-			dnsPolicy = v1alpha1.NewDNSPolicy("test-dns-policy", testNamespace).
+			dnsPolicy = tests.NewDNSPolicy("test-dns-policy", testNamespace).
 				WithProviderSecret(*dnsProviderSecret).
 				WithTargetGateway(gateway.Name).
 				WithExcludeAddresses([]string{tests.IPAddressOne, tests.IPAddressTwo})

--- a/tests/common/dnspolicy/dnspolicy_controller_test.go
+++ b/tests/common/dnspolicy/dnspolicy_controller_test.go
@@ -59,14 +59,24 @@ var _ = Describe("DNSPolicy controller", func() {
 		if dnsPolicy != nil {
 			err := k8sClient.Delete(ctx, dnsPolicy)
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
-			// Wait until dns records are finished deleting since it can't finish deleting without the DNS provider secret
-			Eventually(func(g Gomega) {
-				dnsRecords := &kuadrantdnsv1alpha1.DNSRecordList{}
-				err := k8sClient.List(ctx, dnsRecords, client.InNamespace(testNamespace))
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(dnsRecords.Items).To(HaveLen(0))
-			}).WithContext(ctx).Should(Succeed())
 		}
+
+		//Ensure all dns records in the test namespace are deleted
+		dnsRecords := &kuadrantdnsv1alpha1.DNSRecordList{}
+		err := k8sClient.List(ctx, dnsRecords, client.InNamespace(testNamespace))
+		Expect(err).ToNot(HaveOccurred())
+		for _, record := range dnsRecords.Items {
+			err := k8sClient.Delete(ctx, &record, client.PropagationPolicy(metav1.DeletePropagationForeground))
+			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())
+		}
+
+		// Wait until dns records are finished deleting since it can't finish deleting without the DNS provider secret
+		Eventually(func(g Gomega) {
+			err := k8sClient.List(ctx, dnsRecords, client.InNamespace(testNamespace))
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(dnsRecords.Items).To(HaveLen(0))
+		}).WithContext(ctx).Should(Succeed())
+
 		if dnsProviderSecret != nil {
 			err := k8sClient.Delete(ctx, dnsProviderSecret)
 			Expect(client.IgnoreNotFound(err)).ToNot(HaveOccurred())


### PR DESCRIPTION
[tests: Add common label to all test suite resources](https://github.com/Kuadrant/kuadrant-operator/commit/d11ed02e667d9df07bbf56317c132c065d4a908f)

All resources created with the common helpers in the integration test suite have a common label added to more easily find resources created by the test suite:

```
kubectl get ns,gatewayclass,gateway,dnspolicy -l app.kubernetes.io/part-of=kuadrant-test-suite -A
NAME                             STATUS        AGE
namespace/test-namespace-4r6cl   Active        0s
namespace/test-namespace-6qmvp   Active        6s
namespace/test-namespace-7pxsm   Terminating   5s
namespace/test-namespace-w25d8   Active        0s
namespace/test-namespace-wv85k   Terminating   1s

NAME                                                              CONTROLLER        ACCEPTED   AGE
gatewayclass.gateway.networking.k8s.io/gwc-test-namespace-4r6cl   kuadrant.io/bar   Unknown    0s
gatewayclass.gateway.networking.k8s.io/gwc-test-namespace-6qmvp   kuadrant.io/bar   Unknown    6s
gatewayclass.gateway.networking.k8s.io/gwc-test-namespace-w25d8   kuadrant.io/bar   Unknown    0s

NAMESPACE              NAME                                                    CLASS                      ADDRESS     PROGRAMMED   AGE
test-namespace-4r6cl   gateway.gateway.networking.k8s.io/test-gateway1         gwc-test-namespace-4r6cl   172.0.0.1   Unknown      0s
test-namespace-4r6cl   gateway.gateway.networking.k8s.io/test-gateway2         gwc-test-namespace-4r6cl   172.0.0.1   Unknown      0s
test-namespace-6qmvp   gateway.gateway.networking.k8s.io/test-placed-gateway   gwc-test-namespace-6qmvp   172.0.0.1   Unknown      6s
test-namespace-w25d8   gateway.gateway.networking.k8s.io/test-placed-gateway   gwc-test-namespace-w25d8   172.0.0.1   Unknown      0s

NAMESPACE              NAME                                     AGE
test-namespace-4r6cl   dnspolicy.kuadrant.io/test-dns-policy1   0s
test-namespace-4r6cl   dnspolicy.kuadrant.io/test-dns-policy2   0s
test-namespace-6qmvp   dnspolicy.kuadrant.io/test-dns-policy    6s
test-namespace-w25d8   dnspolicy.kuadrant.io/test-dns-policy    0s
```

[tests: Allow overriding packages for integration test](https://github.com/Kuadrant/kuadrant-operator/pull/941/commits/5d2331ecaeca153cedfb488f23568a905c3ddcdb)

Adds a new variable `INTEGRATION_TEST_PACKAGES` which sets the packages used by the `test-integration` make target allowing it to be more easily modified for local development testing.

Example:
```
INTEGRATION_TEST_PACKAGES=tests/common/dnspolicy/... INTEGRATION_TESTS_EXTRA_ARGS='-v --repeat=4 --focus="valid target"' INTEGRATION_TEST_NUM_PROCESSES=4 INTEGRATION_TEST_NUM_CORES=2 make test-integration
```

[tests: Ensure all dnsrecords are removed in cleanup](https://github.com/Kuadrant/kuadrant-operator/commit/1744472ddbe4f4ff65a50c1156dbedfbec735751)

Ensures all DNSrecord resources in the current spec test namespace are marked for deletion and removed before removing the secret.
