### PR TITLE
enable build image trigger based on tags with -rc suffix

### DIFF
--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
 env:
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant


### PR DESCRIPTION
### Verification steps

Tested with the tag `v1.0.2-dev4` https://github.com/Kuadrant/kuadrant-operator/releases/tag/v1.0.2-dev4