### PR TITLE
Set more lenient timeouts for protection services

### DIFF
--- a/pkg/wasm/types.go
+++ b/pkg/wasm/types.go
@@ -43,7 +43,7 @@ func (c *Config) EqualTo(other *Config) bool {
 	}
 
 	for key, service := range c.Services {
-		if otherService, ok := other.Services[key]; !ok || service != otherService {
+		if otherService, ok := other.Services[key]; !ok || !service.EqualTo(otherService) {
 			return false
 		}
 	}
@@ -62,6 +62,17 @@ type Service struct {
 	Type        ServiceType     `json:"type"`
 	FailureMode FailureModeType `json:"failureMode"`
 	Timeout     *string         `json:"timeout,omitempty"`
+}
+
+func (s Service) EqualTo(other Service) bool {
+	if s.Endpoint != other.Endpoint ||
+		s.Type != other.Type ||
+		s.FailureMode != other.FailureMode ||
+		((s.Timeout == nil) != (other.Timeout == nil)) ||
+		(s.Timeout != nil && other.Timeout != nil && *s.Timeout != *other.Timeout) {
+		return false
+	}
+	return true
 }
 
 // +kubebuilder:validation:Enum:=ratelimit;auth

--- a/pkg/wasm/types_test.go
+++ b/pkg/wasm/types_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 )
 
@@ -55,6 +56,7 @@ func TestConfigEqual(t *testing.T) {
 						Type:        "ratelimit",
 						Endpoint:    "kuadrant-ratelimit-service",
 						FailureMode: "allow",
+						Timeout:     ptr.To("100ms"),
 					},
 				},
 				ActionSets: []ActionSet{
@@ -88,7 +90,7 @@ func TestConfigEqual(t *testing.T) {
 					},
 				},
 			},
-			config2: &Config{ // same config as config1 with fields orted alphabetically
+			config2: &Config{ // same config as config1 with fields sorted alphabetically
 				ActionSets: []ActionSet{
 					{
 						Actions: []Action{
@@ -124,6 +126,7 @@ func TestConfigEqual(t *testing.T) {
 						Type:        "ratelimit",
 						Endpoint:    "kuadrant-ratelimit-service",
 						FailureMode: "allow",
+						Timeout:     ptr.To("100ms"),
 					},
 				},
 			},
@@ -139,7 +142,8 @@ func TestConfigEqual(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(subT *testing.T) {
 			if tc.config1.EqualTo(tc.config2) != tc.expected {
-				subT.Fatalf("unexpected config equality result")
+				diff := cmp.Diff(tc.config1, tc.config2)
+				subT.Fatalf("unexpected config equality result (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/wasm/utils.go
+++ b/pkg/wasm/utils.go
@@ -12,6 +12,8 @@ import (
 	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/structpb"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/env"
+	"k8s.io/utils/ptr"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/pkg/gatewayapi"
@@ -24,6 +26,14 @@ const (
 	AuthServiceName      = "auth-service"
 )
 
+func AuthServiceTimeout() string {
+	return env.GetString("AUTH_SERVICE_TIMEOUT", "200ms")
+}
+
+func RatelimitServiceTimeout() string {
+	return env.GetString("RATELIMIT_SERVICE_TIMEOUT", "100ms")
+}
+
 func ExtensionName(gatewayName string) string {
 	return fmt.Sprintf("kuadrant-%s", gatewayName)
 }
@@ -35,11 +45,13 @@ func BuildConfigForActionSet(actionSets []ActionSet) Config {
 				Type:        AuthServiceType,
 				Endpoint:    kuadrant.KuadrantAuthClusterName,
 				FailureMode: FailureModeDeny,
+				Timeout:     ptr.To(AuthServiceTimeout()),
 			},
 			RateLimitServiceName: {
 				Type:        RateLimitServiceType,
 				Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 				FailureMode: FailureModeAllow,
+				Timeout:     ptr.To(RatelimitServiceTimeout()),
 			},
 		},
 		ActionSets: actionSets,

--- a/pkg/wasm/utils_test.go
+++ b/pkg/wasm/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"gotest.tools/assert"
+	"k8s.io/utils/ptr"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -22,11 +23,13 @@ var (
 				Type:        "auth",
 				Endpoint:    "kuadrant-auth-service",
 				FailureMode: "deny",
+				Timeout:     ptr.To("200ms"),
 			},
 			"ratelimit-service": {
 				Type:        "ratelimit",
 				Endpoint:    "kuadrant-ratelimit-service",
 				FailureMode: "allow",
+				Timeout:     ptr.To("100ms"),
 			},
 		},
 		ActionSets: []ActionSet{
@@ -107,17 +110,19 @@ var (
 			},
 		},
 	}
-	testBasicConfigJSON = `{"services":{"auth-service":{"endpoint":"kuadrant-auth-service","type":"auth","failureMode":"deny"},"ratelimit-service":{"endpoint":"kuadrant-ratelimit-service","type":"ratelimit","failureMode":"allow"}},"actionSets":[{"name":"5755da0b3c275ba6b8f553890eb32b04768a703b60ab9a5d7f4e0948e23ef0ab","routeRuleConditions":{"hostnames":["other.example.com"],"predicates":["request.url_path.startsWith('/')"]},"actions":[{"service":"ratelimit-service","scope":"default/other","predicates":["source.address != \"127.0.0.1\""],"data":[{"static":{"key":"limit.global__f63bec56","value":"1"}}]}]},{"name":"21cb3adc608c09a360d62a03fd1afd7cc6f8720999a51d7916927fff26a34ef8","routeRuleConditions":{"hostnames":["*"],"predicates":["request.method == 'GET'","request.url_path.startsWith('/')"]},"actions":[{"service":"auth-service","scope":"e2db39952dd3bc72e152330a2eb15abbd9675c7ac6b54a1a292f07f25f09f138"},{"service":"ratelimit-service","scope":"default/toystore","data":[{"static":{"key":"limit.specific__69ea4d2d","value":"1"}}]},{"service":"ratelimit-service","scope":"default/toystore","predicates":["source.address != \"127.0.0.1\""],"data":[{"static":{"key":"limit.global__f63bec56","value":"1"}}]}]}]}`
+	testBasicConfigJSON = `{"services":{"auth-service":{"endpoint":"kuadrant-auth-service","type":"auth","failureMode":"deny","timeout":"200ms"},"ratelimit-service":{"endpoint":"kuadrant-ratelimit-service","type":"ratelimit","failureMode":"allow","timeout":"100ms"}},"actionSets":[{"name":"5755da0b3c275ba6b8f553890eb32b04768a703b60ab9a5d7f4e0948e23ef0ab","routeRuleConditions":{"hostnames":["other.example.com"],"predicates":["request.url_path.startsWith('/')"]},"actions":[{"service":"ratelimit-service","scope":"default/other","predicates":["source.address != \"127.0.0.1\""],"data":[{"static":{"key":"limit.global__f63bec56","value":"1"}}]}]},{"name":"21cb3adc608c09a360d62a03fd1afd7cc6f8720999a51d7916927fff26a34ef8","routeRuleConditions":{"hostnames":["*"],"predicates":["request.method == 'GET'","request.url_path.startsWith('/')"]},"actions":[{"service":"auth-service","scope":"e2db39952dd3bc72e152330a2eb15abbd9675c7ac6b54a1a292f07f25f09f138"},{"service":"ratelimit-service","scope":"default/toystore","data":[{"static":{"key":"limit.specific__69ea4d2d","value":"1"}}]},{"service":"ratelimit-service","scope":"default/toystore","predicates":["source.address != \"127.0.0.1\""],"data":[{"static":{"key":"limit.global__f63bec56","value":"1"}}]}]}]}`
 	testBasicConfigYAML = `
 services:
   auth-service:
     type: auth
     endpoint: kuadrant-auth-service
     failureMode: deny
+    timeout: 200ms
   ratelimit-service:
     type: ratelimit
     endpoint: kuadrant-ratelimit-service
     failureMode: allow
+    timeout: 100ms
 actionSets:
   - name: 5755da0b3c275ba6b8f553890eb32b04768a703b60ab9a5d7f4e0948e23ef0ab
     routeRuleConditions:

--- a/tests/envoygateway/extension_reconciler_test.go
+++ b/tests/envoygateway/extension_reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -171,11 +172,13 @@ var _ = Describe("wasm controller", func() {
 						Type:        wasm.AuthServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.FailureModeDeny,
+						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitServiceName: {
 						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.FailureModeAllow,
+						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 					},
 				},
 				ActionSets: []wasm.ActionSet{
@@ -335,11 +338,13 @@ var _ = Describe("wasm controller", func() {
 						Type:        wasm.AuthServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.FailureModeDeny,
+						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitServiceName: {
 						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.FailureModeAllow,
+						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 					},
 				},
 				ActionSets: []wasm.ActionSet{

--- a/tests/istio/extension_reconciler_test.go
+++ b/tests/istio/extension_reconciler_test.go
@@ -149,11 +149,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 						Type:        wasm.AuthServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.FailureModeDeny,
+						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitServiceName: {
 						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.FailureModeAllow,
+						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 					},
 				},
 				ActionSets: []wasm.ActionSet{
@@ -287,6 +289,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 				Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 				FailureMode: wasm.FailureModeAllow,
 				Type:        wasm.RateLimitServiceType,
+				Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 			}))
 			Expect(existingWASMConfig.ActionSets).To(HaveLen(6))
 
@@ -714,11 +717,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 						Type:        wasm.AuthServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.FailureModeDeny,
+						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitServiceName: {
+						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.FailureModeAllow,
-						Type:        wasm.RateLimitServiceType,
+						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 					},
 				},
 				ActionSets: []wasm.ActionSet{
@@ -932,14 +937,16 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 				expectedPlugin := &wasm.Config{
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
+							Type:        wasm.AuthServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.FailureModeDeny,
-							Type:        wasm.AuthServiceType,
+							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitServiceName: {
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.FailureModeAllow,
-							Type:        wasm.RateLimitServiceType,
+							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1145,11 +1152,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Type:        wasm.AuthServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.FailureModeDeny,
+							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitServiceName: {
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.FailureModeAllow,
-							Type:        wasm.RateLimitServiceType,
+							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1273,11 +1282,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Type:        wasm.AuthServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.FailureModeDeny,
+							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitServiceName: {
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.FailureModeAllow,
-							Type:        wasm.RateLimitServiceType,
+							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1473,11 +1484,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Type:        wasm.AuthServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.FailureModeDeny,
+							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitServiceName: {
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.FailureModeAllow,
-							Type:        wasm.RateLimitServiceType,
+							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1564,11 +1577,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Type:        wasm.AuthServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.FailureModeDeny,
+							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitServiceName: {
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.FailureModeAllow,
-							Type:        wasm.RateLimitServiceType,
+							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1739,11 +1754,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Type:        wasm.AuthServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.FailureModeDeny,
+							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitServiceName: {
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.FailureModeAllow,
-							Type:        wasm.RateLimitServiceType,
+							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1848,11 +1865,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Type:        wasm.AuthServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.FailureModeDeny,
+							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitServiceName: {
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.FailureModeAllow,
-							Type:        wasm.RateLimitServiceType,
+							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -2059,11 +2078,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Type:        wasm.AuthServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.FailureModeDeny,
+							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitServiceName: {
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.FailureModeAllow,
-							Type:        wasm.RateLimitServiceType,
+							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -2165,11 +2186,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Type:        wasm.AuthServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.FailureModeDeny,
+							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitServiceName: {
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.FailureModeAllow,
-							Type:        wasm.RateLimitServiceType,
+							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -2330,11 +2353,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 						Type:        wasm.AuthServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.FailureModeDeny,
+						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitServiceName: {
+						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.FailureModeAllow,
-						Type:        wasm.RateLimitServiceType,
+						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 					},
 				},
 				ActionSets: []wasm.ActionSet{
@@ -2406,11 +2431,13 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 						Type:        wasm.AuthServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.FailureModeDeny,
+						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitServiceName: {
+						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.FailureModeAllow,
-						Type:        wasm.RateLimitServiceType,
+						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
 					},
 				},
 				ActionSets: []wasm.ActionSet{


### PR DESCRIPTION
The [default connection timeout](https://github.com/Kuadrant/wasm-shim/blob/main/src/configuration.rs#L172-L176) used by the wasm-shim when the value is omitted is 20ms. This could be too short when set to use external redis for rate limiting, or with complex auth policies. By default I have increased this to:

* 200ms for auth (this matches the value in [envoy ext auth](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/ext_authz/v3/ext_authz.proto))
* 100ms for rate limiting

This is also not exposed by the API in anyway, and any changes to the `WasmPlugin` will be overridden by the operator, so it's not possible to set these values. For now until we decide how to expose this in the API I've added two env vars:
* `AUTH_SERVICE_TIMEOUT`
* `RATELIMIT_SERVICE_TIMEOUT`

These let us override the defaults if a user requires.