### PR TITLE
doc: remove multiple network resources with identical hostnames limitation

### DIFF
--- a/doc/overviews/rate-limiting.md
+++ b/doc/overviews/rate-limiting.md
@@ -213,7 +213,6 @@ Check out the following user guides for examples of rate limiting services with 
 ### Known limitations
 
 - RateLimitPolicies can only target HTTPRoutes/Gateways defined within the same namespace of the RateLimitPolicy.
-- 2+ RateLimitPolicies cannot target network resources that define/inherit the same exact hostname.
 
 ## Implementation details
 


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/702

https://github.com/Kuadrant/kuadrant-operator/issues/702 has been fixed and with the refactor to effective policies the limitatation for multiple network resources with identical hostnames no longer applies for Auth and RateLimit policy

# Verification
* You can follow https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/auth-for-app-devs-and-platform-engineers.md but at step 4, create a `HTTPRoute` that defines the same hostname with a different path:
```
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: other
spec:
  parentRefs:
  - name: kuadrant-ingressgateway
    namespace: gateway-system
  hostnames:
  - api.toystore.com
  rules:
  - matches: # rule-1
    - method: GET
      path:
        type: PathPrefix
        value: "/other"
    backendRefs:
    - name: toystore
      port: 80
EOF
``` 
* Curling this path should give a `403` as it's protected by the GW policy
```
 curl -H 'Host: api.toystore.com'  http://$GATEWAY_URL/other -i
```