### PR TITLE
Update TLS/DNSPolicy guides with v1 apiVersion

### DIFF
--- a/doc/overviews/dns.md
+++ b/doc/overviews/dns.md
@@ -170,7 +170,7 @@ When a DNSPolicy targets a Gateway, the policy will be enforced on all gateway l
 Target a Gateway by setting the `spec.targetRef` field of the DNSPolicy as follows:
 
 ```yaml
-apiVersion: kuadrant.io/v1beta2
+apiVersion: kuadrant.io/v1
 kind: DNSPolicy
 metadata:
   name: <DNSPolicy name>
@@ -186,7 +186,7 @@ spec:
 A DNSPolicy can target a specific listener in a gateway using the `sectionName` property of the targetRef configuration. When you set the `sectionName`, the DNSPolicy will only affect that listener and no others. If you also have another DNSPolicy targeting the entire gateway, the more specific policy targeting the listerner will be the policy that is applied.
 
 ```yaml
-apiVersion: kuadrant.io/v1beta2
+apiVersion: kuadrant.io/v1
 kind: DNSPolicy
 metadata:
   name: <DNSPolicy name>

--- a/doc/overviews/tls.md
+++ b/doc/overviews/tls.md
@@ -50,7 +50,7 @@ When a TLSPolicy targets a Gateway, the policy will be enforced on all gateway l
 Target a Gateway by setting the `spec.targetRef` field of the TLSPolicy as follows:
 
 ```yaml
-apiVersion: kuadrant.io/v1beta2
+apiVersion: kuadrant.io/v1
 kind: TLSPolicy
 metadata:
   name: <TLSPolicy name>


### PR DESCRIPTION
Fix a few errant versions on policies in guides pulled into docs site.

Will cherry-pick to release-v1.0.1 branch after merge to avoid confusion on v1 of docs site.