### PR TITLE
solution for fatal error when checking CRDs installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ $(HELM):
 	set -e ;\
 	mkdir -p $(dir $(HELM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl https://get.helm.sh/helm-${HELM_VERSION}-$${OS}-$${ARCH}.tar.gz -o helm.tar.gz ;\
+	curl https://get.helm.sh/helm-$(HELM_VERSION)-$${OS}-$${ARCH}.tar.gz -o helm.tar.gz ;\
 	tar -zxvf helm.tar.gz ;\
 	mv $${OS}-$${ARCH}/helm $(HELM) ;\
 	chmod +x $(HELM) ;\

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ $(HELM):
 	set -e ;\
 	mkdir -p $(dir $(HELM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	wget -O helm.tar.gz https://get.helm.sh/helm-$(HELM_VERSION)-$${OS}-$${ARCH}.tar.gz ;\
+	curl https://get.helm.sh/helm-${HELM_VERSION}-$${OS}-$${ARCH}.tar.gz -o helm.tar.gz ;\
 	tar -zxvf helm.tar.gz ;\
 	mv $${OS}-$${ARCH}/helm $(HELM) ;\
 	chmod +x $(HELM) ;\

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -170,7 +170,11 @@ func main() {
 		}
 	}
 
-	stateOfTheWorld := controllers.NewPolicyMachineryController(mgr, client, log.Log)
+	stateOfTheWorld, err := controllers.NewPolicyMachineryController(mgr, client, log.Log)
+	if err != nil {
+		setupLog.Error(err, "unable to setup policy controller")
+		os.Exit(1)
+	}
 	if err = stateOfTheWorld.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "unable to start stateOfTheWorld controller")
 		os.Exit(1)

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -184,31 +184,75 @@ type BootOptionsBuilder struct {
 }
 
 func (b *BootOptionsBuilder) getOptions() ([]controller.ControllerOption, error) {
-	var opts []controller.ControllerOption
-	opts = append(opts, b.getGatewayAPIOptions()...)
-	istioOpts, err := b.getIstioOptions()
-	if err != nil {
-		return opts, err
+	var (
+		opts      []controller.ControllerOption
+		optionErr error
+	)
+
+	gwapiOpts, optionErr := b.getGatewayAPIOptions()
+	if optionErr != nil {
+		return opts, optionErr
+	}
+	opts = append(opts, gwapiOpts...)
+
+	istioOpts, optionErr := b.getIstioOptions()
+	if optionErr != nil {
+		return opts, optionErr
 	}
 	opts = append(opts, istioOpts...)
-	opts = append(opts, b.getEnvoyGatewayOptions()...)
-	opts = append(opts, b.getCertManagerOptions()...)
-	opts = append(opts, b.getConsolePluginOptions()...)
-	opts = append(opts, b.getDNSOperatorOptions()...)
-	opts = append(opts, b.getLimitadorOperatorOptions()...)
-	opts = append(opts, b.getAuthorinoOperatorOptions()...)
-	opts = append(opts, b.getObservabilityOptions()...)
+
+	envoyGatewayOpts, optionErr := b.getEnvoyGatewayOptions()
+	if optionErr != nil {
+		return opts, optionErr
+	}
+	opts = append(opts, envoyGatewayOpts...)
+
+	certManagerOpts, optionErr := b.getCertManagerOptions()
+	if optionErr != nil {
+		return opts, optionErr
+	}
+	opts = append(opts, certManagerOpts...)
+
+	consoleOpts, optionErr := b.getConsolePluginOptions()
+	if optionErr != nil {
+		return opts, optionErr
+	}
+	opts = append(opts, consoleOpts...)
+
+	dnsOpts, optionErr := b.getDNSOperatorOptions()
+	if optionErr != nil {
+		return opts, optionErr
+	}
+	opts = append(opts, dnsOpts...)
+
+	limitadorOpts, optionErr := b.getLimitadorOperatorOptions()
+	if optionErr != nil {
+		return opts, optionErr
+	}
+	opts = append(opts, limitadorOpts...)
+
+	authorinoOpts, optionErr := b.getAuthorinoOperatorOptions()
+	if optionErr != nil {
+		return opts, optionErr
+	}
+	opts = append(opts, authorinoOpts...)
+
+	observabilityOpts, optionErr := b.getObservabilityOptions()
+	if optionErr != nil {
+		return opts, optionErr
+	}
+	opts = append(opts, observabilityOpts...)
 
 	return opts, nil
 }
 
-func (b *BootOptionsBuilder) getGatewayAPIOptions() []controller.ControllerOption {
+func (b *BootOptionsBuilder) getGatewayAPIOptions() ([]controller.ControllerOption, error) {
 	var opts []controller.ControllerOption
 	var err error
 	b.isGatewayAPIInstalled, err = kuadrantgatewayapi.IsGatewayAPIInstalled(b.manager.GetRESTMapper())
 	if err != nil || !b.isGatewayAPIInstalled {
 		b.logger.Info("gateway api is not installed, skipping watches and reconcilers", "err", err)
-		return opts
+		return opts, err
 	}
 
 	opts = append(opts,
@@ -229,18 +273,17 @@ func (b *BootOptionsBuilder) getGatewayAPIOptions() []controller.ControllerOptio
 		)),
 	)
 
-	return opts
+	return opts, nil
 }
 
-func (b *BootOptionsBuilder) getEnvoyGatewayOptions() []controller.ControllerOption {
+func (b *BootOptionsBuilder) getEnvoyGatewayOptions() ([]controller.ControllerOption, error) {
 	var opts []controller.ControllerOption
 	var err error
 	b.isEnvoyGatewayInstalled, err = envoygateway.IsEnvoyGatewayInstalled(b.manager.GetRESTMapper())
 	if err != nil || !b.isEnvoyGatewayInstalled {
 		b.logger.Info("envoygateway is not installed, skipping related watches and reconcilers", "err", err)
-		return opts
+		return opts, err
 	}
-
 	opts = append(opts,
 		controller.WithRunnable("envoypatchpolicy watcher", controller.Watch(
 			&egv1alpha1.EnvoyPatchPolicy{},
@@ -264,17 +307,17 @@ func (b *BootOptionsBuilder) getEnvoyGatewayOptions() []controller.ControllerOpt
 		),
 	)
 
-	return opts
+	return opts, nil
 }
 
 func (b *BootOptionsBuilder) getIstioOptions() ([]controller.ControllerOption, error) {
 	var opts []controller.ControllerOption
 	var err error
 	b.isIstioInstalled, err = istio.IsIstioInstalled(b.manager.GetRESTMapper())
-	if err != nil {
+	if err != nil || !b.isIstioInstalled {
+		b.logger.Info("istio is not installed. skipping related watches and reconcilers", "err", err)
 		return opts, err
 	}
-
 	opts = append(opts,
 		controller.WithRunnable("envoyfilter watcher", controller.Watch(
 			&istioclientnetworkingv1alpha3.EnvoyFilter{},
@@ -309,27 +352,27 @@ func (b *BootOptionsBuilder) getIstioOptions() ([]controller.ControllerOption, e
 	return opts, nil
 }
 
-func (b *BootOptionsBuilder) getCertManagerOptions() []controller.ControllerOption {
+func (b *BootOptionsBuilder) getCertManagerOptions() ([]controller.ControllerOption, error) {
 	var opts []controller.ControllerOption
 	var err error
 	b.isCertManagerInstalled, err = kuadrantgatewayapi.IsCertManagerInstalled(b.manager.GetRESTMapper(), b.logger)
 	if err != nil || !b.isCertManagerInstalled {
 		b.logger.Info("cert manager is not installed, skipping related watches and reconcilers", "err", err)
-		return opts
+		return opts, err
 	}
 
 	opts = append(opts, certManagerControllerOpts()...)
 
-	return opts
+	return opts, nil
 }
 
-func (b *BootOptionsBuilder) getConsolePluginOptions() []controller.ControllerOption {
+func (b *BootOptionsBuilder) getConsolePluginOptions() ([]controller.ControllerOption, error) {
 	var opts []controller.ControllerOption
 	var err error
 	b.isConsolePluginInstalled, err = openshift.IsConsolePluginInstalled(b.manager.GetRESTMapper())
 	if err != nil || !b.isConsolePluginInstalled {
 		b.logger.Info("console plugin is not installed, skipping related watches and reconcilers", "err", err)
-		return opts
+		return opts, err
 	}
 
 	opts = append(opts,
@@ -339,16 +382,16 @@ func (b *BootOptionsBuilder) getConsolePluginOptions() []controller.ControllerOp
 		controller.WithObjectKinds(openshift.ConsolePluginGVK.GroupKind()),
 	)
 
-	return opts
+	return opts, nil
 }
 
-func (b *BootOptionsBuilder) getDNSOperatorOptions() []controller.ControllerOption {
+func (b *BootOptionsBuilder) getDNSOperatorOptions() ([]controller.ControllerOption, error) {
 	var opts []controller.ControllerOption
 	var err error
 	b.isDNSOperatorInstalled, err = utils.IsCRDInstalled(b.manager.GetRESTMapper(), DNSRecordGroupKind.Group, DNSRecordGroupKind.Kind, kuadrantdnsv1alpha1.GroupVersion.Version)
 	if err != nil || !b.isDNSOperatorInstalled {
 		b.logger.Info("dns operator is not installed, skipping related watches and reconcilers", "err", err)
-		return opts
+		return opts, err
 	}
 
 	opts = append(opts,
@@ -364,16 +407,16 @@ func (b *BootOptionsBuilder) getDNSOperatorOptions() []controller.ControllerOpti
 		),
 	)
 
-	return opts
+	return opts, nil
 }
 
-func (b *BootOptionsBuilder) getLimitadorOperatorOptions() []controller.ControllerOption {
+func (b *BootOptionsBuilder) getLimitadorOperatorOptions() ([]controller.ControllerOption, error) {
 	var opts []controller.ControllerOption
 	var err error
 	b.isLimitadorOperatorInstalled, err = utils.IsCRDInstalled(b.manager.GetRESTMapper(), kuadrantv1beta1.LimitadorGroupKind.Group, kuadrantv1beta1.LimitadorGroupKind.Kind, limitadorv1alpha1.GroupVersion.Version)
 	if err != nil || !b.isLimitadorOperatorInstalled {
 		b.logger.Info("limitador operator is not installed, skipping related watches and reconcilers", "err", err)
-		return opts
+		return opts, err
 	}
 
 	opts = append(opts,
@@ -391,16 +434,16 @@ func (b *BootOptionsBuilder) getLimitadorOperatorOptions() []controller.Controll
 		),
 	)
 
-	return opts
+	return opts, nil
 }
 
-func (b *BootOptionsBuilder) getAuthorinoOperatorOptions() []controller.ControllerOption {
+func (b *BootOptionsBuilder) getAuthorinoOperatorOptions() ([]controller.ControllerOption, error) {
 	var opts []controller.ControllerOption
 	var err error
 	b.isAuthorinoOperatorInstalled, err = authorino.IsAuthorinoOperatorInstalled(b.manager.GetRESTMapper(), b.logger)
 	if err != nil || !b.isAuthorinoOperatorInstalled {
 		b.logger.Info("authorino operator is not installed, skipping related watches and reconcilers", "err", err)
-		return opts
+		return opts, err
 	}
 
 	opts = append(opts,
@@ -425,22 +468,22 @@ func (b *BootOptionsBuilder) getAuthorinoOperatorOptions() []controller.Controll
 		),
 	)
 
-	return opts
+	return opts, nil
 }
 
-func (b *BootOptionsBuilder) getObservabilityOptions() []controller.ControllerOption {
+func (b *BootOptionsBuilder) getObservabilityOptions() ([]controller.ControllerOption, error) {
 	var opts []controller.ControllerOption
 	var err error
 
 	b.isPrometheusOperatorInstalled, err = utils.IsCRDInstalled(b.manager.GetRESTMapper(), monitoringv1.SchemeGroupVersion.Group, monitoringv1.ServiceMonitorsKind, monitoringv1.SchemeGroupVersion.Version)
 	if err != nil || !b.isPrometheusOperatorInstalled {
 		b.logger.Info("prometheus operator is not installed (ServiceMonitor CRD not found), skipping related watches and reconcilers", "err", err)
-		return opts
+		return opts, err
 	}
 	b.isPrometheusOperatorInstalled, err = utils.IsCRDInstalled(b.manager.GetRESTMapper(), monitoringv1.SchemeGroupVersion.Group, monitoringv1.PodMonitorsKind, monitoringv1.SchemeGroupVersion.Version)
 	if err != nil || !b.isPrometheusOperatorInstalled {
 		b.logger.Info("prometheus operator is not installed (PodMonitor CRD not found), skipping related watches and reconcilers", "err", err)
-		return opts
+		return opts, err
 	}
 	opts = append(opts,
 		controller.WithRunnable("servicemonitor watcher", controller.Watch(
@@ -465,7 +508,7 @@ func (b *BootOptionsBuilder) getObservabilityOptions() []controller.ControllerOp
 		),
 	)
 
-	return opts
+	return opts, nil
 }
 
 func (b *BootOptionsBuilder) isGatewayProviderInstalled() bool {

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -250,9 +250,12 @@ func (b *BootOptionsBuilder) getGatewayAPIOptions() ([]controller.ControllerOpti
 	var opts []controller.ControllerOption
 	var err error
 	b.isGatewayAPIInstalled, err = kuadrantgatewayapi.IsGatewayAPIInstalled(b.manager.GetRESTMapper())
-	if err != nil || !b.isGatewayAPIInstalled {
-		b.logger.Info("gateway api is not installed, skipping watches and reconcilers", "err", err)
-		return opts, err
+	if err != nil {
+		return nil, err
+	}
+	if !b.isGatewayAPIInstalled {
+		b.logger.Info("gateway api is not installed, skipping watches and reconcilers")
+		return opts, nil
 	}
 
 	opts = append(opts,
@@ -280,9 +283,12 @@ func (b *BootOptionsBuilder) getEnvoyGatewayOptions() ([]controller.ControllerOp
 	var opts []controller.ControllerOption
 	var err error
 	b.isEnvoyGatewayInstalled, err = envoygateway.IsEnvoyGatewayInstalled(b.manager.GetRESTMapper())
-	if err != nil || !b.isEnvoyGatewayInstalled {
-		b.logger.Info("envoygateway is not installed, skipping related watches and reconcilers", "err", err)
-		return opts, err
+	if err != nil {
+		return nil, err
+	}
+	if !b.isEnvoyGatewayInstalled {
+		b.logger.Info("envoygateway is not installed, skipping related watches and reconcilers")
+		return opts, nil
 	}
 	opts = append(opts,
 		controller.WithRunnable("envoypatchpolicy watcher", controller.Watch(
@@ -314,9 +320,12 @@ func (b *BootOptionsBuilder) getIstioOptions() ([]controller.ControllerOption, e
 	var opts []controller.ControllerOption
 	var err error
 	b.isIstioInstalled, err = istio.IsIstioInstalled(b.manager.GetRESTMapper())
-	if err != nil || !b.isIstioInstalled {
-		b.logger.Info("istio is not installed. skipping related watches and reconcilers", "err", err)
-		return opts, err
+	if err != nil {
+		return nil, err
+	}
+	if !b.isIstioInstalled {
+		b.logger.Info("istio is not installed. skipping related watches and reconcilers")
+		return opts, nil
 	}
 	opts = append(opts,
 		controller.WithRunnable("envoyfilter watcher", controller.Watch(
@@ -356,9 +365,12 @@ func (b *BootOptionsBuilder) getCertManagerOptions() ([]controller.ControllerOpt
 	var opts []controller.ControllerOption
 	var err error
 	b.isCertManagerInstalled, err = kuadrantgatewayapi.IsCertManagerInstalled(b.manager.GetRESTMapper(), b.logger)
-	if err != nil || !b.isCertManagerInstalled {
-		b.logger.Info("cert manager is not installed, skipping related watches and reconcilers", "err", err)
-		return opts, err
+	if err != nil {
+		return nil, err
+	}
+	if !b.isCertManagerInstalled {
+		b.logger.Info("cert manager is not installed, skipping related watches and reconcilers")
+		return opts, nil
 	}
 
 	opts = append(opts, certManagerControllerOpts()...)
@@ -370,9 +382,12 @@ func (b *BootOptionsBuilder) getConsolePluginOptions() ([]controller.ControllerO
 	var opts []controller.ControllerOption
 	var err error
 	b.isConsolePluginInstalled, err = openshift.IsConsolePluginInstalled(b.manager.GetRESTMapper())
-	if err != nil || !b.isConsolePluginInstalled {
-		b.logger.Info("console plugin is not installed, skipping related watches and reconcilers", "err", err)
-		return opts, err
+	if err != nil {
+		return nil, err
+	}
+	if !b.isConsolePluginInstalled {
+		b.logger.Info("console plugin is not installed, skipping related watches and reconcilers")
+		return opts, nil
 	}
 
 	opts = append(opts,
@@ -389,9 +404,12 @@ func (b *BootOptionsBuilder) getDNSOperatorOptions() ([]controller.ControllerOpt
 	var opts []controller.ControllerOption
 	var err error
 	b.isDNSOperatorInstalled, err = utils.IsCRDInstalled(b.manager.GetRESTMapper(), DNSRecordGroupKind.Group, DNSRecordGroupKind.Kind, kuadrantdnsv1alpha1.GroupVersion.Version)
-	if err != nil || !b.isDNSOperatorInstalled {
-		b.logger.Info("dns operator is not installed, skipping related watches and reconcilers", "err", err)
-		return opts, err
+	if err != nil {
+		return nil, err
+	}
+	if !b.isDNSOperatorInstalled {
+		b.logger.Info("dns operator is not installed, skipping related watches and reconcilers")
+		return opts, nil
 	}
 
 	opts = append(opts,
@@ -414,9 +432,12 @@ func (b *BootOptionsBuilder) getLimitadorOperatorOptions() ([]controller.Control
 	var opts []controller.ControllerOption
 	var err error
 	b.isLimitadorOperatorInstalled, err = utils.IsCRDInstalled(b.manager.GetRESTMapper(), kuadrantv1beta1.LimitadorGroupKind.Group, kuadrantv1beta1.LimitadorGroupKind.Kind, limitadorv1alpha1.GroupVersion.Version)
-	if err != nil || !b.isLimitadorOperatorInstalled {
-		b.logger.Info("limitador operator is not installed, skipping related watches and reconcilers", "err", err)
-		return opts, err
+	if err != nil {
+		return nil, err
+	}
+	if !b.isLimitadorOperatorInstalled {
+		b.logger.Info("limitador operator is not installed, skipping related watches and reconcilers")
+		return nil, err
 	}
 
 	opts = append(opts,
@@ -441,9 +462,12 @@ func (b *BootOptionsBuilder) getAuthorinoOperatorOptions() ([]controller.Control
 	var opts []controller.ControllerOption
 	var err error
 	b.isAuthorinoOperatorInstalled, err = authorino.IsAuthorinoOperatorInstalled(b.manager.GetRESTMapper(), b.logger)
-	if err != nil || !b.isAuthorinoOperatorInstalled {
-		b.logger.Info("authorino operator is not installed, skipping related watches and reconcilers", "err", err)
-		return opts, err
+	if err != nil {
+		return nil, err
+	}
+	if !b.isAuthorinoOperatorInstalled {
+		b.logger.Info("authorino operator is not installed, skipping related watches and reconcilers")
+		return opts, nil
 	}
 
 	opts = append(opts,
@@ -476,9 +500,12 @@ func (b *BootOptionsBuilder) getObservabilityOptions() ([]controller.ControllerO
 	var err error
 
 	b.isPrometheusOperatorInstalled, err = utils.IsCRDInstalled(b.manager.GetRESTMapper(), monitoringv1.SchemeGroupVersion.Group, monitoringv1.ServiceMonitorsKind, monitoringv1.SchemeGroupVersion.Version)
-	if err != nil || !b.isPrometheusOperatorInstalled {
-		b.logger.Info("prometheus operator is not installed (ServiceMonitor CRD not found), skipping related watches and reconcilers", "err", err)
-		return opts, err
+	if err != nil {
+		return nil, err
+	}
+	if !b.isPrometheusOperatorInstalled {
+		b.logger.Info("prometheus operator is not installed (ServiceMonitor CRD not found), skipping related watches and reconcilers")
+		return opts, nil
 	}
 	b.isPrometheusOperatorInstalled, err = utils.IsCRDInstalled(b.manager.GetRESTMapper(), monitoringv1.SchemeGroupVersion.Group, monitoringv1.PodMonitorsKind, monitoringv1.SchemeGroupVersion.Version)
 	if err != nil || !b.isPrometheusOperatorInstalled {

--- a/internal/controller/test_common.go
+++ b/internal/controller/test_common.go
@@ -63,7 +63,8 @@ func SetupKuadrantOperatorForTest(s *runtime.Scheme, cfg *rest.Config) {
 	dClient, err := dynamic.NewForConfig(mgr.GetConfig())
 	Expect(err).NotTo(HaveOccurred())
 
-	stateOfTheWorld := NewPolicyMachineryController(mgr, dClient, log.Log)
+	stateOfTheWorld, err := NewPolicyMachineryController(mgr, dClient, log.Log)
+	Expect(err).NotTo(HaveOccurred())
 
 	go func() {
 		defer GinkgoRecover()

--- a/internal/istio/utils.go
+++ b/internal/istio/utils.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
@@ -147,7 +146,7 @@ func IsPeerAuthenticationInstalled(restMapper meta.RESTMapper) (bool, error) {
 func IsIstioInstalled(restMapper meta.RESTMapper) (bool, error) {
 	ok, err := IsWASMPluginInstalled(restMapper)
 	if err != nil {
-		return false, client.IgnoreNotFound(err)
+		return false, err
 	}
 	if !ok {
 		return false, nil
@@ -155,7 +154,7 @@ func IsIstioInstalled(restMapper meta.RESTMapper) (bool, error) {
 
 	ok, err = IsEnvoyFilterInstalled(restMapper)
 	if err != nil {
-		return false, client.IgnoreNotFound(err)
+		return false, err
 	}
 	if !ok {
 		return false, nil

--- a/internal/istio/utils.go
+++ b/internal/istio/utils.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
@@ -146,7 +147,7 @@ func IsPeerAuthenticationInstalled(restMapper meta.RESTMapper) (bool, error) {
 func IsIstioInstalled(restMapper meta.RESTMapper) (bool, error) {
 	ok, err := IsWASMPluginInstalled(restMapper)
 	if err != nil {
-		return false, err
+		return false, client.IgnoreNotFound(err)
 	}
 	if !ok {
 		return false, nil
@@ -154,7 +155,7 @@ func IsIstioInstalled(restMapper meta.RESTMapper) (bool, error) {
 
 	ok, err = IsEnvoyFilterInstalled(restMapper)
 	if err != nil {
-		return false, err
+		return false, client.IgnoreNotFound(err)
 	}
 	if !ok {
 		return false, nil


### PR DESCRIPTION
I have updated this now to add an error check now for each options handler. 

Ideally I would be able to test the BootOptionsBuilder and ensure errors are returned. This is proving tricky as we pass a full manager object around. I will work some more to see can I get some form of coverage as a e2e test is not possible as we are looking to hit a connection to the API server error 

@eguzki @guicassolato @Boomatang 