### PR TITLE
Add test helm upgrade path

### DIFF
--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -97,10 +97,19 @@ jobs:
           --version ${{ inputs.kuadrantStartVersion }} \
           --namespace ${{ inputs.kuadrantNamespace }} \
           --create-namespace
+      - name: Deploy Kuadrant
+        run: |
+          kubectl -n ${{ inputs.kuadrantNamespace }} apply -f - <<EOF
+          apiVersion: kuadrant.io/v1beta1
+          kind: Kuadrant
+          metadata:
+            name: kuadrant
+          spec: {}
+          EOF
       - name: Verify Kuadrant installation
         run: |
-          # TODO
-          echo "kuadrant installation ✅" &&  exit 0
+          kubectl wait --timeout=300s --for=condition=Ready kuadrant kuadrant -n ${{ inputs.kuadrantNamespace }}
+          echo "kuadrant installation ✅"
       - name: Build local chart dependencies for version ${{ steps.upgrade-version.outputs.version }}
         run: |
           make helm-dependency-build
@@ -122,5 +131,5 @@ jobs:
         run: exit 1
       - name: Verify Kuadrant upgrade
         run: |
-          # TODO
-          echo "kuadrant upgrade ✅" &&  exit 0
+          kubectl wait --timeout=300s --for=condition=Ready kuadrant kuadrant -n ${{ inputs.kuadrantNamespace }}
+          echo "kuadrant upgrade ✅"

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -29,6 +29,7 @@ jobs:
       KIND_CLUSTER_NAME: kuadrant-test
       K8S_USER: kuadrant-admin  # can be whatever, it does not matter.
       CLUSTER_NAME: remote-cluster
+      LOCAL_CLUSTER: ${{ inputs.clusterServer == '' && inputs.clusterToken == '' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -47,7 +48,7 @@ jobs:
       - name: Print versions
         run: echo "Installing version ${{ inputs.kuadrantStartVersion }}, upgrading to version ${{ steps.upgrade-version.outputs.version }}"
       - name: Deploy local Kind cluster
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        if: ${{ env.LOCAL_CLUSTER }}
         uses: helm/kind-action@v1.12.0
         with:
           version: v0.23.0
@@ -55,18 +56,18 @@ jobs:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s
       - name: Install kubectl for remote cluster
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer != '' }}
+        if: ${{ !env.LOCAL_CLUSTER }}
         uses: azure/setup-kubectl@v4
         with:
           version: v1.25.3
       - name: Mask cluster token
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterToken != '' }}
+        if: ${{ !env.LOCAL_CLUSTER }}
         run: |
           CLUSTER_TOKEN=$(jq -r '.inputs.clusterToken' $GITHUB_EVENT_PATH)
           echo ::add-mask::$CLUSTER_TOKEN
           echo CLUSTER_TOKEN=$CLUSTER_TOKEN >> $GITHUB_ENV
       - name: Setup kubectl for remote cluster
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer != '' }}
+        if: ${{ !env.LOCAL_CLUSTER }}
         run: |
           kubectl config set-credentials ${{ env.K8S_USER }}/${{ env.CLUSTER_NAME }} --token ${{ env.CLUSTER_TOKEN }}
           kubectl config set-cluster ${{ env.CLUSTER_NAME }} --insecure-skip-tls-verify=true --server=${{ inputs.clusterServer }}
@@ -77,7 +78,7 @@ jobs:
           kubectl cluster-info
           kubectl get nodes
       - name: Deploy pre-requisites on local Kind cluster
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        if: ${{ env.LOCAL_CLUSTER }}
         run: |
           make install-metallb
           make install-cert-manager
@@ -85,7 +86,6 @@ jobs:
           make deploy-eg-gateway
       - name: Install helm and add Kuadrant repo
         run: |
-          make helm
           make helm-add-kuadrant-repo
           bin/helm search repo kuadrant
       - name: Install Kuadrant ${{ inputs.kuadrantStartVersion }}

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -25,7 +25,6 @@ jobs:
   helm-charts-upgrade-test:
     runs-on: ubuntu-latest
     name: Helm Charts Upgrade Test
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     env:
       KIND_CLUSTER_NAME: kuadrant-test
       K8S_USER: kuadrant-admin  # can be whatever, it does not matter.

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -1,0 +1,126 @@
+---
+name: Kuadrant Upgrade Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      kuadrantStartVersion:
+        description: Kuadrant start version
+        required: true
+        type: string
+      clusterServer:
+        description: Cluster server URL
+        required: false
+        type: string
+      clusterToken:
+        description: Cluster Server Bearer Token
+        required: false
+        type: string
+      kuadrantNamespace:
+        description: Namespace where Kuadrant is installed
+        required: false
+        default: kuadrant-system
+        type: string
+jobs:
+  helm-charts-upgrade-test:
+    runs-on: ubuntu-latest
+    name: Helm Charts Upgrade Test
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    env:
+      KIND_CLUSTER_NAME: kuadrant-test
+      K8S_USER: kuadrant-admin  # can be whatever, it does not matter.
+      CLUSTER_NAME: remote-cluster
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install helm
+        run: |
+          make helm
+      - name: Install yq tool
+        run: |
+          # following sub-shells running make target should have yq already installed
+          make yq
+      - name: Determine upgrade version
+        id: upgrade-version
+        run: |
+          version=`make helm-print-chart-version`
+          echo version=$version >> $GITHUB_OUTPUT
+      - name: Print versions
+        run: echo "Installing version ${{ inputs.kuadrantStartVersion }}, upgrading to version ${{ steps.upgrade-version.outputs.version }}"
+      - name: Deploy local Kind cluster
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        uses: helm/kind-action@v1.12.0
+        with:
+          version: v0.23.0
+          config: utils/kind-cluster.yaml
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          wait: 120s
+      - name: Install kubectl for remote cluster
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer != '' }}
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.25.3
+      - name: Mask cluster token
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterToken != '' }}
+        run: |
+          CLUSTER_TOKEN=$(jq -r '.inputs.clusterToken' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$CLUSTER_TOKEN
+          echo CLUSTER_TOKEN=$CLUSTER_TOKEN >> $GITHUB_ENV
+      - name: Setup kubectl for remote cluster
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer != '' }}
+        run: |
+          kubectl config set-credentials ${{ env.K8S_USER }}/${{ env.CLUSTER_NAME }} --token ${{ env.CLUSTER_TOKEN }}
+          kubectl config set-cluster ${{ env.CLUSTER_NAME }} --insecure-skip-tls-verify=true --server=${{ inputs.clusterServer }}
+          kubectl config set-context ${{ inputs.kuadrantNamespace }}/${{ env.CLUSTER_NAME }}/${{ env.K8S_USER }} --user=${{ env.K8S_USER }}/${{ env.CLUSTER_NAME }} --namespace=${{ inputs.kuadrantNamespace }} --cluster=${{ env.CLUSTER_NAME }}
+          kubectl config use-context ${{ inputs.kuadrantNamespace }}/${{ env.CLUSTER_NAME }}/${{ env.K8S_USER }}
+      ## makes sure cluster is up and running
+      - run: |
+          kubectl cluster-info
+          kubectl get nodes
+      - name: Deploy pre-requisites on local Kind cluster
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        run: |
+          make install-metallb
+          make install-cert-manager
+          make envoy-gateway-install
+          make deploy-eg-gateway
+      - name: Install helm and add Kuadrant repo
+        run: |
+          make helm
+          make helm-add-kuadrant-repo
+          bin/helm search repo kuadrant
+      - name: Install Kuadrant ${{ inputs.kuadrantStartVersion }}
+        run: |
+          bin/helm install kuadrant kuadrant/kuadrant-operator \
+          --wait \
+          --timeout 3m0s \
+          --version ${{ inputs.kuadrantStartVersion }} \
+          --namespace ${{ inputs.kuadrantNamespace }} \
+          --create-namespace
+      - name: Verify Kuadrant installation
+        run: |
+          # TODO
+          echo "kuadrant installation ✅" &&  exit 0
+      - name: Build local chart dependencies for version ${{ steps.upgrade-version.outputs.version }}
+        run: |
+          make helm-dependency-build
+      - name: Start upgrade to kuadrant ${{ steps.upgrade-version.outputs.version }}
+        run: |
+          bin/helm upgrade kuadrant charts/kuadrant-operator \
+          --wait \
+          --timeout 3m0s \
+          --namespace ${{ inputs.kuadrantNamespace }}
+      - name: Determine installed chart
+        id: installed-version-after-upgrade
+        run: |
+          installed_version=`make helm-print-installed-chart-version`
+          echo installed_version=$installed_version >> $GITHUB_OUTPUT
+      - name: Print versions
+        run: echo "Installed version ${{ steps.installed-version-after-upgrade.outputs.installed_version }}, expected version ${{steps.upgrade-version.outputs.version}}"
+      - name: Fail when installed version is not the upgraded one
+        if: ${{ steps.installed-version-after-upgrade.outputs.installed_version != steps.upgrade-version.outputs.version }}
+        run: exit 1
+      - name: Verify Kuadrant upgrade
+        run: |
+          # TODO
+          echo "kuadrant upgrade ✅" &&  exit 0

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -89,3 +89,10 @@ helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-ch
 	  -H "X-GitHub-Api-Version: 2022-11-28" \
 	  https://api.github.com/repos/$(ORG)/$(HELM_REPO_NAME)/dispatches \
 	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)"}}'
+
+.PHONY: helm-print-chart-version
+helm-print-chart-version: $(HELM) ## Reads chart version
+	@$(HELM) show chart charts/$(REPO) | grep -E "^version:" | awk '{print $$2}'
+
+helm-print-installed-chart-version: $(YQ) $(HELM) ## Reads chart version
+	@$(HELM) list --all-namespaces -o yaml | $(YQ) '(.[] | select(.name == "kuadrant") | .app_version)'

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -91,8 +91,8 @@ helm-sync-package-deleted: ## Sync the deleted helm chart package to the helm-ch
 	  -d '{"event_type":"chart-deleted","client_payload":{"chart":"$(CHART_NAME)","version":"$(CHART_VERSION)"}}'
 
 .PHONY: helm-print-chart-version
-helm-print-chart-version: $(HELM) ## Reads chart version
-	@$(HELM) show chart charts/$(REPO) | grep -E "^version:" | awk '{print $$2}'
+helm-print-chart-version: $(HELM) ## Reads local chart version
+	@$(HELM) show chart charts/$(CHART_NAME) | grep -E "^version:" | awk '{print $$2}'
 
-helm-print-installed-chart-version: $(YQ) $(HELM) ## Reads chart version
+helm-print-installed-chart-version: $(YQ) $(HELM) ## Reads installed chart version
 	@$(HELM) list --all-namespaces -o yaml | $(YQ) '(.[] | select(.name == "kuadrant") | .app_version)'


### PR DESCRIPTION
### What

Implements #1123 and is part of the work being done for https://github.com/Kuadrant/kuadrant-operator/issues/1112

It's a Github Action Workflow to test the Kuadrant upgrade process using **helm charts**.

It is being triggered manually (`on.workflow_dispatch`) and accepts as input:
* `kuadrantStartVersion`:  Kuadrant start version (*required*). For example: `1.0.0` (without `v` prefix)
* `kuadrantNamespace`: Namespace where Kuadrant is installed (*optional* defaults to `kuadrant-system`).
* `clusterServer`: Cluster server URL (*optional* defaults to local kind cluster). For example: `https://example.com:443`
* `clusterToken`:  Cluster Server Bearer Token (*optional* defaults to local kind cluster token). For example: `sha256~abcdefghijk12345432432`

The workflow installs published Kuadrant release from `https://kuadrant.io/helm-charts` with the version specified by `kuadrantStartVersion`. As of today, existing release versions:

```
❯ bin/helm search repo kuadrant -l
NAME                       	CHART VERSION	APP VERSION	DESCRIPTION                                       
kuadrant/kuadrant-operator 	1.0.2        	1.0.2      	The Operator to install and manage the lifecycl...
kuadrant/kuadrant-operator 	1.0.1        	1.0.1      	The Operator to install and manage the lifecycl...
kuadrant/kuadrant-operator 	1.0.0        	1.0.0      	The Operator to install and manage the lifecycl...
kuadrant/kuadrant-operator 	0.11.0       	           	The Operator to install and manage the lifecycl...
kuadrant/authorino-operator	0.16.0       	0.16.0     	Kubernetes operator for managing Authorino inst...
kuadrant/authorino-operator	0.15.1       	0.15.1     	Kubernetes operator for managing Authorino inst...
kuadrant/authorino-operator	0.14.0       	           	Kubernetes operator for managing Authorino inst...
kuadrant/authorino-operator	0.13.1       	           	Kubernetes operator for managing Authorino inst...
kuadrant/authorino-operator	0.13.0       	           	Kubernetes operator for managing Authorino inst...
kuadrant/authorino-operator	0.12.0       	           	Kubernetes operator for managing Authorino inst...
kuadrant/dns-operator      	0.12.0       	0.12.0     	Kubernetes operator responsible for reconciling...
kuadrant/dns-operator      	0.11.0       	0.11.0     	Kubernetes operator responsible for reconciling...
kuadrant/dns-operator      	0.10.1       	0.10.1     	Kubernetes operator responsible for reconciling...
kuadrant/dns-operator      	0.10.0       	0.10.0     	Kubernetes operator responsible for reconciling...
kuadrant/dns-operator      	0.9.0        	           	Kubernetes operator responsible for reconciling...
kuadrant/dns-operator      	0.8.0        	           	Kubernetes operator responsible for reconciling...
kuadrant/dns-operator      	0.7.0        	           	Kubernetes operator responsible for reconciling...
kuadrant/dns-operator      	0.6.0        	           	Kubernetes operator responsible for reconciling...
kuadrant/dns-operator      	0.5.0        	           	Kubernetes operator responsible for reconciling...
kuadrant/dns-operator      	0.4.1        	           	Kubernetes operator responsible for reconciling...
kuadrant/limitador-operator	0.12.1       	0.12.1     	Kubernetes operator for managing Limitador inst...
kuadrant/limitador-operator	0.12.0       	           	Kubernetes operator for managing Limitador inst...
kuadrant/limitador-operator	0.11.0       	           	Kubernetes operator for managing Limitador inst...
```
Then, deploys kuadrant CR and checks status is *Ready*. The kuadrant operator, runs a set of tests to mark the resource status as ready, so effectively, the workflow is relying on those tests to verify installation. 

When the starting point installation is ready, it proceeds with the upgrade process. The upgrade is being carried out running [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) command. The command waits until all deployments are ready (with a timeout set to 3 mins) and fails if some deployment is not ready after the timeout expires. Upgrade may fail for instance if some referenced docker image is not valid or does not exist. The upgrade verification steps by the workflow relies, once again, on the kuadrant CR status. After the upgrade, the kuadrant CR status should be Ready to pass the test. For example, if for whatever reason, let's say the limitador operator, or limitador instance, is not up and running, kuadrant CR would report on the status and the upgrade test would fail. 

Simple commands are being coded as part of the Github workflow. For high level commands, those are implemented using makefile targets or third party tools so they can be easily run locally to dev/test. 
