### PR TITLE
Prepare release 1.1.0

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -108,14 +108,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.1.0-rc2
-    createdAt: "2025-03-27T12:36:35Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.1.0
+    createdAt: "2025-03-31T12:24:45Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.1.0-rc2
+  name: kuadrant-operator.v1.1.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -455,7 +455,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.1.0-rc2
+                image: quay.io/kuadrant/kuadrant-operator:v1.1.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -561,4 +561,4 @@ spec:
     name: wasmshim
   - image: quay.io/kuadrant/console-plugin:v0.1.0
     name: consoleplugin
-  version: 1.1.0-rc2
+  version: 1.1.0

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.1.0-rc2"
-appVersion: "1.1.0-rc2"
+version: "1.1.0"
+appVersion: "1.1.0"
 dependencies:
   - name: authorino-operator
     version: 0.18.0

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -9452,7 +9452,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.1.0-rc2
+        image: quay.io/kuadrant/kuadrant-operator:v1.1.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.1.0-rc2
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.1.0
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.1.0-rc2
+  newTag: v1.1.0

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -5,13 +5,13 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.1.0-rc2
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.1.0
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.1.0-rc2
+  name: kuadrant-operator.v1.1.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -87,4 +87,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.1.0-rc2
+  version: 1.1.0

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.1.0-rc2"
+  version: "1.1.0"
 olm:
   channels:
     - "stable"


### PR DESCRIPTION
The following release candidate of Kuadrant Operator version 1.1.0 includes:
  * Authorino Operator version 0.18.0
  * Console Plugin version 0.1.0
  * DNS Operator version 0.13.0
  * Limitador Operator version 0.13.1
  * WASM Shim version 0.9.0
