### PR TITLE
Fix image creation for tag push event

### DIFF
--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -1,6 +1,7 @@
 name: Build and Publish Images For Tag Release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+-?**"

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code at git ref
         uses: actions/checkout@v4
+        with:
+          token: '${{ secrets.KUADRANT_DEV_PAT }}'
       - name: Set environment variables
         id: set_env_variables
         run: |


### PR DESCRIPTION
This PR aims to fix the creation of images on tag push using a specific PAT, in order to avoid https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

> An action can access the GITHUB_TOKEN through the github.token context even if the workflow does not explicitly pass the GITHUB_TOKEN to the action. As a good security practice, you should always make sure that actions only have the minimum access they require by limiting the permissions granted to the GITHUB_TOKEN. For more information, see [Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).