### PR TITLE
dep: Bump dns-operator version to v0.10.0

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -109,7 +109,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2024-11-18T10:54:46Z"
+    createdAt: "2024-11-25T09:30:08Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -98,15 +98,19 @@ spec:
                     - name
                     type: object
                   failureThreshold:
-                    description: FailureThreshold is a limit of consecutive failures
-                      that must occur for a host to be considered unhealthy
+                    default: 5
+                    description: |-
+                      FailureThreshold is a limit of consecutive failures that must occur for a host to be considered unhealthy
+                      Defaults to 5
                     type: integer
                     x-kubernetes-validations:
                     - message: Failure threshold must be greater than 0
                       rule: self > 0
                   interval:
-                    description: Interval defines how frequently this probe should
-                      execute
+                    default: 5m
+                    description: |-
+                      Interval defines how frequently this probe should execute
+                      Defaults to 5 minutes
                     type: string
                   path:
                     description: |-
@@ -115,15 +119,19 @@ spec:
                     pattern: ^(?:\?|\/)[\w\-.~:\/?#\[\]@!$&'()*+,;=]+(?:[a-zA-Z0-9]|\/){1}$
                     type: string
                   port:
-                    description: Port to connect to the host on. Must be either 80,
-                      443 or 1024-49151
+                    default: 443
+                    description: |-
+                      Port to connect to the host on. Must be either 80, 443 or 1024-49151
+                      Defaults to port 443
                     type: integer
                     x-kubernetes-validations:
                     - message: Only ports 80, 443, 1024-49151 are allowed
                       rule: self in [80, 443] || (self >= 1024 && self <= 49151)
                   protocol:
-                    description: Protocol to use when connecting to the host, valid
-                      values are "HTTP" or "HTTPS"
+                    default: HTTPS
+                    description: |-
+                      Protocol to use when connecting to the host, valid values are "HTTP" or "HTTPS"
+                      Defaults to HTTPS
                     type: string
                     x-kubernetes-validations:
                     - message: Only HTTP or HTTPS protocols are allowed

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -7064,15 +7064,19 @@ spec:
                     - name
                     type: object
                   failureThreshold:
-                    description: FailureThreshold is a limit of consecutive failures
-                      that must occur for a host to be considered unhealthy
+                    default: 5
+                    description: |-
+                      FailureThreshold is a limit of consecutive failures that must occur for a host to be considered unhealthy
+                      Defaults to 5
                     type: integer
                     x-kubernetes-validations:
                     - message: Failure threshold must be greater than 0
                       rule: self > 0
                   interval:
-                    description: Interval defines how frequently this probe should
-                      execute
+                    default: 5m
+                    description: |-
+                      Interval defines how frequently this probe should execute
+                      Defaults to 5 minutes
                     type: string
                   path:
                     description: |-
@@ -7081,15 +7085,19 @@ spec:
                     pattern: ^(?:\?|\/)[\w\-.~:\/?#\[\]@!$&'()*+,;=]+(?:[a-zA-Z0-9]|\/){1}$
                     type: string
                   port:
-                    description: Port to connect to the host on. Must be either 80,
-                      443 or 1024-49151
+                    default: 443
+                    description: |-
+                      Port to connect to the host on. Must be either 80, 443 or 1024-49151
+                      Defaults to port 443
                     type: integer
                     x-kubernetes-validations:
                     - message: Only ports 80, 443, 1024-49151 are allowed
                       rule: self in [80, 443] || (self >= 1024 && self <= 49151)
                   protocol:
-                    description: Protocol to use when connecting to the host, valid
-                      values are "HTTP" or "HTTPS"
+                    default: HTTPS
+                    description: |-
+                      Protocol to use when connecting to the host, valid values are "HTTP" or "HTTPS"
+                      Defaults to HTTPS
                     type: string
                     x-kubernetes-validations:
                     - message: Only HTTP or HTTPS protocols are allowed

--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -97,15 +97,19 @@ spec:
                     - name
                     type: object
                   failureThreshold:
-                    description: FailureThreshold is a limit of consecutive failures
-                      that must occur for a host to be considered unhealthy
+                    default: 5
+                    description: |-
+                      FailureThreshold is a limit of consecutive failures that must occur for a host to be considered unhealthy
+                      Defaults to 5
                     type: integer
                     x-kubernetes-validations:
                     - message: Failure threshold must be greater than 0
                       rule: self > 0
                   interval:
-                    description: Interval defines how frequently this probe should
-                      execute
+                    default: 5m
+                    description: |-
+                      Interval defines how frequently this probe should execute
+                      Defaults to 5 minutes
                     type: string
                   path:
                     description: |-
@@ -114,15 +118,19 @@ spec:
                     pattern: ^(?:\?|\/)[\w\-.~:\/?#\[\]@!$&'()*+,;=]+(?:[a-zA-Z0-9]|\/){1}$
                     type: string
                   port:
-                    description: Port to connect to the host on. Must be either 80,
-                      443 or 1024-49151
+                    default: 443
+                    description: |-
+                      Port to connect to the host on. Must be either 80, 443 or 1024-49151
+                      Defaults to port 443
                     type: integer
                     x-kubernetes-validations:
                     - message: Only ports 80, 443, 1024-49151 are allowed
                       rule: self in [80, 443] || (self >= 1024 && self <= 49151)
                   protocol:
-                    description: Protocol to use when connecting to the host, valid
-                      values are "HTTP" or "HTTPS"
+                    default: HTTPS
+                    description: |-
+                      Protocol to use when connecting to the host, valid values are "HTTP" or "HTTPS"
+                      Defaults to HTTPS
                     type: string
                     x-kubernetes-validations:
                     - message: Only HTTP or HTTPS protocols are allowed

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/kuadrant/authorino v0.19.0
 	github.com/kuadrant/authorino-operator v0.11.1
-	github.com/kuadrant/dns-operator v0.0.0-20241108101824-a0cca97b2ef8
+	github.com/kuadrant/dns-operator v0.10.0
 	github.com/kuadrant/limitador-operator v0.9.0
 	github.com/kuadrant/policy-machinery v0.6.4
 	github.com/martinlindhe/base36 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/kuadrant/authorino v0.19.0 h1:vPkDWVgQPi5A91MfIyWe06rLW0ZaACd+8j2SZPK
 github.com/kuadrant/authorino v0.19.0/go.mod h1:J9B/8aZMSyim6CxdmSlS2kRfQt3xMrZub2V/qHnkNeA=
 github.com/kuadrant/authorino-operator v0.11.1 h1:jndTZhiHMU+2Dk0NU+KP2+MUSfvclrn+YtTCQDJj+1s=
 github.com/kuadrant/authorino-operator v0.11.1/go.mod h1:TeFFdX477vUTMushCojaHpvwPLga4DpErGI2oQbqFIs=
-github.com/kuadrant/dns-operator v0.0.0-20241108101824-a0cca97b2ef8 h1:z+pdlUIPjLCeytxmL5/NcORm3elZDAP8i+MLIpMba9U=
-github.com/kuadrant/dns-operator v0.0.0-20241108101824-a0cca97b2ef8/go.mod h1:LGG4R3KEz93Ep0CV1/tziCmRk+VtojWUHR9mXkOHZks=
+github.com/kuadrant/dns-operator v0.10.0 h1:3NfHauZ7bnldfNPcd5rlreU9vVV9yKTGl8M0O+k1cKk=
+github.com/kuadrant/dns-operator v0.10.0/go.mod h1:7JmHQZJC9JUwzb0ZCZRml6qy6oDkOGU+lMeX2+2cgu0=
 github.com/kuadrant/limitador-operator v0.9.0 h1:hTQ6CFPayf/sL7cIzwWjCoU8uTn6fzWdsJgKbDlnFts=
 github.com/kuadrant/limitador-operator v0.9.0/go.mod h1:DQOlg9qFOcnWPrwO529JRCMLLOEXJQxkmOes952S/Hw=
 github.com/kuadrant/policy-machinery v0.6.4 h1:UMdZ2p7WyUdOKcWlJA2w2MzJnB8/Nn4dT6hE9cUcbeg=


### PR DESCRIPTION
For consistency across our module dependencies we should update this. Released versions should probably always pin these to a tag. 