### PR TITLE
test improvement

### DIFF
--- a/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
+++ b/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
@@ -672,7 +672,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 			Expect(k8sClient.Create(ctx, gwRLP)).To(Succeed())
 			gwRLPKey := client.ObjectKey{Name: gwRLP.Name, Namespace: testNamespace}
 			Eventually(assertPolicyIsAcceptedAndNotEnforced(ctx, gwRLPKey)).WithContext(ctx).Should(BeTrue())
-			Expect(tests.RLPEnforcedCondition(ctx, testClient(), gwRLPKey, kuadrant.PolicyReasonUnknown, "RateLimitPolicy is not in the path to any existing routes"))
+			Expect(tests.RLPEnforcedCondition(ctx, testClient(), gwRLPKey, kuadrant.PolicyReasonUnknown, "RateLimitPolicy is not in the path to any existing routes")).To(BeTrue())
 		}, testTimeOut)
 	})
 
@@ -730,6 +730,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 			Expect(k8sClient.Create(ctx, rlp2)).To(Succeed())
 
 			Eventually(assertAcceptedConditionTrue(rlp), time.Minute, 5*time.Second).Should(BeTrue())
+			Eventually(assertAcceptedConditionTrue(rlp2), time.Minute, 5*time.Second).Should(BeTrue())
 		}, testTimeOut)
 	})
 


### PR DESCRIPTION
Improves two Rate Limit Policy tests: 
1. The test does not evaluate one of the conditions (always passes)
2. The test does not check for the second policy. Leaves a possibility of false positive. 