### PR TITLE
Replace `dynamicMetadata` with `filters` in user-guides

### DIFF
--- a/doc/reference/authpolicy.md
+++ b/doc/reference/authpolicy.md
@@ -107,10 +107,10 @@
 
 ##### SuccessResponseSpec
 
-| **Field**         | **Type**                                                 | **Required** | **Description**                                                                                                                                   |
-|-------------------|----------------------------------------------------------|:------------:|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| `headers`         | Map<String: [SuccessResponseItem](#successresponseitem)> | No           | Custom success response items wrapped as HTTP headers to be injected in the request.                                                              |
-| `dynamicMetadata` | Map<String: [SuccessResponseItem](#successresponseitem)> | No           | Custom success response items wrapped as Envoy Dynamic Metadata. Use it to pass data along to other proxy filters, such as the rate-limit filter. |
+| **Field** | **Type**                                                 | **Required** | **Description**                                                                                      |
+|-----------|----------------------------------------------------------|:------------:|------------------------------------------------------------------------------------------------------|
+| `headers` | Map<String: [SuccessResponseItem](#successresponseitem)> |      No      | Custom success response items wrapped as HTTP headers to be injected in the request.                 |
+| `filters` | Map<String: [SuccessResponseItem](#successresponseitem)> |      No      | Custom success response items made available to other filters managed by Kuadrant (i.e. Rate Limit). |
 
 ###### SuccessResponseItem
 

--- a/doc/user-guides/authenticated-rl-for-app-developers.md
+++ b/doc/user-guides/authenticated-rl-for-app-developers.md
@@ -140,7 +140,7 @@ spec:
             prefix: APIKEY
     response:
       success:
-        dynamicMetadata:
+        filters:
           "identity":
             json:
               properties:

--- a/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
+++ b/doc/user-guides/authenticated-rl-with-jwt-and-k8s-authnz.md
@@ -158,7 +158,7 @@ spec:
             selector: auth.identity.sub
     response:
       success:
-        dynamicMetadata:
+        filters:
           "identity":
             json:
               properties:

--- a/doc/user-guides/secure-protect-connect.md
+++ b/doc/user-guides/secure-protect-connect.md
@@ -427,7 +427,7 @@ spec:
             prefix: APIKEY
     response:
       success:
-        dynamicMetadata:
+        filters:
           "identity":
             json:
               properties:

--- a/examples/toystore/authpolicy.yaml
+++ b/examples/toystore/authpolicy.yaml
@@ -20,7 +20,7 @@ spec:
           prefix: APIKEY
     response:
       success:
-        dynamicMetadata:
+        filters:
           "ext_auth_data":
             json:
               properties:


### PR DESCRIPTION
`dynamicMetadata` is now `filters` in the spec for `AuthPolicy v1beta3`

See here https://github.com/Kuadrant/kuadrant-operator/blob/main/api/v1beta3/authpolicy_types.go#L599-L600