### PR TITLE
Automated release operator workflow

### DIFF
--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -1,0 +1,138 @@
+name: Automated Release Operator
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: Commit SHA, tag or branch name (usually main branch)
+        required: true
+        default: "main"
+        type: string
+      kuadrantOperatorVersion:
+        description: Kuadrant Operator version (semver)
+        default: 0.0.0
+        type: string
+      authorinoOperatorVersion:
+        description: Authorino Operator bundle version (semver)
+        default: 0.0.0
+        type: string
+      limitadorOperatorVersion:
+        description: Limitador Operator bundle version (semver)
+        default: 0.0.0
+        type: string
+      dnsOperatorVersion:
+        description: DNS Operator bundle version (semver)
+        default: 0.0.0
+        type: string
+      wasmShimVersion:
+        description: WASM Shim version (semver)
+        default: 0.0.0
+        type: string
+      consolePluginVersion:
+        description: ConsolePlugin version (semver)
+        default: 0.0.0
+        type: string
+      olmChannel:
+        description: OLM channel
+        required: false
+        type: string
+        default: "stable"
+
+jobs:
+  auto-release:
+    name: Release operator
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.22.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.22.x
+        id: go
+      - name: Checkout code at git ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.gitRef }}
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
+
+      - name: Install gettext-base
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext-base
+
+      - name: Install yq tool
+        run: |
+          make yq
+
+      - name: Create release branch(es)
+        id: create-release-branch
+        shell: bash
+        run: |
+          base_branch=release-v$(echo "${{ github.event.inputs.kuadrantOperatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          echo BASE_BRANCH=$base_branch >> $GITHUB_ENV
+          
+          if git ls-remote --exit-code --heads origin $base_branch ; then
+            echo "Base branch $base_branch already exists"
+          else
+            echo Creating branch "$base_branch"
+            git checkout -b "$base_branch"
+            git push origin
+          fi
+
+      - name: Prepare release
+        id: prepare-release
+        run: |
+          echo "Updating release.yaml with desired versions"
+
+          VERSION=${{ github.event.inputs.kuadrantOperatorVersion }} \
+          AUTHORINO_OPERATOR_VERSION=${{ github.event.inputs.authorinoOperatorVersion }} \
+          DNS_OPERATOR_VERSION=${{ github.event.inputs.dnsOperatorVersion }} \
+          LIMITADOR_OPERATOR_VERSION=${{ github.event.inputs.limitadorOperatorVersion }} \
+          CONSOLE_PLUGIN_VERSION=${{ github.event.inputs.consolePluginVersion }} \
+          WASM_SHIM_VERSION=${{ github.event.inputs.wasmShimVersion }} \
+          OLM_CHANNEL=${{ github.event.inputs.olmChannel }} \
+          yq eval '(.kuadrant-operator.version = strenv(VERSION)) |
+            (.dependencies.authorino-operator = strenv(AUTHORINO_OPERATOR_VERSION)) |
+            (.dependencies.dns-operator = strenv(DNS_OPERATOR_VERSION)) |
+            (.dependencies.limitador-operator = strenv(LIMITADOR_OPERATOR_VERSION)) |
+            (.dependencies.console-plugin = strenv(CONSOLE_PLUGIN_VERSION)) |
+            (.dependencies.wasm-shim = strenv(WASM_SHIM_VERSION)) |
+            (.olm.default-channel = strenv(OLM_CHANNEL)) |
+            (.olm.channels[0] = strenv(OLM_CHANNEL))' --inplace ./release.yaml
+
+          echo "release.yaml file updated as follows:"
+
+          cat ./release.yaml
+
+          echo "Running prepare-release script"
+
+          make prepare-release
+          
+      - name: Create Pull Request
+        id: cpr
+        if: ${{ !env.ACT }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
+          commit-message: Prepare release ${{ github.event.inputs.kuadrantOperatorVersion }}
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          signoff: true
+          base: ${{ env.BASE_BRANCH }}
+          branch: release-v${{ github.event.inputs.kuadrantOperatorVersion }}
+          delete-branch: true
+          title: '[Release] Kuadrant Operator v${{ github.event.inputs.kuadrantOperatorVersion }}'
+          body: |
+            The following PR for the release candidate of Kuadrant Operator version ${{ github.event.inputs.kuadrantOperatorVersion }} includes:
+            - Authorino Operator version ${{ github.event.inputs.authorinoOperatorVersion }}
+            - DNS Operator version ${{ github.event.inputs.dnsOperatorVersion }}
+            - Limitador Operator version ${{ github.event.inputs.limitadorOperatorVersion }}
+            - Console Plugin version ${{ github.event.inputs.consolePluginVersion }}
+            - WASM Shim version ${{ github.event.inputs.wasmShimVersion }}
+            
+            Auto-generated by [create-pull-request][1]
+
+            [1]: https://github.com/peter-evans/create-pull-request
+          team-reviewers: |
+            Kuadrant/developers
+            Kuadrant/qe
+          draft: false

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,32 +1,28 @@
 # How to release Kuadrant Operator
 
-## Kuadrant Operator Release
+To release a version _“vX.Y.Z”_ of Kuadrant Operator in GitHub and Quay.io, there are two options, a manual and an automated process.
+For both processes, first make sure every [Kuadrant Operator dependency](https://github.com/Kuadrant/kuadrant-operator/blob/main/RELEASE.md#kuadrant-operator-dependencies) has been already released.
 
-To release a version _“v0.W.Z”_ of Kuadrant Operator in GitHub and Quay.io, follow these steps:
+## Automated Workflow
 
-### Release file format.
-This example of the `release.yaml` file uses tag `v1.0.1` as reference.
+1. Run the GHA  [Automated Release](https://github.com/Kuadrant/kuadrant-operator/actions/workflows/automated-release.yaml)
+   filling the following fields:
+   - gitRef: Select the branch/tag/commit where you want to cut a release from.
+   - kuadrantOperatorVersion: the [Semantic Version](https://semver.org/) of the desired release.
+   - authorinoOperatorVersion: Authorino Operator bundle version (X.Y.Z)
+   - limitadorOperatorVersion: Limitador Operator bundle version (X.Y.Z)
+   - dnsOperatorVersion: DNS Operator bundle version (X.Y.Z)
+   - wasmShimVersion: WASM Shim version (X.Y.Z)
+   - consolePluginVersion: ConsolePlugin version (X.Y.Z)
+   - olmChannel: This will set the OLM `channels` and `default-channel` annotations
+2. The workflow will create a Pull Request that should be peer-reviewed and approved by a member of the Kuadrant team, focusing on the changes made in Kustomize config, OLM bundles and Helm Charts.
+3. Once the PR is merged, a release workflow will be triggered tagging and publishing the [Github release](https://github.com/Kuadrant/kuadrant-operator/releases)
+   it will also build the images and packages and publish them on Quay, Helm repository.
 
-```yaml
-# FILE: ./release.yaml
-kuadrant:
-  release: "1.0.1"
-olm:
- channels:
- - "alpha"
- default_channel: "alpha"
-dependencies:
- Authorino: "0.16.0"
- Console_plugin: "0.0.14"
- DNS: "0.12.0"
- Limitador: "0.12.1"
- Wasm_shim: "0.8.1"
-```
-The `kuadrant` section relates to the release version of the kuadrant operator.
-While the `olm` section relates to fields required for building the olm catalogs.
-And the `dependencies` section relates to the released versions of the subcomponents that will be included in a release.
-There are validation steps during the `make prepare-release` that require the dependencies to be release before generating the release of the Kuadrant operator.
+### Notes
+* It's not possible to cherry-pick commits, the workflow will pick a branch/tag/commit and all the history behind to the PR.
 
+## Manual Workflow
 
 ### Local steps
 
@@ -34,9 +30,8 @@ There are validation steps during the `make prepare-release` that require the de
 2. Push the `release-vX.Y` to the remote (kuadrant/kuadrant-operator)
 3. Create the `release-vX.Y.Z-rc(n)` branch with `release-vX.Y` as the base.
 4. Cherry-pick commits to the `kudrant-vX.Y.Z-rc(n)` from the relevant sources, i.e. `main`.
-5. Update the applicable version in the `release.yaml`.
-6. Run `make prepare-release` on the `release-vX.Y.Z-rc(n)` 
-
+5. Update the applicable version in the [release.yaml](https://github.com/Kuadrant/kuadrant-operator/blob/main/RELEASE.md#release-file-format).
+6. Run `make prepare-release` on the `release-vX.Y.Z-rc(n)`
 
 ### Remote steps
 
@@ -53,20 +48,39 @@ There are validation steps during the `make prepare-release` that require the de
    * Creates tags
 6. Verify that the build [release tag workflow](https://github.com/Kuadrant/kuadrant-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag.
 
-## Kuadrant Operator Dependencies
+## Release file format.
+This example of the `release.yaml` file uses tag `v1.0.1` as reference.
 
-1. Release Kuadrant dependencies as required:
+```yaml
+# FILE: ./release.yaml
+kuadrant-operator:
+  version: "1.0.1"
+olm:
+  default-channel: "stable"
+  channels:
+    - "stable"
+dependencies:
+  authorino-operator: "0.16.0"
+  console-plugin: "0.0.14"
+  dns-operator: "0.12.0"
+  limitador-operator: "0.12.1"
+  wasm-shim: "0.8.1"
+```
+
+The `kuadrant-operator` section relates to the release version of the kuadrant operator.
+While the `olm` section relates to fields required for building the olm catalogs.
+And the `dependencies` section relates to the released versions of the subcomponents that will be included in a release.
+There are validation steps during the `make prepare-release` that require the dependencies to be release before generating the release of the Kuadrant operator.
+
+## Kuadrant Operator Dependencies
    * [Authorino Operator](https://github.com/Kuadrant/authorino-operator/blob/main/RELEASE.md).
    * [Limitador Operator](https://github.com/Kuadrant/limitador-operator/blob/main/RELEASE.md).
    * [DNS Operator](https://github.com/Kuadrant/dns-operator/blob/main/docs/RELEASE.md).
    * [WASM Shim](https://github.com/Kuadrant/wasm-shim/).
    * [Console Plugin](https://github.com/Kuadrant/kuadrant-console-plugin).
 
-2. Update the `release.yaml` with the versions of required dependencies.
-
-
-
 ## Verification 
+
 ### Verify OLM Deployment
 
 1. Deploy the OLM catalog image following the [Deploy kuadrant operator using OLM](/doc/development.md#deploy-kuadrant-operator-using-olm) and providing the generated catalog image. For example:


### PR DESCRIPTION
This PR introduces an automated process for releasing the Kuadrant Operator. Similar to the [previous one](https://github.com/Kuadrant/kuadrant-operator/actions/workflows/release.yaml), one needs to provide the following inputs:

   - `gitRef`: Select the branch/tag/commit where you want to cut a release from.
   - `kuadrantOperatorVersion`: the [Semantic Version](https://semver.org/) of the desired release.
   - `authorinoOperatorVersion`: Authorino Operator bundle version (X.Y.Z)
   - limitadorOperatorVersion: Limitador Operator bundle version (X.Y.Z)
   - `dnsOperatorVersion`: DNS Operator bundle version (X.Y.Z)
   - `wasmShimVersion`: WASM Shim version (X.Y.Z)
   - `consolePluginVersion`: ConsolePlugin version (X.Y.Z)
   - `olmChannel`: This will set the OLM `channels` and `default-channel`.

But instead of tagging and creating the release automatically, instead it creates a PR in the same fashion that dictates the [Manual Workflow](https://github.com/Kuadrant/kuadrant-operator/pull/1150)

**Verification steps**
Sadly, it's not possible at the moment to fully check the workflow, since it needs to be merged to main and we might need to do some cleaning in our release branches before triggering it. But at the time being, we could use [Act](https://github.com/nektos/act):

1. With act installed, you can run the following command
```sh
act -j auto-release --secret KUADRANT_DEV_PAT=[CHECK IN BITWARDEN] --input gitRef=8d8a86fbf25a2e6d6ad8aacf0d62423c3055eb83 --input kuadrantOperatorVersion=1.0.3-alpha1 --input authorinoOperatorVersion=0.16.0 --input limitadorOperatorVersion=0.12.1 --input dnsOperatorVersion=0.12.0 --input consolePluginVersion=0.0.19 --input wasmShimVersion=0.8.1 --input olmChannel=alpha --container-architecture linux/amd64
```
2. The output should be:
```sh
[Automated Release Operator/Release operator]   ✅  Success - Complete job
[Automated Release Operator/Release operator] 🏁  Job succeeded
```
3. At the step _Prepare release_, you should see
```sh
| Updating release.yaml with desired versions
| release.yaml file updated as follows:
| kuadrant-operator:
|   version: "1.0.3-alpha1"
| olm:
|   channels:
|     - "alpha"
|   default-channel: "alpha"
| dependencies:
|   authorino-operator: "0.16.0"
|   console-plugin: "0.0.19"
|   dns-operator: "0.12.0"
|   limitador-operator: "0.12.1"
|   wasm-shim: "0.8.1"
```
and at the end of the step, the following:
```sh
| INFO[0000] All validation tests have completed successfully
```


