### PR TITLE
Fix make bundle

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -134,6 +134,7 @@ make bundle [IMG=quay.io/kuadrant/kuadrant-operator:latest] \
             [AUTHORINO_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/authorino-operator-bundle:latest] \
             [DNS_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:latest] \
             [RELATED_IMAGE_WASMSHIM=oci://quay.io/kuadrant/wasm-shim:latest] \
+            [RELATED_IMAGE_CONSOLEPLUGIN=quay.io/kuadrant/console-plugin:latest] \
             [CHANNELS=alpha] \
             [DEFAULT_CHANNEL=alpha]
 ```

--- a/utils/update-operator-dependencies.sh
+++ b/utils/update-operator-dependencies.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+COMPONENT="${1?:Error \$COMPONENT not set. Bye}"
+IMG="${2?:Error \$IMG not set. Bye}"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+DEP_FILE="${SCRIPT_DIR}/../bundle/metadata/dependencies.yaml"
+V="$( ${SCRIPT_DIR}/parse-bundle-version.sh opm yq ${IMG} )"
+
+COMPONENT=$COMPONENT V=$V \
+  yq eval '(.dependencies[] | select(.value.packageName == strenv(COMPONENT)).value.version) = strenv(V)' -i $DEP_FILE


### PR DESCRIPTION
### What
`bundle` makefile phony target does not fail when a referenced bundle image does not exist

This fix makes it *fail fast* when bundle image does not exist on.

For example, with the changes of this branch, running

```
make bundle IMG=quay.io/kuadrant/kuadrant-operator:latest VERSION=0.12.0 LIMITADOR_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:unknown AUTHORINO_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/authorino-operator-bundle:unknown DNS_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:unknown RELATED_IMAGE_WASMSHIM=oci://quay.io/kuadrant/wasm-shim:latest
```

> Note that `quay.io/kuadrant/limitador-operator-bundle:unknown ` does not exist

The resulting error is:

```
ATH=/home/eguzki/git/kuadrant/kuadrant-operator/bin:$PATH; \
		 /home/eguzki/git/kuadrant/kuadrant-operator/utils/update-operator-dependencies.sh limitador-operator quay.io/kuadrant/limitador-operator-bundle:unknown
2024/11/11 11:53:12 render reference "quay.io/kuadrant/limitador-operator-bundle:unknown": error resolving name : quay.io/kuadrant/limitador-operator-bundle:unknown: not found
```
And the command returns early with the error.

On the other hand, without the changes of this PR (checkout on `main` branch), running the command:

```
make bundle IMG=quay.io/kuadrant/kuadrant-operator:latest VERSION=0.12.0 LIMITADOR_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:unknown AUTHORINO_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/authorino-operator-bundle:unknown DNS_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:unknown RELATED_IMAGE_WASMSHIM=oci://quay.io/kuadrant/wasm-shim:latest
```

The command still fails, but the error is a bundle validation step

```
ERRO[0000] error validating format in bundle: Bundle validation errors: Package version is empty,Package version is empty,Package version is empty
```
Just because the generated bundle is not correct (due to missing bundle image)