### PR TITLE
Custom gateway controller names

### DIFF
--- a/internal/controller/auth_policy_status_updater.go
+++ b/internal/controller/auth_policy_status_updater.go
@@ -223,7 +223,8 @@ func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolic
 
 	// check the status of the gateways' configuration resources
 	for _, g := range affectedGateways {
-		switch g.gatewayClass.Spec.ControllerName {
+		controllerName := g.gatewayClass.Spec.ControllerName
+		switch defaultGatewayControllerName(controllerName) {
 		case defaultIstioGatewayControllerName:
 			// EnvoyFilter
 			istioAuthClustersModifiedGateways, _ := state.Load(StateIstioAuthClustersModified)
@@ -242,12 +243,12 @@ func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolic
 			// EnvoyPatchPolicy
 			envoyGatewayAuthClustersModifiedGateways, _ := state.Load(StateEnvoyGatewayAuthClustersModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantenvoygateway.EnvoyPatchPolicyGroupKind, envoyGatewayAuthClustersModifiedGateways, topology, func(obj machinery.Object) bool {
-				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyPatchPolicy).Status, defaultEnvoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(envoygatewayv1alpha1.PolicyConditionProgrammed))
+				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyPatchPolicy).Status, controllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(envoygatewayv1alpha1.PolicyConditionProgrammed))
 			})...)
 			// EnvoyExtensionPolicy
 			envoyGatewayExtensionsModifiedGateways, _ := state.Load(StateEnvoyGatewayExtensionsModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantenvoygateway.EnvoyExtensionPolicyGroupKind, envoyGatewayExtensionsModifiedGateways, topology, func(obj machinery.Object) bool {
-				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyExtensionPolicy).Status, defaultEnvoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(gatewayapiv1alpha2.PolicyConditionAccepted))
+				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyExtensionPolicy).Status, controllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(gatewayapiv1alpha2.PolicyConditionAccepted))
 			})...)
 		default:
 			componentsToSync = append(componentsToSync, fmt.Sprintf("%s (%s/%s)", machinery.GatewayGroupKind.Kind, g.gateway.GetNamespace(), g.gateway.GetName()))

--- a/internal/controller/auth_policy_status_updater.go
+++ b/internal/controller/auth_policy_status_updater.go
@@ -224,7 +224,7 @@ func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolic
 	// check the status of the gateways' configuration resources
 	for _, g := range affectedGateways {
 		switch g.gatewayClass.Spec.ControllerName {
-		case istioGatewayControllerName:
+		case defaultIstioGatewayControllerName:
 			// EnvoyFilter
 			istioAuthClustersModifiedGateways, _ := state.Load(StateIstioAuthClustersModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantistio.EnvoyFilterGroupKind, istioAuthClustersModifiedGateways, topology, func(_ machinery.Object) bool {
@@ -237,17 +237,17 @@ func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolic
 				// return meta.IsStatusConditionTrue(lo.Map(obj.(*controller.RuntimeObject).Object.(*istioclientgoextensionv1alpha1.WasmPlugin).Status.Conditions, kuadrantistio.ConditionToProperConditionFunc), "Ready")
 				return true // Istio won't ever populate the status stanza of WasmPlugin resources, so we cannot expect to find a given a condition there
 			})...)
-		case envoyGatewayGatewayControllerName:
+		case defaultEnvoyGatewayGatewayControllerName:
 			gatewayAncestor := gatewayapiv1.ParentReference{Name: gatewayapiv1.ObjectName(g.gateway.GetName()), Namespace: ptr.To(gatewayapiv1.Namespace(g.gateway.GetNamespace()))}
 			// EnvoyPatchPolicy
 			envoyGatewayAuthClustersModifiedGateways, _ := state.Load(StateEnvoyGatewayAuthClustersModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantenvoygateway.EnvoyPatchPolicyGroupKind, envoyGatewayAuthClustersModifiedGateways, topology, func(obj machinery.Object) bool {
-				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyPatchPolicy).Status, envoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(envoygatewayv1alpha1.PolicyConditionProgrammed))
+				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyPatchPolicy).Status, defaultEnvoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(envoygatewayv1alpha1.PolicyConditionProgrammed))
 			})...)
 			// EnvoyExtensionPolicy
 			envoyGatewayExtensionsModifiedGateways, _ := state.Load(StateEnvoyGatewayExtensionsModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantenvoygateway.EnvoyExtensionPolicyGroupKind, envoyGatewayExtensionsModifiedGateways, topology, func(obj machinery.Object) bool {
-				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyExtensionPolicy).Status, envoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(gatewayapiv1alpha2.PolicyConditionAccepted))
+				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyExtensionPolicy).Status, defaultEnvoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(gatewayapiv1alpha2.PolicyConditionAccepted))
 			})...)
 		default:
 			componentsToSync = append(componentsToSync, fmt.Sprintf("%s (%s/%s)", machinery.GatewayGroupKind.Kind, g.gateway.GetNamespace(), g.gateway.GetName()))

--- a/internal/controller/data_plane_policies_workflow.go
+++ b/internal/controller/data_plane_policies_workflow.go
@@ -18,9 +18,8 @@ import (
 )
 
 const (
-	// make these configurable?
-	istioGatewayControllerName        = "istio.io/gateway-controller"
-	envoyGatewayGatewayControllerName = "gateway.envoyproxy.io/gatewayclass-controller"
+	defaultIstioGatewayControllerName        = "istio.io/gateway-controller"
+	defaultEnvoyGatewayGatewayControllerName = "gateway.envoyproxy.io/gatewayclass-controller"
 )
 
 var (

--- a/internal/controller/data_plane_policies_workflow_test.go
+++ b/internal/controller/data_plane_policies_workflow_test.go
@@ -1,0 +1,32 @@
+package controllers
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestGetGatewayControllerNames(t *testing.T) {
+	t.Setenv("ISTIO_GATEWAY_CONTROLLER_NAMES", "istio-alpha1 , istio-alpha2  ")
+
+	istioGwCtrlNames := getGatewayControllerNames("ISTIO_GATEWAY_CONTROLLER_NAMES", "default-istio")
+	envoyGwGwCtrlNames := getGatewayControllerNames("ENVOY_GATEWAY_GATEWAY_CONTROLLER_NAMES", "default-envoy")
+
+	assert.Equal(t, len(istioGwCtrlNames), 3)
+	assert.Equal(t, istioGwCtrlNames[0], gatewayapiv1.GatewayController("istio-alpha1"))
+	assert.Equal(t, istioGwCtrlNames[1], gatewayapiv1.GatewayController("istio-alpha2"))
+	assert.Equal(t, istioGwCtrlNames[2], gatewayapiv1.GatewayController("default-istio"))
+
+	assert.Equal(t, len(envoyGwGwCtrlNames), 1)
+	assert.Equal(t, envoyGwGwCtrlNames[0], gatewayapiv1.GatewayController("default-envoy"))
+}
+
+func TestDefaultGatewayControllerNames(t *testing.T) {
+	istioGatewayControllerNames = []gatewayapiv1.GatewayController{"istio-alpha1"}
+	envoyGatewayGatewayControllerNames = []gatewayapiv1.GatewayController{"envoy-alpha1"}
+
+	assert.Equal(t, defaultGatewayControllerName("istio-alpha1"), gatewayapiv1.GatewayController("istio.io/gateway-controller"))
+	assert.Equal(t, defaultGatewayControllerName("envoy-alpha1"), gatewayapiv1.GatewayController("gateway.envoyproxy.io/gatewayclass-controller"))
+	assert.Equal(t, defaultGatewayControllerName("envoy-alpha2"), gatewayapiv1.GatewayController("Unknown"))
+}

--- a/internal/controller/envoy_gateway_auth_cluster_reconciler.go
+++ b/internal/controller/envoy_gateway_auth_cluster_reconciler.go
@@ -74,7 +74,7 @@ func (r *EnvoyGatewayAuthClusterReconciler) Reconcile(ctx context.Context, _ []c
 
 	gateways := lo.UniqBy(lo.FilterMap(lo.Values(effectivePolicies.(EffectiveAuthPolicies)), func(effectivePolicy EffectiveAuthPolicy, _ int) (*machinery.Gateway, bool) {
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
-		return gateway, gatewayClass.Spec.ControllerName == envoyGatewayGatewayControllerName
+		return gateway, gatewayClass.Spec.ControllerName == defaultEnvoyGatewayGatewayControllerName
 	}), func(gateway *machinery.Gateway) string {
 		return gateway.GetLocator()
 	})

--- a/internal/controller/envoy_gateway_auth_cluster_reconciler.go
+++ b/internal/controller/envoy_gateway_auth_cluster_reconciler.go
@@ -74,7 +74,7 @@ func (r *EnvoyGatewayAuthClusterReconciler) Reconcile(ctx context.Context, _ []c
 
 	gateways := lo.UniqBy(lo.FilterMap(lo.Values(effectivePolicies.(EffectiveAuthPolicies)), func(effectivePolicy EffectiveAuthPolicy, _ int) (*machinery.Gateway, bool) {
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
-		return gateway, gatewayClass.Spec.ControllerName == defaultEnvoyGatewayGatewayControllerName
+		return gateway, lo.Contains(envoyGatewayGatewayControllerNames, gatewayClass.Spec.ControllerName)
 	}), func(gateway *machinery.Gateway) string {
 		return gateway.GetLocator()
 	})

--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -174,7 +174,7 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(path)
 
 		// ignore if not an envoy gateway gateway
-		if gatewayClass.Spec.ControllerName != defaultEnvoyGatewayGatewayControllerName {
+		if !lo.Contains(envoyGatewayGatewayControllerNames, gatewayClass.Spec.ControllerName) {
 			continue
 		}
 

--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -174,7 +174,7 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(path)
 
 		// ignore if not an envoy gateway gateway
-		if gatewayClass.Spec.ControllerName != envoyGatewayGatewayControllerName {
+		if gatewayClass.Spec.ControllerName != defaultEnvoyGatewayGatewayControllerName {
 			continue
 		}
 

--- a/internal/controller/envoy_gateway_ratelimit_cluster_reconciler.go
+++ b/internal/controller/envoy_gateway_ratelimit_cluster_reconciler.go
@@ -74,7 +74,7 @@ func (r *EnvoyGatewayRateLimitClusterReconciler) Reconcile(ctx context.Context, 
 
 	gateways := lo.UniqBy(lo.FilterMap(lo.Values(effectivePolicies.(EffectiveRateLimitPolicies)), func(effectivePolicy EffectiveRateLimitPolicy, _ int) (*machinery.Gateway, bool) {
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
-		return gateway, gatewayClass.Spec.ControllerName == envoyGatewayGatewayControllerName
+		return gateway, gatewayClass.Spec.ControllerName == defaultEnvoyGatewayGatewayControllerName
 	}), func(gateway *machinery.Gateway) string {
 		return gateway.GetLocator()
 	})

--- a/internal/controller/envoy_gateway_ratelimit_cluster_reconciler.go
+++ b/internal/controller/envoy_gateway_ratelimit_cluster_reconciler.go
@@ -74,7 +74,7 @@ func (r *EnvoyGatewayRateLimitClusterReconciler) Reconcile(ctx context.Context, 
 
 	gateways := lo.UniqBy(lo.FilterMap(lo.Values(effectivePolicies.(EffectiveRateLimitPolicies)), func(effectivePolicy EffectiveRateLimitPolicy, _ int) (*machinery.Gateway, bool) {
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
-		return gateway, gatewayClass.Spec.ControllerName == defaultEnvoyGatewayGatewayControllerName
+		return gateway, lo.Contains(envoyGatewayGatewayControllerNames, gatewayClass.Spec.ControllerName)
 	}), func(gateway *machinery.Gateway) string {
 		return gateway.GetLocator()
 	})

--- a/internal/controller/istio_auth_cluster_reconciler.go
+++ b/internal/controller/istio_auth_cluster_reconciler.go
@@ -74,7 +74,7 @@ func (r *IstioAuthClusterReconciler) Reconcile(ctx context.Context, _ []controll
 
 	gateways := lo.UniqBy(lo.FilterMap(lo.Values(effectivePolicies.(EffectiveAuthPolicies)), func(effectivePolicy EffectiveAuthPolicy, _ int) (*machinery.Gateway, bool) {
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
-		return gateway, gatewayClass.Spec.ControllerName == istioGatewayControllerName
+		return gateway, gatewayClass.Spec.ControllerName == defaultIstioGatewayControllerName
 	}), func(gateway *machinery.Gateway) string {
 		return gateway.GetLocator()
 	})

--- a/internal/controller/istio_auth_cluster_reconciler.go
+++ b/internal/controller/istio_auth_cluster_reconciler.go
@@ -74,7 +74,7 @@ func (r *IstioAuthClusterReconciler) Reconcile(ctx context.Context, _ []controll
 
 	gateways := lo.UniqBy(lo.FilterMap(lo.Values(effectivePolicies.(EffectiveAuthPolicies)), func(effectivePolicy EffectiveAuthPolicy, _ int) (*machinery.Gateway, bool) {
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
-		return gateway, gatewayClass.Spec.ControllerName == defaultIstioGatewayControllerName
+		return gateway, lo.Contains(istioGatewayControllerNames, gatewayClass.Spec.ControllerName)
 	}), func(gateway *machinery.Gateway) string {
 		return gateway.GetLocator()
 	})

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -179,7 +179,7 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, state *
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(path)
 
 		// ignore if not an istio gateway
-		if gatewayClass.Spec.ControllerName != defaultIstioGatewayControllerName {
+		if !lo.Contains(istioGatewayControllerNames, gatewayClass.Spec.ControllerName) {
 			continue
 		}
 

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -179,7 +179,7 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, state *
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(path)
 
 		// ignore if not an istio gateway
-		if gatewayClass.Spec.ControllerName != istioGatewayControllerName {
+		if gatewayClass.Spec.ControllerName != defaultIstioGatewayControllerName {
 			continue
 		}
 

--- a/internal/controller/istio_ratelimit_cluster_reconciler.go
+++ b/internal/controller/istio_ratelimit_cluster_reconciler.go
@@ -74,7 +74,7 @@ func (r *IstioRateLimitClusterReconciler) Reconcile(ctx context.Context, _ []con
 
 	gateways := lo.UniqBy(lo.FilterMap(lo.Values(effectivePolicies.(EffectiveRateLimitPolicies)), func(effectivePolicy EffectiveRateLimitPolicy, _ int) (*machinery.Gateway, bool) {
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
-		return gateway, gatewayClass.Spec.ControllerName == istioGatewayControllerName
+		return gateway, gatewayClass.Spec.ControllerName == defaultIstioGatewayControllerName
 	}), func(gateway *machinery.Gateway) string {
 		return gateway.GetLocator()
 	})

--- a/internal/controller/istio_ratelimit_cluster_reconciler.go
+++ b/internal/controller/istio_ratelimit_cluster_reconciler.go
@@ -74,7 +74,7 @@ func (r *IstioRateLimitClusterReconciler) Reconcile(ctx context.Context, _ []con
 
 	gateways := lo.UniqBy(lo.FilterMap(lo.Values(effectivePolicies.(EffectiveRateLimitPolicies)), func(effectivePolicy EffectiveRateLimitPolicy, _ int) (*machinery.Gateway, bool) {
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
-		return gateway, gatewayClass.Spec.ControllerName == defaultIstioGatewayControllerName
+		return gateway, lo.Contains(istioGatewayControllerNames, gatewayClass.Spec.ControllerName)
 	}), func(gateway *machinery.Gateway) string {
 		return gateway.GetLocator()
 	})

--- a/internal/controller/observability_reconciler.go
+++ b/internal/controller/observability_reconciler.go
@@ -402,7 +402,7 @@ func (r *ObservabilityReconciler) Reconcile(baseCtx context.Context, _ []control
 	for _, gatewayClass := range gatewayClasses {
 		gateways := topology.All().Children(gatewayClass)
 		gwClass := gatewayClass.(*machinery.GatewayClass)
-		if gwClass.GatewayClass.Spec.ControllerName == istioGatewayControllerName {
+		if gwClass.GatewayClass.Spec.ControllerName == defaultIstioGatewayControllerName {
 			istiodMonitor := istiodMonitorBuild(istiodMonitorNS)
 			r.createServiceMonitor(ctx, istiodMonitor, logger)
 
@@ -410,7 +410,7 @@ func (r *ObservabilityReconciler) Reconcile(baseCtx context.Context, _ []control
 				istioPodMonitor := istioPodMonitorBuild(gateway.GetNamespace())
 				r.createPodMonitor(ctx, istioPodMonitor, logger)
 			}
-		} else if gwClass.GatewayClass.Spec.ControllerName == envoyGatewayGatewayControllerName {
+		} else if gwClass.GatewayClass.Spec.ControllerName == defaultEnvoyGatewayGatewayControllerName {
 			envoyGatewayMonitor := envoyGatewayMonitorBuild(envoyGatewayMonitorNS)
 			r.createServiceMonitor(ctx, envoyGatewayMonitor, logger)
 

--- a/internal/controller/observability_reconciler.go
+++ b/internal/controller/observability_reconciler.go
@@ -402,7 +402,7 @@ func (r *ObservabilityReconciler) Reconcile(baseCtx context.Context, _ []control
 	for _, gatewayClass := range gatewayClasses {
 		gateways := topology.All().Children(gatewayClass)
 		gwClass := gatewayClass.(*machinery.GatewayClass)
-		if gwClass.GatewayClass.Spec.ControllerName == defaultIstioGatewayControllerName {
+		if lo.Contains(istioGatewayControllerNames, gwClass.GatewayClass.Spec.ControllerName) {
 			istiodMonitor := istiodMonitorBuild(istiodMonitorNS)
 			r.createServiceMonitor(ctx, istiodMonitor, logger)
 
@@ -410,7 +410,7 @@ func (r *ObservabilityReconciler) Reconcile(baseCtx context.Context, _ []control
 				istioPodMonitor := istioPodMonitorBuild(gateway.GetNamespace())
 				r.createPodMonitor(ctx, istioPodMonitor, logger)
 			}
-		} else if gwClass.GatewayClass.Spec.ControllerName == defaultEnvoyGatewayGatewayControllerName {
+		} else if lo.Contains(envoyGatewayGatewayControllerNames, gwClass.GatewayClass.Spec.ControllerName) {
 			envoyGatewayMonitor := envoyGatewayMonitorBuild(envoyGatewayMonitorNS)
 			r.createServiceMonitor(ctx, envoyGatewayMonitor, logger)
 

--- a/internal/controller/ratelimit_policy_status_updater.go
+++ b/internal/controller/ratelimit_policy_status_updater.go
@@ -194,7 +194,7 @@ func (r *RateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.Rate
 	// check the status of the gateways' configuration resources
 	for _, g := range affectedGateways {
 		switch g.gatewayClass.Spec.ControllerName {
-		case istioGatewayControllerName:
+		case defaultIstioGatewayControllerName:
 			// EnvoyFilter
 			istioRateLimitClustersModifiedGateways, _ := state.Load(StateIstioRateLimitClustersModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantistio.EnvoyFilterGroupKind, istioRateLimitClustersModifiedGateways, topology, func(_ machinery.Object) bool {
@@ -207,17 +207,17 @@ func (r *RateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.Rate
 				// return meta.IsStatusConditionTrue(lo.Map(obj.(*controller.RuntimeObject).Object.(*istioclientgoextensionv1alpha1.WasmPlugin).Status.Conditions, kuadrantistio.ConditionToProperConditionFunc), "Ready")
 				return true // Istio won't ever populate the status stanza of WasmPlugin resources, so we cannot expect to find a given a condition there
 			})...)
-		case envoyGatewayGatewayControllerName:
+		case defaultEnvoyGatewayGatewayControllerName:
 			gatewayAncestor := gatewayapiv1.ParentReference{Name: gatewayapiv1.ObjectName(g.gateway.GetName()), Namespace: ptr.To(gatewayapiv1.Namespace(g.gateway.GetNamespace()))}
 			// EnvoyPatchPolicy
 			envoyGatewayRateLimitClustersModifiedGateways, _ := state.Load(StateEnvoyGatewayRateLimitClustersModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantenvoygateway.EnvoyPatchPolicyGroupKind, envoyGatewayRateLimitClustersModifiedGateways, topology, func(obj machinery.Object) bool {
-				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyPatchPolicy).Status, envoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(envoygatewayv1alpha1.PolicyConditionProgrammed))
+				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyPatchPolicy).Status, defaultEnvoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(envoygatewayv1alpha1.PolicyConditionProgrammed))
 			})...)
 			// EnvoyExtensionPolicy
 			envoyGatewayExtensionsModifiedGateways, _ := state.Load(StateEnvoyGatewayExtensionsModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantenvoygateway.EnvoyExtensionPolicyGroupKind, envoyGatewayExtensionsModifiedGateways, topology, func(obj machinery.Object) bool {
-				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyExtensionPolicy).Status, envoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(gatewayapiv1alpha2.PolicyConditionAccepted))
+				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyExtensionPolicy).Status, defaultEnvoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(gatewayapiv1alpha2.PolicyConditionAccepted))
 			})...)
 		default:
 			componentsToSync = append(componentsToSync, fmt.Sprintf("%s (%s/%s)", machinery.GatewayGroupKind.Kind, g.gateway.GetNamespace(), g.gateway.GetName()))

--- a/internal/controller/ratelimit_policy_status_updater.go
+++ b/internal/controller/ratelimit_policy_status_updater.go
@@ -193,7 +193,8 @@ func (r *RateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.Rate
 
 	// check the status of the gateways' configuration resources
 	for _, g := range affectedGateways {
-		switch g.gatewayClass.Spec.ControllerName {
+		controllerName := g.gatewayClass.Spec.ControllerName
+		switch defaultGatewayControllerName(controllerName) {
 		case defaultIstioGatewayControllerName:
 			// EnvoyFilter
 			istioRateLimitClustersModifiedGateways, _ := state.Load(StateIstioRateLimitClustersModified)
@@ -212,12 +213,12 @@ func (r *RateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.Rate
 			// EnvoyPatchPolicy
 			envoyGatewayRateLimitClustersModifiedGateways, _ := state.Load(StateEnvoyGatewayRateLimitClustersModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantenvoygateway.EnvoyPatchPolicyGroupKind, envoyGatewayRateLimitClustersModifiedGateways, topology, func(obj machinery.Object) bool {
-				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyPatchPolicy).Status, defaultEnvoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(envoygatewayv1alpha1.PolicyConditionProgrammed))
+				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyPatchPolicy).Status, controllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(envoygatewayv1alpha1.PolicyConditionProgrammed))
 			})...)
 			// EnvoyExtensionPolicy
 			envoyGatewayExtensionsModifiedGateways, _ := state.Load(StateEnvoyGatewayExtensionsModified)
 			componentsToSync = append(componentsToSync, gatewayComponentsToSync(g.gateway, kuadrantenvoygateway.EnvoyExtensionPolicyGroupKind, envoyGatewayExtensionsModifiedGateways, topology, func(obj machinery.Object) bool {
-				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyExtensionPolicy).Status, defaultEnvoyGatewayGatewayControllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(gatewayapiv1alpha2.PolicyConditionAccepted))
+				return meta.IsStatusConditionTrue(kuadrantgatewayapi.PolicyStatusConditionsFromAncestor(obj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyExtensionPolicy).Status, controllerName, gatewayAncestor, gatewayapiv1.Namespace(obj.GetNamespace())), string(gatewayapiv1alpha2.PolicyConditionAccepted))
 			})...)
 		default:
 			componentsToSync = append(componentsToSync, fmt.Sprintf("%s (%s/%s)", machinery.GatewayGroupKind.Kind, g.gateway.GetNamespace(), g.gateway.GetName()))


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/1200

This PR introduces a way to configure multiple controller names, as in [GatewayClass.ControllerName](https://gateway-api.sigs.k8s.io/api-types/gatewayclass/#gatewayclass-parameters) exposing an environment variable per Gateway implementation, `ISTIO_GATEWAY_CONTROLLER_NAMES` and `ENVOY_GATEWAY_GATEWAY_CONTROLLER_NAMES` respectively. Which configures the operator to also reconcile with multiple custom names, i.e:

`ISTIO_GATEWAY_CONTROLLER_NAMES= istio.io/gateway-controller-alpha1, istio.io/gateway-controller-rc2`

Kuadrant operator will reconcile not only the controllers defined in the env var, but also the default one `istio.io/gateway-controller`

**Notes**
* Should we document this? and if so, how/where?
* To configure this on Helm Charts/OLM would be best to have a different issue, since it's a much bigger topic, at least with helm values.yml