### PR TITLE
fix: Remove dnspolicy lb immutable validation

### DIFF
--- a/api/v1alpha1/dnspolicy_types.go
+++ b/api/v1alpha1/dnspolicy_types.go
@@ -54,7 +54,6 @@ const (
 )
 
 // DNSPolicySpec defines the desired state of DNSPolicy
-// +kubebuilder:validation:XValidation:rule="(!has(oldSelf.loadBalancing) || has(self.loadBalancing)) && (has(oldSelf.loadBalancing) || !has(self.loadBalancing))", message="loadBalancing is immutable"
 type DNSPolicySpec struct {
 	// targetRef identifies an API object to apply policy to.
 	// +kubebuilder:validation:XValidation:rule="self.group == 'gateway.networking.k8s.io'",message="Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'"

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-10-25T15:27:18Z"
+    createdAt: "2024-10-31T12:05:38Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -227,10 +227,6 @@ spec:
             - providerRefs
             - targetRef
             type: object
-            x-kubernetes-validations:
-            - message: loadBalancing is immutable
-              rule: (!has(oldSelf.loadBalancing) || has(self.loadBalancing)) && (has(oldSelf.loadBalancing)
-                || !has(self.loadBalancing))
           status:
             description: DNSPolicyStatus defines the observed state of DNSPolicy
             properties:

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -6995,10 +6995,6 @@ spec:
             - providerRefs
             - targetRef
             type: object
-            x-kubernetes-validations:
-            - message: loadBalancing is immutable
-              rule: (!has(oldSelf.loadBalancing) || has(self.loadBalancing)) && (has(oldSelf.loadBalancing)
-                || !has(self.loadBalancing))
           status:
             description: DNSPolicyStatus defines the observed state of DNSPolicy
             properties:

--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -226,10 +226,6 @@ spec:
             - providerRefs
             - targetRef
             type: object
-            x-kubernetes-validations:
-            - message: loadBalancing is immutable
-              rule: (!has(oldSelf.loadBalancing) || has(self.loadBalancing)) && (has(oldSelf.loadBalancing)
-                || !has(self.loadBalancing))
           status:
             description: DNSPolicyStatus defines the observed state of DNSPolicy
             properties:


### PR DESCRIPTION
Removes the immutable validation on the loadBalancing field of the dnspolicy spec. 

Updates made as part of [section name support ](https://github.com/Kuadrant/kuadrant-operator/pull/961) allow the controller to handle changes to endpoint record types,  so it's now possible to switch from what we used to refer to as simple policy types (loadBalancing field not set) to loadbalanced (loadBalancing field set) and vice versa without deleting and re-creating the policy.