### PR TITLE
Fixup obs for v1

### DIFF
--- a/config/observability/kustomization.yaml
+++ b/config/observability/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
   - github.com/prometheus-operator/kube-prometheus?ref=release-0.13
-  - github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.5.0
+  - github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.6.0
 # We're using the additionalScrapeConfigs field of the Prometheus CR
 # here to read existing prometheus scrape annotations on pods.
 # Ideally this would be done via another PodMonitor or ServicMonitor,

--- a/doc/install/install-openshift.md
+++ b/doc/install/install-openshift.md
@@ -183,7 +183,7 @@ To scrape these additional metrics, you can install a `kube-state-metrics` insta
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/main/config/observability/openshift/kube-state-metrics.yaml
-kubectl apply -k https://github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.5.0
+kubectl apply -k https://github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.6.0
 ```
 
 To enable request metrics in Istio and scrape them, create the following resource:

--- a/doc/user-guides/secure-protect-connect-single-multi-cluster.md
+++ b/doc/user-guides/secure-protect-connect-single-multi-cluster.md
@@ -192,7 +192,7 @@ spec:
             ["__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape"]
         - action: replace
           regex: (\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})
-          replacement: "[$2]:$1"
+          replacement: "[\$2]:\$1"
           sourceLabels:
             [
               "__meta_kubernetes_pod_annotation_prometheus_io_port",
@@ -201,7 +201,7 @@ spec:
           targetLabel: "__address__"
         - action: replace
           regex: (\d+);((([0-9]+?)(\.|$)){4})
-          replacement: "$2:$1"
+          replacement: "\$2:\$1"
           sourceLabels:
             [
               "__meta_kubernetes_pod_annotation_prometheus_io_port",


### PR DESCRIPTION
- use latest 0.6.0 release of gateway-api-state-metrics with v1 kuadrant crd versions
- fixup escaping of $ in podmonitor bash cmd