### PR TITLE
chore: TLS and DNS Policy API cleanup

### DIFF
--- a/controllers/dnspolicies_validator.go
+++ b/controllers/dnspolicies_validator.go
@@ -40,8 +40,8 @@ func (r *DNSPoliciesValidator) validate(ctx context.Context, _ []controller.Reso
 
 	state.Store(StateDNSPolicyAcceptedKey, lo.SliceToMap(policies, func(policy *kuadrantv1alpha1.DNSPolicy) (string, error) {
 		if len(policy.GetTargetRefs()) == 0 || len(topology.Targetables().Children(policy)) == 0 {
-			return policy.GetLocator(), kuadrant.NewErrTargetNotFound(policy.Kind(), policy.GetTargetRef(),
-				apierrors.NewNotFound(kuadrantv1alpha1.DNSPoliciesResource.GroupResource(), policy.GetName()))
+			return policy.GetLocator(), kuadrant.NewErrTargetNotFound(kuadrantv1alpha1.DNSPolicyGroupKind.Kind, policy.GetTargetRef(),
+				apierrors.NewNotFound(controller.GatewaysResource.GroupResource(), policy.GetName()))
 		}
 		return policy.GetLocator(), policy.Validate()
 	}))

--- a/controllers/dnspolicy_status_updater.go
+++ b/controllers/dnspolicy_status_updater.go
@@ -138,7 +138,7 @@ func enforcedCondition(records []*kuadrantdnsv1alpha1.DNSRecord, dnsPolicy *kuad
 
 	// if there are records and none of the records are ready
 	if len(records) > 0 && len(notReadyRecords) == len(records) {
-		return kuadrant.EnforcedCondition(dnsPolicy, kuadrant.NewErrUnknown(dnsPolicy.Kind(), errors.New("policy is not enforced on any DNSRecord: not a single DNSRecord is ready")), false)
+		return kuadrant.EnforcedCondition(dnsPolicy, kuadrant.NewErrUnknown(kuadrantv1alpha1.DNSPolicyGroupKind.Kind, errors.New("policy is not enforced on any DNSRecord: not a single DNSRecord is ready")), false)
 	}
 
 	// some of the records are not ready

--- a/controllers/tlspolicies_validator.go
+++ b/controllers/tlspolicies_validator.go
@@ -93,7 +93,7 @@ func (t *TLSPoliciesValidator) Validate(ctx context.Context, _ []controller.Reso
 // TODO: What should happen if multiple target refs is supported in the future in terms of reporting in log and policy status?
 func (t *TLSPoliciesValidator) isTargetRefsFound(topology *machinery.Topology, p *kuadrantv1alpha1.TLSPolicy) error {
 	if len(p.GetTargetRefs()) != len(topology.Targetables().Children(p)) {
-		return kuadrant.NewErrTargetNotFound(p.Kind(), p.GetTargetRef(), apierrors.NewNotFound(kuadrantv1alpha1.TLSPoliciesResource.GroupResource(), p.GetName()))
+		return kuadrant.NewErrTargetNotFound(kuadrantv1alpha1.TLSPolicyGroupKind.Kind, p.GetTargetRef(), apierrors.NewNotFound(controller.GatewaysResource.GroupResource(), p.GetName()))
 	}
 
 	return nil
@@ -102,7 +102,7 @@ func (t *TLSPoliciesValidator) isTargetRefsFound(topology *machinery.Topology, p
 // isValidIssuerKind Validates that the Issuer Ref kind is either empty, Issuer or ClusterIssuer
 func (t *TLSPoliciesValidator) isValidIssuerKind(p *kuadrantv1alpha1.TLSPolicy) error {
 	if !lo.Contains([]string{"", certmanv1.IssuerKind, certmanv1.ClusterIssuerKind}, p.Spec.IssuerRef.Kind) {
-		return kuadrant.NewErrInvalid(p.Kind(), fmt.Errorf(`invalid value %q for issuerRef.kind. Must be empty, %q or %q`,
+		return kuadrant.NewErrInvalid(kuadrantv1alpha1.TLSPolicyGroupKind.Kind, fmt.Errorf(`invalid value %q for issuerRef.kind. Must be empty, %q or %q`,
 			p.Spec.IssuerRef.Kind, certmanv1.IssuerKind, certmanv1.ClusterIssuerKind))
 	}
 
@@ -132,7 +132,7 @@ func (t *TLSPoliciesValidator) isIssuerFound(topology *machinery.Topology, p *ku
 	})
 
 	if !ok {
-		return kuadrant.NewErrInvalid(p.Kind(), errors.New("unable to find issuer"))
+		return kuadrant.NewErrInvalid(kuadrantv1alpha1.TLSPolicyGroupKind.Kind, errors.New("unable to find issuer"))
 	}
 
 	return nil

--- a/controllers/tlspolicy_status_updater.go
+++ b/controllers/tlspolicy_status_updater.go
@@ -106,11 +106,11 @@ func (t *TLSPolicyStatusUpdater) UpdateStatus(ctx context.Context, _ []controlle
 
 func (t *TLSPolicyStatusUpdater) enforcedCondition(ctx context.Context, policy *kuadrantv1alpha1.TLSPolicy, topology *machinery.Topology) *metav1.Condition {
 	if err := t.isIssuerReady(ctx, policy, topology); err != nil {
-		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(policy.Kind(), err), false)
+		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(kuadrantv1alpha1.TLSPolicyGroupKind.Kind, err), false)
 	}
 
 	if err := t.isCertificatesReady(policy, topology); err != nil {
-		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(policy.Kind(), err), false)
+		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrUnknown(kuadrantv1alpha1.TLSPolicyGroupKind.Kind, err), false)
 	}
 
 	return kuadrant.EnforcedCondition(policy, nil, true)


### PR DESCRIPTION
* Remove unnecessary implementation of kuadrant.Referrer
* Mark implementation of kuadrant.Policy as Deprecated
* Avoid the use of Kind() method in DNS/TLS policy validator/status tasks
* Set type of missing resource to Gateway rather than the Policy. This isn't 100% correct since it could be a section name not found, but it's closer than using the policy.