### PR TITLE
fix: nil pointer for invalid path for auth

### DIFF
--- a/controllers/auth_policy_status_updater.go
+++ b/controllers/auth_policy_status_updater.go
@@ -2,11 +2,13 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sync"
 
 	envoygatewayv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/go-logr/logr"
 	authorinooperatorv1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
 	authorinov1beta3 "github.com/kuadrant/authorino/api/v1beta3"
 	"github.com/kuadrant/policy-machinery/controller"
@@ -86,7 +88,7 @@ func (r *AuthPolicyStatusUpdater) UpdateStatus(ctx context.Context, _ []controll
 		if !accepted {
 			meta.RemoveStatusCondition(&newStatus.Conditions, string(kuadrant.PolicyConditionEnforced))
 		} else {
-			enforcedCond := r.enforcedCondition(policy, topology, state)
+			enforcedCond := r.enforcedCondition(policy, topology, state, logger)
 			meta.SetStatusCondition(&newStatus.Conditions, *enforcedCond)
 		}
 
@@ -114,7 +116,7 @@ func (r *AuthPolicyStatusUpdater) UpdateStatus(ctx context.Context, _ []controll
 	return nil
 }
 
-func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolicy, topology *machinery.Topology, state *sync.Map) *metav1.Condition {
+func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolicy, topology *machinery.Topology, state *sync.Map, logger logr.Logger) *metav1.Condition {
 	kObj := GetKuadrantFromTopology(topology)
 	if kObj == nil {
 		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrSystemResource("kuadrant"), false)
@@ -149,6 +151,11 @@ func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolic
 		}
 		gatewayClass, gateway, listener, httpRoute, httpRouteRule, err := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
 		if err != nil {
+			if errors.As(err, &kuadrantpolicymachinery.ErrInvalidPath{}) {
+				logger.V(1).Info("skipping effectivePolicy for invalid path", "path", effectivePolicy.Path)
+			} else {
+				logger.Error(err, "unable to process effectivePolicy", "path", effectivePolicy.Path)
+			}
 			continue
 		}
 		if !kuadrantgatewayapi.IsListenerReady(listener.Listener, gateway.Gateway) || !kuadrantgatewayapi.IsHTTPRouteReady(httpRoute.HTTPRoute, gateway.Gateway, gatewayClass.GatewayClass.Spec.ControllerName) {

--- a/controllers/auth_policy_status_updater.go
+++ b/controllers/auth_policy_status_updater.go
@@ -147,7 +147,10 @@ func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolic
 		if len(kuadrantv1.PoliciesInPath(effectivePolicy.Path, func(p machinery.Policy) bool { return p.GetLocator() == policy.GetLocator() })) == 0 {
 			continue
 		}
-		gatewayClass, gateway, listener, httpRoute, httpRouteRule, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
+		gatewayClass, gateway, listener, httpRoute, httpRouteRule, err := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
+		if err != nil {
+			continue
+		}
 		if !kuadrantgatewayapi.IsListenerReady(listener.Listener, gateway.Gateway) || !kuadrantgatewayapi.IsHTTPRouteReady(httpRoute.HTTPRoute, gateway.Gateway, gatewayClass.GatewayClass.Spec.ControllerName) {
 			continue
 		}

--- a/controllers/authconfigs_reconciler.go
+++ b/controllers/authconfigs_reconciler.go
@@ -67,7 +67,11 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 	modifiedAuthConfigs := []string{}
 
 	for pathID, effectivePolicy := range effectivePoliciesMap {
-		_, _, _, httpRoute, httpRouteRule, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
+		_, _, _, httpRoute, httpRouteRule, err := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
+		if err != nil {
+			logger.Error(err, "failed to reconcile authconfig objects", "path", effectivePolicy.Path)
+			continue
+		}
 		httpRouteKey := k8stypes.NamespacedName{Name: httpRoute.GetName(), Namespace: httpRoute.GetNamespace()}
 		httpRouteRuleKey := httpRouteRule.Name
 


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/990

Fixes a `nil` pointer due to attempting to create  an`AuthConfig` for an invalid path.

In the described scenario in the issue, `HTTPRouteRule` is returned `nil` due to invalid path as the `HTTPRoute` only matches only one of the Listener hostname from:
https://github.com/Kuadrant/kuadrant-operator/blob/d5f0184506ee4a71b397b8686add3e348e26d87f/pkg/policymachinery/utils.go#L62-L87

# Verification
* Passing integration tests should be enough as it now includes an integration test for this

If you want to verify manually:
* Checkout main
* Create env
```sh
make local-env-setup
```
* Create resources
```
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant  
metadata:
  name: kuadrant
spec: {} 
---
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: gw
spec:
  gatewayClassName: istio
  listeners:
    - allowedRoutes:
        namespaces:
          from: All
      hostname: prefix1.example.com
      name: api
      port: 80
      protocol: HTTP
    - allowedRoutes:
        namespaces:
          from: All
      hostname: prefix2.example.com
      name: api-second
      port: 81
      protocol: HTTP
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: route
spec:
  hostnames:
    - prefix1.example.com
  parentRefs:
    - group: gateway.networking.k8s.io
      kind: Gateway
      name: gw
  rules:
    - backendRefs:
        - group: ''
          kind: Service
          name: httpbin
          namespace: kuadrant
          port: 8080
          weight: 1
      matches:
        - path:
            type: PathPrefix
            value: /
---                               
apiVersion: kuadrant.io/v1
kind: AuthPolicy
metadata:
  name: authz
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: route
  defaults:
    strategy: merge
    rules:
      authentication:
        "api-key-authn":
          apiKey:
            selector:
              matchLabels:
                app: toystore
          credentials:
            authorizationHeader:
              prefix: APIKEY
EOF
```
* Run operator
```
make run
```
* Verify nil pointer crash
* Checkout this branch
* Run operator again
```
make run
```
* Verify no nil pointer exception
* Verify `AuthPolicy` is enforced
```
kubectl get authpolicy authz -o yaml | yq '.status'
```