### PR TITLE
Add test OLM  upgrade path

### DIFF
--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -135,23 +135,20 @@ jobs:
   olm-upgrade-test:
     runs-on: ubuntu-latest
     name: OLM Upgrade Test
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     env:
       KIND_CLUSTER_NAME: kuadrant-test
       K8S_USER: kuadrant-admin  # can be whatever, it does not matter.
       CLUSTER_NAME: remote-cluster
+      LOCAL_CLUSTER: ${{ inputs.clusterServer == '' && inputs.clusterToken == '' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Install helm
-        run: |
-          make helm
       - name: Install yq tool
         run: |
           # following sub-shells running make target should have yq already installed
           make yq
       - name: Deploy local Kind cluster
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        if: ${{ env.LOCAL_CLUSTER }}
         uses: helm/kind-action@v1.12.0
         with:
           version: v0.23.0
@@ -159,18 +156,18 @@ jobs:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
           wait: 120s
       - name: Install kubectl for remote cluster
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer != '' }}
+        if: ${{ !env.LOCAL_CLUSTER }}
         uses: azure/setup-kubectl@v4
         with:
           version: v1.31.0
       - name: Mask cluster token
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterToken != '' }}
+        if: ${{ !env.LOCAL_CLUSTER }}
         run: |
           CLUSTER_TOKEN=$(jq -r '.inputs.clusterToken' $GITHUB_EVENT_PATH)
           echo ::add-mask::$CLUSTER_TOKEN
           echo CLUSTER_TOKEN=$CLUSTER_TOKEN >> $GITHUB_ENV
       - name: Setup kubectl for remote cluster
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer != '' }}
+        if: ${{ !env.LOCAL_CLUSTER }}
         run: |
           kubectl config set-credentials ${{ env.K8S_USER }}/${{ env.CLUSTER_NAME }} --token ${{ env.CLUSTER_TOKEN }}
           kubectl config set-cluster ${{ env.CLUSTER_NAME }} --insecure-skip-tls-verify=true --server=${{ inputs.clusterServer }}
@@ -181,11 +178,11 @@ jobs:
           kubectl cluster-info
           kubectl get nodes
       - name: Deploy OLM on local Kind cluster
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        if: ${{ env.LOCAL_CLUSTER }}
         run: |
           make install-olm
       - name: Deploy pre-requisites on local Kind cluster
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        if: ${{ env.LOCAL_CLUSTER }}
         run: |
           make install-metallb
           make install-cert-manager

--- a/.github/workflows/test-upgrade.yaml
+++ b/.github/workflows/test-upgrade.yaml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       kuadrantStartVersion:
-        description: Kuadrant start version
+        description: Kuadrant start version (format X.Y.Z)
         required: true
         type: string
       clusterServer:
-        description: Cluster server URL
+        description: Cluster Server URL
         required: false
         type: string
       clusterToken:
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
       kuadrantNamespace:
-        description: Namespace where Kuadrant is installed
+        description: Namespace
         required: false
         default: kuadrant-system
         type: string
@@ -59,7 +59,7 @@ jobs:
         if: ${{ !env.LOCAL_CLUSTER }}
         uses: azure/setup-kubectl@v4
         with:
-          version: v1.25.3
+          version: v1.31.0
       - name: Mask cluster token
         if: ${{ !env.LOCAL_CLUSTER }}
         run: |
@@ -128,6 +128,183 @@ jobs:
       - name: Fail when installed version is not the upgraded one
         if: ${{ steps.installed-version-after-upgrade.outputs.installed_version != steps.upgrade-version.outputs.version }}
         run: exit 1
+      - name: Verify Kuadrant upgrade
+        run: |
+          kubectl wait --timeout=300s --for=condition=Ready kuadrant kuadrant -n ${{ inputs.kuadrantNamespace }}
+          echo "kuadrant upgrade ✅"
+  olm-upgrade-test:
+    runs-on: ubuntu-latest
+    name: OLM Upgrade Test
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    env:
+      KIND_CLUSTER_NAME: kuadrant-test
+      K8S_USER: kuadrant-admin  # can be whatever, it does not matter.
+      CLUSTER_NAME: remote-cluster
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install helm
+        run: |
+          make helm
+      - name: Install yq tool
+        run: |
+          # following sub-shells running make target should have yq already installed
+          make yq
+      - name: Deploy local Kind cluster
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        uses: helm/kind-action@v1.12.0
+        with:
+          version: v0.23.0
+          config: utils/kind-cluster.yaml
+          cluster_name: ${{ env.KIND_CLUSTER_NAME }}
+          wait: 120s
+      - name: Install kubectl for remote cluster
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer != '' }}
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.31.0
+      - name: Mask cluster token
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterToken != '' }}
+        run: |
+          CLUSTER_TOKEN=$(jq -r '.inputs.clusterToken' $GITHUB_EVENT_PATH)
+          echo ::add-mask::$CLUSTER_TOKEN
+          echo CLUSTER_TOKEN=$CLUSTER_TOKEN >> $GITHUB_ENV
+      - name: Setup kubectl for remote cluster
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer != '' }}
+        run: |
+          kubectl config set-credentials ${{ env.K8S_USER }}/${{ env.CLUSTER_NAME }} --token ${{ env.CLUSTER_TOKEN }}
+          kubectl config set-cluster ${{ env.CLUSTER_NAME }} --insecure-skip-tls-verify=true --server=${{ inputs.clusterServer }}
+          kubectl config set-context ${{ inputs.kuadrantNamespace }}/${{ env.CLUSTER_NAME }}/${{ env.K8S_USER }} --user=${{ env.K8S_USER }}/${{ env.CLUSTER_NAME }} --namespace=${{ inputs.kuadrantNamespace }} --cluster=${{ env.CLUSTER_NAME }}
+          kubectl config use-context ${{ inputs.kuadrantNamespace }}/${{ env.CLUSTER_NAME }}/${{ env.K8S_USER }}
+      ## makes sure cluster is up and running
+      - run: |
+          kubectl cluster-info
+          kubectl get nodes
+      - name: Deploy OLM on local Kind cluster
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        run: |
+          make install-olm
+      - name: Deploy pre-requisites on local Kind cluster
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.clusterServer == '' }}
+        run: |
+          make install-metallb
+          make install-cert-manager
+          make envoy-gateway-install
+          make deploy-eg-gateway
+      - name: Determine versions and URLs
+        id: versions
+        run: |
+          operator_repo=`make print-operator-repo`
+          echo starting_operator_url=${operator_repo}:v${{ inputs.kuadrantStartVersion }} >> $GITHUB_OUTPUT
+          catalog_repo=`make print-catalog-repo`
+          echo starting_catalog_url=${catalog_repo}:v${{ inputs.kuadrantStartVersion }} >> $GITHUB_OUTPUT
+          upgrade_version=`make read-release-version`
+          echo upgrade_version=$upgrade_version >> $GITHUB_OUTPUT
+          upgrade_operator_url=`make print-operator-image`
+          echo upgrade_operator_url=$upgrade_operator_url >> $GITHUB_OUTPUT
+          upgrade_bundle_url=`make print-bundle-image`
+          echo upgrade_bundle_url=$upgrade_bundle_url >> $GITHUB_OUTPUT
+          upgrade_catalog_url=`make print-catalog-image`
+          echo upgrade_catalog_url=${upgrade_catalog_url} >> $GITHUB_OUTPUT
+      - name: Print summary
+        run: echo "Installing version ${{ inputs.kuadrantStartVersion }}, upgrading to version ${{ steps.versions.outputs.upgrade_version }}"
+      - name: Create namespace
+        run: |
+          kubectl create namespace ${{ inputs.kuadrantNamespace }}
+      - name: Install Kuadrant ${{ inputs.kuadrantStartVersion }}
+        run: |
+          kubectl apply -f - <<EOF
+          ---
+          apiVersion: operators.coreos.com/v1alpha2
+          kind: OperatorGroup
+          metadata:
+            name: all-namespaces-operator-group
+            namespace: ${{ inputs.kuadrantNamespace }}
+          ---
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: CatalogSource
+          metadata:
+            name: kuadrant-operator-catalog-starting-version
+            namespace: ${{ inputs.kuadrantNamespace }}
+          spec:
+            sourceType: grpc
+            image: ${{ steps.versions.outputs.starting_catalog_url }}
+            displayName: Kuadrant Operators
+            publisher: grpc
+            updateStrategy:
+              registryPoll:
+                interval: 45m
+          ---
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: Subscription
+          metadata:
+            name: kuadrant-operator
+            namespace: ${{ inputs.kuadrantNamespace }}
+          spec:
+            channel: stable
+            name: kuadrant-operator
+            source: kuadrant-operator-catalog-starting-version
+            sourceNamespace: ${{ inputs.kuadrantNamespace }}
+          EOF
+      - name: Wait for subscription to be ready
+        run: |
+          kubectl wait --for=jsonpath='{.status.state}'=AtLatestKnown subscription/kuadrant-operator -n ${{ inputs.kuadrantNamespace }} --timeout=600s
+          echo "kuadrant subscription ✅"
+      - name: Wait for CSV to be ready
+        run: |
+          kubectl wait --for=jsonpath='{.status.phase}'=Succeeded csv/kuadrant-operator.v${{ inputs.kuadrantStartVersion }} --timeout=300s -n ${{ inputs.kuadrantNamespace }}
+          echo "kuadrant CSV ✅"
+      - name: Verify kuadrant start version deployment image
+        run: |
+          kubectl wait --timeout=300s --for=jsonpath='{.spec.template.spec.containers[0].image}'=${{ steps.versions.outputs.starting_operator_url }} deployment kuadrant-operator-controller-manager -n ${{ inputs.kuadrantNamespace }}
+          echo "kuadrant start version deployment image ✅"
+      - name: Deploy Kuadrant
+        run: |
+          kubectl -n ${{ inputs.kuadrantNamespace }} apply -f - <<EOF
+          apiVersion: kuadrant.io/v1beta1
+          kind: Kuadrant
+          metadata:
+            name: kuadrant
+          spec: {}
+          EOF
+      - name: Verify Kuadrant installation
+        run: |
+          kubectl wait --timeout=300s --for=condition=Ready kuadrant kuadrant -n ${{ inputs.kuadrantNamespace }}
+          echo "kuadrant installation ✅"
+      - name: Note for debugging failed upgrades
+        run: |
+          echo "📝 If the upgrade fails, you can debug it by running it locally with OLM and Catalog Operator in debugging mode."
+          echo "📝 If the upgrade fails, make sure dependencies have also upgrade path available from available operator catalogs in the cluster."
+      - name: Start upgrade to kuadrant ${{ steps.versions.outputs.upgrade_version }}
+        run: |
+          kubectl apply -f - <<EOF
+          apiVersion: operators.coreos.com/v1alpha1
+          kind: CatalogSource
+          metadata:
+            name: kuadrant-operator-catalog-upgraded-version
+            namespace: ${{ inputs.kuadrantNamespace }}
+          spec:
+            sourceType: grpc
+            image: ${{ steps.versions.outputs.upgrade_catalog_url }}
+            displayName: Kuadrant Operators
+            publisher: grpc
+            updateStrategy:
+              registryPoll:
+                interval: 45m
+          EOF
+          bin/operator-sdk run bundle-upgrade \
+          --namespace ${{ inputs.kuadrantNamespace }} \
+          --skip-tls-verify \
+          --timeout 3m0s \
+          ${{ steps.versions.outputs.upgrade_bundle_url }}
+      - name: Wait for upgraded CSV to be ready
+        run: |
+          kubectl wait --for=jsonpath='{.status.phase}'=Succeeded csv/kuadrant-operator.${{ steps.versions.outputs.upgrade_version }} --timeout=300s -n ${{ inputs.kuadrantNamespace }}
+          echo "kuadrant upgraded CSV ✅"
+      - name: Verify kuadrant upgraded version deployment image
+        run: |
+          kubectl wait --timeout=300s --for=jsonpath='{.spec.template.spec.containers[0].image}'=${{ steps.versions.outputs.upgrade_operator_url }} deployment kuadrant-operator-controller-manager -n ${{ inputs.kuadrantNamespace }}
+          echo "kuadrant upgraded version deployment image ✅"
       - name: Verify Kuadrant upgrade
         run: |
           kubectl wait --timeout=300s --for=condition=Ready kuadrant kuadrant -n ${{ inputs.kuadrantNamespace }}

--- a/Makefile
+++ b/Makefile
@@ -487,8 +487,14 @@ bundle-operator-image-url: $(YQ) ## Read operator image reference URL from the m
 read-release-version: ## Reads release version
 	@echo "v$(VERSION)"
 
-print-bundle-image: ## Pring bundle images.
+print-bundle-image: ## Print bundle image
 	@echo $(BUNDLE_IMG)
+
+print-operator-repo: ## Print operator repo
+	@echo $(IMAGE_TAG_BASE)
+
+print-operator-image: ## Print operator image
+	@echo $(IMG)
 
 .PHONY: update-catalogsource
 update-catalogsource:

--- a/make/catalog.mk
+++ b/make/catalog.mk
@@ -2,7 +2,8 @@
 
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:$(IMAGE_TAG)
+CATALOG_IMG_REPO ?= $(IMAGE_TAG_BASE)-catalog
+CATALOG_IMG ?= $(CATALOG_IMG_REPO):$(IMAGE_TAG)
 
 CATALOG_FILE = $(PROJECT_PATH)/catalog/kuadrant-operator-catalog/operator.yaml
 CATALOG_DOCKERFILE = $(PROJECT_PATH)/catalog/kuadrant-operator-catalog.Dockerfile
@@ -74,3 +75,9 @@ deploy-catalog: $(KUSTOMIZE) $(YQ) ## Deploy operator to the K8s cluster specifi
 .PHONY: undeploy-catalog
 undeploy-catalog: $(KUSTOMIZE) ## Undeploy controller from the K8s cluster specified in ~/.kube/config using OLM catalog image.
 	$(KUSTOMIZE) build config/deploy/olm | kubectl delete -f -
+
+print-catalog-repo: ## Print catalog repo
+	@echo $(CATALOG_IMG_REPO)
+
+print-catalog-image: ## Print catalog image
+	@echo $(CATALOG_IMG)


### PR DESCRIPTION
### What

Implements #1117 and is part of the work being done for https://github.com/Kuadrant/kuadrant-operator/issues/1112

It's a Github Action Workflow to test the Kuadrant upgrade process using **OLM** APIs.

It is being triggered manually (`on.workflow_dispatch`) and accepts as input:
* `kuadrantStartVersion`:  Kuadrant start version (*required*). For example: `1.0.0` (without `v` prefix)
* `kuadrantNamespace`: Namespace where Kuadrant is installed (*optional* defaults to `kuadrant-system`).
* `clusterServer`: Cluster server URL (*optional* defaults to local kind cluster). For example: `https://example.com:443`
* `clusterToken`:  Cluster Server Bearer Token (*optional* defaults to local kind cluster token). For example: `sha256~abcdefghijk12345432432`

The workflow goes as follows:

* It Installs  Kuadrant release with the version specified by `kuadrantStartVersion`. It's being installed traditionally using OLM: OperatorGroup + CatalogSource (with the catalog build for the `kuadrantStartVersion`) + Subscription. 
* Waits for subscription, CSV and deployments to be ready
* Deploys kuadrant CR and checks status is *Ready*. The kuadrant operator, runs a set of tests to mark the resource status as ready, so effectively, the workflow is relying on those tests to verify installation. 
* When the starting point installation is ready, it proceeds with the upgrade process. The upgrade is being carried out running [operator-sdk run bundle-upgrade](https://sdk.operatorframework.io/docs/cli/operator-sdk_run_bundle-upgrade//) command. The command, basically, builds an ephemeral index adding an upgrade path from the existing installed bundle to the given bundle as input param. Then, waits until all deployments are ready (with a timeout set to 3 mins) and fails if some deployment is not ready after the timeout expires. Upgrade may fail for instance if some referenced docker image is not valid or does not exist. The upgrade verification steps by the workflow relies, once again, on 1) upgraded CSV readiness, 2) upgraded deployment image and 3) the kuadrant CR status. For example, if for whatever reason, let's say the limitador operator, or limitador instance, is not up and running, kuadrant CR would report on the status and the upgrade test would fail. The upgrade command may fail if kuadrant dependencies cannot be upgraded as well. This issue is not obvious from the upgrade command output, so digging is required. 

Simple commands are being coded as part of the Github workflow. For high level commands, those are implemented using makefile targets or third party tools so they can be easily run locally to dev/test. 

### Verification Steps

Prepare a new release, let's say v1.0.2

```
git checkout -b testing-upgrade
make prepare-release VERSION=1.0.2 AUTHORINO_OPERATOR_VERSION=0.16.0 LIMITADOR_OPERATOR_VERSION=0.12.1 DNS_OPERATOR_VERSION=0.12.0 WASM_SHIM_VERSION=0.8.1 RELATED_IMAGE_CONSOLEPLUGIN=quay.io/kuadrant/console-plugin:v0.0.18
```
Commit and push the branch (`testing-upgrade` in the example).

Then, run workflow manually (cannot be done from github UI as it has not been merged to `main` branch). This run would test upgrade from `v1.0.1` to `v1.0.2`:

```
gh workflow run test-upgrade.yaml --ref testing-upgrade -f kuadrantStartVersion=1.0.1
```
Check the [upgrade test workflow run](https://github.com/Kuadrant/kuadrant-operator/actions/workflows/test-upgrade.yaml) to complete successfully. 

