### PR TITLE
Update tutorials to reference 'Getting Started' as prereq

### DIFF
--- a/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+++ b/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
@@ -61,7 +61,7 @@ kubectl create ns ${KUADRANT_GATEWAY_NS}
 
 Create a gateway using toystore as the listener hostname:
 
-```sh
+```bash
 kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -98,7 +98,7 @@ kubectl create ns ${KUADRANT_DEVELOPER_NS}
 ```
 Deploy the Toy store 
 ```sh
-kubectl apply -f examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/heads/main/examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
 ```
 
 Create the Toy Store HTTPRoute

--- a/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+++ b/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
@@ -36,11 +36,13 @@ Topology:
 ```
 
 ## Prerequisites
-- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
+
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 
 ### Setup environment variables
 
-Set the following environment variables used for convenience in this guide:
+Set the following environment variables used for convenience in this tutorial:
 
 ```bash
 export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
@@ -345,4 +347,3 @@ curl -H 'Host: foo.other-apps.com' http://$KUADRANT_GATEWAY_URL/ -i
 #   "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
 # }
 ```
-

--- a/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+++ b/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
@@ -1,6 +1,6 @@
 # Enforcing authentication & authorization with Kuadrant AuthPolicy
 
-This guide walks you through the process of setting up a local Kubernetes cluster with Kuadrant where you will protect [Gateway API](https://gateway-api.sigs.k8s.io/) endpoints by declaring Kuadrant AuthPolicy custom resources.
+This tutorial walks you through the process of setting up a local Kubernetes cluster with Kuadrant where you will protect [Gateway API](https://gateway-api.sigs.k8s.io/) endpoints by declaring Kuadrant AuthPolicy custom resources.
 
 Three AuthPolicies will be declared:
 
@@ -14,7 +14,7 @@ Topology:
 ```
                             ┌─────────────────────────┐
                             │        (Gateway)        │   ┌───────────────┐
-                            │ kuadrant-ingressgateway │◄──│ (AuthPolicy)  │
+                            │         external        │◄──│ (AuthPolicy)  │
                             │                         │   │    gw-auth    │
                             │            *            │   └───────────────┘
                             └─────────────────────────┘
@@ -35,24 +35,85 @@ Topology:
             └─────────────────┘
 ```
 
-## Setup the environment
+## Prerequisites
+- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
 
-Follow this [setup doc](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/install/install-make.md) to set up your environment before continuing with this doc.
+### Setup environment variables
+
+Set the following environment variables used for convenience in this guide:
+
+```bash
+export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
+export KUADRANT_GATEWAY_NAME=external # Name for the example Gateway
+export KUADRANT_DEVELOPER_NS=toystore # Namespace for an example toystore app
+
+```
+
+### Create an Ingress Gateway
+
+Create the namespace the Gateway will be deployed in:
+
+```bash
+kubectl create ns ${KUADRANT_GATEWAY_NS}
+```
+
+Create a gateway using toystore as the listener hostname:
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${KUADRANT_GATEWAY_NAME}
+  namespace: ${KUADRANT_GATEWAY_NS}
+  labels:
+    kuadrant.io/gateway: "true"
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+EOF
+```
+
+Check the status of the `Gateway` ensuring the gateway is Accepted and Programmed:
+
+```bash
+kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Programmed")].message}{"\n"}'
+```
 
 ### Deploy the Toy Store sample application (Persona: _App developer_)
 
+
+Create the namespace for the toystore API:
+
+```bash
+kubectl create ns ${KUADRANT_DEVELOPER_NS}
+```
+Deploy the Toy store 
 ```sh
-kubectl apply -f examples/toystore/toystore.yaml
+kubectl apply -f examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
+```
+
+Create the Toy Store HTTPRoute
+```bash
 
 kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: toystore
+  namespace: ${KUADRANT_DEVELOPER_NS}
+  labels:
+     app: toystore
 spec:
   parentRefs:
-  - name: kuadrant-ingressgateway
-    namespace: gateway-system
+  - name: ${KUADRANT_GATEWAY_NAME}
+    namespace: ${KUADRANT_GATEWAY_NS}
   hostnames:
   - api.toystore.com
   rules:
@@ -81,25 +142,25 @@ EOF
 Export the gateway hostname and port:
 
 ```sh
-export INGRESS_HOST=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.status.addresses[0].value}')
-export INGRESS_PORT=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
-export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
+export KUADRANT_INGRESS_HOST=$(kubectl get gtw ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o jsonpath='{.status.addresses[0].value}')
+export KUADRANT_INGRESS_PORT=$(kubectl get gtw ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
+export KUADRANT_GATEWAY_URL=${KUADRANT_INGRESS_HOST}:${KUADRANT_INGRESS_PORT}
 ```
 
 Send requests to the application unprotected:
 
 ```sh
-curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/cars -i
+curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/cars -i
 # HTTP/1.1 200 OK
 ```
 
 ```sh
-curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/dolls -i
+curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/dolls -i
 # HTTP/1.1 200 OK
 ```
 
 ```sh
-curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/admin -i
+curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/admin -i
 # HTTP/1.1 200 OK
 ```
 
@@ -118,6 +179,7 @@ apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
   name: toystore-authn
+  namespace: ${KUADRANT_DEVELOPER_NS}
 spec:
   targetRef:
     group: gateway.networking.k8s.io
@@ -140,6 +202,7 @@ apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
   name: toystore-admins
+  namespace: ${KUADRANT_DEVELOPER_NS}
 spec:
   targetRef:
     group: gateway.networking.k8s.io
@@ -189,25 +252,25 @@ EOF
 Send requests to the application protected by Kuadrant:
 
 ```sh
-curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/cars -i
+curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/cars -i
 # HTTP/1.1 401 Unauthorized
 # www-authenticate: APIKEY realm="api-key-authn"
 # x-ext-auth-reason: credential not found
 ```
 
 ```sh
-curl -H 'Host: api.toystore.com' -H 'Authorization: APIKEY iamaregularuser' http://$GATEWAY_URL/cars -i
+curl -H 'Host: api.toystore.com' -H 'Authorization: APIKEY iamaregularuser' http://$KUADRANT_GATEWAY_URL/cars -i
 # HTTP/1.1 200 OK
 ```
 
 ```sh
-curl -H 'Host: api.toystore.com' -H 'Authorization: APIKEY iamaregularuser' http://$GATEWAY_URL/admin -i
+curl -H 'Host: api.toystore.com' -H 'Authorization: APIKEY iamaregularuser' http://$KUADRANT_GATEWAY_URL/admin -i
 # HTTP/1.1 403 Forbidden
 # x-ext-auth-reason: Unauthorized
 ```
 
 ```sh
-curl -H 'Host: api.toystore.com' -H 'Authorization: APIKEY iamanadmin' http://$GATEWAY_URL/admin -i
+curl -H 'Host: api.toystore.com' -H 'Authorization: APIKEY iamanadmin' http://$KUADRANT_GATEWAY_URL/admin -i
 # HTTP/1.1 200 OK
 ```
 
@@ -216,16 +279,17 @@ curl -H 'Host: api.toystore.com' -H 'Authorization: APIKEY iamanadmin' http://$G
 Create the policy:
 
 ```sh
-kubectl -n gateway-system apply -f - <<EOF
+kubectl apply -f - <<EOF
 apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
   name: gw-auth
+  namespace: ${KUADRANT_GATEWAY_NS}
 spec:
   targetRef:
     group: gateway.networking.k8s.io
     kind: Gateway
-    name: kuadrant-ingressgateway
+    name: ${KUADRANT_GATEWAY_NAME}
   defaults:
     strategy: atomic
     rules:
@@ -257,10 +321,11 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: other
+  namespace: ${KUADRANT_DEVELOPER_NS}
 spec:
   parentRefs:
-  - name: kuadrant-ingressgateway
-    namespace: gateway-system
+  - name: ${KUADRANT_GATEWAY_NAME}
+    namespace: ${KUADRANT_GATEWAY_NS}
   hostnames:
   - "*.other-apps.com"
 EOF
@@ -269,7 +334,7 @@ EOF
 Send requests to the route protected by the default policy set at the level of the gateway:
 
 ```sh
-curl -H 'Host: foo.other-apps.com' http://$GATEWAY_URL/ -i
+curl -H 'Host: foo.other-apps.com' http://$KUADRANT_GATEWAY_URL/ -i
 # HTTP/1.1 403 Forbidden
 # content-type: application/json
 # x-ext-auth-reason: Unauthorized
@@ -284,5 +349,5 @@ curl -H 'Host: foo.other-apps.com' http://$GATEWAY_URL/ -i
 ## Cleanup
 
 ```sh
-make local-cleanup
+kind delete cluster
 ```

--- a/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+++ b/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
@@ -346,8 +346,3 @@ curl -H 'Host: foo.other-apps.com' http://$KUADRANT_GATEWAY_URL/ -i
 # }
 ```
 
-## Cleanup
-
-```sh
-kind delete cluster
-```

--- a/doc/user-guides/dns/gateway-dns.md
+++ b/doc/user-guides/dns/gateway-dns.md
@@ -1,18 +1,16 @@
 # Gateway DNS configuration for routes attached to a ingress gateway
 
-This user guide walks you through an example of how to configure DNS for all routes attached to an ingress gateway.
+This tutorial walks you through an example of how to configure DNS for all routes attached to an ingress gateway. 
 
 ## Prerequisites
 
-- kubectl command line tool.
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 - AWS/Azure or GCP with DNS capabilities.
-- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
-
-
 
 ### Setup environment variables
 
-Set the following environment variables used for convenience in this guide:
+Set the following environment variables used for convenience in this tutorial:
 
 ```bash
 export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
@@ -158,10 +156,4 @@ Verify DNS using curl you should get a status 200:
 
 ```shell
 curl http://api.$KUADRANT_ZONE_ROOT_DOMAIN/cars -i
-```
-
-## Cleanup
-
-```shell
-kind delete cluster
 ```

--- a/doc/user-guides/full-walkthrough/secure-protect-connect.md
+++ b/doc/user-guides/full-walkthrough/secure-protect-connect.md
@@ -2,18 +2,17 @@
 
 ## Overview
 
-This tutorial walks you through using Kuadrant to secure, protect, and connect an API exposed by a Gateway (Kubernetes Gateway API) from the personas platform engineer and application developer. For more information on the different personas please see the [Gateway API documentation](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas)
+This tutorial walks you through using Kuadrant to secure, protect, and connect an API exposed by a Gateway (Kubernetes Gateway API) from the personas platform engineer and application developer. For more information on the different personas please see the [Gateway API documentation](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas) 
 
 ## Prerequisites
 
-- Kubernetes cluster with Kuadrant operator installed. 
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 - AWS/Azure or GCP with DNS capabilities.
 
-
 ### Set the environment variables
 
-Set the following environment variables used for convenience in this guide:
+Set the following environment variables used for convenience in this tutorial:
 
 ```bash
 export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
@@ -471,8 +470,6 @@ while :; do curl -k --write-out '%{http_code}\n' --silent --output /dev/null -H 
 ## Next Steps
 
 - [mTLS Configuration](../../install/mtls-configuration.md)
-To learn more about Kuadrant and see more how to guides, visit Kuadrant [documentation](https://docs.kuadrant.io)
-
 
 ### Optional
 

--- a/doc/user-guides/full-walkthrough/secure-protect-connect.md
+++ b/doc/user-guides/full-walkthrough/secure-protect-connect.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide walks you through using Kuadrant to secure, protect, and connect an API exposed by a Gateway (Kubernetes Gateway API) from the personas platform engineer and application developer. For more information on the different personas please see the [Gateway API documentation](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas)
+This tutorial walks you through using Kuadrant to secure, protect, and connect an API exposed by a Gateway (Kubernetes Gateway API) from the personas platform engineer and application developer. For more information on the different personas please see the [Gateway API documentation](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas)
 
 ## Prerequisites
 

--- a/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
+++ b/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
@@ -84,7 +84,7 @@ kubectl create ns ${KUADRANT_DEVELOPER_NS}
 Deploy the Toystore app to the developer namespace:
 
 ```bash
-kubectl apply -f examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
 ```
 
 Create a HTTPRoute to route traffic to the service via Istio Ingress Gateway:

--- a/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
+++ b/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md
@@ -1,8 +1,8 @@
 # Authenticated Rate Limiting for Application developers
 
-For more info on the different personas see [Gateway API](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas)
+For more info on the different personas see [Gateway API](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas) 
 
-This tutorial guide walks you through an example of how to configure authenticated rate limiting for an application using Kuadrant.
+This tutorial walks you through an example of how to configure authenticated rate limiting for an application using Kuadrant.
 
 Authenticated rate limiting rate limits the traffic directed to an application based on attributes of the client user, who is authenticated by some authentication method. A few examples of authenticated rate limiting use cases are:
 
@@ -20,11 +20,13 @@ We will define 2 users of the API, which can send requests to the API at differe
 | bob     | 2rp10s ("2 requests every 10 seconds") |
 
 ## Prerequisites
-- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
+
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 
 ### Setup environment variables
 
-Set the following environment variables used for convenience in this guide:
+Set the following environment variables used for convenience in this tutorial:
 
 ```bash
 export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
@@ -270,10 +272,4 @@ Up to 2 successful (`200 OK`) requests every 10 seconds allowed for Bob, then `4
 
 ```sh
 while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMBOB' -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy | grep -E --color "\b(429)\b|$"; sleep 1; done
-```
-
-## Cleanup
-
-```sh
-kind delete cluster
 ```

--- a/doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
+++ b/doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
@@ -1,6 +1,6 @@
 # Authenticated Rate Limiting with JWTs and Kubernetes RBAC
 
-This tutorial walks you through an example of how to use Kuadrant to protect an application with policies to enforce:
+This tutorial walks you through an example of how to use Kuadrant to protect an application with policies to enforce: 
 
 - authentication based OpenId Connect (OIDC) ID tokens (signed JWTs), issued by a Keycloak server;
 - alternative authentication method by Kubernetes Service Account tokens;
@@ -24,11 +24,13 @@ Privileges to execute the requested operation (read, create or delete) will be g
 Each user will be entitled to a maximum of 5rp10s (5 requests every 10 seconds).
 
 ## Prerequisites
-- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
+
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 
 ### Setup environment variables
 
-Set the following environment variables used for convenience in this guide:
+Set the following environment variables used for convenience in this tutorial:
 
 ```bash
 export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
@@ -397,10 +399,4 @@ Send requests as the Kubernetes service account:
 
 ```sh
 while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Authorization: Bearer $KUADRANT_SA_TOKEN" -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy | grep -E --color "\b(429)\b|$"; sleep 1; done
-```
-
-## Cleanup
-
-```sh
-kind delete cluster
 ```

--- a/doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
+++ b/doc/user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md
@@ -86,7 +86,7 @@ kubectl create ns ${KUADRANT_DEVELOPER_NS}
 Deploy the Toystore app to the developer namespace:
 
 ```bash
-kubectl apply -f examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
 ```
 Create a HTTPRoute to route traffic to the service via Istio Ingress Gateway:
 
@@ -149,7 +149,7 @@ It should return `200 OK`.
 
 ### Deploy Keycloak
 
-Create the  for Keycloak:
+Create the namespace for Keycloak:
 
 ```sh
 kubectl create namespace keycloak

--- a/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
+++ b/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
@@ -12,7 +12,7 @@ This tutorial walks you through an example of how to configure rate limiting for
 ### Deploy the Toystore example API:
 
 ```sh
-kubectl apply -f examples/toystore/toystore.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml
 
 ```
 

--- a/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
+++ b/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
@@ -2,11 +2,10 @@
 
 For more info on the different personas see [Gateway API](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas)
 
-This user guide walks you through an example of how to configure rate limiting for all routes attached to a specific ingress gateway.
+This tutorial walks you through an example of how to configure rate limiting for all routes attached to a specific ingress gateway.
 
-### Setup the environment
-
-Follow this [setup doc](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/install/install-make.md) to set up your environment before continuing with this doc.
+## Prerequisites
+- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
 
 ### Deploy the Toystore example API:
 
@@ -171,5 +170,5 @@ while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Ho
 ## Cleanup
 
 ```sh
-make local-cleanup
+kind delete cluster
 ```

--- a/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
+++ b/doc/user-guides/ratelimiting/gateway-rl-for-cluster-operators.md
@@ -1,11 +1,13 @@
 # Gateway Rate Limiting for Cluster Operators
 
-For more info on the different personas see [Gateway API](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas)
+For more info on the different personas see [Gateway API](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas) 
 
 This tutorial walks you through an example of how to configure rate limiting for all routes attached to a specific ingress gateway.
 
 ## Prerequisites
-- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
+
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 
 ### Deploy the Toystore example API:
 
@@ -165,10 +167,4 @@ Unlimited successful (`200 OK`) through the `internal` ingress gateway (`*.local
 
 ```sh
 while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.local' http://localhost:9082 | grep -E --color "\b(429)\b|$"; sleep 1; done
-```
-
-## Cleanup
-
-```sh
-kind delete cluster
 ```

--- a/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
+++ b/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
@@ -1,10 +1,10 @@
 # Gateway Rate Limiting
 
-This user guide walks you through an example of how to configure multiple rate limit polices for different listeners in an ingress gateway.
+This tutorial walks you through an example of how to configure multiple rate limit polices for different listeners in an ingress gateway.
 
-### Setup the environment
+## Prerequisites
+- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
 
-Follow this [setup doc](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/install/install-make.md) to set up your environment before continuing with this doc.
 
 ### Deploy the sample API:
 
@@ -138,5 +138,5 @@ while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Ho
 ## Cleanup
 
 ```sh
-make local-cleanup
+kind delete cluster
 ```

--- a/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
+++ b/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
@@ -11,7 +11,7 @@ This tutorial walks you through an example of how to configure multiple rate lim
 ### Deploy the sample API:
 
 ```sh
-kubectl apply -f examples/toystore/toystore.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml
 ```
 
 ### Create the ingress gateways

--- a/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
+++ b/doc/user-guides/ratelimiting/multi-auth-rlp-diff-section.md
@@ -1,9 +1,11 @@
 # Gateway Rate Limiting
 
-This tutorial walks you through an example of how to configure multiple rate limit polices for different listeners in an ingress gateway.
+This tutorial walks you through an example of how to configure multiple rate limit polices for different listeners in an ingress gateway. 
 
 ## Prerequisites
-- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
+
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 
 
 ### Deploy the sample API:
@@ -133,10 +135,4 @@ Unlimited successful (`200 OK`) through the `internal` ingress gateway (`*.local
 
 ```sh
 while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.local' http://localhost:9081 | grep -E --color "\b(429)\b|$"; sleep 1; done
-```
-
-## Cleanup
-
-```sh
-kind delete cluster
 ```

--- a/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
+++ b/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
@@ -1,6 +1,6 @@
 # Multi authenticated Rate Limiting for an Application
 
-This tutorial walks you through an example of how to configure multiple authenticated rate limiting for an application using Kuadrant.
+This tutorial walks you through an example of how to configure multiple authenticated rate limiting for an application using Kuadrant. 
 
 Authenticated rate limiting, rate limits the traffic directed to an application based on attributes of the client user, who is authenticated by some authentication method. A few examples of authenticated rate limiting use cases are:
 
@@ -8,7 +8,7 @@ Authenticated rate limiting, rate limits the traffic directed to an application 
 - Each user can send up to 20rpm ("request per minute").
 - Admin users (members of the 'admin' group) can send up to 100rps, while regular users (non-admins) can send up to 20rpm and no more than 5rps.
 
-In this guide, we will rate limit a sample REST API called **Toy Store**, an echo service that echoes back to the user whatever attributes it gets in the request. The API exposes an endpoint at `GET http://api.toystore.com/toy`, to mimic an operation of reading toy records.
+In this tutorial, we will rate limit a sample REST API called **Toy Store**, an echo service that echoes back to the user whatever attributes it gets in the request. The API exposes an endpoint at `GET http://api.toystore.com/toy`, to mimic an operation of reading toy records.
 
 We will define 2 users of the API, which can send requests to the API at different rates, based on their user IDs. The authentication method used is **API key**.
 
@@ -18,11 +18,13 @@ We will define 2 users of the API, which can send requests to the API at differe
 | bob     | 2rp10s ("2 requests every 10 seconds") |
 
 ## Prerequisites
-- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
+
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 
 ### Setup environment variables
 
-Set the following environment variables used for convenience in this guide:
+Set the following environment variables used for convenience in this tutorial:
 
 ```bash
 export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
@@ -282,10 +284,4 @@ Up to 2 successful (`200 OK`) requests every 10 seconds allowed for Bob, then `4
 
 ```sh
 while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMBOB' -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy | grep -E --color "\b(429)\b|$"; sleep 1; done
-```
-
-## Cleanup
-
-```sh
-kind delete cluster
 ```

--- a/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
+++ b/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
@@ -72,7 +72,7 @@ kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpa
 ### Deploy the Toy Store API
 
 ```sh
-kubectl apply -f examples/toystore/toystore.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml
 ```
 
 ### Create a HTTPRoute to route traffic to the service via Istio Ingress Gateway:
@@ -125,7 +125,7 @@ curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy -i
 > **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service and accessing over localhost:
 >
 > ```sh
-> kubectl port-forward -n ${KUADRANT_GATEWAY_NS} service/-${KUADRANT_GATEWAY_NAME}-istio 9080:80 >/dev/null 2>&1 &
+> kubectl port-forward -n ${KUADRANT_GATEWAY_NS} service/${KUADRANT_GATEWAY_NAME}-istio 9080:80 >/dev/null 2>&1 &
 > export KUADRANT_GATEWAY_URL=localhost:9080
 > ```
 >

--- a/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
+++ b/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
@@ -20,6 +20,53 @@ We will define 2 users of the API, which can send requests to the API at differe
 ## Prerequisites
 - Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
 
+### Setup environment variables
+
+Set the following environment variables used for convenience in this guide:
+
+```bash
+export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
+export KUADRANT_GATEWAY_NAME=external # Name for the example Gateway
+export KUADRANT_DEVELOPER_NS=toystore # Namespace for an example toystore app
+```
+
+### Create an Ingress Gateway
+
+Create the namespace the Gateway will be deployed in:
+
+```bash
+kubectl create ns ${KUADRANT_GATEWAY_NS}
+```
+
+Create a gateway using toystore as the listener hostname:
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${KUADRANT_GATEWAY_NAME}
+  namespace: ${KUADRANT_GATEWAY_NS}
+  labels:
+    kuadrant.io/gateway: "true"
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+EOF
+```
+
+Check the status of the `Gateway` ensuring the gateway is Accepted and Programmed:
+
+```bash
+kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Programmed")].message}{"\n"}'
+```
+
 ### Deploy the Toy Store API
 
 ```sh
@@ -38,8 +85,8 @@ metadata:
   name: toystore
 spec:
   parentRefs:
-  - name: kuadrant-ingressgateway
-    namespace: gateway-system
+  - name: ${KUADRANT_GATEWAY_NAME}
+    namespace: ${KUADRANT_GATEWAY_NS}
   hostnames:
   - api.toystore.com
   rules:
@@ -61,27 +108,27 @@ EOF
 ### Export the gateway hostname and port:
 
 ```sh
-export INGRESS_HOST=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.status.addresses[0].value}')
-export INGRESS_PORT=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
-export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
+export KUADRANT_INGRESS_HOST=$(kubectl get gtw ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o jsonpath='{.status.addresses[0].value}')
+export KUADRANT_INGRESS_PORT=$(kubectl get gtw ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
+export KUADRANT_GATEWAY_URL=${KUADRANT_INGRESS_HOST}:${KUADRANT_INGRESS_PORT}
 ```
 
 ### Verify the route works:
 
 ```sh
-curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy -i
+curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy -i
 # HTTP/1.1 200 OK
 ```
 
 > **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service and accessing over localhost:
 >
 > ```sh
-> kubectl port-forward -n gateway-system service/kuadrant-ingressgateway-istio 9080:80 >/dev/null 2>&1 &
-> export GATEWAY_URL=localhost:9080
+> kubectl port-forward -n ${KUADRANT_GATEWAY_NS} service/-${KUADRANT_GATEWAY_NAME}-istio 9080:80 >/dev/null 2>&1 &
+> export KUADRANT_GATEWAY_URL=localhost:9080
 > ```
 >
 > ```sh
-> curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy -i
+> curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy -i
 > # HTTP/1.1 200 OK
 > ```
 
@@ -125,7 +172,7 @@ EOF
 ### Verify the authentication works by sending a request to the Toy Store API without API key:
 
 ```sh
-curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy -i
+curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy -i
 # HTTP/1.1 401 Unauthorized
 # www-authenticate: APIKEY realm="api-key-users"
 # x-ext-auth-reason: "credential not found"
@@ -228,13 +275,13 @@ Verify the rate limiting works by sending requests as Alice and Bob.
 Up to 5 successful (`200 OK`) requests every 10 seconds allowed for Alice, then `429 Too Many Requests`:
 
 ```sh
-while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy | grep -E --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMALICE' -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy | grep -E --color "\b(429)\b|$"; sleep 1; done
 ```
 
 Up to 2 successful (`200 OK`) requests every 10 seconds allowed for Bob, then `429 Too Many Requests`:
 
 ```sh
-while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMBOB' -H 'Host: api.toystore.com' http://$GATEWAY_URL/toy | grep -E --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Authorization: APIKEY IAMBOB' -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy | grep -E --color "\b(429)\b|$"; sleep 1; done
 ```
 
 ## Cleanup

--- a/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
+++ b/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
@@ -1,6 +1,6 @@
 # Multi authenticated Rate Limiting for an Application
 
-This user guide walks you through an example of how to configure multiple authenticated rate limiting for an application using Kuadrant.
+This tutorial walks you through an example of how to configure multiple authenticated rate limiting for an application using Kuadrant.
 
 Authenticated rate limiting, rate limits the traffic directed to an application based on attributes of the client user, who is authenticated by some authentication method. A few examples of authenticated rate limiting use cases are:
 
@@ -17,9 +17,8 @@ We will define 2 users of the API, which can send requests to the API at differe
 | alice   | 5rp10s ("5 requests every 10 seconds") |
 | bob     | 2rp10s ("2 requests every 10 seconds") |
 
-### Setup the environment
-
-Follow this [setup doc](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/install/install-make.md) to set up your environment before continuing with this doc.
+## Prerequisites
+- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
 
 ### Deploy the Toy Store API
 
@@ -241,5 +240,5 @@ while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Au
 ## Cleanup
 
 ```sh
-make local-cleanup
+kind delete cluster
 ```

--- a/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
+++ b/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
@@ -13,6 +13,53 @@ We will rate limit the `POST /toys` endpoint to a maximum of 5rp10s ("5 requests
 - Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 
+### Setup environment variables
+
+Set the following environment variables used for convenience in this tutorial:
+
+```bash
+export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
+export KUADRANT_GATEWAY_NAME=external # Name for the example Gateway
+export KUADRANT_DEVELOPER_NS=toystore # Namespace for an example toystore app
+```
+
+### Create an Ingress Gateway
+
+Create the namespace the Gateway will be deployed in:
+
+```bash
+kubectl create ns ${KUADRANT_GATEWAY_NS}
+```
+
+Create a gateway using toystore as the listener hostname:
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${KUADRANT_GATEWAY_NAME}
+  namespace: ${KUADRANT_GATEWAY_NS}
+  labels:
+    kuadrant.io/gateway: "true"
+spec:
+  gatewayClassName: istio
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+EOF
+```
+
+Check the status of the `Gateway` ensuring the gateway is Accepted and Programmed:
+
+```bash
+kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Programmed")].message}{"\n"}'
+```
+
 ### Deploy the Toy Store API
 
 Create the deployment:
@@ -33,8 +80,8 @@ metadata:
   name: toystore
 spec:
   parentRefs:
-  - name: kuadrant-ingressgateway
-    namespace: gateway-system
+  - name: ${KUADRANT_GATEWAY_NAME}
+    namespace: ${KUADRANT_GATEWAY_NS}
   hostnames:
   - api.toystore.com
   rules:
@@ -60,27 +107,27 @@ EOF
 Export the gateway hostname and port:
 
 ```sh
-export INGRESS_HOST=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.status.addresses[0].value}')
-export INGRESS_PORT=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
-export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT
+export KUADRANT_INGRESS_HOST=$(kubectl get gtw ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o jsonpath='{.status.addresses[0].value}')
+export KUADRANT_INGRESS_PORT=$(kubectl get gtw ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
+export KUADRANT_GATEWAY_URL=${KUADRANT_INGRESS_HOST}:${KUADRANT_INGRESS_PORT}
 ```
 
 Verify the route works:
 
 ```sh
-curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -i
+curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toys -i
 # HTTP/1.1 200 OK
 ```
 
 > **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service and accessing over localhost:
 >
 > ```sh
-> kubectl port-forward -n gateway-system service/kuadrant-ingressgateway-istio 9080:80 >/dev/null 2>&1 &
-> export GATEWAY_URL=localhost:9080
+> kubectl port-forward -n ${KUADRANT_GATEWAY_NS} service/-${KUADRANT_GATEWAY_NAME}-istio 9080:80 >/dev/null 2>&1 &
+> export KUADRANT_GATEWAY_URL=localhost:9080
 > ```
 >
 > ```sh
-> curl -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -i
+> curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy -i
 > # HTTP/1.1 200 OK
 > ```
 
@@ -119,11 +166,11 @@ Verify the rate limiting works by sending requests in a loop.
 Up to 5 successful (`200 OK`) requests every 10 seconds to `POST /toys`, then `429 Too Many Requests`:
 
 ```sh
-while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys -X POST | grep -E --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toys -X POST | grep -E --color "\b(429)\b|$"; sleep 1; done
 ```
 
 Unlimited successful (`200 OK`) to `GET /toys`:
 
 ```sh
-while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys | grep -E --color "\b(429)\b|$"; sleep 1; done
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toys | grep -E --color "\b(429)\b|$"; sleep 1; done
 ```

--- a/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
+++ b/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
@@ -65,7 +65,7 @@ kubectl get gateway ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o=jsonpa
 Create the deployment:
 
 ```sh
-kubectl apply -f examples/toystore/toystore.yaml
+kubectl apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml
 ```
 
 Create a HTTPRoute to route traffic to the service via Istio Ingress Gateway:
@@ -122,7 +122,7 @@ curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toys -i
 > **Note**: If the command above fails to hit the Toy Store API on your environment, try forwarding requests to the service and accessing over localhost:
 >
 > ```sh
-> kubectl port-forward -n ${KUADRANT_GATEWAY_NS} service/-${KUADRANT_GATEWAY_NAME}-istio 9080:80 >/dev/null 2>&1 &
+> kubectl port-forward -n ${KUADRANT_GATEWAY_NS} service/${KUADRANT_GATEWAY_NAME}-istio 9080:80 >/dev/null 2>&1 &
 > export KUADRANT_GATEWAY_URL=localhost:9080
 > ```
 >

--- a/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
+++ b/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
@@ -8,9 +8,8 @@ In this guide, we will rate limit a sample REST API called **Toy Store**. In rea
 
 We will rate limit the `POST /toys` endpoint to a maximum of 5rp10s ("5 requests every 10 seconds").
 
-### Setup the environment
-
-Follow this [setup doc](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/install/install-make.md) to set up your environment before continuing with this doc.
+## Prerequisites
+- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
 
 ### Deploy the Toy Store API
 
@@ -130,5 +129,5 @@ while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Ho
 ## Cleanup
 
 ```sh
-make local-cleanup
+kind delete cluster
 ```

--- a/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
+++ b/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
@@ -1,15 +1,17 @@
 # Simple Rate Limiting for Application developers
 
-For more info on the different personas see [Gateway API](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas)
+For more info on the different personas see [Gateway API](https://gateway-api.sigs.k8s.io/concepts/roles-and-personas/#key-roles-and-personas) 
 
-This user guide walks you through an example of how to configure rate limiting for an endpoint of an application using Kuadrant.
+This tutorial walks you through an example of how to configure rate limiting for an endpoint of an application using Kuadrant.
 
-In this guide, we will rate limit a sample REST API called **Toy Store**. In reality, this API is just an echo service that echoes back to the user whatever attributes it gets in the request. The API listens to requests at the hostname `api.toystore.com`, where it exposes the endpoints `GET /toys*` and `POST /toys`, respectively, to mimic operations of reading and writing toy records.
+In this tutorial, we will rate limit a sample REST API called **Toy Store**. In reality, this API is just an echo service that echoes back to the user whatever attributes it gets in the request. The API listens to requests at the hostname `api.toystore.com`, where it exposes the endpoints `GET /toys*` and `POST /toys`, respectively, to mimic operations of reading and writing toy records.
 
 We will rate limit the `POST /toys` endpoint to a maximum of 5rp10s ("5 requests every 10 seconds").
 
 ## Prerequisites
-- Kubernetes cluster with Kuadrant operator installed. See our [getting started](getting-started.md) guide for more information.
+
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 
 ### Deploy the Toy Store API
 
@@ -124,10 +126,4 @@ Unlimited successful (`200 OK`) to `GET /toys`:
 
 ```sh
 while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H 'Host: api.toystore.com' http://$GATEWAY_URL/toys | grep -E --color "\b(429)\b|$"; sleep 1; done
-```
-
-## Cleanup
-
-```sh
-kind delete cluster
 ```

--- a/doc/user-guides/tls/gateway-tls.md
+++ b/doc/user-guides/tls/gateway-tls.md
@@ -1,29 +1,13 @@
 # Gateway TLS for Cluster Operators
 
-This tutorial walks you through an example of how to configure TLS for all routes attached to an ingress gateway.
+This tutorial walks you through an example of how to configure TLS for all routes attached to an ingress gateway. 
 
-## Requisites
+## Prerequisites
 
-- [Docker](https://docker.io)
+- Kubernetes cluster with Kuadrant operator installed. See our [Getting Started](/getting-started) guide for more information.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) command line tool.
 
 ### Setup
-
-This step uses tooling from the Kuadrant Operator component to create a containerized Kubernetes server locally using [Kind](https://kind.sigs.k8s.io),
-where it installs Istio, Kubernetes Gateway API, CertManager and Kuadrant itself.
-
-Clone the project:
-
-```shell
-git clone https://github.com/Kuadrant/kuadrant-operator && cd kuadrant-operator
-```
-
-Setup the environment:
-
-```shell
-make local-setup
-```
-
-Create a namespace:
 
 ```shell
 kubectl create namespace my-gateways
@@ -268,10 +252,4 @@ x-envoy-upstream-service-time: 1
 
 <
 * Connection #0 to host api.toystore.local left intact
-```
-
-## Cleanup
-
-```shell
-make local-cleanup
 ```

--- a/doc/user-guides/tls/gateway-tls.md
+++ b/doc/user-guides/tls/gateway-tls.md
@@ -136,7 +136,7 @@ toystore-local-tls   kubernetes.io/tls   3      7m42s
 Deploy the sample API:
 
 ```shell
-kubectl -n my-gateways apply -f examples/toystore/toystore.yaml
+kubectl -n my-gateways apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml
 kubectl -n my-gateways wait --for=condition=Available deployments toystore --timeout=60s
 ```
 

--- a/doc/user-guides/tls/gateway-tls.md
+++ b/doc/user-guides/tls/gateway-tls.md
@@ -1,6 +1,6 @@
 # Gateway TLS for Cluster Operators
 
-This user guide walks you through an example of how to configure TLS for all routes attached to an ingress gateway.
+This tutorial walks you through an example of how to configure TLS for all routes attached to an ingress gateway.
 
 ## Requisites
 


### PR DESCRIPTION
Replaces https://github.com/Kuadrant/kuadrant-operator/pull/1126

Closes https://github.com/Kuadrant/kuadrant-operator/issues/1093

Other changes:
- Add Gateway creation to some tutorials where before it relied on a Gateway created by a make target
- Add some missing HTTPRoute sectionNames
- Remove make cleanup references
- Some small typos fixed