### PR TITLE
Fixing a broken link to successresponsespec

### DIFF
--- a/doc/reference/authpolicy.md
+++ b/doc/reference/authpolicy.md
@@ -109,8 +109,8 @@
 
 | **Field** | **Type**                                                 | **Required** | **Description**                                                                                      |
 |-----------|----------------------------------------------------------|:------------:|------------------------------------------------------------------------------------------------------|
-| `headers` | Map<String: [SuccessResponseItem](#successresponseitem)> |      No      | Custom success response items wrapped as HTTP headers to be injected in the request.                 |
-| `filters` | Map<String: [SuccessResponseItem](#successresponseitem)> |      No      | Custom success response items made available to other filters managed by Kuadrant (i.e. Rate Limit). |
+| `headers` | Map&lt;string:[SuccessResponseItem](#successresponseitem)&gt; |      No      | Custom success response items wrapped as HTTP headers to be injected in the request.                 |
+| `filters` | Map&lt;string:[SuccessResponseItem](#successresponseitem)&gt; |      No      | Custom success response items made available to other filters managed by Kuadrant (i.e. Rate Limit). |
 
 ###### SuccessResponseItem
 


### PR DESCRIPTION
![Screenshot 2024-11-11 at 12 24 30](https://github.com/user-attachments/assets/93c0a6ea-01d3-4350-a8a0-593c4b7d5f2b)

![Screenshot 2024-11-11 at 12 23 47](https://github.com/user-attachments/assets/66848d08-4ede-4a90-84ad-9f396846e649)


Note: Test was ran with HEAD from latest, some content changes here recently I believe
