### PR TITLE
alignment: TargetSection print column for DNS and TLS policy

### DIFF
--- a/api/v1/dnspolicy_types.go
+++ b/api/v1/dnspolicy_types.go
@@ -157,6 +157,7 @@ var _ kuadrant.Policy = &DNSPolicy{}
 // +kubebuilder:printcolumn:name="Enforced",type=string,JSONPath=`.status.conditions[?(@.type=="Enforced")].status`,description="DNSPolicy Enforced",priority=2
 // +kubebuilder:printcolumn:name="TargetRefKind",type="string",JSONPath=".spec.targetRef.kind",description="Type of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="TargetRefName",type="string",JSONPath=".spec.targetRef.name",description="Name of the referenced Gateway API resource",priority=2
+// +kubebuilder:printcolumn:name="TargetSection",type="string",JSONPath=".spec.targetRef.sectionName",description="Name of the Listener section within the Gateway to which the policy applies ",priority=2
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // DNSPolicy is the Schema for the dnspolicies API

--- a/api/v1/tlspolicy_types.go
+++ b/api/v1/tlspolicy_types.go
@@ -134,6 +134,7 @@ var _ kuadrant.Policy = &TLSPolicy{}
 // +kubebuilder:printcolumn:name="Enforced",type=string,JSONPath=`.status.conditions[?(@.type=="Enforced")].status`,description="TLSPolicy Enforced",priority=2
 // +kubebuilder:printcolumn:name="TargetRefKind",type="string",JSONPath=".spec.targetRef.kind",description="Type of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="TargetRefName",type="string",JSONPath=".spec.targetRef.name",description="Name of the referenced Gateway API resource",priority=2
+// +kubebuilder:printcolumn:name="TargetSection",type="string",JSONPath=".spec.targetRef.sectionName",description="Name of the section within the object to which the policy applies ",priority=2
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // TLSPolicy is the Schema for the tlspolicies API

--- a/api/v1/tlspolicy_types.go
+++ b/api/v1/tlspolicy_types.go
@@ -134,7 +134,7 @@ var _ kuadrant.Policy = &TLSPolicy{}
 // +kubebuilder:printcolumn:name="Enforced",type=string,JSONPath=`.status.conditions[?(@.type=="Enforced")].status`,description="TLSPolicy Enforced",priority=2
 // +kubebuilder:printcolumn:name="TargetRefKind",type="string",JSONPath=".spec.targetRef.kind",description="Type of the referenced Gateway API resource",priority=2
 // +kubebuilder:printcolumn:name="TargetRefName",type="string",JSONPath=".spec.targetRef.name",description="Name of the referenced Gateway API resource",priority=2
-// +kubebuilder:printcolumn:name="TargetSection",type="string",JSONPath=".spec.targetRef.sectionName",description="Name of the section within the object to which the policy applies ",priority=2
+// +kubebuilder:printcolumn:name="TargetSection",type="string",JSONPath=".spec.targetRef.sectionName",description="Name of the Listener section within the Gateway to which the policy applies ",priority=2
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // TLSPolicy is the Schema for the tlspolicies API

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -38,6 +38,12 @@ spec:
       name: TargetRefName
       priority: 2
       type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/bundle/manifests/kuadrant.io_tlspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_tlspolicies.yaml
@@ -38,6 +38,12 @@ spec:
       name: TargetRefName
       priority: 2
       type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -7016,6 +7016,12 @@ spec:
       name: TargetRefName
       priority: 2
       type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -8114,6 +8120,12 @@ spec:
     - description: Name of the referenced Gateway API resource
       jsonPath: .spec.targetRef.name
       name: TargetRefName
+      priority: 2
+      type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
       priority: 2
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -37,6 +37,12 @@ spec:
       name: TargetRefName
       priority: 2
       type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/crd/bases/kuadrant.io_tlspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_tlspolicies.yaml
@@ -37,6 +37,12 @@ spec:
       name: TargetRefName
       priority: 2
       type: string
+    - description: 'Name of the Listener section within the Gateway to which the policy
+        applies '
+      jsonPath: .spec.targetRef.sectionName
+      name: TargetSection
+      priority: 2
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/1014

Adds a `TargetSection` for displaying `SectionName` of the target ref for DNS and TLS policies like how it is currently for Rate Limit and Auth policy

![image](https://github.com/user-attachments/assets/ac46d6db-6405-411b-8122-60b8cb5d974e)
