### PR TITLE
Bump state metrics to v0.7.0 with probe support

### DIFF
--- a/config/install/configure/observability/kustomization.yaml
+++ b/config/install/configure/observability/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.6.0
+  - github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.7.0
   - ../../../observability/openshift/
   - ../../../observability/prometheus/monitors/

--- a/config/observability/kustomization.yaml
+++ b/config/observability/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 
 resources:
   - github.com/prometheus-operator/kube-prometheus?ref=release-0.13
-  - github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.6.0
+  - github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.7.0
 # We're using the additionalScrapeConfigs field of the Prometheus CR
 # here to read existing prometheus scrape annotations on pods.
 # Ideally this would be done via another PodMonitor or ServicMonitor,

--- a/doc/install/install-openshift.md
+++ b/doc/install/install-openshift.md
@@ -191,7 +191,7 @@ To scrape these additional metrics, you can install a `kube-state-metrics` insta
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/main/config/observability/openshift/kube-state-metrics.yaml
-kubectl apply -k https://github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.6.0
+kubectl apply -k https://github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.7.0
 ```
 
 To enable request metrics in Istio and scrape them, create the following resource:


### PR DESCRIPTION
https://github.com/Kuadrant/gateway-api-state-metrics/releases/tag/0.7.0

