### PR TITLE
Docs: add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+## PR Type
+<!-- Check all that apply -->
+- [ ] Bug fix (non-breaking change)
+- [ ] New feature (non-breaking change)
+- [ ] Breaking change (fix/feature causing existing behavior to change)
+- [ ] Documentation update (standalone)
+- [ ] Code refactor (no functional changes)
+- [ ] Test cases (added/modified)
+- [ ] CI/CD changes
+- [ ] Other (please specify: ______)
+
+
+
+## Related Issues
+<!-- If you use an issue tracker, please put references to them -->
+**Resolves:** #  
+**See also:** #
+
+## Change Description
+
+### Concise Summary
+<!-- 
+  Summarize changes in around 50 characters or less  
+-->
+
+### Technical Details
+<!-- 
+  Explain the problem being solved and why this change is necessary. Focus on:
+  - Motivation behind the change
+  - Architectural decisions
+  - Unintended side effects
+  - Alternative approaches considered
+-->
+
+## Testing
+<!-- Describe the tests you ran and/or added to verify your changes -->
+- [ ] Added new unit tests
+- [ ] Added new integration tests
+- [ ] Ran existing test suite
+- [ ] Tested manually (please provide steps)
+
+## Documentation Updates Required
+<!-- Check all that apply -->
+- [ ] Updated markdown docs (file path: ______)
+- [ ] Updated code comments/docstrings
+- [ ] Needs user guide updates (`docs/`)
+- [ ] Needs ReadTheDocs updates
+- [ ] No docs needed (requires maintainer approval)
+
+## Additional Context
+*(Optional: follow-up tasks, special considerations)*


### PR DESCRIPTION
## Proposed Changes
Adds standardized PR template to improve contribution process with:
- Structured change description format
- Conventional commits guidance
- Explicit documentation update requirements

## Documentation Updates Required
- [x] Updated markdown docs (file path: .github/PULL_REQUEST_TEMPLATE.md)
- [x] Needs ReadTheDocs updates (repository documentation guidelines)