### PR TITLE
Prepare release 1.2.0-rc2

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -108,14 +108,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc1
-    createdAt: "2025-04-08T08:02:47Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc2
+    createdAt: "2025-04-09T14:15:32Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.2.0-rc1
+  name: kuadrant-operator.v1.2.0-rc2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -455,7 +455,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc1
+                image: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -561,4 +561,4 @@ spec:
     name: wasmshim
   - image: quay.io/kuadrant/console-plugin:v0.1.1
     name: consoleplugin
-  version: 1.2.0-rc1
+  version: 1.2.0-rc2

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.2.0-rc1"
-appVersion: "1.2.0-rc1"
+version: "1.2.0-rc2"
+appVersion: "1.2.0-rc2"
 dependencies:
   - name: authorino-operator
     version: 0.18.0

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -9452,7 +9452,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc1
+        image: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0-rc1
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0-rc2
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.2.0-rc1
+  newTag: v1.2.0-rc2

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -5,13 +5,13 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc1
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc2
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.2.0-rc1
+  name: kuadrant-operator.v1.2.0-rc2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -87,4 +87,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.2.0-rc1
+  version: 1.2.0-rc2

--- a/internal/controller/limitador_limits_reconciler.go
+++ b/internal/controller/limitador_limits_reconciler.go
@@ -124,7 +124,7 @@ func (r *LimitadorLimitsReconciler) buildLimitadorLimits(ctx context.Context, st
 					Namespace:  limitsNamespace,
 					MaxValue:   maxValue,
 					Seconds:    seconds,
-					Conditions: []string{fmt.Sprintf("%s == \"1\"", limitIdentifier)},
+					Conditions: []string{fmt.Sprintf("descriptors[0][\"%s\"] == \"1\"", limitIdentifier)},
 					Variables:  utils.GetEmptySliceIfNil(limit.CountersAsStringList()),
 				}
 			})

--- a/internal/ratelimit/index_test.go
+++ b/internal/ratelimit/index_test.go
@@ -140,49 +140,49 @@ func TestIndexToRateLimits(t *testing.T) {
 
 func TestEqualsTo(t *testing.T) {
 	global_l0 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l0",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l1 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l1",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l2 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l2",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l3 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l3",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l4 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l4",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l5 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._global___3f2bfd8b == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l5",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	global_l6 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._httproute_level__ac417cac == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._global___3f2bfd8b\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l6",
 		Seconds:    10,
@@ -190,21 +190,21 @@ func TestEqualsTo(t *testing.T) {
 	}
 
 	httproute_l0 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._httproute_level__e4abd750 == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._httproute_level__ac417cac\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l0",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	httproute_l1 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._httproute_level__e4abd750 == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._httproute_level__e4abd750\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l1",
 		Seconds:    10,
 		Variables:  []string{},
 	}
 	httproute_l5 := limitadorv1alpha1.RateLimit{
-		Conditions: []string{"limit._httproute_level__e1d71177 == \"1\""},
+		Conditions: []string{"descriptors[0][\"limit._httproute_level__e1d71177\"] == \"1\""},
 		MaxValue:   3,
 		Namespace:  "default/test-3-gw0-l5",
 		Seconds:    10,

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.2.0-rc1"
+  version: "1.2.0-rc2"
 olm:
   channels:
     - "alpha"

--- a/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
+++ b/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
@@ -266,7 +266,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					MaxValue:   1,
 					Seconds:    3 * 60,
 					Namespace:  controllers.LimitsNamespaceFromRoute(httpRoute),
-					Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
+					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
 					Variables:  []string{},
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -339,7 +339,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					MaxValue:   1,
 					Seconds:    3 * 60,
 					Namespace:  controllers.LimitsNamespaceFromRoute(httpRoute),
-					Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
+					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(rlpKey, "l1"))},
 					Variables:  []string{},
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -421,7 +421,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					MaxValue:   10,
 					Seconds:    5,
 					Namespace:  controllers.LimitsNamespaceFromRoute(httpRoute),
-					Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "l1"))},
+					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "l1"))},
 					Variables:  []string{},
 				})).WithContext(ctx).Should(Succeed())
 			})
@@ -520,7 +520,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
+				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 
@@ -532,7 +532,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
+				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
@@ -557,7 +557,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  controllers.LimitsNamespaceFromRoute(httpRoute),
-				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
+				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
@@ -588,7 +588,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
+				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 
@@ -610,7 +610,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
+				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
@@ -637,7 +637,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   1,
 				Seconds:    180,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
+				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(gwRLPKey, "l1"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 
@@ -659,7 +659,7 @@ var _ = Describe("RateLimitPolicy controller", func() {
 				MaxValue:   10,
 				Seconds:    5,
 				Namespace:  limitsNamespace,
-				Conditions: []string{fmt.Sprintf(`%s == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
+				Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, controllers.LimitNameToLimitadorIdentifier(routeRLPKey, "route"))},
 				Variables:  []string{},
 			})).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
@@ -851,28 +851,28 @@ var _ = Describe("RateLimitPolicy controller", func() {
 					MaxValue:   1000,
 					Seconds:    1,
 					Namespace:  controllers.LimitsNamespaceFromRoute(targetedRoute),
-					Conditions: []string{fmt.Sprintf(`%s == "1"`, limitIdentifierGwA)},
+					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, limitIdentifierGwA)},
 					Variables:  []string{},
 				},
 				limitadorv1alpha1.RateLimit{
 					MaxValue:   100,
 					Seconds:    1,
 					Namespace:  controllers.LimitsNamespaceFromRoute(targetedRoute),
-					Conditions: []string{fmt.Sprintf(`%s == "1"`, limitIdentifierGwB)},
+					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, limitIdentifierGwB)},
 					Variables:  []string{},
 				},
 				limitadorv1alpha1.RateLimit{ // FIXME(@guicassolato): we need to create one limit definition per gateway × route combination, not one per gateway × policy combination
 					MaxValue:   1000,
 					Seconds:    1,
 					Namespace:  controllers.LimitsNamespaceFromRoute(untargetedRoute),
-					Conditions: []string{fmt.Sprintf(`%s == "1"`, limitIdentifierGwA)},
+					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, limitIdentifierGwA)},
 					Variables:  []string{},
 				},
 				limitadorv1alpha1.RateLimit{
 					MaxValue:   100,
 					Seconds:    1,
 					Namespace:  controllers.LimitsNamespaceFromRoute(untargetedRoute),
-					Conditions: []string{fmt.Sprintf(`%s == "1"`, limitIdentifierGwB)},
+					Conditions: []string{fmt.Sprintf(`descriptors[0]["%s"] == "1"`, limitIdentifierGwB)},
 					Variables:  []string{},
 				},
 			)).WithContext(ctx).Should(Succeed())


### PR DESCRIPTION
The following release candidate of Kuadrant Operator version 1.2.0-rc2 includes:
  * Authorino Operator version 0.18.0
  * Console Plugin version 0.1.1
  * DNS Operator version 0.14.0
  * Limitador Operator version 0.14.0
  * WASM Shim version 0.9.0

