### PR TITLE
remove secret perm as not using it

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -106,7 +106,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-10-31T12:05:38Z"
+    createdAt: "2024-11-04T15:47:12Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -172,14 +172,6 @@ spec:
           - list
           - patch
           - update
-          - watch
-        - apiGroups:
-          - ""
-          resources:
-          - secrets
-          verbs:
-          - get
-          - list
           - watch
         - apiGroups:
           - apps

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -8437,14 +8437,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - apps
   resources:
   - deployments

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -24,14 +24,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
   - apps
   resources:
   - deployments

--- a/controllers/effective_tls_policies_reconciler.go
+++ b/controllers/effective_tls_policies_reconciler.go
@@ -49,7 +49,6 @@ func (t *EffectiveTLSPoliciesReconciler) Subscription() *controller.Subscription
 //+kubebuilder:rbac:groups=kuadrant.io,resources=tlspolicies/finalizers,verbs=update
 //+kubebuilder:rbac:groups="cert-manager.io",resources=issuers,verbs=get;list;watch;
 //+kubebuilder:rbac:groups="cert-manager.io",resources=clusterissuers,verbs=get;list;watch;
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="cert-manager.io",resources=certificates,verbs=get;list;watch;create;update;patch;delete
 
 func (t *EffectiveTLSPoliciesReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, s *sync.Map) error {
@@ -60,7 +59,7 @@ func (t *EffectiveTLSPoliciesReconciler) Reconcile(ctx context.Context, _ []cont
 		return ok
 	})
 
-	// Get all certs in topology for comparison with expected certs to determine orphaned certs later
+	// Get all certs in the topology for comparison with expected certs to determine orphaned certs later
 	// Only certs owned by TLSPolicies should be in the topology - no need to check again
 	certs := lo.FilterMap(topology.Objects().Items(), func(item machinery.Object, index int) (*certmanv1.Certificate, bool) {
 		r, ok := item.(*controller.RuntimeObject)


### PR DESCRIPTION
TLSPolicy no longer interacts with the secret created. So this permission is no longer needed

#962 

Signed-off-by: craig <cbrookes@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED