### PR TITLE
basereconciler: logger removed

### DIFF
--- a/controllers/consoleplugin_reconciler.go
+++ b/controllers/consoleplugin_reconciler.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/utils/ptr"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 
-	"github.com/kuadrant/kuadrant-operator/pkg/log"
 	"github.com/kuadrant/kuadrant-operator/pkg/openshift"
 	"github.com/kuadrant/kuadrant-operator/pkg/openshift/consoleplugin"
 	"github.com/kuadrant/kuadrant-operator/pkg/reconcilers"
@@ -39,7 +38,6 @@ func NewConsolePluginReconciler(mgr ctrlruntime.Manager, namespace string) *Cons
 			mgr.GetClient(),
 			mgr.GetScheme(),
 			mgr.GetAPIReader(),
-			log.Log.WithName("consoleplugin"),
 		),
 		namespace: namespace,
 	}
@@ -67,9 +65,10 @@ func (r *ConsolePluginReconciler) Subscription() *controller.Subscription {
 }
 
 func (r *ConsolePluginReconciler) Run(eventCtx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
-	logger := r.Logger()
-	logger.V(1).Info("task started")
+	logger := controller.LoggerFromContext(eventCtx).WithName("ConsolePluginReconciler")
 	ctx := logr.NewContext(eventCtx, logger)
+	logger.V(1).Info("reconciling console plugin", "status", "started")
+	defer logger.V(1).Info("reconciling console plugin", "status", "completed")
 
 	existingTopologyConfigMaps := topology.Objects().Items(func(object machinery.Object) bool {
 		return object.GetName() == TopologyConfigMapName && object.GetNamespace() == r.namespace && object.GroupVersionKind().Kind == ConfigMapGroupKind.Kind

--- a/pkg/reconcilers/base_reconciler.go
+++ b/pkg/reconcilers/base_reconciler.go
@@ -70,18 +70,16 @@ type BaseReconciler struct {
 	client          client.Client
 	scheme          *runtime.Scheme
 	apiClientReader client.Reader
-	logger          logr.Logger
 }
 
 // blank assignment to verify that BaseReconciler implements reconcile.Reconciler
 var _ reconcile.Reconciler = &BaseReconciler{}
 
-func NewBaseReconciler(client client.Client, scheme *runtime.Scheme, apiClientReader client.Reader, logger logr.Logger) *BaseReconciler {
+func NewBaseReconciler(client client.Client, scheme *runtime.Scheme, apiClientReader client.Reader) *BaseReconciler {
 	return &BaseReconciler{
 		client:          client,
 		scheme:          scheme,
 		apiClientReader: apiClientReader,
-		logger:          logger,
 	}
 }
 
@@ -103,10 +101,6 @@ func (b *BaseReconciler) APIClientReader() client.Reader {
 
 func (b *BaseReconciler) Scheme() *runtime.Scheme {
 	return b.scheme
-}
-
-func (b *BaseReconciler) Logger() logr.Logger {
-	return b.logger
 }
 
 // ReconcileResource attempts to mutate the existing state

--- a/pkg/reconcilers/base_reconciler_test.go
+++ b/pkg/reconcilers/base_reconciler_test.go
@@ -77,7 +77,7 @@ func TestBaseReconcilerCreate(t *testing.T) {
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 	clientAPIReader := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
-	baseReconciler := NewBaseReconciler(cl, s, clientAPIReader, log.Log)
+	baseReconciler := NewBaseReconciler(cl, s, clientAPIReader)
 
 	desiredConfigmap := &v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -143,7 +143,7 @@ func TestBaseReconcilerUpdateNeeded(t *testing.T) {
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 	clientAPIReader := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
-	baseReconciler := NewBaseReconciler(cl, s, clientAPIReader, log.Log)
+	baseReconciler := NewBaseReconciler(cl, s, clientAPIReader)
 
 	desiredConfigmap := &v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -228,7 +228,7 @@ func TestBaseReconcilerDelete(t *testing.T) {
 	cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 	clientAPIReader := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 
-	baseReconciler := NewBaseReconciler(cl, s, clientAPIReader, log.Log)
+	baseReconciler := NewBaseReconciler(cl, s, clientAPIReader)
 
 	desired := &v1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
No need to have a custom field on the BaseReconciler type, the logger is read from the context for all the actions it provides