### PR TITLE
move to latest patch of golang 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/kuadrant-operator
 
-go 1.22.5
+go 1.22.9
 
 require (
 	github.com/cert-manager/cert-manager v1.16.2


### PR DESCRIPTION
Signed-off-by: craig <cbrookes@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED