### PR TITLE
FIX: Release Note Generation

### DIFF
--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -39,6 +39,7 @@ jobs:
           name: ${{ env.kuadrantOperatorTag }}
           tag_name: ${{ env.kuadrantOperatorTag }}
           body: "${{ env.releaseBody }}"
+          # TODO: https://github.com/Kuadrant/kuadrant-operator/issues/1229
           # The generate of release notes does not pick up the correct tag to compare.
           # There is an open PR within softprops/action-gh-release that would solve the problem.
           # Till then we cannot use the generate release notes feature.

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -28,6 +28,10 @@ jobs:
           tag_name="${{ env.kuadrantOperatorTag }}"
           git tag $tag_name
           git push origin $tag_name
+      - name: Generate release body
+        id: generate_release_body
+        run: |
+          GITHUB_TOKEN=${{ secrets.KUADRANT_WORKFLOWS_PAT }} bash ./utils/release/github-release-changelog.sh
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -35,6 +39,10 @@ jobs:
           name: ${{ env.kuadrantOperatorTag }}
           tag_name: ${{ env.kuadrantOperatorTag }}
           body: "${{ env.releaseBody }}"
-          generate_release_notes: true
+          # The generate of release notes does not pick up the correct tag to compare.
+          # There is an open PR within softprops/action-gh-release that would solve the problem.
+          # Till then we cannot use the generate release notes feature.
+          # https://github.com/softprops/action-gh-release/pull/372
+          generate_release_notes: false
           target_commitish: ${{ env.releaseBranch }}
           prerelease: ${{ env.prerelease }}

--- a/utils/release/github-release-changelog.sh
+++ b/utils/release/github-release-changelog.sh
@@ -2,7 +2,7 @@
 
 # Access token will be required. Check to ensure that is it provied
 if [[ -z "$GITHUB_TOKEN" ]]; then
-	echo "GITHUB_TOKEN most be set"
+	echo "GITHUB_TOKEN must be set"
 fi
 auth_header="-H Authorization: Bearer $GITHUB_TOKEN"
 
@@ -10,9 +10,9 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source $script_dir/shared.sh
 
 # Get latest release version
-log "Getti previous release version tag"
+log "Getting 'latest' release version tag"
 previous_tag_name=$(curl -L "https://api.github.com/repos/kuadrant/kuadrant-operator/releases/latest" -H "Accept: apllication/vnd.github+json" | yq '.tag_name')
-log "Previous released version is $previous_tag_name"
+log "'latest' released version is $previous_tag_name"
 
 # Get current release tag
 log "Getting this releases tag"
@@ -28,7 +28,8 @@ EOF
 
 data=$(curl -L "https://api.github.com/repos/kuadrant/kuadrant-operator/releases/generate-notes" -X POST -H "Accept: apllication/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" -d "$payload")
 
-release_body=$(echo $data | yq '.body')
+release_body_data=$(echo $data | yq '.body')
+release_body="**This release enables installations of Authorino Operator v$AUTHORINO_OPERATOR_VERSION, Limitador Operator v$LIMITADOR_OPERATOR_VERSION, DNS Operator v$DNS_OPERATOR_VERSION, WASM Shim v$WASM_SHIM_VERSION and ConsolePlugin $CONSOLEPLUGIN_URL**$release_body_data"
 
 if [[ $_log == "1" ]]; then
 	log "releaseBody=$release_body"

--- a/utils/release/github-release-changelog.sh
+++ b/utils/release/github-release-changelog.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Access token will be required. Check to ensure that is it provied
+if [[ -z "$GITHUB_TOKEN" ]]; then
+	echo "GITHUB_TOKEN most be set"
+fi
+auth_header="-H Authorization: Bearer $GITHUB_TOKEN"
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+source $script_dir/shared.sh
+
+# Get latest release version
+log "Getti previous release version tag"
+previous_tag_name=$(curl -L "https://api.github.com/repos/kuadrant/kuadrant-operator/releases/latest" -H "Accept: apllication/vnd.github+json" | yq '.tag_name')
+log "Previous released version is $previous_tag_name"
+
+# Get current release tag
+log "Getting this releases tag"
+release_tag=$KUADRANT_OPERATOR_TAG
+log "Release in progress for $KUADRANT_OPERATOR_TAG"
+
+# Generate the release change log
+log "Generate release change log"
+payload=$(cat <<EOF
+{"tag_name": "$release_tag","previous_tag_name": "$previous_tag_name"}
+EOF
+)
+
+data=$(curl -L "https://api.github.com/repos/kuadrant/kuadrant-operator/releases/generate-notes" -X POST -H "Accept: apllication/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" -d "$payload")
+
+release_body=$(echo $data | yq '.body')
+
+if [[ $_log == "1" ]]; then
+	log "releaseBody=$release_body"
+fi
+
+if [[ $dry_run == "0" ]]; then
+	echo "releaseBody=$release_body" >> "$GITHUB_ENV"
+fi

--- a/utils/release/load_github_envvar.sh
+++ b/utils/release/load_github_envvar.sh
@@ -11,7 +11,6 @@ source $script_dir/shared.sh
 
 log "Loading Environment Variables"
 
-releaseBody="**This release enables installations of Authorino Operator v$AUTHORINO_OPERATOR_VERSION, Limitador Operator v$LIMITADOR_OPERATOR_VERSION, DNS Operator v$DNS_OPERATOR_VERSION, WASM Shim v$WASM_SHIM_VERSION and ConsolePlugin $CONSOLEPLUGIN_URL**"
 releaseBranch="release-$(echo "$KUADRANT_OPERATOR_TAG" | sed -E 's/^(v[0-9]+\.[0-9]+).*/\1/')"
 
 prerelease=false
@@ -21,14 +20,12 @@ fi
 
 if [[ $_log == "1" ]]; then
 	log "kuadrantOperatorTag=$KUADRANT_OPERATOR_TAG"
-	log "releaseBody=$releaseBody"
 	log "prerelease=$prerelease"
 	log "releaseBranch=$releaseBranch"
 fi
 
 if [[ $dry_run == "0" ]]; then
 	echo "kuadrantOperatorTag=$KUADRANT_OPERATOR_TAG" >> "$GITHUB_ENV"
-	echo "releaseBody=$releaseBody" >> "$GITHUB_ENV"
 	echo "prerelease=$prerelease" >> "$GITHUB_ENV"
 	echo "releaseBranch=$releaseBranch" >> "$GITHUB_ENV"
 fi


### PR DESCRIPTION
closes: #1211 

The softprops/action-gh-release does not correctly pick up the tag for comparing when creating the release notes. Here the GitHub api is directly used to generate the release notes. softporps/action-gh-release is still used to create the actual release. Lines below dotted lines will be ignored, and an empty title aborts the creation process.