### PR TITLE
fix(#1282): 'simply' look variable up by expression in descriptors[0]

### DIFF
--- a/api/v1/ratelimitpolicy_types.go
+++ b/api/v1/ratelimitpolicy_types.go
@@ -241,7 +241,7 @@ func (l Limit) CountersAsStringList() []string {
 	}
 	return utils.Map(l.Counters, func(counter Counter) string {
 		str := string(counter.Expression)
-		if exp, err := transformer.TransformCounterVariable(str); err != nil {
+		if exp, err := transformer.TransformCounterVariable(str, false); err == nil {
 			return *exp
 		}
 		return str

--- a/api/v1/ratelimitpolicy_types_test.go
+++ b/api/v1/ratelimitpolicy_types_test.go
@@ -6,6 +6,26 @@ import (
 	"testing"
 )
 
+func TestVariablesRewritten(t *testing.T) {
+
+	limit := &Limit{
+		Counters: []Counter{
+			{Expression("auth.identity.username")},
+		},
+	}
+
+	actual := limit.CountersAsStringList()
+	expected := []string{`descriptors[0]["auth.identity.username"]`}
+	if len(actual) != len(expected) {
+		t.Errorf("maxValue does not match, expected(%v), got (%v)", expected, actual)
+	}
+	for i := range actual {
+		if actual[i] != expected[i] {
+			t.Errorf("maxValue does not match, expected(%s), got (%s)", expected[i], actual[i])
+		}
+	}
+}
+
 func TestConvertRateIntoSeconds(t *testing.T) {
 	testCases := []struct {
 		name             string

--- a/internal/cel/transformer.go
+++ b/internal/cel/transformer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
@@ -34,7 +35,11 @@ func parseExpression(expression string) (*ast.AST, error) {
 // anyway. This function does *NOT* try to validate or make any assumption about the expression being otherwise valid.
 // Rather than transforming the AST directly, it only uses the AST to find the `Ident` that need renaming directly in
 // the `expression` passed in. This keeps the resulting expression as close to the input as possible.
-func TransformCounterVariable(expression string) (*string, error) {
+func TransformCounterVariable(expression string, celAstTransform bool) (*string, error) {
+	if !celAstTransform {
+		exp := fmt.Sprintf(`descriptors[0]["%s"]`, strings.TrimSpace(expression))
+		return &exp, nil
+	}
 	knownAttributes := []string{"request", "source", "destination", "connection", "metadata", "filter_state", "auth", "ratelimit"}
 	var err error
 	var p *ast.AST


### PR DESCRIPTION
see #1282 - tho this isn't a complete fix tbh, the issue is mostly related to how we set `Key` [here](https://github.com/Kuadrant/kuadrant-operator/blob/be5cae0e6beeb0cb3aa537fc73c250a7966a95b7/internal/controller/ratelimit_workflow_helpers.go#L230-L233) and is related to this [discussion](https://kuadrant.zulipchat.com/#narrow/channel/493520-Rate-Limiting/topic/Qualified.20counters.20and.20.22variable.20semantics.22)