### PR TITLE
prepare-release: make default-channel optional

### DIFF
--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -25,15 +25,15 @@ jobs:
       - name: Create tag
         id: create_tag
         run: |
-          tag_name="${{ env.kuadratantOperatorTag }}"
+          tag_name="${{ env.kuadrantOperatorTag }}"
           git tag $tag_name
           git push origin $tag_name
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ env.kuadratantOperatorTag }}
-          tag_name: ${{ env.kuadratantOperatorTag }}
+          name: ${{ env.kuadrantOperatorTag }}
+          tag_name: ${{ env.kuadrantOperatorTag }}
           body: "${{ env.releaseBody }}"
           generate_release_notes: true
           target_commitish: ${{ env.releaseBranch }}

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -13,4 +13,4 @@ annotations:
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
   # Custom annotations
-  com.redhat.openshift.versions: v4.12
+  com.redhat.openshift.versions: v4.14

--- a/release.yaml
+++ b/release.yaml
@@ -2,7 +2,7 @@ kuadrant-operator:
   version: "0.0.0"
 
 olm:
-  channels: 
+  channels:
   - "alpha"
   default-channel: "alpha"
 

--- a/utils/release/load_github_envvar.sh
+++ b/utils/release/load_github_envvar.sh
@@ -7,56 +7,27 @@ if [[ -z "${ROOT}" ]]; then
 	ROOT=$(pwd)
 fi
 
-dry_run="0"
-_log="0"
-
-while [[ $# -gt 0 ]]; do
-	echo "ARG: \"$1\""
-	if [[ "$1" == "--dry_run" ]]; then
-		dry_run="1"
-	elif [[ "$1" == "--echo" ]]; then
-		_log="1"
-	else
-		grep="$1"
-	fi
-	shift
-done
-
-log() {
-	if [[ $dry_run == "1" ]]; then
-		echo "[DRY_RUN]: $1"
-	else
-		echo "$1"
-	fi
-}
+source $script_dir/shared.sh
 
 log "Loading Environment Variables"
 
-authorinoOperatorVersion=$(yq '.dependencies.authorino-operator' $ROOT/release.yaml)
-consolePluginURL=$(yq '.dependencies.console-plugin' $ROOT/release.yaml)
-dnsOperatorVersion=$(yq '.dependencies.dns-operator' $ROOT/release.yaml)
-limitadorOperatorVersion=$(yq '.dependencies.limitador-operator' $ROOT/release.yaml)
-wasmShimVersion=$(yq '.dependencies.wasm-shim' $ROOT/release.yaml)
-
-releaseBody="**This release enables installations of Authorino Operator v$authorinoOperatorVersion, Limitador Operator v$limitadorOperatorVersion, DNS Operator v$dnsOperatorVersion, WASM Shim v$wasmShimVersion and ConsolePlugin $consolePluginURL**"
-
-kuadratantOperatorTag="v$(yq '.kuadrant-operator.version' $ROOT/release.yaml)"
-releaseBranch="release-$(echo "$kuadratantOperatorTag" | sed -E 's/^(v[0-9]+\.[0-9]+).*/\1/')"
+releaseBody="**This release enables installations of Authorino Operator v$AUTHORINO_OPERATOR_VERSION, Limitador Operator v$LIMITADOR_OPERATOR_VERSION, DNS Operator v$DNS_OPERATOR_VERSION, WASM Shim v$WASM_SHIM_VERSION and ConsolePlugin $CONSOLEPLUGIN_URL**"
+releaseBranch="release-$(echo "$KUADRANT_OPERATOR_TAG" | sed -E 's/^(v[0-9]+\.[0-9]+).*/\1/')"
 
 prerelease=false
-if [[ "$kuadratantOperatorTag" =~ [-+] ]]; then
+if [[ "$KUADRANT_OPERATOR_TAG" =~ [-+] ]]; then
 	prerelease=true
 fi
 
 if [[ $_log == "1" ]]; then
-	log "kuadratantOperatorTag=$kuadratantOperatorTag"
+	log "kuadrantOperatorTag=$KUADRANT_OPERATOR_TAG"
 	log "releaseBody=$releaseBody"
 	log "prerelease=$prerelease"
 	log "releaseBranch=$releaseBranch"
 fi
 
 if [[ $dry_run == "0" ]]; then
-	echo "kuadratantOperatorTag=$kuadratantOperatorTag" >> "$GITHUB_ENV"
+	echo "kuadrantOperatorTag=$KUADRANT_OPERATOR_TAG" >> "$GITHUB_ENV"
 	echo "releaseBody=$releaseBody" >> "$GITHUB_ENV"
 	echo "prerelease=$prerelease" >> "$GITHUB_ENV"
 	echo "releaseBranch=$releaseBranch" >> "$GITHUB_ENV"

--- a/utils/release/operator/make_bundles.sh
+++ b/utils/release/operator/make_bundles.sh
@@ -42,11 +42,16 @@ cd -
 
 channels=$(yq '.olm.channels | join(",")' $env/release.yaml)
 default_channel=$(yq '.olm.default-channel' $env/release.yaml)
-kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --version $operator_version --channels $channels --default-channel $default_channel
+default_channel_opt="--default-channel $default_channel"
+if [[ "$default_channel" == "null" ]]; then
+  default_channel_opt=""
+fi
+
+kustomize build config/manifests | operator-sdk generate bundle -q --overwrite --version $operator_version --channels $channels $default_channel_opt
 
 openshift_version_annotation_key="com.redhat.openshift.versions"
-# Supports Openshift v4.12+ (https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions)
-openshift_supported_versions="v4.12"
+# Supports Openshift v4.14+ (https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions)
+openshift_supported_versions="v4.14"
 key=$openshift_version_annotation_key value=$openshift_supported_versions yq --inplace '.annotations[strenv(key)] = strenv(value)' bundle/metadata/annotations.yaml
 key=$openshift_version_annotation_key yq --inplace '(.annotations[strenv(key)] | key) headComment = "Custom annotations"' bundle/metadata/annotations.yaml
 

--- a/utils/release/post-validation/verify_default_olm_channel.sh
+++ b/utils/release/post-validation/verify_default_olm_channel.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+source $env/utils/release/shared.sh
+
+echo "Verifying OLM default channel"
+
+if [[ "$OLM_DEFAULT_CHANNEL" == "null" ]]; then
+  echo "OLM default channel is not set in release.yaml"
+  bundle_default_channel=$(yq '.annotations | has("operators.operatorframework.io.bundle.channel.default.v1")' $env/bundle/metadata/annotations.yaml)
+  if [[ "$bundle_default_channel" == "true" ]]; then
+    echo "🚨 OLM default channel is set in bundle and should not be"
+    exit 1
+  fi
+else
+  echo "OLM default channel is set in release.yaml"
+  bundle_default_channel=$(yq '.annotations."operators.operatorframework.io.bundle.channel.default.v1"' $env/bundle/metadata/annotations.yaml)
+  if [[ "$bundle_default_channel" != "$OLM_DEFAULT_CHANNEL" ]]; then
+    echo "🚨 OLM default channel in release.yaml ($OLM_DEFAULT_CHANNEL) does not match bundle annotations ($bundle_default_channel)"
+    exit 1
+  fi
+fi
+
+echo "✅ OLM default channel verified"

--- a/utils/release/pre-validation/verify_release_file.sh
+++ b/utils/release/pre-validation/verify_release_file.sh
@@ -20,7 +20,6 @@ check_field() {
 }
 
 check_field ".olm.channels" "olm.channels"
-check_field ".olm.default-channel" "olm.default-channel"
 check_field ".kuadrant-operator.version" "kuadrant.version"
 check_field ".dependencies.authorino-operator" "dependencies.authorino-operator"
 check_field ".dependencies.console-plugin" "dependencies.console-plugin"

--- a/utils/release/release.sh
+++ b/utils/release/release.sh
@@ -61,7 +61,7 @@ log "RUN: root: $ROOT -- grep: $grep"
 log "$script_dir"
 
 # Run all phases
-phases=("pre-validation" "dependencies" "operator")
+phases=("pre-validation" "dependencies" "operator" "post-validation")
 for phase in "${phases[@]}"; do
     run_tasks "$phase"
 done

--- a/utils/release/shared.sh
+++ b/utils/release/shared.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+if [[ -z "${env}" ]]; then
+	echo "[WARNING] env var env not set, using $(pwd)"
+	env=$(pwd)
+fi
+
+dry_run="0"
+_log="0"
+
+while [[ $# -gt 0 ]]; do
+	echo "ARG: \"$1\""
+	if [[ "$1" == "--dry_run" ]]; then
+		dry_run="1"
+	elif [[ "$1" == "--echo" ]]; then
+		_log="1"
+	else
+		grep="$1"
+	fi
+	shift
+done
+
+log() {
+	if [[ $dry_run == "1" ]]; then
+		echo "[DRY_RUN]: $1"
+	else
+		echo "$1"
+	fi
+}
+
+AUTHORINO_OPERATOR_VERSION=$(yq '.dependencies.authorino-operator' $env/release.yaml)
+CONSOLEPLUGIN_VERSION=$(yq '.dependencies.console-plugin' $env/release.yaml)
+DNS_OPERATOR_VERSION=$(yq '.dependencies.dns-operator' $env/release.yaml)
+LIMITADOR_OPERATOR_VERSION=$(yq '.dependencies.limitador-operator' $env/release.yaml)
+WASM_SHIM_VERSION=$(yq '.dependencies.wasm-shim' $env/release.yaml)
+KUADRANT_OPERATOR_VERSION="$(yq '.kuadrant-operator.version' $env/release.yaml)"
+KUADRANT_OPERATOR_TAG="v$KUADRANT_OPERATOR_VERSION"
+OLM_CHANNELS="$(yq '.olm.channels | join(",")' $env/release.yaml)"
+OLM_DEFAULT_CHANNEL="$(yq '.olm.default-channel' $env/release.yaml)"


### PR DESCRIPTION
when default channel is not in `release.yaml`, a valid bundle is generated. 

Added post-validation check to make sure OLM default channel in bundle is consistent with release.yaml

*  If olm default channel is not set in the release.yaml => bundle must not have the property
*  if olm default channel is set in the release.yaml => bundle must have the property and matching value


### Verification steps

* remove default channel
```
yq e 'del(.olm.default-channel)' -i release.yaml
```
* prepare release
````
make prepare-release
````

The bundle annotations and bundle.Dockerfile should have changed

```diff
diff --git a/bundle.Dockerfile b/bundle.Dockerfile
index d3daffb4..cb5d5e9b 100644
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,6 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=kuadrant-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
diff --git a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
index 64f99687..f9ed4762 100644
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -109,7 +109,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2025-02-25T10:17:48Z"
+    createdAt: "2025-03-19T11:02:23Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
diff --git a/bundle/metadata/annotations.yaml b/bundle/metadata/annotations.yaml
index 1f1e882c..49b1bdfa 100644
--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kuadrant-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.bundle.channel.default.v1: alpha
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
diff --git a/release.yaml b/release.yaml
index 12b8e97d..726e1ff4 100644
--- a/release.yaml
+++ b/release.yaml
@@ -1,11 +1,8 @@
 kuadrant-operator:
   version: "0.0.0"
-
 olm:
   channels:
-  - "alpha"
-  default-channel: "alpha"
-
+    - "alpha"
 dependencies:
   authorino-operator: "0.0.0"
   console-plugin: "0.0.0"
```

Additionally, set min OCP version as 4.14 (the other reached EOL)
