### PR TITLE
Update secure-protect-connect-openshift.md to include service label

### DIFF
--- a/doc/user-guides/full-walkthrough/secure-protect-connect-openshift.md
+++ b/doc/user-guides/full-walkthrough/secure-protect-connect-openshift.md
@@ -361,6 +361,8 @@ kind: HTTPRoute
 metadata:
   name: test
   namespace: ${gatewayNS}
+  labels:
+    service: toystore
 spec:
   parentRefs:
   - name: ${gatewayName}


### PR DESCRIPTION
This label is needed for metric queries in grafana