### PR TITLE
Limitador sort function refactor

### DIFF
--- a/controllers/auth_policy_status_updater.go
+++ b/controllers/auth_policy_status_updater.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 
 	envoygatewayv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
@@ -108,6 +109,10 @@ func (r *AuthPolicyStatusUpdater) UpdateStatus(ctx context.Context, _ []controll
 
 		_, err = r.client.Resource(kuadrantv1.AuthPoliciesResource).Namespace(policy.GetNamespace()).UpdateStatus(ctx, obj, metav1.UpdateOptions{})
 		if err != nil {
+			if strings.Contains(err.Error(), "StorageError: invalid object") {
+				logger.Info("possible error updating resource", "err", err, "possible_cause", "resource has being removed from the cluster already")
+				continue
+			}
 			logger.Error(err, "unable to update status for authpolicy", "name", policy.GetName(), "namespace", policy.GetNamespace())
 			// TODO: handle error
 		}

--- a/controllers/effective_tls_policies_reconciler.go
+++ b/controllers/effective_tls_policies_reconciler.go
@@ -58,7 +58,7 @@ func (t *EffectiveTLSPoliciesReconciler) Reconcile(ctx context.Context, _ []cont
 	var certTargets []CertTarget
 	for _, l := range listeners {
 		if err := validateGatewayListenerBlock(field.NewPath(""), *l.Listener, l.Gateway).ToAggregate(); err != nil {
-			logger.Info("Skipped a listener block: " + err.Error())
+			logger.V(1).Info("Skipped a listener block: " + err.Error())
 			continue
 		}
 

--- a/controllers/event_logger.go
+++ b/controllers/event_logger.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"slices"
 	"sync"
 
 	"github.com/kuadrant/policy-machinery/controller"
@@ -16,13 +17,15 @@ func NewEventLogger() *EventLogger {
 
 func (e *EventLogger) Log(ctx context.Context, resourceEvents []controller.ResourceEvent, _ *machinery.Topology, err error, _ *sync.Map) error {
 	logger := controller.LoggerFromContext(ctx).WithName("event logger")
+	eventType := make(map[string]int, 0)
+	resources := make([]string, 0)
 	for _, event := range resourceEvents {
 		// log the event
 		obj := event.OldObject
 		if obj == nil {
 			obj = event.NewObject
 		}
-		logger.Info("new event",
+		logger.V(1).Info("new event",
 			"type", event.EventType.String(),
 			"kind", obj.GetObjectKind().GroupVersionKind().Kind,
 			"namespace", obj.GetNamespace(),
@@ -31,7 +34,20 @@ func (e *EventLogger) Log(ctx context.Context, resourceEvents []controller.Resou
 		if err != nil {
 			logger.Error(err, "error passed to reconcile")
 		}
+
+		_, ok := eventType[event.EventType.String()]
+		if ok {
+			eventType[event.EventType.String()]++
+		} else {
+			eventType[event.EventType.String()] = 1
+		}
+
+		if !slices.Contains(resources, obj.GetObjectKind().GroupVersionKind().Kind) {
+			resources = append(resources, obj.GetObjectKind().GroupVersionKind().Kind)
+		}
 	}
+
+	logger.Info("new events", "resources", resources, "eventTypes", eventType)
 
 	return nil
 }

--- a/controllers/gateway_policy_discoverability_reconciler.go
+++ b/controllers/gateway_policy_discoverability_reconciler.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -53,6 +54,10 @@ func (r *GatewayPolicyDiscoverabilityReconciler) reconcile(ctx context.Context, 
 		if !equality.Semantic.DeepEqual(updatedStatus, gw.Status) {
 			gw.Status = *updatedStatus
 			if err := r.updateGatewayStatus(ctx, gw); err != nil {
+				if strings.Contains(err.Error(), "StorageError: invalid object") {
+					logger.Info("possible error updating resource", "err", err, "possible_cause", "resource has being removed from the cluster already")
+					continue
+				}
 				logger.Error(err, "failed to update gateway status", "gateway", gw.GetName())
 			}
 		}

--- a/controllers/httproute_policy_discoverability_reconciler.go
+++ b/controllers/httproute_policy_discoverability_reconciler.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -78,6 +79,10 @@ func (r *HTTPRoutePolicyDiscoverabilityReconciler) reconcile(ctx context.Context
 		if !equality.Semantic.DeepEqual(routeStatusParents, route.Status.Parents) {
 			route.Status.Parents = routeStatusParents
 			if err := r.updateRouteStatus(ctx, route, logger); err != nil {
+				if strings.Contains(err.Error(), "StorageError: invalid object") {
+					logger.Info("possible error updating resource", "err", err, "possible_cause", "resource has being removed from the cluster already")
+					continue
+				}
 				logger.Error(err, "unable to update route status", "name", route.GetName(), "namespace", route.GetNamespace(), "uid", route.GetUID())
 			}
 		}

--- a/pkg/ratelimit/index.go
+++ b/pkg/ratelimit/index.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -126,8 +127,63 @@ func (l LimitadorRateLimits) EqualTo(other LimitadorRateLimits) bool {
 		sort.Strings(bCopy[idx].Variables)
 	}
 
-	sort.Sort(aCopy)
-	sort.Sort(bCopy)
+	slices.SortFunc(aCopy, l.sort)
+	slices.SortFunc(bCopy, l.sort)
 
 	return reflect.DeepEqual(aCopy, bCopy)
+}
+
+func (l LimitadorRateLimits) sort(a, b limitadorv1alpha1.RateLimit) int {
+	if a.Name < b.Name {
+		return -1
+	} else if a.Name > b.Name {
+		return 1
+	}
+
+	if a.Namespace < b.Namespace {
+		return -1
+	} else if a.Namespace > b.Namespace {
+		return 1
+	}
+
+	if a.MaxValue < b.MaxValue {
+		return -1
+	} else if a.MaxValue > b.MaxValue {
+		return 1
+	}
+
+	if a.Seconds < b.Seconds {
+		return -1
+	} else if a.Seconds > b.Seconds {
+		return 1
+	}
+
+	if len(a.Conditions) < len(b.Conditions) {
+		return -1
+	} else if len(a.Conditions) > len(b.Conditions) {
+		return 1
+	} else if result := compareLists(a.Conditions, b.Conditions); result != 0 {
+		return result
+	}
+
+	if len(a.Variables) < len(b.Variables) {
+		return -1
+	} else if len(a.Variables) > len(b.Variables) {
+		return 1
+	} else if result := compareLists(a.Variables, b.Variables); result != 0 {
+		return result
+	}
+
+	return 0
+}
+
+func compareLists(a, b []string) int {
+	for idx := range a {
+		if a[idx] < b[idx] {
+			return -1
+		} else if a[idx] > b[idx] {
+			return 1
+		}
+	}
+	return 0
 }

--- a/pkg/ratelimit/index_test.go
+++ b/pkg/ratelimit/index_test.go
@@ -137,3 +137,142 @@ func TestIndexToRateLimits(t *testing.T) {
 		}
 	})
 }
+
+func TestEqualsTo(t *testing.T) {
+	global_l0 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l0",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+	global_l1 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l1",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+	global_l2 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l2",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+	global_l3 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l3",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+	global_l4 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l4",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+	global_l5 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l5",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+	global_l6 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l6",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+
+	httproute_l0 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._httproute_level__ac417cac == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l0",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+	httproute_l1 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._httproute_level__e4abd750 == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l1",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+	httproute_l5 := limitadorv1alpha1.RateLimit{
+		Conditions: []string{"limit._httproute_level__e1d71177 == \"1\""},
+		MaxValue:   3,
+		Namespace:  "default/test-3-gw0-l5",
+		Seconds:    10,
+		Variables:  []string{},
+	}
+
+	t.Run("basic compare are the same", func(subT *testing.T) {
+		limit1 := LimitadorRateLimits{
+			httproute_l5,
+		}
+
+		limit2 := LimitadorRateLimits{
+			httproute_l5,
+		}
+
+		if !limit1.EqualTo(limit2) {
+			subT.Fatal("limit one is not equal to limit one")
+		}
+	})
+
+	t.Run("global vs two routes", func(subT *testing.T) {
+		existing := LimitadorRateLimits{
+			global_l5,
+			global_l1,
+			global_l6,
+			global_l3,
+			global_l0,
+			global_l4,
+			global_l2,
+		}
+
+		desired := LimitadorRateLimits{
+			httproute_l1,
+			httproute_l0,
+			global_l5,
+			global_l4,
+			global_l3,
+			global_l6,
+		}
+
+		if existing.EqualTo(desired) {
+			subT.Fatal("existing limit should not be the same as desired limit")
+		}
+	})
+
+	t.Run("5 global & 2 routes vs 5 global & 2 routes, order differ", func(subT *testing.T) {
+		existing := LimitadorRateLimits{
+			httproute_l1,
+			httproute_l0,
+			global_l2,
+			global_l5,
+			global_l4,
+			global_l3,
+			global_l6,
+		}
+
+		desired := LimitadorRateLimits{
+			global_l6,
+			global_l5,
+			global_l2,
+			httproute_l1,
+			global_l3,
+			httproute_l0,
+			global_l4,
+		}
+
+		if !existing.EqualTo(desired) {
+			subT.Fatal("existing limit should be the same desired limit, list are only in different orders")
+		}
+	})
+}


### PR DESCRIPTION
Partial: #1085 

# What
From the investigate to reconciling large amounts of gateways and listeners it was found that the sort function used to sort the limitador limits before doing the compare on the existing and desired was not working. This change use the `slices.SortFunc` to define a custom sort function. 

There are now not multiple writes to the limitador Resource.
Some very noisy log messages were refactored. 

# Note
Currently I have only looked into the affects on AuthPolices and RateLimitPolices on the reconcile. I still need to look into the TLS and DNS policies, but I found this to be a big enough change to introduce with out waiting for the rest.

# Verification
The best way to verify these chances would be to run the load test, which can be found here: https://github.com/Kuadrant/testsuite/tree/main/scale_test

If  load test seems a bit to much to verify this, I do have a set of scripts that can be used for testing it locally. They are still a work in progress. You may need to ask how to run them, but they can be found here: https://github.com/Boomatang/probable-octo-bassoon


