### PR TITLE
guides: fix missing label for AuthPolicy for guide

### DIFF
--- a/doc/user-guides/auth-for-app-devs-and-platform-engineers.md
+++ b/doc/user-guides/auth-for-app-devs-and-platform-engineers.md
@@ -193,6 +193,7 @@ metadata:
   name: api-key-regular-user
   labels:
     authorino.kuadrant.io/managed-by: authorino
+    app: toystore
 stringData:
   api_key: iamaregularuser
 type: Opaque
@@ -203,6 +204,7 @@ metadata:
   name: api-key-admin-user
   labels:
     authorino.kuadrant.io/managed-by: authorino
+    app: toystore
   annotations:
     kuadrant.io/groups: admins
 stringData:


### PR DESCRIPTION
# Description
The API keys secret is missing the `app: toystore` label which was selected for by the `AuthPolicy` in order for the guide to work as expected

# Verification
* Going through the guide should work as described by the guide