### PR TITLE
Add ns to apikey secret

### DIFF
--- a/doc/user-guides/secure-protect-connect.md
+++ b/doc/user-guides/secure-protect-connect.md
@@ -384,6 +384,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: bob-key
+  namespace: kuadrant-system
   labels:
     authorino.kuadrant.io/managed-by: authorino
     app: toystore
@@ -397,6 +398,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: alice-key
+  namespace: kuadrant-system
   labels:
     authorino.kuadrant.io/managed-by: authorino
     app: toystore


### PR DESCRIPTION
Secrets need to be in the same namespace as the Authorino CR.

Discussion about this at https://kubernetes.slack.com/archives/C05J0D0V525/p1732556753363609