### PR TITLE
fix(ratelimit): transform counter "`variable.expression`s" properly

### DIFF
--- a/api/v1/ratelimitpolicy_types.go
+++ b/api/v1/ratelimitpolicy_types.go
@@ -237,7 +237,7 @@ func (l Limit) CountersAsStringList() []string {
 	if len(l.Counters) == 0 {
 		return nil
 	}
-	return utils.Map(l.Counters, func(counter Counter) string { return string(counter.Expression) })
+	return utils.Map(l.Counters, func(counter Counter) string { return "descriptors[0]." + string(counter.Expression) })
 }
 
 var _ MergeableRule = &Limit{}

--- a/api/v1/ratelimitpolicy_types.go
+++ b/api/v1/ratelimitpolicy_types.go
@@ -243,9 +243,8 @@ func (l Limit) CountersAsStringList() []string {
 		str := string(counter.Expression)
 		if exp, err := transformer.TransformCounterVariable(str); err != nil {
 			return *exp
-		} else {
-			return str
 		}
+		return str
 	})
 }
 

--- a/api/v1/ratelimitpolicy_types.go
+++ b/api/v1/ratelimitpolicy_types.go
@@ -19,6 +19,8 @@ package v1
 import (
 	"time"
 
+	transformer "github.com/kuadrant/kuadrant-operator/internal/cel"
+
 	"github.com/kuadrant/policy-machinery/machinery"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -237,7 +239,14 @@ func (l Limit) CountersAsStringList() []string {
 	if len(l.Counters) == 0 {
 		return nil
 	}
-	return utils.Map(l.Counters, func(counter Counter) string { return "descriptors[0]." + string(counter.Expression) })
+	return utils.Map(l.Counters, func(counter Counter) string {
+		str := string(counter.Expression)
+		if transformer.SafeToSimplyPrefix(str) {
+			return "descriptors[0]." + str
+		} else {
+			return str
+		}
+	})
 }
 
 var _ MergeableRule = &Limit{}

--- a/api/v1/ratelimitpolicy_types.go
+++ b/api/v1/ratelimitpolicy_types.go
@@ -241,8 +241,8 @@ func (l Limit) CountersAsStringList() []string {
 	}
 	return utils.Map(l.Counters, func(counter Counter) string {
 		str := string(counter.Expression)
-		if transformer.SafeToSimplyPrefix(str) {
-			return "descriptors[0]." + str
+		if exp, err := transformer.TransformCounterVariable(str); err != nil {
+			return *exp
 		} else {
 			return str
 		}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/elliotchance/orderedmap/v2 v2.2.0
 	github.com/envoyproxy/gateway v1.1.0
 	github.com/go-logr/logr v1.4.2
+	github.com/google/cel-go v0.21.0
 	github.com/google/go-cmp v0.6.0
 	github.com/kuadrant/authorino v0.20.0
 	github.com/kuadrant/authorino-operator v0.11.1
@@ -38,6 +39,7 @@ require (
 )
 
 require (
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -73,6 +75,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/telepresenceio/watchable v0.0.0-20220726211108-9bb86f92afa7 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
@@ -87,6 +90,7 @@ require (
 	golang.org/x/tools v0.24.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240827150818-7e3bb234dfed // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v0.3.5 h1:rybKppoxBoyv1JiXjzlqE4gdrhB0Xk/us0OW7yDEAl0=
 dario.cat/mergo v0.3.5/go.mod h1:fvkCdyGtdx6UQvuEimZ9mB2dzc2AymrLoRgHC4lz6ec=
+github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
+github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cert-manager/cert-manager v1.16.2 h1:c9UU2E+8XWGruyvC/mdpc1wuLddtgmNr8foKdP7a8Jg=
@@ -46,6 +48,8 @@ github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/cel-go v0.21.0 h1:cl6uW/gxN+Hy50tNYvI691+sXxioCnstFzLp2WO4GCI=
+github.com/google/cel-go v0.21.0/go.mod h1:rHUlWCcBKgyEk+eV03RPdZUekPp6YcJwV0FxuUksYxc=
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -122,9 +126,16 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
+github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/telepresenceio/telepresence/rpc/v2 v2.6.8 h1:q5V85LBT9bA/c4YPa/kMvJGyKZDgBPJTftlAMqJx7j4=
@@ -187,7 +198,6 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
 gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
-google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de h1:F6qOa9AZTYJXOUEr4jDysRDLrm4PHePlge4v4TGAlxY=
 google.golang.org/genproto/googleapis/api v0.0.0-20240827150818-7e3bb234dfed h1:3RgNmBoI9MZhsj3QxC+AP/qQhNwpCLOvYDYYsFrhFt0=
 google.golang.org/genproto/googleapis/api v0.0.0-20240827150818-7e3bb234dfed/go.mod h1:OCdP9MfskevB/rbYvHTsXTtKC+3bHWajPdoKgjcYkfo=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 h1:pPJltXNxVzT4pK9yD8vR9X75DaWYYmLGMsEvBfFQZzQ=

--- a/internal/cel/transformer.go
+++ b/internal/cel/transformer.go
@@ -45,12 +45,8 @@ func TransformCounterVariable(expression string) (*string, error) {
 			}
 		} else if expr.Kind() == ast.CallKind {
 			call := expr.AsCall()
-			if call.FunctionName() == "_[_]" {
-				stack.push(call.Args()[0])
-			} else {
-				for _, arg := range call.Args() {
-					stack.push(arg)
-				}
+			for _, arg := range call.Args() {
+				stack.push(arg)
 			}
 		} else if expr.Kind() == ast.SelectKind {
 			stack.push(expr.AsSelect().Operand())

--- a/internal/cel/transformer.go
+++ b/internal/cel/transformer.go
@@ -3,6 +3,7 @@ package transformer
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/google/cel-go/common"
@@ -25,6 +26,7 @@ func parseExpression(expression string) (*ast.AST, error) {
 }
 
 func TransformCounterVariable(expression string) (*string, error) {
+	knownAttributes := []string{"request", "source", "destination", "connection", "metadata", "filter_state", "auth", "ratelimit"}
 	var err error
 	var p *ast.AST
 	if p, err = parseExpression(expression); err != nil {
@@ -38,7 +40,7 @@ func TransformCounterVariable(expression string) (*string, error) {
 
 	for next := stack.pop(); next != nil; next = stack.pop() {
 		expr := *next
-		if expr.Kind() == ast.IdentKind && expr.AsIdent() != "descriptors" {
+		if expr.Kind() == ast.IdentKind && slices.Contains(knownAttributes, expr.AsIdent()) {
 			if decls[expr.AsIdent()] == nil {
 				if offset, found := p.SourceInfo().GetOffsetRange(expr.ID()); found {
 					toReplace = append(toReplace, offset)

--- a/internal/cel/transformer.go
+++ b/internal/cel/transformer.go
@@ -19,7 +19,7 @@ func parseExpression(expression string) (*ast.AST, error) {
 
 	p, iss := prsr.Parse(common.NewTextSource(expression))
 	if len(iss.GetErrors()) > 0 {
-		return nil, errors.New("got errors parsing")
+		return nil, errors.New(iss.ToDisplayString())
 	}
 
 	return p, nil

--- a/internal/cel/transformer.go
+++ b/internal/cel/transformer.go
@@ -1,0 +1,45 @@
+package transformer
+
+import (
+	"errors"
+
+	//"github.com/google/cel-go/checker/decls"
+	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/ast"
+	//"github.com/google/cel-go/common/types/ref"
+	//"github.com/google/cel-go/ext"
+	"github.com/google/cel-go/parser"
+)
+
+func parseExpression(expression string) (*ast.AST, error) {
+	prsr, err := parser.NewParser()
+	if err != nil {
+		return nil, err
+	}
+
+	p, iss := prsr.Parse(common.NewTextSource(expression))
+	if len(iss.GetErrors()) > 0 {
+		return nil, errors.New("got errors parsing")
+	}
+
+	return p, nil
+}
+
+func SafeToSimplyPrefix(expression string) bool {
+	if p, err := parseExpression(expression); err != nil {
+		return false
+	} else {
+		expr := p.Expr()
+		for {
+			if expr.Kind() == ast.IdentKind && expr.AsIdent() != "descriptors" {
+				return true
+			} else if expr.Kind() == ast.CallKind && len(expr.AsCall().Args()) == 2 && expr.AsCall().FunctionName() == "_[_]" {
+				expr = expr.AsCall().Args()[0]
+			} else if expr.Kind() == ast.SelectKind {
+				expr = expr.AsSelect().Operand()
+			} else {
+				return false
+			}
+		}
+	}
+}

--- a/internal/cel/transformer.go
+++ b/internal/cel/transformer.go
@@ -63,7 +63,6 @@ func TransformCounterVariable(expression string) (*string, error) {
 					stack.push(mapEntry.Key())
 					stack.push(mapEntry.Value())
 				}
-
 			}
 		}
 

--- a/internal/cel/transformer_test.go
+++ b/internal/cel/transformer_test.go
@@ -1,0 +1,26 @@
+package transformer
+
+import (
+	"testing"
+)
+
+func TestSafeToPrefix(t *testing.T) {
+	if !SafeToSimplyPrefix("foobar") {
+		t.Errorf("Should be safe to simply prefix")
+	}
+	if !SafeToSimplyPrefix("foobar[0]['foo'].bar") {
+		t.Errorf("Should be safe to simply prefix")
+	}
+	if SafeToSimplyPrefix("descriptors") {
+		t.Errorf("Should not be safe to simply prefix")
+	}
+	if SafeToSimplyPrefix("descriptors[0]['foo'].bar") {
+		t.Errorf("Should not be safe to simply prefix")
+	}
+	if SafeToSimplyPrefix("!foobar") {
+		t.Errorf("Should not be safe to simply prefix")
+	}
+	if SafeToSimplyPrefix("foobar(foo, bar)") {
+		t.Errorf("Should not be safe to simply prefix")
+	}
+}

--- a/internal/cel/transformer_test.go
+++ b/internal/cel/transformer_test.go
@@ -90,3 +90,9 @@ descriptors[0].test: descriptors[0].other.thingy,
 		}
 	}
 }
+
+func TestTransformErrsOutOnBadSyntax(t *testing.T) {
+	if exp, err := TransformCounterVariable("[foobar"); err == nil {
+		t.Errorf(`We expected to fail here! But got "%s"`, *exp)
+	}
+}

--- a/internal/cel/transformer_test.go
+++ b/internal/cel/transformer_test.go
@@ -47,3 +47,46 @@ func TestTransformWithComplexReplaces(t *testing.T) {
 		}
 	}
 }
+
+func TestTransformWithListReplaces(t *testing.T) {
+	exp := `[test, other.thingy, "foo", foo(descriptors[0].test)]`
+	if out, err := TransformCounterVariable(exp); err != nil {
+		t.Errorf(`err: %v`, err)
+	} else {
+		if *out != `[descriptors[0].test, descriptors[0].other.thingy, "foo", foo(descriptors[0].test)]` {
+			t.Errorf(`Not transformed as expected: %s`, *out)
+		}
+	}
+}
+
+func TestTransformWithMapReplaces(t *testing.T) {
+	exp := `{test: other.thingy, "foo": foo(descriptors[0].test)}`
+	if out, err := TransformCounterVariable(exp); err != nil {
+		t.Errorf(`err: %v`, err)
+	} else {
+		if *out != `{descriptors[0].test: descriptors[0].other.thingy, "foo": foo(descriptors[0].test)}` {
+			t.Errorf(`Not transformed as expected: %s`, *out)
+		}
+	}
+}
+
+func TestTransformMultiLines(t *testing.T) {
+	exp := `{
+test: other.thingy, 
+"foo": foo(descriptors[0].test),
+"bar": [test, other.thingy, "foo", foo(descriptors[0].test)],
+}
+`
+	if out, err := TransformCounterVariable(exp); err != nil {
+		t.Errorf(`err: %v`, err)
+	} else {
+		if *out != `{
+descriptors[0].test: descriptors[0].other.thingy, 
+"foo": foo(descriptors[0].test),
+"bar": [descriptors[0].test, descriptors[0].other.thingy, "foo", foo(descriptors[0].test)],
+}
+` {
+			t.Errorf(`Not transformed as expected: %s`, *out)
+		}
+	}
+}

--- a/internal/cel/transformer_test.go
+++ b/internal/cel/transformer_test.go
@@ -5,22 +5,22 @@ import (
 )
 
 func TestTransformNoReplaces(t *testing.T) {
-	exp := "foobar('test', 'otherthingy')"
+	exp := "foobar('auth', 'request')"
 	if out, err := TransformCounterVariable(exp); err != nil {
 		t.Errorf(`err: %v`, err)
 	} else {
-		if *out != `foobar('test', 'otherthingy')` {
+		if *out != `foobar('auth', 'request')` {
 			t.Errorf(`This must not be transformed: %s`, *out)
 		}
 	}
 }
 
 func TestTransformWithStraightReplaces(t *testing.T) {
-	exp := `test`
+	exp := `request`
 	if out, err := TransformCounterVariable(exp); err != nil {
 		t.Errorf(`err: %v`, err)
 	} else {
-		if *out != `descriptors[0].test` {
+		if *out != `descriptors[0].request` {
 			t.Errorf(`Not transformed as expected: %s`, *out)
 		}
 	}
@@ -38,44 +38,44 @@ func TestTransformNoRecursiveReplaces(t *testing.T) {
 }
 
 func TestTransformWithComplexReplaces(t *testing.T) {
-	exp := `foobar(test, other.thingy, "foo") + foo(descriptors[0].test)`
+	exp := `foobar(request, auth.thingy, "foo") + foo(descriptors[0].test)`
 	if out, err := TransformCounterVariable(exp); err != nil {
 		t.Errorf(`err: %v`, err)
 	} else {
-		if *out != `foobar(descriptors[0].test, descriptors[0].other.thingy, "foo") + foo(descriptors[0].test)` {
+		if *out != `foobar(descriptors[0].request, descriptors[0].auth.thingy, "foo") + foo(descriptors[0].test)` {
 			t.Errorf(`Not transformed as expected: %s`, *out)
 		}
 	}
 }
 
 func TestTransformWithListReplaces(t *testing.T) {
-	exp := `[test, other.thingy, "foo", foo(descriptors[0].test)]`
+	exp := `[source, destination.thingy, "foo", foo(descriptors[0].test)]`
 	if out, err := TransformCounterVariable(exp); err != nil {
 		t.Errorf(`err: %v`, err)
 	} else {
-		if *out != `[descriptors[0].test, descriptors[0].other.thingy, "foo", foo(descriptors[0].test)]` {
+		if *out != `[descriptors[0].source, descriptors[0].destination.thingy, "foo", foo(descriptors[0].test)]` {
 			t.Errorf(`Not transformed as expected: %s`, *out)
 		}
 	}
 }
 
 func TestTransformWithMapReplaces(t *testing.T) {
-	exp := `{test: other.thingy, "foo": foo(descriptors[0].test)}`
+	exp := `{test: source.thingy, "foo": foo(descriptors[0].test)}`
 	if out, err := TransformCounterVariable(exp); err != nil {
 		t.Errorf(`err: %v`, err)
 	} else {
-		if *out != `{descriptors[0].test: descriptors[0].other.thingy, "foo": foo(descriptors[0].test)}` {
+		if *out != `{test: descriptors[0].source.thingy, "foo": foo(descriptors[0].test)}` {
 			t.Errorf(`Not transformed as expected: %s`, *out)
 		}
 	}
 }
 
 func TestTransformWithMapLookupReplaces(t *testing.T) {
-	exp := `other[thingy]`
+	exp := `source[destination.thingy]`
 	if out, err := TransformCounterVariable(exp); err != nil {
 		t.Errorf(`err: %v`, err)
 	} else {
-		if *out != `descriptors[0].other[descriptors[0].thingy]` {
+		if *out != `descriptors[0].source[descriptors[0].destination.thingy]` {
 			t.Errorf(`Not transformed as expected: %s`, *out)
 		}
 	}
@@ -83,18 +83,18 @@ func TestTransformWithMapLookupReplaces(t *testing.T) {
 
 func TestTransformMultiLines(t *testing.T) {
 	exp := `{
-test: other.thingy, 
+source: request.thingy, 
 "foo": foo(descriptors[0].test),
-"bar": [test, other.thingy, "foo", foo(descriptors[0].test)],
+"bar": [request, other.thingy, "foo", foo(descriptors[0].test)],
 }
 `
 	if out, err := TransformCounterVariable(exp); err != nil {
 		t.Errorf(`err: %v`, err)
 	} else {
 		if *out != `{
-descriptors[0].test: descriptors[0].other.thingy, 
+descriptors[0].source: descriptors[0].request.thingy, 
 "foo": foo(descriptors[0].test),
-"bar": [descriptors[0].test, descriptors[0].other.thingy, "foo", foo(descriptors[0].test)],
+"bar": [descriptors[0].request, other.thingy, "foo", foo(descriptors[0].test)],
 }
 ` {
 			t.Errorf(`Not transformed as expected: %s`, *out)

--- a/internal/cel/transformer_test.go
+++ b/internal/cel/transformer_test.go
@@ -70,6 +70,17 @@ func TestTransformWithMapReplaces(t *testing.T) {
 	}
 }
 
+func TestTransformWithMapLookupReplaces(t *testing.T) {
+	exp := `other[thingy]`
+	if out, err := TransformCounterVariable(exp); err != nil {
+		t.Errorf(`err: %v`, err)
+	} else {
+		if *out != `descriptors[0].other[descriptors[0].thingy]` {
+			t.Errorf(`Not transformed as expected: %s`, *out)
+		}
+	}
+}
+
 func TestTransformMultiLines(t *testing.T) {
 	exp := `{
 test: other.thingy, 


### PR DESCRIPTION
~~Tho, that fix isn't really correct. We should parse the expression and apply an AST transformation that has all "root `ident`s" be accessed through `descriptors[0]` instead.~~


~~This would "fix" variables/counter qualifiers such as `user.id`, prefixing with `descriptors[0].`...
But e.g. "real" expressions, e.g. `"foo/" + user.id` would just fail completely. So I guess that's _not_ good. I don't know that we really documented these tho, but we need to properly transform the AST to make this "correct".~~

update: As of 9c451e8, this was actually doing the proper thing and using the AST to do the rewrite