### PR TITLE
ci: Add kuadrant status check step to test jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,8 @@ on:
   schedule:
     - cron: "15 1 * * *"
 
+  workflow_dispatch:
+
 jobs:
   unit-tests:
     name: Unit Tests
@@ -102,6 +104,10 @@ jobs:
           flags: controllers-integration
           fail_ci_if_error: false
           verbose: true
+      - name: Check kuadrant status
+        if: always()
+        run: |
+          kubectl get pods -n kuadrant-system
 
   bare-k8s-integration-tests:
     name: Integration Tests for kuadrant-operator/tests/bare_k8s
@@ -241,6 +247,10 @@ jobs:
           flags: ${{ matrix.gatewayapi-provider }}-integration
           fail_ci_if_error: false
           verbose: true
+      - name: Check kuadrant status
+        if: always()
+        run: |
+          kubectl get pods -n kuadrant-system
 
   verify-manifests:
     name: Verify manifests


### PR DESCRIPTION
Adds a step to the integration test jobs to display the pods in the kuadrant-system namespace. More info could be added here, but for now this is enough to tell you if the pods were restarting during the test run for some reason (panic in the operator itself).

Add workflow dispatch to "Test" workflow.