### PR TITLE
docs: Fix incorrect geo code in DNS user guide

### DIFF
--- a/doc/user-guides/dns/load-balanced-dns.md
+++ b/doc/user-guides/dns/load-balanced-dns.md
@@ -135,7 +135,7 @@ metadata:
 spec:
   loadBalancing:
     weight: 130
-    geo: GEO-US
+    geo: US
     defaultGeo: false
   targetRef:
     group: gateway.networking.k8s.io


### PR DESCRIPTION
GEO-US -> US

Only the following codes will be accepted with a "GEO-" prefix:

```
AWS_CONTINENT_CODE_AFRICA        = "AF"
AWS_CONTINENT_CODE_ANTARTICA     = "AN"
AWS_CONTINENT_CODE_ASIA          = "AS"
AWS_CONTINENT_CODE_EUROPE        = "EU"
AWS_CONTINENT_CODE_OCEANIA       = "OC"
AWS_CONTINENT_CODE_NORTH_AMERICA = "NA"
AWS_CONTINENT_CODE_SOUTH_AMERICA = "SA"
```