### PR TITLE
fix: incorrect kuadrant status if limitador/authorino is not found

### DIFF
--- a/controllers/kuadrant_status_updater.go
+++ b/controllers/kuadrant_status_updater.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -163,7 +162,7 @@ func checkLimitadorReady(topology *machinery.Topology, logger logr.Logger) *stri
 
 func checkAuthorinoAvailable(topology *machinery.Topology, logger logr.Logger) *string {
 	authorinoObj, err := GetAuthorinoFromTopology(topology)
-	if err != nil && !errors.Is(err, ErrMissingAuthorino) {
+	if err != nil {
 		logger.V(1).Error(err, "failed getting Authorino resource from topology", "status", "error")
 		return ptr.To(err.Error())
 	}

--- a/tests/bare_k8s/kuadrant_controller_test.go
+++ b/tests/bare_k8s/kuadrant_controller_test.go
@@ -7,18 +7,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/kuadrant-operator/controllers"
 	"github.com/kuadrant/kuadrant-operator/tests"
 )
 
-var _ = Describe("Kuadrant controller is disabled", func() {
+var _ = Describe("Controller", func() {
 	var (
 		testNamespace    string
-		kuadrantName     string = "local"
-		afterEachTimeOut        = NodeTimeout(3 * time.Minute)
+		testTimeOut      = SpecTimeout(15 * time.Second)
+		afterEachTimeOut = NodeTimeout(3 * time.Minute)
 	)
 
 	BeforeEach(func(ctx SpecContext) {
@@ -30,24 +32,28 @@ var _ = Describe("Kuadrant controller is disabled", func() {
 	}, afterEachTimeOut)
 
 	Context("when default kuadrant CR is created", func() {
-		It("Status is not populated", func(ctx SpecContext) {
+		It("Status is populated with missing GatewayProvide", func(ctx SpecContext) {
 			kuadrantCR := &kuadrantv1beta1.Kuadrant{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "Kuadrant",
 					APIVersion: kuadrantv1beta1.GroupVersion.String(),
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      kuadrantName,
+					Name:      "local",
 					Namespace: testNamespace,
 				},
 			}
 			Expect(testClient().Create(ctx, kuadrantCR)).ToNot(HaveOccurred())
 
-			kObj := &kuadrantv1beta1.Kuadrant{}
-			err := testClient().Get(ctx, client.ObjectKeyFromObject(kuadrantCR), kObj)
-			Expect(err).ToNot(HaveOccurred())
-			// expected empty. The controller should not have updated it
-			Expect(kObj.Status).To(Equal(kuadrantv1beta1.KuadrantStatus{}))
-		})
+			Eventually(func(g Gomega) {
+				g.Expect(testClient().Get(ctx, client.ObjectKeyFromObject(kuadrantCR), kuadrantCR)).To(Succeed())
+
+				cond := meta.FindStatusCondition(kuadrantCR.Status.Conditions, controllers.ReadyConditionType)
+				g.Expect(cond).ToNot(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal("GatewayAPIProviderNotFound"))
+				g.Expect(cond.Message).To(Equal("GatewayAPI provider not found"))
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
 	})
 })


### PR DESCRIPTION
# Description
* fix: incorrect kuadrant status if limitador/authorino is not found
  * Kuadrant status would incorrectly report as `Ready` if limitador or authorino was not found within the topology
* test: kuadrant status on bare k8s 
  * Kuadrant status test on bare k8s was incorrect and should report `GatewayAPIProviderNotFound` instead

# Verification
* Passing integration tests should be enough

Otherwise to manually verify:
* watch Kuadrant CR
```
watch -n 0.5 "kubectl get kuadrant -A -o yaml"
```
* Deploy Kuadrant CR
```
kubectl -n kuadrant-system apply -f - <<EOF                                 
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```
* Verify Kuadrant CR status eventually becomes ready as Limitador or Authorino recomes ready