### PR TITLE
guides: auth anonymous access

### DIFF
--- a/doc/user-guides/anonymous-access.md
+++ b/doc/user-guides/anonymous-access.md
@@ -1,0 +1,177 @@
+# Enforcing anonymous access with Kuadrant AuthPolicy
+
+Learn how to allow anonymous access to certain endpoints using Kuadrant's `AuthPolicy`
+
+## Requisites
+
+- [Docker](https://docker.io)
+
+## Run the guide ① → ④
+
+### ①  Setup 
+
+Clone the repo:
+
+```sh
+git clone git@github.com:Kuadrant/kuadrant-operator.git && cd kuadrant-operator
+```
+
+Run the following command to create a local Kubernetes cluster with [Kind](https://kind.sigs.k8s.io/), install & deploy Kuadrant:
+
+```sh
+make local-setup
+```
+
+Request an instance of Kuadrant in the `kuadrant-system` namespace:
+
+```sh
+kubectl -n kuadrant-system apply -f - <<EOF
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+spec: {}
+EOF
+```
+
+### ② Deploy the Talker API
+
+```sh
+kubectl apply -f examples/toystore/toystore.yaml
+
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: toystore
+spec:
+  parentRefs:
+  - name: kuadrant-ingressgateway
+    namespace: gateway-system
+  hostnames:
+  - api.toystore.com
+  rules:
+  - matches: # rule-1
+    - method: GET
+      path:
+        type: PathPrefix
+        value: "/cars"
+    backendRefs:
+    - name: toystore
+      port: 80
+  - matches: # rule-2
+    - method: GET
+      path:
+        type: PathPrefix
+        value: "/public"
+    backendRefs:
+    - name: toystore
+      port: 80
+EOF
+```
+
+Export the gateway hostname and port:
+
+```sh
+export INGRESS_HOST=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.status.addresses[0].value}')
+export INGRESS_PORT=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
+export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
+```
+
+Test requests to the unprotected application:
+
+```sh
+curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/cars -i
+# HTTP/1.1 200 OK
+```
+
+```sh
+curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/public -i
+# HTTP/1.1 200 OK
+```
+
+### ③ Protect the Toy Store application
+
+Create an `AuthPolicy` to protect the `HTTPRoute`:
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: route-auth
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: toystore
+  defaults:
+    strategy: atomic
+    rules:
+      authorization:
+        deny-all:
+          opa:
+            rego: "allow = false"
+EOF
+```
+
+Test requests to the protected application:
+
+```sh
+curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/cars -i
+# HTTP/1.1 403 Forbidden
+```
+
+```sh
+curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/public -i
+# HTTP/1.1 403 Forbidden
+```
+
+### ④ Allow Anonymous Access to the Public Route
+Create an `AuthPolicy` to enable anonymous access for the `/public` rule:
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: rule-2-auth
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: toystore
+    sectionName: rule-2
+  defaults:
+    rules:
+      authentication:
+        "public":
+          anonymous: {}
+EOF
+```
+
+The example above enables anonymous access (i.e. removes authentication) to the `/public` rule of the `HTTPRoute`.
+
+### ④ Consume the API
+
+Test requests to the application protected by Kuadrant:
+
+```sh
+curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/cars -i
+# HTTP/1.1 403 Forbidden
+```
+
+```sh
+curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/public -i
+# HTTP/1.1 200 OK
+```
+
+## Cleanup
+
+```sh
+kubectl delete -f examples/toystore/toystore.yaml
+kubectl delete httproute toystore
+kubectl delete authpolicy route-auth
+kubectl delete authpolicy rule-2-auth
+kubectl delete kuadrant kuadrant -n kuadrant-system
+```

--- a/doc/user-guides/auth/anonymous-access.md
+++ b/doc/user-guides/auth/anonymous-access.md
@@ -4,7 +4,7 @@ Learn how to allow anonymous access to certain endpoints using Kuadrant's `AuthP
 
 ## Prerequisites
 
-You have installed Kuadrant in a [kubernetes](https://docs.kuadrant.io/latest/kuadrant-operator/doc/install/install-kubernetes/) or [OpenShift](https://docs.kuadrant.io/latest/kuadrant-operator/doc/install/install-openshift/) cluster with a Gateway provider.
+Kubernetes cluster with Kuadrant installed.
 
 ### Create Gateway
 Create a `Gateway` resource for this guide:

--- a/doc/user-guides/auth/anonymous-access.md
+++ b/doc/user-guides/auth/anonymous-access.md
@@ -6,8 +6,7 @@ Learn how to allow anonymous access to certain endpoints using Kuadrant's `AuthP
 
 You have installed Kuadrant in a [kubernetes](https://docs.kuadrant.io/latest/kuadrant-operator/doc/install/install-kubernetes/) or [OpenShift](https://docs.kuadrant.io/latest/kuadrant-operator/doc/install/install-openshift/) cluster.
 
-## Run the guide ① → ⑦
-### ① Deploy Toy Store application
+### Deploy Toy Store application
 
 Deploy a simple HTTP application service that echoes back the request data:
 
@@ -15,7 +14,7 @@ Deploy a simple HTTP application service that echoes back the request data:
 kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/heads/main/examples/toystore/toystore.yaml
 ```
 
-### ② Expose the Application
+### Expose the Application
 
 Create an `HTTPRoute` to expose an `/cars` and `/public` path to the application:
 
@@ -59,7 +58,7 @@ export INGRESS_PORT=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system 
 export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
 ```
 
-### ③ Test the Unprotected Application
+### Test the Unprotected Application
 Test requests to the unprotected application:
 
 ```sh
@@ -72,7 +71,7 @@ curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/public -i
 # HTTP/1.1 200 OK
 ```
 
-### ④ Deny All Traffic with AuthPolicy
+### Deny All Traffic with AuthPolicy
 
 Apply an `AuthPolicy` to deny all traffic to the `HTTPRoute`:
 
@@ -97,7 +96,7 @@ spec:
 EOF
 ```
 
-### ⑤ Test the Protected Application
+### Test the Protected Application
 
 ```sh
 curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/cars -i
@@ -109,7 +108,7 @@ curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/public -i
 # HTTP/1.1 403 Forbidden
 ```
 
-### ⑥ Allow Anonymous Access to /public
+### Allow Anonymous Access to /public
 Create an `AuthPolicy` to allow anonymous access to the `/public` endpoint:
 
 ```sh
@@ -134,7 +133,7 @@ EOF
 
 The example above enables anonymous access (i.e. removes authentication) to the `/public` rule of the `HTTPRoute`.
 
-### ⑦ Test the Application with Anonymous Access
+### Test the Application with Anonymous Access
 
 Test requests to the application protected by Kuadrant:
 


### PR DESCRIPTION
# Description
Part of https://github.com/Kuadrant/docs.kuadrant.io/issues/25

Introduces an `AuthPolicy` guide describing how anonymous acces can be enforced to a section of a `HTTPRoute`.
This can serve as an equivalent / replacement guide to https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/anonymous-access.md guide on https://docs.kuadrant.io/0.11.0/authorino/docs/user-guides/anonymous-access/

# Verification
* Running through the guide should work as expected where the `/cars` endpint is protected but anonymous access is explicitly allows for the `/pubic` endpoint 