### PR TITLE
Fix verifications

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,15 +1,15 @@
 name: Test
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ 'main', 'release-*' ]
+    branches: ['main', 'release-v*']
   pull_request:
     branches: ['*']
   merge_group:
     types: [ checks_requested ]
   schedule:
     - cron: "15 1 * * *"
-  workflow_dispatch:
 
 jobs:
   pre-job:
@@ -272,10 +272,9 @@ jobs:
         if: always()
         run: |
           kubectl get pods -n kuadrant-system
-
   verify-release:
-    name: Validate release data 
-    if: needs.pre-job.outputs.should_skip != 'true'
+    name: Validate release data
+    if: startsWith(github.ref_name, 'release-v') && needs.pre-job.outputs.should_skip != 'true'
     needs: pre-job
     runs-on: ubuntu-latest
     steps:
@@ -288,6 +287,26 @@ jobs:
         uses: actions/checkout@v4
       - name: Check bundles and manifests
         run: make verify-prepare-release
+
+  verify-manifests:
+    name: Validate set of manifests
+    if: !startsWith(github.ref_name, 'release-v') && needs.pre-job.outputs.should_skip != 'true'
+    needs: pre-job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install gettext-base
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gettext-base
+      - name: Set up Go 1.22.x
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.22.x
+        id: go
+      - name: Checkout code at git ref
+        uses: actions/checkout@v4
+      - name: Check bundles and manifests
+        run: make verify-manifests
 
   verify-fmt:
     name: Verify fmt
@@ -369,7 +388,7 @@ jobs:
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ unit-tests, controllers-integration-tests, bare-k8s-integration-tests, gatewayapi-integration-tests, gatewayapi-provider-integration-tests, verify-release, verify-fmt, test-scripts, verify-generate, verify-go-mod ]
+    needs: [ unit-tests, controllers-integration-tests, bare-k8s-integration-tests, gatewayapi-integration-tests, gatewayapi-provider-integration-tests, verify-fmt, test-scripts, verify-generate, verify-go-mod ]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/make/verify.mk
+++ b/make/verify.mk
@@ -16,7 +16,28 @@ verify-go-mod: ## Verify go.mod matches source code
 	go mod tidy
 	git diff --exit-code ./go.mod
 
-.PHONY: verify-prepare-release
+.PHONY: verify-controller-manifests
+verify-controller-manifests: manifests ## Verify controller-gen manifests update.
+	git diff --exit-code ./config
+	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./config)" ]
+
+.PHONY: verify-bundle
+verify-bundle: bundle ## Verify bundle update.
+	git diff --exit-code ./bundle
+	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./bundle)" ]
+
+.PHONY: verify-helm-charts
+verify-helm-charts: helm-build ## Verify helm charts update.
+	git diff --exit-code ./charts
+	[ -z "$$(git ls-files --other --exclude-standard --directory --no-empty-directory ./charts)" ]
+
+.PHONY: verify-manifests ## Verify controller-gen, bundle and helm charts manifests.
+verify-manifests: ## Verify manifests update.
+	make verify-controller-manifests
+	make verify-bundle
+	make verify-helm-charts
+
+.PHONY: verify-prepare-release ## Verify set of manifests based on release.yaml file.
 verify-prepare-release: prepare-release
 	git diff --exit-code .
 


### PR DESCRIPTION
This PR re introduces the make targets that were asserting the validity of manifests such as _bundle_, _controller-gen_ and _helm-charts_ in order to be used for non release manifest verification. Now the test.yaml will conditionally trigger the verification manifests for a release consuming the release shell scripts _or_ the verification of manifests how it was done before, without running the whole release scripts that consumes GH API, checks agains the release.yaml file, etc.
