### PR TITLE
Extensions OOP Logging

### DIFF
--- a/internal/extension/oop.go
+++ b/internal/extension/oop.go
@@ -97,7 +97,7 @@ func (p *OOPExtension) Start() error {
 	go func() {
 		if err := cmd.Wait(); err != nil {
 			close(stopChan)
-			p.logger.Error(err, fmt.Sprintf("Extension %q finished with an error", p.name))
+			p.logStderr(1, fmt.Sprintf("Extension %q finished with an error", p.name), err)
 		}
 	}()
 
@@ -188,13 +188,14 @@ func (p *OOPExtension) monitorStderr(stderr io.ReadCloser, stopChan <-chan struc
 			// If the channel has been closed when the cmd has exited, we return
 			return
 		default:
+			//nolint:revive,staticcheck
 			if !lastReadTime.IsZero() && time.Since(lastReadTime) > 30*time.Second {
 				// We could check for liveness here
 			}
 
 			if scanner.Scan() {
-				// Call StderrParser, for now just logging as INFO
-				p.logger.Info(scanner.Text())
+				lvl, text, err := parseStderr(scanner.Bytes())
+				p.logStderr(lvl, text, err)
 				lastReadTime = time.Now()
 			} else if err := scanner.Err(); err != nil {
 				p.logger.Error(err, "failed to read stderr")
@@ -204,4 +205,33 @@ func (p *OOPExtension) monitorStderr(stderr io.ReadCloser, stopChan <-chan struc
 			// If this turns out to be causing busy-waiting/CPU spikes we could sleep for a brief time
 		}
 	}
+}
+
+func (p *OOPExtension) logStderr(logLevel int, logString string, err error) {
+	switch logLevel {
+	case 0:
+		p.logger.Info(logString)
+	default:
+		p.logger.Error(err, logString)
+	}
+}
+
+func parseStderr(logLine []byte) (logLevel int, logString string, err error) {
+	if len(logLine) == 0 {
+		return 1, "", fmt.Errorf("input byte slice is empty")
+	}
+
+	// Convert first byte to integer and validate log range
+	logLevel = int(logLine[0])
+	if logLevel < 0 || logLevel > 1 {
+		// At the moment only differencing from Info and Error
+		return 1, "", fmt.Errorf("first byte value %d is not a valid log level range 0-1", logLevel)
+	}
+
+	// Convert rest to string (if exists)
+	if len(logLine) > 1 {
+		logString = string(logLine[1:])
+	}
+
+	return logLevel, logString, nil
 }

--- a/internal/extension/oop_test.go
+++ b/internal/extension/oop_test.go
@@ -17,10 +17,13 @@ limitations under the License.
 package extension
 
 import (
-	"github.com/go-logr/logr/funcr"
-	"gotest.tools/assert"
 	"strings"
 	"testing"
+
+	"github.com/samber/lo"
+
+	"github.com/go-logr/logr/funcr"
+	"gotest.tools/assert"
 
 	"github.com/go-logr/logr"
 )
@@ -76,7 +79,7 @@ func TestOOPExtensionForwardsLog(t *testing.T) {
 
 	_ = oopErrorLog.Stop()
 
-	errorMsg := messages[2]
-	assert.Assert(t, strings.Contains(errorMsg, "error from extension \\\"testErrorLog\\\""))
-	assert.Assert(t, strings.Contains(strings.ToLower(errorMsg), "usage:"))
+	logAsString := strings.Join(messages, "\n")
+	assert.Assert(t, lo.Contains(messages, "\"msg\"=\"Extension \\\"testErrorLog\\\" finished with an error\" \"error\"=\"exit status 1\""))
+	assert.Assert(t, strings.Contains(strings.ToLower(logAsString), "usage"))
 }

--- a/internal/extension/oop_test.go
+++ b/internal/extension/oop_test.go
@@ -87,22 +87,22 @@ func TestOOPExtensionForwardsLog(t *testing.T) {
 
 func TestOOPExtensionParseStderr(t *testing.T) {
 	lvl, text, err := parseStderr(append([]byte{0}, []byte("Info")...))
-	assert.Equal(t, lvl, 0)
+	assert.Equal(t, lvl, LogLevelInfo)
 	assert.Equal(t, text, "Info")
 	assert.Equal(t, err, nil)
 
 	lvl, text, err = parseStderr(append([]byte{1}, []byte("Error")...))
-	assert.Equal(t, lvl, 1)
+	assert.Equal(t, lvl, LogLevelError)
 	assert.Equal(t, text, "Error")
 	assert.Equal(t, err, nil)
 
 	lvl, text, err = parseStderr(append([]byte{5}, []byte("not valid log level")...))
-	assert.Equal(t, lvl, 1)
+	assert.Equal(t, lvl, LogLevelError)
 	assert.Equal(t, text, "")
 	assert.Error(t, err, "first byte is not a valid log level range 0-1. log: \"\\x05not valid log level\"")
 
 	lvl, text, err = parseStderr([]byte{})
-	assert.Equal(t, lvl, 1)
+	assert.Equal(t, lvl, LogLevelError)
 	assert.Equal(t, text, "")
 	assert.Error(t, err, "input byte slice is empty")
 }

--- a/internal/extension/oop_test.go
+++ b/internal/extension/oop_test.go
@@ -81,5 +81,27 @@ func TestOOPExtensionForwardsLog(t *testing.T) {
 
 	logAsString := strings.Join(messages, "\n")
 	assert.Assert(t, lo.Contains(messages, "\"msg\"=\"Extension \\\"testErrorLog\\\" finished with an error\" \"error\"=\"exit status 1\""))
-	assert.Assert(t, strings.Contains(strings.ToLower(logAsString), "usage"))
+	assert.Assert(t, strings.Contains(strings.ToLower(logAsString), "is not a valid log level range 0-1"))
+}
+
+func TestOOPExtensionParseStderr(t *testing.T) {
+	lvl, text, err := parseStderr(append([]byte{0}, []byte("Info")...))
+	assert.Equal(t, lvl, 0)
+	assert.Equal(t, text, "Info")
+	assert.Equal(t, err, nil)
+
+	lvl, text, err = parseStderr(append([]byte{1}, []byte("Error")...))
+	assert.Equal(t, lvl, 1)
+	assert.Equal(t, text, "Error")
+	assert.Equal(t, err, nil)
+
+	lvl, text, err = parseStderr(append([]byte{5}, []byte("not valid log level")...))
+	assert.Equal(t, lvl, 1)
+	assert.Equal(t, text, "")
+	assert.Error(t, err, "first byte value 5 is not a valid log level range 0-1")
+
+	lvl, text, err = parseStderr([]byte{})
+	assert.Equal(t, lvl, 1)
+	assert.Equal(t, text, "")
+	assert.Error(t, err, "input byte slice is empty")
 }


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/1259

The approach to forwarding logging implemented is using the `Stderr` of the extension and an opinionated parsing of the log lines, deciding on the log level, based on the first `byte`. So far only discerning from `0 -> Info` and `1--> Error`. We could expand on the format and log levels in the future as needed.