### PR TITLE
🪛 permissions to update kuadrant finalizer 🔙

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -105,7 +105,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-11-08T16:43:37Z"
+    createdAt: "2024-11-11T17:42:02Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -328,6 +328,7 @@ spec:
           resources:
           - authpolicies/finalizers
           - dnspolicies/finalizers
+          - kuadrants/finalizers
           - ratelimitpolicies/finalizers
           - tlspolicies/finalizers
           verbs:

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -8679,6 +8679,7 @@ rules:
   resources:
   - authpolicies/finalizers
   - dnspolicies/finalizers
+  - kuadrants/finalizers
   - ratelimitpolicies/finalizers
   - tlspolicies/finalizers
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -176,6 +176,7 @@ rules:
   resources:
   - authpolicies/finalizers
   - dnspolicies/finalizers
+  - kuadrants/finalizers
   - ratelimitpolicies/finalizers
   - tlspolicies/finalizers
   verbs:

--- a/controllers/state_of_the_world.go
+++ b/controllers/state_of_the_world.go
@@ -57,6 +57,7 @@ var (
 
 // kuadrant permissions
 //+kubebuilder:rbac:groups=kuadrant.io,resources=kuadrants,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=kuadrant.io,resources=kuadrants/finalizers,verbs=update
 //+kubebuilder:rbac:groups=kuadrant.io,resources=kuadrants/status,verbs=get;update;patch
 
 // core, apps, coordination.k8s,io permissions


### PR DESCRIPTION
### What

On Openshift, when the Kuadrant CR is created, limitador and authorino are not deployed. On trying to create limitador and authorino resources, the operator logs the error:

```
{"level":"error","ts":"2024-11-11T16:57:46Z","logger":"kuadrant-operator.AuthorinoReconciler","msg":"failed to create authorino resource","status":"error","error":"authorinos.operator.authorino.kuadrant.io \"authorino\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>","stacktrace":"github.com/kuadrant/kuadrant-operator/controllers.(*AuthorinoReconciler).Reconcile\n\t/remote-source/app/controllers/authorino_reconciler.go:112\ngithub.com/kuadrant/policy-machinery/controller.Subscription.Reconcile\n\t/remote-source/deps/gomod/pkg/mod/github.com/kuadrant/policy-machinery@v0.6.4/controller/subscriber.go:34\ngithub.com/kuadrant/policy-machinery/controller.(*Workflow).Run.func1\n\t/remote-source/deps/gomod/pkg/mod/github.com/kuadrant/policy-machinery@v0.6.4/controller/workflow.go:42\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/remote-source/deps/gomod/pkg/mod/golang.org/x/sync@v0.8.0/errgroup/errgroup.go:78"}
```

Important bits:

```
authorinos.operator.authorino.kuadrant.io \"authorino\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on
```

Openshift has admission controller that rejects adding ownerefs with `blockOwnerDeletion: true` when the controller does not have permission to add finalizer on the owner object. 

In the PR https://github.com/Kuadrant/kuadrant-operator/pull/992 a 🐛 🪲 was introduced, creating a regression, which removed permissions to add finalizers to Kuadrant CR's. Thus, the operator cannot create resources with ownerrefs to Kuadrant CR like the Limtador CR and Authorino CR managed by the operator. 

This PR adds the permissions to update finalizers on the Kuadrant CR.

Additionally, the Kuadrant CR status it does not reported the error (the creation of limitador and authorino CR's fail) and reports "READY". It is left as TODO to fix the error reporting, catching error on creating limitador and authorino resources and report back on the status.