### PR TITLE
add i18n preload flag for ConsolePlugin

### DIFF
--- a/pkg/openshift/consoleplugin/consoleplugin.go
+++ b/pkg/openshift/consoleplugin/consoleplugin.go
@@ -18,6 +18,9 @@ func ConsolePlugin(ns string) *consolev1.ConsolePlugin {
 		},
 		Spec: consolev1.ConsolePluginSpec{
 			DisplayName: "Kuadrant Console Plugin",
+			I18n: consolev1.ConsolePluginI18n{
+				LoadType: consolev1.Preload,
+			},
 			Backend: consolev1.ConsolePluginBackend{
 				Type: consolev1.Service,
 				Service: &consolev1.ConsolePluginService{


### PR DESCRIPTION
Related: https://github.com/Kuadrant/kuadrant-console-plugin/issues/166

Adds a flag to get `console` to preload i18n resources before rendering the plugin