### PR TITLE
Add observability steps and configuration

### DIFF
--- a/config/install/configure/observability/kustomization.yaml
+++ b/config/install/configure/observability/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.5.0
+  - ../../../observability/openshift/
+  - ../../../observability/prometheus/monitors/

--- a/config/observability/openshift/grafana/.gitignore
+++ b/config/observability/openshift/grafana/.gitignore
@@ -1,0 +1,1 @@
+datasource.env

--- a/config/observability/openshift/grafana/dashboards.yaml
+++ b/config/observability/openshift/grafana/dashboards.yaml
@@ -1,0 +1,59 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-platform-engineer
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  configMapRef:
+    name: grafana-platform-engineer
+    key: platform_engineer.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-business-user
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  configMapRef:
+    name: grafana-business-user
+    key: business_user.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-controller-resources-metrics
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  configMapRef:
+    name: grafana-controller-resources-metrics
+    key: controller-resources-metrics.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-controller-runtime-metrics
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  configMapRef:
+    name: grafana-controller-runtime-metrics
+    key: controller-runtime-metrics.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-app-developer
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  configMapRef:
+    name: grafana-app-developer
+    key: app_developer.json

--- a/config/observability/openshift/grafana/datasource.yaml
+++ b/config/observability/openshift/grafana/datasource.yaml
@@ -1,0 +1,20 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: thanos-query-ds
+spec:
+  datasource:
+    access: proxy
+    isDefault: true
+    jsonData:
+      httpHeaderName1: 'Authorization'
+      timeInterval: 5s
+      tlsSkipVerify: true
+    secureJsonData:
+      httpHeaderValue1: 'REPLACED_BY_ENV'
+    name: thanos-query-ds
+    type: prometheus
+    url: 'REPLACED_BY_ENV'
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana

--- a/config/observability/openshift/grafana/grafana.yaml
+++ b/config/observability/openshift/grafana/grafana.yaml
@@ -1,0 +1,19 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  labels:
+    dashboards: grafana
+  name: grafana
+spec:
+  config:
+    auth:
+      disable_login_form: 'false'
+    log:
+      mode: console
+    security:
+      admin_password: secret
+      admin_user: root
+  route:
+    metadata: {}
+    spec: {}
+  version: 10.4.3

--- a/config/observability/openshift/grafana/kustomization.yaml
+++ b/config/observability/openshift/grafana/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: monitoring
+
+resources:
+  - grafana.yaml
+  - datasource.yaml
+  - dashboards.yaml
+
+# Generate a ConfigMap from the .env file
+configMapGenerator:
+  - name: datasource-env-config
+    envs:
+      - datasource.env
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: datasource-env-config
+      fieldPath: data.TOKEN
+    targets:
+      - select:
+          kind: GrafanaDatasource
+          name: thanos-query-ds
+        fieldPaths:
+          - spec.datasource.secureJsonData.httpHeaderValue1
+  - source:
+      kind: ConfigMap
+      name: datasource-env-config
+      fieldPath: data.HOST
+    targets:
+      - select:
+          kind: GrafanaDatasource
+          name: thanos-query-ds
+        fieldPaths:
+          - spec.datasource.url
+

--- a/config/observability/openshift/grafana/subscription.yaml
+++ b/config/observability/openshift/grafana/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  labels:
+    operators.coreos.com/grafana-operator.openshift-operators: ""
+  name: grafana-operator
+  namespace: openshift-operators
+spec:
+  channel: v5
+  installPlanApproval: Automatic
+  name: grafana-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/config/observability/openshift/kustomization.yaml
+++ b/config/observability/openshift/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - telemetry.yaml
+  - kube-state-metrics.yaml
+  - grafana/subscription.yaml

--- a/config/observability/openshift/telemetry.yaml
+++ b/config/observability/openshift/telemetry.yaml
@@ -2,7 +2,7 @@ apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
   name: namespace-metrics
-  namespace: istio-system
+  namespace: gateway-system
 spec:
   metrics:
   - providers:

--- a/config/observability/prometheus/monitors/istio/service-monitor-istiod.yaml
+++ b/config/observability/prometheus/monitors/istio/service-monitor-istiod.yaml
@@ -2,11 +2,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: istiod
-  namespace: istio-system
+  namespace: gateway-system
 spec:
   namespaceSelector:
     matchNames:
-    - istio-system
+    - gateway-system
   selector:
     matchLabels:
       app: istiod

--- a/config/observability/prometheus/monitors/istio/telemetry.yaml
+++ b/config/observability/prometheus/monitors/istio/telemetry.yaml
@@ -2,7 +2,7 @@ apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
   name: namespace-metrics
-  namespace: istio-system
+  namespace: gateway-system
 spec:
   metrics:
   - providers:

--- a/config/observability/prometheus/monitors/kustomization.yaml
+++ b/config/observability/prometheus/monitors/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - istio/service-monitor-istiod.yaml
+  - operators.yaml
+

--- a/examples/dashboards/kustomization.yaml
+++ b/examples/dashboards/kustomization.yaml
@@ -1,26 +1,23 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: monitoring
+
 # grafana-dashboard dashboards as configmaps
 configMapGenerator:
 - name: grafana-app-developer
-  namespace: monitoring
   files:
   - ./app_developer.json
 - name: grafana-business-user
-  namespace: monitoring
   files:
   - ./business_user.json
 - name: grafana-platform-engineer
-  namespace: monitoring
   files:
   - ./platform_engineer.json
-- name: grafana-controller-runtime
-  namespace: monitoring
+- name: grafana-controller-runtime-metrics
   files:
   - ./controller-runtime-metrics.json
-- name: grafana-controller-resources
-  namespace: monitoring
+- name: grafana-controller-resources-metrics
   files:
   - ./controller-resources-metrics.json    
 


### PR DESCRIPTION
- cmds added to end of install doc for observability setup
- Grafana installed via olm
- dashboards referenced in GrafanaDashboard CRs via existing example dashboard configmaps
- thanos datasource setup via GrafanaDatasource CR
- existing servicemonitors applied via kustomize