### PR TITLE
Refactor observability controller

### DIFF
--- a/controllers/observability_reconciler.go
+++ b/controllers/observability_reconciler.go
@@ -12,14 +12,15 @@ import (
 	"github.com/samber/lo"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/ptr"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	"github.com/kuadrant/kuadrant-operator/pkg/kuadrant"
 	"github.com/kuadrant/kuadrant-operator/pkg/observability"
+	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
 )
 
 //+kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors;podmonitors,verbs=get;list;watch;create;update;patch;delete
@@ -37,271 +38,305 @@ const (
 	limitOpMonitorName      = "limitador-operator-monitor"
 )
 
-var kOpMonitorSpec = &monitoringv1.ServiceMonitor{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       monitoringv1.ServiceMonitorsKind,
-		APIVersion: monitoringv1.SchemeGroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: kOpMonitorName,
-		Labels: map[string]string{
-			"control-plane":             "controller-manager",
-			kuadrant.ObservabilityLabel: "true",
+func kOpMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       monitoringv1.ServiceMonitorsKind,
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
-	},
-	Spec: monitoringv1.ServiceMonitorSpec{
-		Endpoints: []monitoringv1.Endpoint{{
-			Port:   "metrics",
-			Path:   "/metrics",
-			Scheme: "http",
-		}},
-		Selector: metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"control-plane": "controller-manager",
-				"app":           "kuadrant",
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kOpMonitorName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"control-plane":             "controller-manager",
+				kuadrant.ObservabilityLabel: "true",
 			},
 		},
-	},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{{
+				Port:   "metrics",
+				Path:   "/metrics",
+				Scheme: "http",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"control-plane": "controller-manager",
+					"app":           "kuadrant",
+				},
+			},
+		},
+	}
 }
 
-var dnsOpMonitorSpec = &monitoringv1.ServiceMonitor{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       monitoringv1.ServiceMonitorsKind,
-		APIVersion: monitoringv1.SchemeGroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: dnsOpMonitorName,
-		Labels: map[string]string{
-			kuadrant.ObservabilityLabel:    "true",
-			"control-plane":                "controller-manager",
-			"app.kubernetes.io/name":       "servicemonitor",
-			"app.kubernetes.io/instance":   "controller-manager-metrics-monitor",
-			"app.kubernetes.io/component":  "metrics",
-			"app.kubernetes.io/created-by": "dns-operator",
-			"app.kubernetes.io/part-of":    "dns-operator",
-			"app.kubernetes.io/managed-by": "kustomize",
+func dnsOpMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       monitoringv1.ServiceMonitorsKind,
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
-	},
-	Spec: monitoringv1.ServiceMonitorSpec{
-		Endpoints: []monitoringv1.Endpoint{{
-			Path:   "/metrics",
-			Port:   "metrics",
-			Scheme: "http",
-		}},
-		Selector: metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"control-plane": "dns-operator-controller-manager",
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dnsOpMonitorName,
+			Namespace: ns,
+			Labels: map[string]string{
+				kuadrant.ObservabilityLabel:    "true",
+				"control-plane":                "controller-manager",
+				"app.kubernetes.io/name":       "servicemonitor",
+				"app.kubernetes.io/instance":   "controller-manager-metrics-monitor",
+				"app.kubernetes.io/component":  "metrics",
+				"app.kubernetes.io/created-by": "dns-operator",
+				"app.kubernetes.io/part-of":    "dns-operator",
+				"app.kubernetes.io/managed-by": "kustomize",
 			},
 		},
-	},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{{
+				Path:   "/metrics",
+				Port:   "metrics",
+				Scheme: "http",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"control-plane": "dns-operator-controller-manager",
+				},
+			},
+		},
+	}
 }
 
-var authOpMonitorSpec = &monitoringv1.ServiceMonitor{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       monitoringv1.ServiceMonitorsKind,
-		APIVersion: monitoringv1.SchemeGroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: authOpMonitorName,
-		Labels: map[string]string{
-			"control-plane":             "controller-manager",
-			kuadrant.ObservabilityLabel: "true",
+func authOpMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       monitoringv1.ServiceMonitorsKind,
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
-	},
-	Spec: monitoringv1.ServiceMonitorSpec{
-		Endpoints: []monitoringv1.Endpoint{{
-			Port:   "metrics",
-			Path:   "/metrics",
-			Scheme: "http",
-		}},
-		Selector: metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"control-plane": "authorino-operator",
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      authOpMonitorName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"control-plane":             "controller-manager",
+				kuadrant.ObservabilityLabel: "true",
 			},
 		},
-	},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{{
+				Port:   "metrics",
+				Path:   "/metrics",
+				Scheme: "http",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"control-plane": "authorino-operator",
+				},
+			},
+		},
+	}
 }
-var limitOpMonitorSpec = &monitoringv1.ServiceMonitor{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       monitoringv1.ServiceMonitorsKind,
-		APIVersion: monitoringv1.SchemeGroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: limitOpMonitorName,
-		Labels: map[string]string{
-			"control-plane":             "controller-manager",
-			kuadrant.ObservabilityLabel: "true",
+
+func limitOpMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       monitoringv1.ServiceMonitorsKind,
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
-	},
-	Spec: monitoringv1.ServiceMonitorSpec{
-		Endpoints: []monitoringv1.Endpoint{{
-			Port:   "metrics",
-			Path:   "/metrics",
-			Scheme: "http",
-		}},
-		Selector: metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"control-plane": "controller-manager",
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      limitOpMonitorName,
+			Namespace: ns,
+			Labels: map[string]string{
+				"control-plane":             "controller-manager",
+				kuadrant.ObservabilityLabel: "true",
 			},
 		},
-	},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{{
+				Port:   "metrics",
+				Path:   "/metrics",
+				Scheme: "http",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"control-plane": "controller-manager",
+				},
+			},
+		},
+	}
 }
-var istiodMonitorSpec = &monitoringv1.ServiceMonitor{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       monitoringv1.ServiceMonitorsKind,
-		APIVersion: monitoringv1.SchemeGroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: istiodMonitorName,
-		Labels: map[string]string{
-			kuadrant.ObservabilityLabel: "true",
+
+func istiodMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       monitoringv1.ServiceMonitorsKind,
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
-	},
-	Spec: monitoringv1.ServiceMonitorSpec{
-		Endpoints: []monitoringv1.Endpoint{{
-			Port: "http-monitoring",
-		}},
-		Selector: metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"app": "istiod",
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      istiodMonitorName,
+			Namespace: ns,
+			Labels: map[string]string{
+				kuadrant.ObservabilityLabel: "true",
 			},
 		},
-	},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{{
+				Port: "http-monitoring",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "istiod",
+				},
+			},
+		},
+	}
 }
 
 var istioPodMonitorPortReplacement1 = `[$2]:$1`
 var istioPodMonitorPortReplacement2 = `$2:$1`
-var istioPodMonitorSpec = &monitoringv1.PodMonitor{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       monitoringv1.PodMonitorsKind,
-		APIVersion: monitoringv1.SchemeGroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: istioPodMonitorName,
-		Labels: map[string]string{
-			kuadrant.ObservabilityLabel: "true",
+
+func istioPodMonitorBuild(ns string) *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       monitoringv1.PodMonitorsKind,
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
-	},
-	Spec: monitoringv1.PodMonitorSpec{
-		Selector: metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      istioPodMonitorName,
+			Namespace: ns,
+			Labels: map[string]string{
+				kuadrant.ObservabilityLabel: "true",
+			},
+		},
+		Spec: monitoringv1.PodMonitorSpec{
+			Selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      "istio-prometheus-ignore",
+						Operator: metav1.LabelSelectorOpDoesNotExist,
+					},
+				},
+			},
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
 				{
-					Key:      "istio-prometheus-ignore",
-					Operator: metav1.LabelSelectorOpDoesNotExist,
-				},
-			},
-		},
-		PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{
-			{
-				Path:     "/stats/prometheus",
-				Interval: "30s",
-				RelabelConfigs: []monitoringv1.RelabelConfig{
-					{
-						Action:       "keep",
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_container_name"},
-						Regex:        "istio-proxy",
-					},
-					{
-						Action:       "keep",
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape"},
-					},
-					{
-						Action: "replace",
-						SourceLabels: []monitoringv1.LabelName{
-							"__meta_kubernetes_pod_annotation_prometheus_io_port",
-							"__meta_kubernetes_pod_ip",
+					Path:     "/stats/prometheus",
+					Interval: "30s",
+					RelabelConfigs: []monitoringv1.RelabelConfig{
+						{
+							Action:       "keep",
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_container_name"},
+							Regex:        "istio-proxy",
 						},
-						Regex:       `(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})`,
-						Replacement: &istioPodMonitorPortReplacement1,
-						TargetLabel: "__address__",
-					},
-					{
-						Action: "replace",
-						SourceLabels: []monitoringv1.LabelName{
-							"__meta_kubernetes_pod_annotation_prometheus_io_port",
-							"__meta_kubernetes_pod_ip",
+						{
+							Action:       "keep",
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_annotationpresent_prometheus_io_scrape"},
 						},
-						Regex:       `(\\d+);((([0-9]+?)(\\.|$)){4})`,
-						Replacement: &istioPodMonitorPortReplacement2,
-						TargetLabel: "__address__",
-					},
-					{
-						Action: "labeldrop",
-						Regex:  "__meta_kubernetes_pod_label_(.+)",
-					},
-					{
-						Action:       "replace",
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_namespace"},
-						TargetLabel:  "namespace",
-					},
-					{
-						Action:       "replace",
-						SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
-						TargetLabel:  "pod_name",
+						{
+							Action: "replace",
+							SourceLabels: []monitoringv1.LabelName{
+								"__meta_kubernetes_pod_annotation_prometheus_io_port",
+								"__meta_kubernetes_pod_ip",
+							},
+							Regex:       `(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})`,
+							Replacement: &istioPodMonitorPortReplacement1,
+							TargetLabel: "__address__",
+						},
+						{
+							Action: "replace",
+							SourceLabels: []monitoringv1.LabelName{
+								"__meta_kubernetes_pod_annotation_prometheus_io_port",
+								"__meta_kubernetes_pod_ip",
+							},
+							Regex:       `(\\d+);((([0-9]+?)(\\.|$)){4})`,
+							Replacement: &istioPodMonitorPortReplacement2,
+							TargetLabel: "__address__",
+						},
+						{
+							Action: "labeldrop",
+							Regex:  "__meta_kubernetes_pod_label_(.+)",
+						},
+						{
+							Action:       "replace",
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_namespace"},
+							TargetLabel:  "namespace",
+						},
+						{
+							Action:       "replace",
+							SourceLabels: []monitoringv1.LabelName{"__meta_kubernetes_pod_name"},
+							TargetLabel:  "pod_name",
+						},
 					},
 				},
 			},
 		},
-	},
+	}
 }
 
-var envoyGatewayMonitorSpec = &monitoringv1.ServiceMonitor{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       monitoringv1.ServiceMonitorsKind,
-		APIVersion: monitoringv1.SchemeGroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: envoyGatewayMonitorName,
-		Labels: map[string]string{
-			kuadrant.ObservabilityLabel: "true",
+func envoyGatewayMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
+	return &monitoringv1.ServiceMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       monitoringv1.ServiceMonitorsKind,
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
-	},
-	Spec: monitoringv1.ServiceMonitorSpec{
-		Endpoints: []monitoringv1.Endpoint{{
-			Port: "metrics",
-		}},
-		Selector: metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"control-plane": "envoy-gateway",
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      envoyGatewayMonitorName,
+			Namespace: ns,
+			Labels: map[string]string{
+				kuadrant.ObservabilityLabel: "true",
 			},
 		},
-	},
+		Spec: monitoringv1.ServiceMonitorSpec{
+			Endpoints: []monitoringv1.Endpoint{{
+				Port: "metrics",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"control-plane": "envoy-gateway",
+				},
+			},
+		},
+	}
 }
 
-var envoyStatsMonitorSpec = &monitoringv1.PodMonitor{
-	TypeMeta: metav1.TypeMeta{
-		Kind:       monitoringv1.PodMonitorsKind,
-		APIVersion: monitoringv1.SchemeGroupVersion.String(),
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name: envoyStatsMonitorName,
-		Labels: map[string]string{
-			kuadrant.ObservabilityLabel: "true",
+func envoyStatsMonitorBuild(ns string) *monitoringv1.PodMonitor {
+	return &monitoringv1.PodMonitor{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       monitoringv1.PodMonitorsKind,
+			APIVersion: monitoringv1.SchemeGroupVersion.String(),
 		},
-	},
-	Spec: monitoringv1.PodMonitorSpec{
-		PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
-			Port: "http-envoy-prom",
-			Path: "/stats/prometheus",
-		}},
-		Selector: metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"app": "kuadrant-ingressgateway",
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      envoyStatsMonitorName,
+			Namespace: ns,
+			Labels: map[string]string{
+				kuadrant.ObservabilityLabel: "true",
 			},
 		},
-	},
+		Spec: monitoringv1.PodMonitorSpec{
+			PodMetricsEndpoints: []monitoringv1.PodMetricsEndpoint{{
+				Port: "http-envoy-prom",
+				Path: "/stats/prometheus",
+			}},
+			Selector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "kuadrant-ingressgateway",
+				},
+			},
+		},
+	}
 }
 
 type ObservabilityReconciler struct {
+	*reconcilers.BaseReconciler
+
 	Client     *dynamic.DynamicClient
 	restMapper meta.RESTMapper
 	namespace  string
 }
 
-func NewObservabilityReconciler(client *dynamic.DynamicClient, rm meta.RESTMapper, namespace string) *ObservabilityReconciler {
+func NewObservabilityReconciler(client *dynamic.DynamicClient, mgr ctrlruntime.Manager, namespace string) *ObservabilityReconciler {
 	return &ObservabilityReconciler{
+		BaseReconciler: reconcilers.NewBaseReconciler(
+			mgr.GetClient(),
+			mgr.GetScheme(),
+			mgr.GetAPIReader(),
+		),
 		Client:     client,
-		restMapper: rm,
+		restMapper: mgr.GetRESTMapper(),
 		namespace:  namespace,
 	}
 }
@@ -318,8 +353,9 @@ func (r *ObservabilityReconciler) Subscription() *controller.Subscription {
 	}
 }
 
-func (r *ObservabilityReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
-	logger := controller.LoggerFromContext(ctx).WithName("ObservabilityReconciler")
+func (r *ObservabilityReconciler) Reconcile(baseCtx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
+	logger := controller.LoggerFromContext(baseCtx).WithName("ObservabilityReconciler")
+	ctx := logr.NewContext(baseCtx, logger)
 	logger.V(1).Info("reconciling observability", "status", "started")
 	defer logger.V(1).Info("reconciling observability", "status", "completed")
 
@@ -344,20 +380,20 @@ func (r *ObservabilityReconciler) Reconcile(ctx context.Context, _ []controller.
 	logger.V(1).Info("observability enabled, creating monitors")
 
 	// Kuadrant Operator monitor
-	kOpMonitorSpec.SetNamespace(r.namespace)
-	r.createMonitor(ctx, monitorObjs, kOpMonitorSpec, observability.ServiceMonitorsResource, logger)
+	kOpMonitor := kOpMonitorBuild(r.namespace)
+	r.createServiceMonitor(ctx, kOpMonitor, logger)
 
 	// DNS Operator monitor
-	dnsOpMonitorSpec.SetNamespace(r.namespace)
-	r.createMonitor(ctx, monitorObjs, dnsOpMonitorSpec, observability.ServiceMonitorsResource, logger)
+	dnsOpMonitor := dnsOpMonitorBuild(r.namespace)
+	r.createServiceMonitor(ctx, dnsOpMonitor, logger)
 
 	// Authorino operator monitor
-	authOpMonitorSpec.SetNamespace(r.namespace)
-	r.createMonitor(ctx, monitorObjs, authOpMonitorSpec, observability.ServiceMonitorsResource, logger)
+	authOpMonitor := authOpMonitorBuild(r.namespace)
+	r.createServiceMonitor(ctx, authOpMonitor, logger)
 
 	// Limitador operator monitor
-	limitOpMonitorSpec.SetNamespace(r.namespace)
-	r.createMonitor(ctx, monitorObjs, limitOpMonitorSpec, observability.ServiceMonitorsResource, logger)
+	limitOpMonitor := limitOpMonitorBuild(r.namespace)
+	r.createServiceMonitor(ctx, limitOpMonitor, logger)
 
 	// Create monitors for each gateway instance of each gateway class
 	gatewayClasses := topology.Targetables().Items(func(o machinery.Object) bool {
@@ -367,18 +403,20 @@ func (r *ObservabilityReconciler) Reconcile(ctx context.Context, _ []controller.
 		gateways := topology.All().Children(gatewayClass)
 		gwClass := gatewayClass.(*machinery.GatewayClass)
 		if gwClass.GatewayClass.Spec.ControllerName == istioGatewayControllerName {
+			istiodMonitor := istiodMonitorBuild(istiodMonitorNS)
+			r.createServiceMonitor(ctx, istiodMonitor, logger)
+
 			for _, gateway := range gateways {
-				istiodMonitorSpec.SetNamespace(istiodMonitorNS)
-				r.createMonitor(ctx, monitorObjs, istiodMonitorSpec, observability.ServiceMonitorsResource, logger)
-				istioPodMonitorSpec.SetNamespace(gateway.GetNamespace())
-				r.createMonitor(ctx, monitorObjs, istioPodMonitorSpec, observability.PodMonitorsResource, logger)
+				istioPodMonitor := istioPodMonitorBuild(gateway.GetNamespace())
+				r.createPodMonitor(ctx, istioPodMonitor, logger)
 			}
 		} else if gwClass.GatewayClass.Spec.ControllerName == envoyGatewayGatewayControllerName {
+			envoyGatewayMonitor := envoyGatewayMonitorBuild(envoyGatewayMonitorNS)
+			r.createServiceMonitor(ctx, envoyGatewayMonitor, logger)
+
 			for _, gateway := range gateways {
-				envoyGatewayMonitorSpec.SetNamespace(envoyGatewayMonitorNS)
-				r.createMonitor(ctx, monitorObjs, envoyGatewayMonitorSpec, observability.ServiceMonitorsResource, logger)
-				envoyStatsMonitorSpec.SetNamespace(gateway.GetNamespace())
-				r.createMonitor(ctx, monitorObjs, envoyStatsMonitorSpec, observability.PodMonitorsResource, logger)
+				envoyStatsMonitor := envoyStatsMonitorBuild(gateway.GetNamespace())
+				r.createPodMonitor(ctx, envoyStatsMonitor, logger)
 			}
 		}
 	}
@@ -386,32 +424,40 @@ func (r *ObservabilityReconciler) Reconcile(ctx context.Context, _ []controller.
 	return nil
 }
 
-func (r *ObservabilityReconciler) createMonitor(ctx context.Context, monitorObjs []machinery.Object, monitor client.Object, mappingResource schema.GroupVersionResource, logger logr.Logger) {
+func (r *ObservabilityReconciler) createServiceMonitor(ctx context.Context, monitor *monitoringv1.ServiceMonitor, logger logr.Logger) error {
 	ns := monitor.GetNamespace()
 	if ns == "" {
 		logger.V(1).Info(fmt.Sprintf("cannot create monitor '%s' as namespace is not set, skipping create", monitor.GetName()))
-		return
-	}
-	_, monitorExists := lo.Find(monitorObjs, func(item machinery.Object) bool {
-		return item.GroupVersionKind().Kind == monitor.GetObjectKind().GroupVersionKind().Kind && item.GetName() == monitor.GetName() && item.GetNamespace() == ns
-	})
-	if monitorExists {
-		logger.V(1).Info(fmt.Sprintf("monitor already exists %s/%s, skipping create", ns, monitor.GetName()))
-		return
+		return nil
 	}
 
-	logger.V(1).Info(fmt.Sprintf("creating monitor %s/%s", ns, monitor.GetName()))
-	obj, err := controller.Destruct(monitor)
+	// Only create, do not mutate if exists.
+	// Effectively the controlller does not revert back external changes
+	err := r.ReconcileResource(ctx, &monitoringv1.ServiceMonitor{}, monitor, reconcilers.CreateOnlyMutator)
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("error destructing monitor %s/%s", ns, monitor.GetName()))
-		return
+		logger.Error(err, "reconciling service monitor", "key", client.ObjectKeyFromObject(monitor))
+		return err
 	}
 
-	if _, err = r.Client.Resource(mappingResource).Namespace(ns).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
-		logger.Error(err, fmt.Sprintf("error creating monitor %s/%s", ns, monitor.GetName()))
-		return
+	return nil
+}
+
+func (r *ObservabilityReconciler) createPodMonitor(ctx context.Context, monitor *monitoringv1.PodMonitor, logger logr.Logger) error {
+	ns := monitor.GetNamespace()
+	if ns == "" {
+		logger.V(1).Info(fmt.Sprintf("cannot create monitor '%s' as namespace is not set, skipping create", monitor.GetName()))
+		return nil
 	}
-	logger.V(1).Info(fmt.Sprintf("created monitor %s/%s", ns, monitor.GetName()))
+
+	// Only create, do not mutate if exists.
+	// Effectively the controlller does not revert back external changes
+	err := r.ReconcileResource(ctx, &monitoringv1.PodMonitor{}, monitor, reconcilers.CreateOnlyMutator)
+	if err != nil {
+		logger.Error(err, "reconciling pod monitor", "key", client.ObjectKeyFromObject(monitor))
+		return err
+	}
+
+	return nil
 }
 
 func (r *ObservabilityReconciler) deleteAllMonitors(ctx context.Context, monitorObjs []machinery.Object, logger logr.Logger) {

--- a/controllers/state_of_the_world.go
+++ b/controllers/state_of_the_world.go
@@ -448,7 +448,7 @@ func (b *BootOptionsBuilder) Reconciler() controller.ReconcileFunc {
 			NewTLSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isCertManagerInstalled).Run,
 			NewDataPlanePoliciesWorkflow(b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled, b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Run,
 			NewKuadrantStatusUpdater(b.client, b.isGatewayAPIInstalled, b.isGatewayProviderInstalled(), b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Subscription().Reconcile,
-			NewObservabilityReconciler(b.client, b.manager.GetRESTMapper(), operatorNamespace).Subscription().Reconcile,
+			NewObservabilityReconciler(b.client, b.manager, operatorNamespace).Subscription().Reconcile,
 		},
 		Postcondition: finalStepsWorkflow(b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled).Run,
 	}


### PR DESCRIPTION
### What

Following up the work being done in https://github.com/Kuadrant/kuadrant-operator/pull/1164. Refactor to, hopefully, simplify the code to maintain. 

* Monitoring resources loaded in memory are no longer static. They are instantiated every time. Reason being that go client might update objects on creation. 
* Implemented mutator pattern with `createOnly` mutator, having the same functionality: resources can externally be updated and the operator will not revert the changes back. 
* ~Added error handling. When resource creation reports error, the error is being returned and propagated up in the stack.~
* istiodMonitor and envoyGatewayMonitor are not created repeatedly for each gateway. They are single instance per Istio control plane / EnvoyGateway control plane. 

### Verification steps

* Setup environment based on EnvoyGateway

```shell
make local-setup GATEWAYAPI_PROVIDER=envoygateway
```

* Apply the Kuadrant custom resource with observability enabled

```yaml
kubectl -n kuadrant-system apply -f - <<EOF
---
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
spec:
  observability:
    enable: true
EOF
```
* Wait for kuadrant instance to be ready
```shell
kubectl wait --timeout=300s --for=condition=Ready kuadrant kuadrant-sample -n kuadrant-system
```

* Verify the monitoring resources are there
```shell
k get servicemonitor,podmonitor -A
```

The expected result:

```shell
NAMESPACE              NAME                                                              AGE
envoy-gateway-system   servicemonitor.monitoring.coreos.com/envoy-gateway-monitor        148m
kuadrant-system        servicemonitor.monitoring.coreos.com/authorino-operator-monitor   148m
kuadrant-system        servicemonitor.monitoring.coreos.com/dns-operator-monitor         148m
kuadrant-system        servicemonitor.monitoring.coreos.com/kuadrant-operator-monitor    148m
kuadrant-system        servicemonitor.monitoring.coreos.com/limitador-operator-monitor   148m

NAMESPACE        NAME                                                   AGE
gateway-system   podmonitor.monitoring.coreos.com/envoy-stats-monitor   148m
```

Filtering by labels `kuadrant-observability=true` should give the same output. 
```shell
k get servicemonitor,podmonitor -l kuadrant.io/observability=true -A
```
* Turn monitoring off

```shell
kubectl patch kuadrant kuadrant-sample --type=merge --patch '{"spec": {"observability": null}}' -n kuadrant-system
```
* Verify the monitoring resources are gone
```shell
k get servicemonitor,podmonitor -l kuadrant.io/observability=true -A
```

The expected result:
```shell
No resources found
```
