### PR TITLE
Test updates (Enable race detection and disable output interceptor)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ run: export OPERATOR_NAMESPACE := $(OPERATOR_NAMESPACE)
 run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 run: DIRTY=$(shell $(PROJECT_PATH)/utils/check-git-dirty.sh || echo "unknown")
 run: generate fmt vet ## Run a controller from your host.
-	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" ./main.go
+	go run -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" --race ./main.go
 
 docker-build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 docker-build: DIRTY=$(shell $(PROJECT_PATH)/utils/check-git-dirty.sh || echo "unknown")

--- a/make/integration-tests.mk
+++ b/make/integration-tests.mk
@@ -22,6 +22,8 @@ test-bare-k8s-integration: clean-cov generate fmt vet ginkgo ## Requires only ba
 		--fail-on-pending \
 		--keep-going \
 		--trace \
+		-v \
+		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) ./tests/bare_k8s/...
 
 .PHONY: test-gatewayapi-env-integration
@@ -40,6 +42,8 @@ test-gatewayapi-env-integration: clean-cov generate fmt vet ginkgo ## Requires k
 		--fail-on-pending \
 		--keep-going \
 		--trace \
+		-v \
+		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) ./tests/gatewayapi/...
 
 .PHONY: test-istio-env-integration
@@ -58,6 +62,8 @@ test-istio-env-integration: clean-cov generate fmt vet ginkgo ## Requires kubern
 		--fail-on-pending \
 		--keep-going \
 		--trace \
+		-v \
+		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) tests/istio/...
 
 test-envoygateway-env-integration: clean-cov generate fmt vet ginkgo ## Requires kubernetes cluster with GatewayAPI and EnvoyGateway installed.
@@ -75,6 +81,8 @@ test-envoygateway-env-integration: clean-cov generate fmt vet ginkgo ## Requires
 		--fail-on-pending \
 		--keep-going \
 		--trace \
+		-v \
+		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) tests/envoygateway/...
 
 .PHONY: test-integration
@@ -93,4 +101,6 @@ test-integration: clean-cov generate fmt vet ginkgo ## Requires kubernetes clust
 		--fail-on-pending \
 		--keep-going \
 		--trace \
+		-v \
+		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) $(INTEGRATION_TEST_PACKAGES)

--- a/make/integration-tests.mk
+++ b/make/integration-tests.mk
@@ -22,7 +22,7 @@ test-bare-k8s-integration: clean-cov generate fmt vet ginkgo ## Requires only ba
 		--fail-on-pending \
 		--keep-going \
 		--trace \
-		-v \
+		--race \
 		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) ./tests/bare_k8s/...
 
@@ -42,7 +42,7 @@ test-gatewayapi-env-integration: clean-cov generate fmt vet ginkgo ## Requires k
 		--fail-on-pending \
 		--keep-going \
 		--trace \
-		-v \
+		--race \
 		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) ./tests/gatewayapi/...
 
@@ -62,7 +62,7 @@ test-istio-env-integration: clean-cov generate fmt vet ginkgo ## Requires kubern
 		--fail-on-pending \
 		--keep-going \
 		--trace \
-		-v \
+		--race \
 		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) tests/istio/...
 
@@ -81,7 +81,7 @@ test-envoygateway-env-integration: clean-cov generate fmt vet ginkgo ## Requires
 		--fail-on-pending \
 		--keep-going \
 		--trace \
-		-v \
+		--race \
 		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) tests/envoygateway/...
 
@@ -101,6 +101,6 @@ test-integration: clean-cov generate fmt vet ginkgo ## Requires kubernetes clust
 		--fail-on-pending \
 		--keep-going \
 		--trace \
-		-v \
+		--race \
 		--output-interceptor-mode=none \
 		$(INTEGRATION_TESTS_EXTRA_ARGS) $(INTEGRATION_TEST_PACKAGES)

--- a/pkg/library/kuadrant/apimachinery_status_conditions.go
+++ b/pkg/library/kuadrant/apimachinery_status_conditions.go
@@ -55,17 +55,28 @@ func (o *AffectedPolicyMap) RemoveAffectedPolicy(p Policy) {
 
 // IsPolicyAffected checks if the provided Policy is affected based on the tracking map maintained.
 func (o *AffectedPolicyMap) IsPolicyAffected(p Policy) bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
 	return o.policies[p.GetUID()] != nil
 }
 
 // IsPolicyOverridden checks if the provided Policy is affected based on the tracking map maintained.
 // It is overridden if there is policies affecting it
 func (o *AffectedPolicyMap) IsPolicyOverridden(p Policy) bool {
-	return o.IsPolicyAffected(p) && len(o.policies[p.GetUID()]) > 0
+	pAffected := o.IsPolicyAffected(p)
+
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	return pAffected && len(o.policies[p.GetUID()]) > 0
 }
 
 // PolicyAffectedBy returns the clients keys that a policy is Affected by
 func (o *AffectedPolicyMap) PolicyAffectedBy(p Policy) []client.ObjectKey {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
 	return o.policies[p.GetUID()]
 }
 


### PR DESCRIPTION
**tests:  Disable all output capture in ginkgo tests**

This creates a lot of extra output during the test runs which is really distracting, and makes the output virtually useless.

Apart from that it can cause the entire test run to freeze under certain situations (which has happened a few times lately) due to the issue described here.
https://github.com/onsi/ginkgo/blob/104752fa2e97f04b1300754e710c419a63d2d30c/internal/output_interceptor.go#L13

**tests:  Add --race option to ginkgo run**

This will cause the test suite to fail if any race condition is detected during the execution of the tests.

Note: When the tests are run in parallel this does not output a descriptive message for the failure. If it fails for seemingly random reasons you should try running the test suite without parallel processes enabled.

**dev: Add --race option to make run task**

Enables the race detector on locally running instances https://go.dev/doc/articles/race_detector. This will report useful
information in the logs about race related issues.

Example output https://gist.github.com/mikenairn/a165c9e8076f3c3437a066e8af5a9ce5
