### PR TITLE
Fix references to renamed dashboard configmaps

### DIFF
--- a/config/observability/grafana/grafana_deployment_patch.yaml
+++ b/config/observability/grafana/grafana_deployment_patch.yaml
@@ -22,17 +22,17 @@
 - op: add
   path: /spec/template/spec/volumes/-
   value:
-    name: grafana-controller-resources
+    name: grafana-controller-resources-metrics
     configMap:
       defaultMode: 420
-      name: grafana-controller-resources
+      name: grafana-controller-resources-metrics
 - op: add
   path: /spec/template/spec/volumes/-
   value:
-    name: grafana-controller-runtime
+    name: grafana-controller-runtime-metrics
     configMap:
       defaultMode: 420
-      name: grafana-controller-runtime
+      name: grafana-controller-runtime-metrics
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value:
@@ -51,10 +51,10 @@
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value:
-    name: grafana-controller-runtime
-    mountPath: /grafana-dashboard-definitions/0/grafana-controller-runtime
+    name: grafana-controller-runtime-metrics
+    mountPath: /grafana-dashboard-definitions/0/grafana-controller-runtime-metrics
 - op: add
   path: /spec/template/spec/containers/0/volumeMounts/-
   value:
-    name: grafana-controller-resources
-    mountPath: /grafana-dashboard-definitions/0/grafana-controller-resources
+    name: grafana-controller-resources-metrics
+    mountPath: /grafana-dashboard-definitions/0/grafana-controller-resources-metrics


### PR DESCRIPTION
Knock on from renaming of configmaps in https://github.com/Kuadrant/kuadrant-operator/commit/526b0c9b8f6bb623159a7d132b21e87b4230fee6#diff-1f10072a23b74e4257ddbad38fb10afc7c0839c839d0af0b550a40bdbd3c22ed
(configmaps were renamed to have to the same name as the json files)


**NOTE:** This affects local/kubernetes setup of dashboards in grafana if the cmds at https://github.com/Kuadrant/kuadrant-operator/blob/main/config/observability/README.md are followed. It does *NOT* affect openshift setup as that's a completely different guide.