### PR TITLE
revert RateLimit.Conditions need explicit scope from #1145

### DIFF
--- a/internal/controller/limitador_limits_reconciler.go
+++ b/internal/controller/limitador_limits_reconciler.go
@@ -124,7 +124,7 @@ func (r *LimitadorLimitsReconciler) buildLimitadorLimits(ctx context.Context, st
 					Namespace:  limitsNamespace,
 					MaxValue:   maxValue,
 					Seconds:    seconds,
-					Conditions: []string{fmt.Sprintf("descriptors[0][\"%s\"] == \"1\"", limitIdentifier)},
+					Conditions: []string{fmt.Sprintf("%s == \"1\"", limitIdentifier)},
 					Variables:  utils.GetEmptySliceIfNil(limit.CountersAsStringList()),
 				}
 			})

--- a/internal/ratelimit/index_test.go
+++ b/internal/ratelimit/index_test.go
@@ -140,49 +140,49 @@ func TestIndexToRateLimits(t *testing.T) {
 
 func TestEqualsTo(t *testing.T) {
 	global_l0 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l0",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l1 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l1",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l2 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l2",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l3 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l3",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l4 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l4",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l5 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
+		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l5",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l6 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
+		Conditions: []string{"limit._httproute_level__ac417cac == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l6",
 		Seconds:    10,
@@ -190,21 +190,21 @@ func TestEqualsTo(t *testing.T) {
 	}
 
 	httproute_l0 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._httproute_level__ac417cac\"] == \"1\""},
+		Conditions: []string{"limit._httproute_level__e4abd750 == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l0",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	httproute_l1 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._httproute_level__e4abd750\"] == \"1\""},
+		Conditions: []string{"limit._httproute_level__e4abd750 == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l1",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	httproute_l5 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"descriptors[0][\"limit._httproute_level__e1d71177\"] == \"1\""},
+		Conditions: []string{"limit._httproute_level__e1d71177 == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l5",
 		Seconds:    10,

--- a/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
+++ b/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
@@ -266,7 +266,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					MaxValue:   1,
 					Seconds:    3 * 60,
 					Namespace:  controllers.LimitsNamespaceFromRoute(httpRoute),
-					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
+					Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
 					Variables:  []string{},
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -339,7 +339,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					MaxValue:   1,
 					Seconds:    3 * 60,
 					Namespace:  controllers.LimitsNamespaceFromRoute(httpRoute),
-					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
+					Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
 					Variables:  []string{},
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -421,7 +421,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					MaxValue:   10,
 					Seconds:    5,
 					Namespace:  controllers.LimitsNamespaceFromRoute(httpRoute),
-					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "l1"))},
+					Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "l1"))},
 					Variables:  []string{},
 				})).WithContext(ctx).Should(Succeed())
 			})
@@ -520,7 +520,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 
@@ -532,7 +532,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
@@ -557,7 +557,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  controllers.LimitsNamespaceFromRoute(httpRoute),
-				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
@@ -588,7 +588,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 
@@ -610,7 +610,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
@@ -637,7 +637,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 
@@ -659,7 +659,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
+				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
@@ -851,28 +851,28 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					MaxValue:   1000,
 					Seconds:    1,
 					Namespace:  controllers.LimitsNamespaceFromRoute(targetedRoute),
-					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, limitIdentifierGwA)},
+					Conditions: []string{fmt.Sprintf(`%s == "1"`, limitIdentifierGwA)},
 					Variables:  []string{},
 				},
 				limitadorv1alpha1.RateLimit{
 					MaxValue:   100,
 					Seconds:    1,
 					Namespace:  controllers.LimitsNamespaceFromRoute(targetedRoute),
-					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, limitIdentifierGwB)},
+					Conditions: []string{fmt.Sprintf(`%s == "1"`, limitIdentifierGwB)},
 					Variables:  []string{},
 				},
 				limitadorv1alpha1.RateLimit{ // FIXME(@guicassolato): we need to create one limit definition per gateway × route combination, not one per gateway × policy combination
 					MaxValue:   1000,
 					Seconds:    1,
 					Namespace:  controllers.LimitsNamespaceFromRoute(untargetedRoute),
-					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, limitIdentifierGwA)},
+					Conditions: []string{fmt.Sprintf(`%s == "1"`, limitIdentifierGwA)},
 					Variables:  []string{},
 				},
 				limitadorv1alpha1.RateLimit{
 					MaxValue:   100,
 					Seconds:    1,
 					Namespace:  controllers.LimitsNamespaceFromRoute(untargetedRoute),
-					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, limitIdentifierGwB)},
+					Conditions: []string{fmt.Sprintf(`%s == "1"`, limitIdentifierGwB)},
 					Variables:  []string{},
 				},
 			)).WithContext(ctx).Should(Succeed())


### PR DESCRIPTION
Reverting the following commit from #1145 
```
commit 42d065f2881b341c0d4123de292eb19e0d150f37
Author: Alex Snaps <alex@wcgw.dev>
Date:   Wed Jan 29 13:28:50 2025 -0500

    RateLimit.Conditions need explicit scope

    With Limitador v2.0, conditions need to specify where the variables
    are to be looked up. Variables coming from the envoy RLP are populated
    in the  root binding. While the protocol allows for
    multiple descriptors (each with multiple entries), the wasm-shim will
    only ever use the first one, i.e. index 0.
``