### PR TITLE
fix: Add policy conflict to dnspolicy validation

### DIFF
--- a/api/v1/dnspolicy_types.go
+++ b/api/v1/dnspolicy_types.go
@@ -197,6 +197,7 @@ func (p *DNSPolicy) Validate() error {
 	return p.Spec.ExcludeAddresses.Validate()
 }
 
+// Deprecated: Use GetTargetRefs instead
 func (p *DNSPolicy) GetTargetRef() gatewayapiv1alpha2.LocalPolicyTargetReference {
 	return p.Spec.TargetRef.LocalPolicyTargetReference
 }

--- a/api/v1/tlspolicy_types.go
+++ b/api/v1/tlspolicy_types.go
@@ -175,6 +175,7 @@ func (p *TLSPolicy) Kind() string {
 	return TLSPolicyGroupKind.Kind
 }
 
+// Deprecated: Use GetTargetRefs instead
 func (p *TLSPolicy) GetTargetRef() gatewayapiv1alpha2.LocalPolicyTargetReference {
 	return p.Spec.TargetRef.LocalPolicyTargetReference
 }

--- a/controllers/tlspolicies_validator.go
+++ b/controllers/tlspolicies_validator.go
@@ -98,7 +98,7 @@ func (t *TLSPoliciesValidator) Validate(ctx context.Context, _ []controller.Reso
 // TODO: What should happen if multiple target refs is supported in the future in terms of reporting in log and policy status?
 func (t *TLSPoliciesValidator) isTargetRefsFound(topology *machinery.Topology, p *kuadrantv1.TLSPolicy) error {
 	if len(p.GetTargetRefs()) != len(topology.Targetables().Children(p)) {
-		return kuadrant.NewErrTargetNotFound(kuadrantv1.TLSPolicyGroupKind.Kind, p.GetTargetRef(), apierrors.NewNotFound(controller.GatewaysResource.GroupResource(), p.GetName()))
+		return kuadrant.NewErrTargetNotFound(kuadrantv1.TLSPolicyGroupKind.Kind, p.Spec.TargetRef.LocalPolicyTargetReference, apierrors.NewNotFound(controller.GatewaysResource.GroupResource(), p.GetName()))
 	}
 
 	return nil


### PR DESCRIPTION
Updates the dnspolicies validator task to check for polices with conflicting target refs, only one policy can currently target a specific gateway or listener. Uses the same logic as TLS, first policy created is given preference over any created later.

Some other small changes to align DNSPolicy and TLSPolicy.