### PR TITLE
Signing Helm packages

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Configure GPG Key
         run: |
-          echo -n "$GPG_SIGNING_KEY" | base64 -d | gpg --import
+          echo -n "$GPG_SIGNING_KEY" | base64 -d > ~/.gnupg/pubring.gpg
         env:
           GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
 

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -25,11 +25,18 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
+      - name: Configure GPG Key
+        run: |
+          echo -n "$GPG_SIGNING_KEY" | base64 -d | gpg --import
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.HELM_CHARTS_SIGNING_KEY }}
+
       - name: Package Helm Chart
         run: |
           make helm-add-kuadrant-repo
           make helm-dependency-build
-          make helm-package
+          GPG_KEY_UID="Kuadrant Development Team" \
+          make helm-package-sign
 
       - name: Parse Tag
         run: |

--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -54,6 +54,16 @@ jobs:
           tag: ${{ env.OPERATOR_TAG }}
           overwrite: true
 
+      - name: Upload provenance file to GitHub Release
+        uses: svenstaro/upload-release-action@v2
+        id: upload-prov-file
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: kuadrant-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+          asset_name: chart-kuadrant-operator-${{ env.OPERATOR_VERSION }}.tgz.prov
+          tag: ${{ env.OPERATOR_TAG }}
+          overwrite: true
+
       - name: Sync Helm Chart with repository
         run: |
           make helm-sync-package-created \

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ tmp
 
 # Vendor dependencies
 vendor
+
+# Helm chart packages
+*operator*.tgz*

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -50,7 +50,7 @@ GPG_KEY_UID ?= 'Kuadrant Development Team'
 .PHONY: helm-package-sign
 helm-package-sign: $(HELM) ## Package the helm chart and GPG sign it
 	# Package the helm chart and sign it
-	$(HELM) package --sign --key $(GPG_KEY_UID) $(CHART_DIRECTORY)
+	$(HELM) package --sign --key "$(GPG_KEY_UID)" $(CHART_DIRECTORY)
 
 .PHONY: helm-dependency-build
 helm-dependency-build: $(HELM) ## Build the chart dependencies

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -44,6 +44,14 @@ helm-package: $(HELM) ## Package the helm chart
 	# Package the helm chart
 	$(HELM) package $(CHART_DIRECTORY)
 
+# GPG_KEY_UID: substring of the desired key's uid, the name or email
+GPG_KEY_UID ?= 'Kuadrant Development Team'
+# The keyring should've been imported before running this target
+.PHONY: helm-package-sign
+helm-package-sign: $(HELM) ## Package the helm chart and GPG sign it
+	# Package the helm chart and sign it
+	$(HELM) package --sign --key $(GPG_KEY_UID) $(CHART_DIRECTORY)
+
 .PHONY: helm-dependency-build
 helm-dependency-build: $(HELM) ## Build the chart dependencies
 	# Fetch and builds dependencies in Chart.yaml, updates the Chart.lock and downloads the charts .tgz

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -1,5 +1,10 @@
 ##@ Helm Charts
 
+# Chart name
+CHART_NAME ?= kuadrant-operator
+# Chart directory
+CHART_DIRECTORY ?= charts/$(CHART_NAME)
+
 .PHONY: helm-build
 helm-build: $(YQ) kustomize manifests ## Build the helm chart from kustomize manifests
 	# Set desired Wasm-shim image
@@ -11,38 +16,38 @@ helm-build: $(YQ) kustomize manifests ## Build the helm chart from kustomize man
 	# Set desired operator image
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	# Build the helm chart templates from kustomize manifests
-	$(KUSTOMIZE) build config/helm > charts/kuadrant-operator/templates/manifests.yaml
+	$(KUSTOMIZE) build config/helm > $(CHART_DIRECTORY)/templates/manifests.yaml
 	# Set the helm chart version and dependencies versions
-	V="$(BUNDLE_VERSION)" $(YQ) -i e '.version = strenv(V)' charts/kuadrant-operator/Chart.yaml
-	V="$(BUNDLE_VERSION)" $(YQ) -i e '.appVersion = strenv(V)' charts/kuadrant-operator/Chart.yaml
-	V="$(AUTHORINO_OPERATOR_BUNDLE_VERSION)" $(YQ) -i e '(.dependencies[] | select(.name == "authorino-operator").version) = strenv(V)' charts/kuadrant-operator/Chart.yaml
-	V="$(LIMITADOR_OPERATOR_BUNDLE_VERSION)" $(YQ) -i e '(.dependencies[] | select(.name == "limitador-operator").version) = strenv(V)' charts/kuadrant-operator/Chart.yaml
-	V="$(DNS_OPERATOR_BUNDLE_VERSION)" $(YQ) -i e '(.dependencies[] | select(.name == "dns-operator").version) = strenv(V)' charts/kuadrant-operator/Chart.yaml
+	V="$(BUNDLE_VERSION)" $(YQ) -i e '.version = strenv(V)' $(CHART_DIRECTORY)/Chart.yaml
+	V="$(BUNDLE_VERSION)" $(YQ) -i e '.appVersion = strenv(V)' $(CHART_DIRECTORY)/Chart.yaml
+	V="$(AUTHORINO_OPERATOR_BUNDLE_VERSION)" $(YQ) -i e '(.dependencies[] | select(.name == "authorino-operator").version) = strenv(V)' $(CHART_DIRECTORY)/Chart.yaml
+	V="$(LIMITADOR_OPERATOR_BUNDLE_VERSION)" $(YQ) -i e '(.dependencies[] | select(.name == "limitador-operator").version) = strenv(V)' $(CHART_DIRECTORY)/Chart.yaml
+	V="$(DNS_OPERATOR_BUNDLE_VERSION)" $(YQ) -i e '(.dependencies[] | select(.name == "dns-operator").version) = strenv(V)' $(CHART_DIRECTORY)/Chart.yaml
 
 .PHONY: helm-install
 helm-install: $(HELM) ## Install the helm chart
 	# Install the helm chart in the cluster
-	$(HELM) install $(REPO) charts/$(REPO)
+	$(HELM) install $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-uninstall
 helm-uninstall: $(HELM) ## Uninstall the helm chart
 	# Uninstall the helm chart from the cluster
-	$(HELM) uninstall $(REPO)
+	$(HELM) uninstall $(CHART_NAME)
 
 .PHONY: helm-upgrade
 helm-upgrade: $(HELM) ## Upgrade the helm chart
 	# Upgrade the helm chart in the cluster
-	$(HELM) upgrade $(REPO) charts/$(REPO)
+	$(HELM) upgrade $(CHART_NAME) $(CHART_DIRECTORY)
 
 .PHONY: helm-package
 helm-package: $(HELM) ## Package the helm chart
 	# Package the helm chart
-	$(HELM) package charts/$(REPO)
+	$(HELM) package $(CHART_DIRECTORY)
 
 .PHONY: helm-dependency-build
 helm-dependency-build: $(HELM) ## Build the chart dependencies
 	# Fetch and builds dependencies in Chart.yaml, updates the Chart.lock and downloads the charts .tgz
-	$(HELM) dependency build charts/$(REPO)
+	$(HELM) dependency build $(CHART_DIRECTORY)
 
 .PHONY: helm-add-kuadrant-repo
 helm-add-kuadrant-repo: $(HELM) ## Add the Kuadrant charts repo and force update it
@@ -65,7 +70,7 @@ helm-sync-package-created: ## Sync the helm chart package to the helm-charts rep
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(REPO)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
+	  -d '{"event_type":"chart-created","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)", "browser_download_url": "$(BROWSER_DOWNLOAD_URL)"}}'
 
 .PHONY: helm-sync-package-deleted
 helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-charts repo
@@ -75,4 +80,4 @@ helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-ch
 	  -H "Authorization: Bearer $(HELM_WORKFLOWS_TOKEN)" \
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
-	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(REPO)","version":"$(CHART_VERSION)"}}'
+	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)"}}'


### PR DESCRIPTION
Part of the work needed for https://github.com/Kuadrant/helm-charts/issues/18

This PR introduces the GPG signing of Helm chart packages upon creation. It also uploads its provenance file to the GH release page.

The job now requires to be passed an environment variable GPG_KEYRING_BASE64 which represents the GPG keyring base64 encoded, in order to be stored as a GH action variable.

The following PRs need to be merged first:

* https://github.com/Kuadrant/dns-operator/pull/370
* https://github.com/Kuadrant/limitador-operator/pull/175
* https://github.com/Kuadrant/authorino-operator/pull/238

