### PR TITLE
Prepare release 1.2.0-rc3

### DIFF
--- a/api/v1/ratelimitpolicy_types.go
+++ b/api/v1/ratelimitpolicy_types.go
@@ -241,7 +241,7 @@ func (l Limit) CountersAsStringList() []string {
 	}
 	return utils.Map(l.Counters, func(counter Counter) string {
 		str := string(counter.Expression)
-		if exp, err := transformer.TransformCounterVariable(str); err != nil {
+		if exp, err := transformer.TransformCounterVariable(str, false); err == nil {
 			return *exp
 		}
 		return str

--- a/api/v1/ratelimitpolicy_types_test.go
+++ b/api/v1/ratelimitpolicy_types_test.go
@@ -6,6 +6,26 @@ import (
 	"testing"
 )
 
+func TestVariablesRewritten(t *testing.T) {
+
+	limit := &Limit{
+		Counters: []Counter{
+			{Expression("auth.identity.username")},
+		},
+	}
+
+	actual := limit.CountersAsStringList()
+	expected := []string{`descriptors[0]["auth.identity.username"]`}
+	if len(actual) != len(expected) {
+		t.Errorf("maxValue does not match, expected(%v), got (%v)", expected, actual)
+	}
+	for i := range actual {
+		if actual[i] != expected[i] {
+			t.Errorf("maxValue does not match, expected(%s), got (%s)", expected[i], actual[i])
+		}
+	}
+}
+
 func TestConvertRateIntoSeconds(t *testing.T) {
 	testCases := []struct {
 		name             string

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -108,14 +108,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc2
-    createdAt: "2025-04-09T14:15:32Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc3
+    createdAt: "2025-04-11T15:04:36Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.2.0-rc2
+  name: kuadrant-operator.v1.2.0-rc3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -455,7 +455,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc2
+                image: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -561,4 +561,4 @@ spec:
     name: wasmshim
   - image: quay.io/kuadrant/console-plugin:v0.1.1
     name: consoleplugin
-  version: 1.2.0-rc2
+  version: 1.2.0-rc3

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.2.0-rc2"
-appVersion: "1.2.0-rc2"
+version: "1.2.0-rc3"
+appVersion: "1.2.0-rc3"
 dependencies:
   - name: authorino-operator
     version: 0.18.0

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -9452,7 +9452,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc2
+        image: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0-rc2
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0-rc3
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.2.0-rc2
+  newTag: v1.2.0-rc3

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -5,13 +5,13 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc2
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.2.0-rc3
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.2.0-rc2
+  name: kuadrant-operator.v1.2.0-rc3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -87,4 +87,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.2.0-rc2
+  version: 1.2.0-rc3

--- a/internal/cel/transformer.go
+++ b/internal/cel/transformer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/ast"
@@ -34,7 +35,11 @@ func parseExpression(expression string) (*ast.AST, error) {
 // anyway. This function does *NOT* try to validate or make any assumption about the expression being otherwise valid.
 // Rather than transforming the AST directly, it only uses the AST to find the `Ident` that need renaming directly in
 // the `expression` passed in. This keeps the resulting expression as close to the input as possible.
-func TransformCounterVariable(expression string) (*string, error) {
+func TransformCounterVariable(expression string, celAstTransform bool) (*string, error) {
+	if !celAstTransform {
+		exp := fmt.Sprintf(`descriptors[0]["%s"]`, strings.TrimSpace(expression))
+		return &exp, nil
+	}
 	knownAttributes := []string{"request", "source", "destination", "connection", "metadata", "filter_state", "auth", "ratelimit"}
 	var err error
 	var p *ast.AST

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.2.0-rc2"
+  version: "1.2.0-rc3"
 olm:
   channels:
     - "alpha"


### PR DESCRIPTION

The following release candidate of Kuadrant Operator version 1.2.0-rc2 includes:
- Authorino Operator version 0.18.0
- Console Plugin version 0.1.1
- DNS Operator version 0.14.0
- Limitador Operator version 0.14.0
- WASM Shim version 0.9.0
