### PR TITLE
makefile: add --load flag only for podman build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ARCH := $(shell uname -m | tr '[:upper:]' '[:lower:]')
 # Container Engine to be used for building image and with kind
 CONTAINER_ENGINE ?= docker
+ifeq (podman,$(CONTAINER_ENGINE))
+	CONTAINER_ENGINE_EXTRA_FLAGS ?= --load
+endif
 
 # VERSION defines the project version for the bundle.
 # Update this value when you upgrade the version of your project.
@@ -353,7 +356,7 @@ docker-build: ## Build docker image with the manager.
 		--build-arg DIRTY=$(DIRTY) \
 		--build-arg VERSION=v$(VERSION) \
 		--build-arg QUAY_IMAGE_EXPIRY=$(QUAY_IMAGE_EXPIRY) \
-		--load \
+		$(CONTAINER_ENGINE_EXTRA_FLAGS) \
 		-t $(IMG) .
 
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
# Description
The `--load` flag only works with podman and not docker as the container engine, with docker failing with the following error:

```
docker build \
                --build-arg QUAY_IMAGE_EXPIRY=never \
                --build-arg GIT_SHA=c61fa68ac239b1a1f819ab5b3c791b5914ddc0b7 \
                --build-arg DIRTY=true \
                --build-arg QUAY_IMAGE_EXPIRY=never \
                --load \
                -t quay.io/kuadrant/kuadrant-operator:dev .
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

unknown flag: --load
See 'docker build --help'.
```

This would cause the `make local-setup` command and other related commands that build the image using docker to fail. 
To workaround, I've added a `CONTAINER_ENGINE_EXTRA_FLAGS` variable to contain any specific container engine related flags for building the image, while also allowing it to be overridden if necessary.

# Verification
* Running `CONTAINER_ENGINE=podman make local-setup` and `CONTAINER_ENGINE=docker make local-setup`should not fail. Alternative you can just verify the image build only using  `CONTAINER_ENGINE=<docker | podman> make 
docker-build` 

Podman build logs:
```
podman build \
                --build-arg QUAY_IMAGE_EXPIRY=never \
                --build-arg GIT_SHA=c61fa68ac239b1a1f819ab5b3c791b5914ddc0b7 \
                --build-arg DIRTY=true \
                --build-arg QUAY_IMAGE_EXPIRY=never \
                --load \
                -t quay.io/kuadrant/kuadrant-operator:dev .
[1/2] STEP 1/16: FROM --platform=linux/arm64/v8 golang:1.22 AS builder
[1/2] STEP 2/16: WORKDIR /workspace
--> Using cache 890b4b1b99073b4a2cdb97cf0498393199abfed38087ac38a52a9c38342dc297
--> 890b4b1b9907
[1/2] STEP 3/16: COPY go.mod go.mod
--> Using cache aec05f2323b8e4421f51920494ed4bec73d2061d0bee889808367e53252a46c0
--> aec05f2323b8
[1/2] STEP 4/16: COPY go.sum go.sum
--> Using cache 80471299a3c9e4b95232124c871ebc48e76ec7acfe06199e26e992cef5d32eef
--> 80471299a3c9
[1/2] STEP 5/16: RUN go mod download
--> Using cache 69fcb01f3e0ff8b85af674c212cc1b5cbf46537200c9af08cec0f83b5d172c32
--> 69fcb01f3e0f
[1/2] STEP 6/16: COPY main.go main.go
--> Using cache f3980b70b60c750d58a9aee0c071bf19880a782a678301cd433acfe5bf568c08
--> f3980b70b60c
[1/2] STEP 7/16: COPY api/ api/
--> Using cache df10b3a8a5bdb780b153d63bed8e9c62298df85164476682144c24e0d12e28bd
--> df10b3a8a5bd
[1/2] STEP 8/16: COPY controllers/ controllers/
--> Using cache 4600d7e4a74210338f0708c39dd22fdb7cfe3edbffe5d6741a44acf0d8423844
--> 4600d7e4a742
[1/2] STEP 9/16: COPY pkg/ pkg/
--> Using cache ae9262d6b017688d844f791a7110b43a326c6836b5ad7e14e5a32b4bdfb578e2
--> ae9262d6b017
[1/2] STEP 10/16: COPY version/ version/
--> Using cache 0eb0bd038e7e6ffcf5777666a73546399477e1b196f5989045671c0130d87975
--> 0eb0bd038e7e
[1/2] STEP 11/16: ARG TARGETARCH
--> Using cache bda9a8958b7f5eb57b803b136bcfc31710289e165db81566ebe5ab54351cf45c
--> bda9a8958b7f
[1/2] STEP 12/16: ARG GIT_SHA
--> Using cache 57a477434efdb32fd4f3cb92da49dbc93d6a10d22ef4da4737b1075e0f4733c2
--> 57a477434efd
[1/2] STEP 13/16: ARG DIRTY
--> Using cache 44ad5ac7e927e0dd6c2ab6706738e5bed15e4478af352782c7cffd9f2dd0a38c
--> 44ad5ac7e927
[1/2] STEP 14/16: ENV GIT_SHA=${GIT_SHA:-unknown}
--> Using cache bc390f4f84f3ceab2e21dbd98ebce940064bcbd3332949109bb965664261cc9c
--> bc390f4f84f3
[1/2] STEP 15/16: ENV DIRTY=${DIRTY:-unknown}
--> Using cache fbed7bda702e7fd20e88fc9f177363c7e771561c547f3939bb634182c2683b3a
--> fbed7bda702e
[1/2] STEP 16/16: RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o manager main.go
--> 2fd928f304ab
[2/2] STEP 1/8: FROM gcr.io/distroless/static:nonroot
[2/2] STEP 2/8: WORKDIR /
--> Using cache 7f545449a44c29045b6b833a90570efd9b75cc9bd27a4fee527bdfafc411714a
--> 7f545449a44c
[2/2] STEP 3/8: COPY --from=builder /workspace/manager .
--> d71b4d67f0b0
[2/2] STEP 4/8: USER 65532:65532
--> d36258690aa8
[2/2] STEP 5/8: ARG QUAY_IMAGE_EXPIRY
--> 31db42cc3df4
[2/2] STEP 6/8: ENV QUAY_IMAGE_EXPIRY=${QUAY_IMAGE_EXPIRY:-never}
--> 7ef3d4ad7e38
[2/2] STEP 7/8: LABEL quay.expires-after=$QUAY_IMAGE_EXPIRY
--> 10ab6a430f10
[2/2] STEP 8/8: ENTRYPOINT ["/manager"]
[2/2] COMMIT quay.io/kuadrant/kuadrant-operator:dev
--> 9066d9224fe3
Successfully tagged quay.io/kuadrant/kuadrant-operator:dev

```

docker build logs:
```
docker build \
                --build-arg QUAY_IMAGE_EXPIRY=never \
                --build-arg GIT_SHA=c61fa68ac239b1a1f819ab5b3c791b5914ddc0b7 \
                --build-arg DIRTY=true \
                --build-arg QUAY_IMAGE_EXPIRY=never \
                 \
                -t quay.io/kuadrant/kuadrant-operator:dev .
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            Install the buildx component to build images with BuildKit:
            https://docs.docker.com/go/buildx/

Sending build context to Docker daemon  105.4MB
[1/2] STEP 1/16: FROM --platform=linux/arm64/v8 golang:1.22 AS builder
[1/2] STEP 2/16: WORKDIR /workspace
--> c7ba41d6b06b
[1/2] STEP 3/16: COPY go.mod go.mod
--> 37064f555bd3
[1/2] STEP 4/16: COPY go.sum go.sum
--> 3413d3495b5d
[1/2] STEP 5/16: RUN go mod download
--> 43535777ae73
[1/2] STEP 6/16: COPY main.go main.go
--> 5a346e3f7a54
[1/2] STEP 7/16: COPY api/ api/
--> a17c58850fe2
[1/2] STEP 8/16: COPY controllers/ controllers/
--> ef29cc73b92a
[1/2] STEP 9/16: COPY pkg/ pkg/
--> 9b6e547802f2
[1/2] STEP 10/16: COPY version/ version/
--> ce986cc9dac9
[1/2] STEP 11/16: ARG TARGETARCH
--> 4d3fb71358d7
[1/2] STEP 12/16: ARG GIT_SHA
--> 5930a746868f
[1/2] STEP 13/16: ARG DIRTY
--> 21b052eb3a4d
[1/2] STEP 14/16: ENV GIT_SHA=${GIT_SHA:-unknown}
--> c00288a4b188
[1/2] STEP 15/16: ENV DIRTY=${DIRTY:-unknown}
--> 9d0847e7345a
[1/2] STEP 16/16: RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -ldflags "-X main.gitSHA=${GIT_SHA} -X main.dirty=${DIRTY}" -o manager main.go
--> 0e43bcc59771
[2/2] STEP 1/8: FROM gcr.io/distroless/static:nonroot
[2/2] STEP 2/8: WORKDIR /
--> 1c309b5acebe
[2/2] STEP 3/8: COPY --from=builder /workspace/manager .
--> a2ca20aaeb20
[2/2] STEP 4/8: USER 65532:65532
--> a204ef2583a6
[2/2] STEP 5/8: ARG QUAY_IMAGE_EXPIRY
--> ce5cf776ff46
[2/2] STEP 6/8: ENV QUAY_IMAGE_EXPIRY=${QUAY_IMAGE_EXPIRY:-never}
--> a73513d25931
[2/2] STEP 7/8: LABEL quay.expires-after=$QUAY_IMAGE_EXPIRY
--> c1653b647e3a
[2/2] STEP 8/8: ENTRYPOINT ["/manager"]
[2/2] COMMIT quay.io/kuadrant/kuadrant-operator:dev
--> d8e91ce7a91b
Successfully tagged quay.io/kuadrant/kuadrant-operator:dev
d8e91ce7a91bb2b25bf18ce2ddfdfc65ac560fc38fdec60342758b4ed2649f3c
Successfully built d8e91ce7a91b
Successfully tagged quay.io/kuadrant/kuadrant-operator:dev

```