### PR TITLE
Enable specification of the container engine for catalog builds

### DIFF
--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -59,7 +59,7 @@ catalog: $(OPM) ## Generate catalog content and validate.
 .PHONY: catalog-build
 catalog-build: ## Build a catalog image.
 	# Build the Catalog
-	docker build $(PROJECT_PATH)/catalog -f $(PROJECT_PATH)/catalog/kuadrant-operator-catalog.Dockerfile -t $(CATALOG_IMG)
+	$(CONTAINER_ENGINE) build $(PROJECT_PATH)/catalog -f $(PROJECT_PATH)/catalog/kuadrant-operator-catalog.Dockerfile -t $(CATALOG_IMG)
 
 # Push the catalog image.
 .PHONY: catalog-push


### PR DESCRIPTION
## Overview

Makefile defines CONTAINER_ENGINE env var setting 'docker' as a default value. This env var should be used rather than having 'docker' hard-coded. 

## Verification Steps

`make catalog-build`
`CONTAINER_ENGINE=docker make catalog-build`
`CONTAINER_ENGINE=podman make catalog-build`

The output depends on your docker/podman config but if you have both installed and configured the commands should work. If you e.g. do not use docker then you can see something along the lines of
`ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`

