### PR TITLE
fix: only register Certificates managed by Kuadrant to the topology

### DIFF
--- a/tests/common/tlspolicy/tlspolicy_controller_test.go
+++ b/tests/common/tlspolicy/tlspolicy_controller_test.go
@@ -1054,7 +1054,7 @@ var _ = Describe("TLSPolicy controller", func() {
 			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
 		})
 
-		It("Should not affect unmanaged cert", func(ctx context.Context) {
+		It("Should not delete unmanaged cert", func(ctx context.Context) {
 			certList := &certmanv1.CertificateList{}
 			Expect(k8sClient.List(ctx, certList, &client.ListOptions{Namespace: testNamespace})).To(Succeed())
 			Expect(len(certList.Items)).To(Equal(1))

--- a/tests/common/tlspolicy/tlspolicy_controller_test.go
+++ b/tests/common/tlspolicy/tlspolicy_controller_test.go
@@ -1033,4 +1033,47 @@ var _ = Describe("TLSPolicy controller", func() {
 			}).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
 	})
+
+	Context("with un-managed certificates", func() {
+		BeforeEach(func(ctx SpecContext) {
+			cert := &certmanv1.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unmanaged-cert",
+					Namespace: testNamespace,
+				},
+				Spec: certmanv1.CertificateSpec{
+					SecretName: "unmanaged-cert",
+					IssuerRef:  *issuerRef,
+					DNSNames:   []string{"unmanaged-cert.example.com"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, cert)).To(Succeed())
+
+			gateway = tests.NewGatewayBuilder("test-gateway", gatewayClass.Name, testNamespace).
+				WithHTTPListener("test-listener", "test.example.com").Gateway
+			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
+		})
+
+		It("Should not affect unmanaged cert", func(ctx context.Context) {
+			certList := &certmanv1.CertificateList{}
+			Expect(k8sClient.List(ctx, certList, &client.ListOptions{Namespace: testNamespace})).To(Succeed())
+			Expect(len(certList.Items)).To(Equal(1))
+
+			By("creating tls policy")
+			tlsPolicy = kuadrantv1.NewTLSPolicy("test-tls-policy", testNamespace).
+				WithTargetGateway(gateway.Name).
+				WithIssuerRef(*issuerRef)
+			Expect(k8sClient.Create(ctx, tlsPolicy)).To(BeNil())
+
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.List(ctx, certList, &client.ListOptions{Namespace: testNamespace})).To(Succeed())
+				g.Expect(len(certList.Items)).To(Equal(2))
+				g.Expect(certList.Items).To(ContainElements(
+					HaveField("Name", "unmanaged-cert"),
+					HaveField("Name", "test-gateway-test1.example.com"),
+				))
+			})
+
+		}, testTimeOut)
+	})
 })

--- a/tests/common/tlspolicy/tlspolicy_controller_test.go
+++ b/tests/common/tlspolicy/tlspolicy_controller_test.go
@@ -1050,8 +1050,8 @@ var _ = Describe("TLSPolicy controller", func() {
 			Expect(k8sClient.Create(ctx, cert)).To(Succeed())
 
 			gateway = tests.NewGatewayBuilder("test-gateway", gatewayClass.Name, testNamespace).
-				WithHTTPListener("test-listener", "test.example.com").Gateway
-			Expect(k8sClient.Create(ctx, gateway)).To(BeNil())
+				WithHTTPSListener("test1.example.com", "test1-tls-secret").Gateway
+			Expect(k8sClient.Create(ctx, gateway)).To(Succeed())
 		})
 
 		It("Should not delete unmanaged cert", func(ctx context.Context) {
@@ -1063,7 +1063,7 @@ var _ = Describe("TLSPolicy controller", func() {
 			tlsPolicy = kuadrantv1.NewTLSPolicy("test-tls-policy", testNamespace).
 				WithTargetGateway(gateway.Name).
 				WithIssuerRef(*issuerRef)
-			Expect(k8sClient.Create(ctx, tlsPolicy)).To(BeNil())
+			Expect(k8sClient.Create(ctx, tlsPolicy)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.List(ctx, certList, &client.ListOptions{Namespace: testNamespace})).To(Succeed())
@@ -1072,8 +1072,7 @@ var _ = Describe("TLSPolicy controller", func() {
 					HaveField("Name", "unmanaged-cert"),
 					HaveField("Name", "test-gateway-test1.example.com"),
 				))
-			})
-
+			}).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
 	})
 })


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/1101

Register only `Certificates` managed by Kuadrant to the topology by filtering by `app: kuadrant-operator` label.
This also removes the need for the custom predicate which now aligns more with other similar resources.

Previous to this, the topology will register all `Certificates` on the cluster and Kuadrant Operator will delete these as unexpected certs.

# Verification
* Checkout main
* Create local cluster
```
make local-env-setup
```
* Create un-managed certificate
```
kubectl apply -n istio-system -f - <<EOF
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: tests
  namespace: istio-system
spec:
  dnsNames:
  - '*.test.io'
  issuerRef:
    group: cert-manager.io
    kind: Issuer
    name: selfsigned-issuer
  secretName: tests
  usages:
  - digital signature
  - key encipherment
EOF
```
* Watch for `Certificates`
```
kubectl get certificates -A
```
* Start kuadrant operator
```
make run
```
* Verify bug where unmanaged certificate was deleted
* Stop kuadrant operator
* Checkout this branch
* Re-create the un-managed certificate from the previous step
* Run kuadrant operator
* Verifiy unmanaged certificate **is not** deleted