### PR TITLE
mTLS  configuration effective only when effective ratelimit and auth policies are in place

### DIFF
--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -548,7 +548,7 @@ func (b *BootOptionsBuilder) Reconciler() controller.ReconcileFunc {
 		Tasks: []controller.ReconcileFunc{
 			NewDNSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isDNSOperatorInstalled).Run,
 			NewTLSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isCertManagerInstalled).Run,
-			NewDataPlanePoliciesWorkflow(b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled, b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Run,
+			NewDataPlanePoliciesWorkflow(b.manager, b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled, b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Run,
 			NewKuadrantStatusUpdater(b.client, b.isGatewayAPIInstalled, b.isGatewayProviderInstalled(), b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Subscription().Reconcile,
 			NewObservabilityReconciler(b.client, b.manager, operatorNamespace).Subscription().Reconcile,
 		},
@@ -572,13 +572,6 @@ func (b *BootOptionsBuilder) Reconciler() controller.ReconcileFunc {
 			NewAuthorinoReconciler(b.client).Subscription().Reconcile)
 	}
 
-	if b.isIstioInstalled && b.isAuthorinoOperatorInstalled && b.isLimitadorOperatorInstalled {
-		mainWorkflow.Tasks = append(mainWorkflow.Tasks,
-			NewPeerAuthenticationReconciler(b.manager, b.client).Subscription().Reconcile,
-			NewLimitadorIstioIntegrationReconciler(b.manager, b.client).Subscription().Reconcile,
-			NewAuthorinoIstioIntegrationReconciler(b.manager, b.client).Subscription().Reconcile,
-		)
-	}
 	return mainWorkflow.Run
 }
 

--- a/tests/istio/authorino_istio_integration_reconciler_test.go
+++ b/tests/istio/authorino_istio_integration_reconciler_test.go
@@ -9,8 +9,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	"github.com/kuadrant/kuadrant-operator/tests"
 )
@@ -18,8 +22,60 @@ import (
 // The tests need to be run in serial as kuadrant CR namespace is shared
 var _ = Describe("Authorino Istio integration reconciler", Serial, func() {
 	const (
-		testTimeOut = SpecTimeout(3 * time.Minute)
+		testTimeOut      = SpecTimeout(3 * time.Minute)
+		afterEachTimeOut = NodeTimeout(3 * time.Minute)
+		kapName          = "toystore-kap"
 	)
+
+	var (
+		testNamespace string
+	)
+
+	beforeEachCallback := func(ctx SpecContext) {
+		testNamespace = tests.CreateNamespace(ctx, testClient())
+		gateway := tests.BuildBasicGateway(TestGatewayName, testNamespace)
+		Expect(testClient().Create(ctx, gateway)).ToNot(HaveOccurred())
+
+		Eventually(tests.GatewayIsReady(ctx, testClient(), gateway)).WithContext(ctx).Should(BeTrue())
+
+		route := tests.BuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
+		Expect(k8sClient.Create(ctx, route)).To(Succeed())
+		Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
+
+		// create authpolicy
+		policy := &kuadrantv1.AuthPolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AuthPolicy",
+				APIVersion: kuadrantv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "toystore",
+				Namespace: testNamespace,
+			},
+			Spec: kuadrantv1.AuthPolicySpec{
+				TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+					LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+						Group: gatewayapiv1.GroupName,
+						Kind:  "HTTPRoute",
+						Name:  TestHTTPRouteName,
+					},
+				},
+				Defaults: &kuadrantv1.MergeableAuthPolicySpec{
+					AuthPolicySpecProper: kuadrantv1.AuthPolicySpecProper{
+						AuthScheme: tests.BuildBasicAuthScheme(),
+					},
+				},
+			},
+		}
+		Expect(testClient().Create(ctx, policy)).ToNot(HaveOccurred())
+		// check policy status
+		Eventually(tests.IsAuthPolicyAcceptedAndEnforced(ctx, testClient(), policy)).WithContext(ctx).Should(BeTrue())
+	}
+
+	BeforeEach(beforeEachCallback)
+	AfterEach(func(ctx SpecContext) {
+		tests.DeleteNamespace(ctx, testClient(), testNamespace)
+	}, afterEachTimeOut)
 
 	Context("when mTLS is on", func() {
 		BeforeEach(func(ctx SpecContext) {
@@ -41,6 +97,20 @@ var _ = Describe("Authorino Istio integration reconciler", Serial, func() {
 				deploymentKey := client.ObjectKey{Name: "authorino", Namespace: kuadrantInstallationNS}
 				g.Expect(testClient().Get(ctx, deploymentKey, deployment)).NotTo(HaveOccurred())
 				g.Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("sidecar.istio.io/inject", "true"))
+				g.Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("kuadrant.io/managed", "true"))
+			}).WithContext(ctx).Should(Succeed())
+
+			// Delete the policy
+			policyKey := client.ObjectKey{Name: "toystore", Namespace: testNamespace}
+			policy := &kuadrantv1.AuthPolicy{}
+			Expect(testClient().Get(ctx, policyKey, policy)).NotTo(HaveOccurred())
+			Expect(testClient().Delete(ctx, policy)).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				deployment := &appsv1.Deployment{}
+				deploymentKey := client.ObjectKey{Name: "authorino", Namespace: kuadrantInstallationNS}
+				g.Expect(testClient().Get(ctx, deploymentKey, deployment)).NotTo(HaveOccurred())
+				g.Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("sidecar.istio.io/inject", "false"))
 				g.Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("kuadrant.io/managed", "true"))
 			}).WithContext(ctx).Should(Succeed())
 

--- a/tests/istio/authorino_istio_integration_reconciler_test.go
+++ b/tests/istio/authorino_istio_integration_reconciler_test.go
@@ -24,7 +24,6 @@ var _ = Describe("Authorino Istio integration reconciler", Serial, func() {
 	const (
 		testTimeOut      = SpecTimeout(3 * time.Minute)
 		afterEachTimeOut = NodeTimeout(3 * time.Minute)
-		kapName          = "toystore-kap"
 	)
 
 	var (

--- a/tests/istio/istio_peerauthentication_reconciler_test.go
+++ b/tests/istio/istio_peerauthentication_reconciler_test.go
@@ -10,16 +10,81 @@ import (
 	. "github.com/onsi/gomega"
 	istiosecurityapiv1 "istio.io/api/security/v1"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/kuadrant-operator/tests"
 )
 
 // The tests need to be run in serial as kuadrant CR namespace is shared
 var _ = Describe("PeerAuthentication reconciler", Serial, func() {
 	const (
-		testTimeOut = SpecTimeout(3 * time.Minute)
+		testTimeOut      = SpecTimeout(3 * time.Minute)
+		afterEachTimeOut = NodeTimeout(3 * time.Minute)
+		rlpName          = "toystore-rlp"
 	)
+
+	var (
+		testNamespace string
+	)
+
+	beforeEachCallback := func(ctx SpecContext) {
+		testNamespace = tests.CreateNamespace(ctx, testClient())
+		gateway := tests.BuildBasicGateway(TestGatewayName, testNamespace)
+		Expect(testClient().Create(ctx, gateway)).ToNot(HaveOccurred())
+
+		Eventually(tests.GatewayIsReady(ctx, testClient(), gateway)).WithContext(ctx).Should(BeTrue())
+
+		route := tests.BuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
+		Expect(k8sClient.Create(ctx, route)).To(Succeed())
+		Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
+
+		// create ratelimitpolicy
+		rlp := &kuadrantv1.RateLimitPolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "RateLimitPolicy",
+				APIVersion: kuadrantv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rlpName,
+				Namespace: testNamespace,
+			},
+			Spec: kuadrantv1.RateLimitPolicySpec{
+				TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+					LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+						Group: gatewayapiv1.GroupName,
+						Kind:  "HTTPRoute",
+						Name:  gatewayapiv1.ObjectName(TestHTTPRouteName),
+					},
+				},
+				RateLimitPolicySpecProper: kuadrantv1.RateLimitPolicySpecProper{
+					Limits: map[string]kuadrantv1.Limit{
+						"l1": {
+							Rates: []kuadrantv1.Rate{
+								{
+									Limit: 1, Window: kuadrantv1.Duration("3m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(testClient().Create(ctx, rlp)).ToNot(HaveOccurred())
+		// Check RLP status is available
+		rlpKey := client.ObjectKey{Name: rlpName, Namespace: testNamespace}
+		Eventually(tests.RLPIsAccepted(ctx, testClient(), rlpKey)).WithContext(ctx).Should(BeTrue())
+		Eventually(tests.RLPIsEnforced(ctx, testClient(), rlpKey)).WithContext(ctx).Should(BeTrue())
+	}
+
+	BeforeEach(beforeEachCallback)
+	AfterEach(func(ctx SpecContext) {
+		tests.DeleteNamespace(ctx, testClient(), testNamespace)
+	}, afterEachTimeOut)
 
 	Context("when mTLS is on", func() {
 		BeforeEach(func(ctx SpecContext) {
@@ -42,6 +107,23 @@ var _ = Describe("PeerAuthentication reconciler", Serial, func() {
 			Expect(peerAuth.Spec.Selector.MatchLabels).To(Equal(map[string]string{
 				"kuadrant.io/managed": "true",
 			}))
+
+			// Delete the policy
+			rlpKey := client.ObjectKey{Name: rlpName, Namespace: testNamespace}
+			rlp := &kuadrantv1.RateLimitPolicy{}
+			Expect(testClient().Get(ctx, rlpKey, rlp)).NotTo(HaveOccurred())
+			Expect(testClient().Delete(ctx, rlp)).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				peerAuthList := &istiosecurityv1.PeerAuthenticationList{}
+				g.Expect(
+					testClient().List(ctx, peerAuthList,
+						client.InNamespace(kuadrantInstallationNS),
+						client.MatchingLabels{"kuadrant.io/managed": "true"},
+					),
+				).NotTo(HaveOccurred())
+				g.Expect(peerAuthList.Items).To(HaveLen(0))
+			}).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
 	})
 

--- a/tests/istio/limitador_istio_integration_reconciler_test.go
+++ b/tests/istio/limitador_istio_integration_reconciler_test.go
@@ -9,8 +9,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
 	"github.com/kuadrant/kuadrant-operator/tests"
@@ -19,8 +23,68 @@ import (
 // The tests need to be run in serial as kuadrant CR namespace is shared
 var _ = Describe("Limitador Istio integration reconciler", Serial, func() {
 	const (
-		testTimeOut = SpecTimeout(3 * time.Minute)
+		testTimeOut      = SpecTimeout(3 * time.Minute)
+		afterEachTimeOut = NodeTimeout(3 * time.Minute)
+		rlpName          = "toystore-rlp"
 	)
+
+	var (
+		testNamespace string
+	)
+
+	beforeEachCallback := func(ctx SpecContext) {
+		testNamespace = tests.CreateNamespace(ctx, testClient())
+		gateway := tests.BuildBasicGateway(TestGatewayName, testNamespace)
+		Expect(testClient().Create(ctx, gateway)).ToNot(HaveOccurred())
+
+		Eventually(tests.GatewayIsReady(ctx, testClient(), gateway)).WithContext(ctx).Should(BeTrue())
+
+		route := tests.BuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
+		Expect(k8sClient.Create(ctx, route)).To(Succeed())
+		Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
+
+		// create ratelimitpolicy
+		rlp := &kuadrantv1.RateLimitPolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "RateLimitPolicy",
+				APIVersion: kuadrantv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rlpName,
+				Namespace: testNamespace,
+			},
+			Spec: kuadrantv1.RateLimitPolicySpec{
+				TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+					LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+						Group: gatewayapiv1.GroupName,
+						Kind:  "HTTPRoute",
+						Name:  gatewayapiv1.ObjectName(TestHTTPRouteName),
+					},
+				},
+				RateLimitPolicySpecProper: kuadrantv1.RateLimitPolicySpecProper{
+					Limits: map[string]kuadrantv1.Limit{
+						"l1": {
+							Rates: []kuadrantv1.Rate{
+								{
+									Limit: 1, Window: kuadrantv1.Duration("3m"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(testClient().Create(ctx, rlp)).ToNot(HaveOccurred())
+		// Check RLP status is available
+		rlpKey := client.ObjectKey{Name: rlpName, Namespace: testNamespace}
+		Eventually(tests.RLPIsAccepted(ctx, testClient(), rlpKey)).WithContext(ctx).Should(BeTrue())
+		Eventually(tests.RLPIsEnforced(ctx, testClient(), rlpKey)).WithContext(ctx).Should(BeTrue())
+	}
+
+	BeforeEach(beforeEachCallback)
+	AfterEach(func(ctx SpecContext) {
+		tests.DeleteNamespace(ctx, testClient(), testNamespace)
+	}, afterEachTimeOut)
 
 	Context("when mTLS is on", func() {
 		BeforeEach(func(ctx SpecContext) {
@@ -42,6 +106,20 @@ var _ = Describe("Limitador Istio integration reconciler", Serial, func() {
 				deploymentKey := client.ObjectKey{Name: "limitador-limitador", Namespace: kuadrantInstallationNS}
 				g.Expect(testClient().Get(ctx, deploymentKey, deployment)).NotTo(HaveOccurred())
 				g.Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("sidecar.istio.io/inject", "true"))
+				g.Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("kuadrant.io/managed", "true"))
+			}).WithContext(ctx).Should(Succeed())
+
+			// Delete the policy
+			rlpKey := client.ObjectKey{Name: rlpName, Namespace: testNamespace}
+			rlp := &kuadrantv1.RateLimitPolicy{}
+			Expect(testClient().Get(ctx, rlpKey, rlp)).NotTo(HaveOccurred())
+			Expect(testClient().Delete(ctx, rlp)).ToNot(HaveOccurred())
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				deployment := &appsv1.Deployment{}
+				deploymentKey := client.ObjectKey{Name: "limitador-limitador", Namespace: kuadrantInstallationNS}
+				g.Expect(testClient().Get(ctx, deploymentKey, deployment)).NotTo(HaveOccurred())
+				g.Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("sidecar.istio.io/inject", "false"))
 				g.Expect(deployment.Spec.Template.Labels).To(HaveKeyWithValue("kuadrant.io/managed", "true"))
 			}).WithContext(ctx).Should(Succeed())
 


### PR DESCRIPTION
### What

Closes #1284 

### Verification steps

* Checkout this branch
* Deploy with Istio
```
make local-setup GATEWAYAPI_PROVIDER=istio
```
* Apply the Kuadrant custom resource with *mtls* enabled
```yaml
kubectl apply  -f - <<EOF               
---                                     
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
  namespace: kuadrant-system
spec: 
  mtls:
    enable: true
EOF
```
* Wait for kuadrant instance to be ready
```shell
kubectl wait --timeout=300s --for=condition=Ready kuadrant kuadrant-sample -n kuadrant-system
```

* Deploy toystore
```sh
kubectl apply -f examples/toystore/toystore.yaml
kubectl wait --timeout=300s --for=condition=Available deployment toystore
```

* Create  HTTPRoute
```yaml
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
spec:
  parentRefs:
  - name: kuadrant-ingressgateway
    namespace: gateway-system
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: "/"
    backendRefs:
    - name: toystore
      port: 80
EOF
``` 
* Create  Rate limit policy

```yaml
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1
kind: RateLimitPolicy
metadata:
  name: toystore
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  limits:
    "limit-a":
      rates:
      - limit: 5
        window: 10s
EOF
```

* Ensure HTTP Route is rate limits at 5 requests every 10 seconds
```shell
export INGRESS_HOST=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.status.addresses[0].value}')
export INGRESS_PORT=$(kubectl get gtw kuadrant-ingressgateway -n gateway-system -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
```

```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null --resolve api.toystore.com:$INGRESS_PORT:$INGRESS_HOST http://api.toystore.com:$INGRESS_PORT/ | grep -E --color "\b(429)\b|$"; sleep 1; done
```

* Verify that a Peer Authentication exists
```bash
kubectl get peerauthentication default -n kuadrant-system -o yaml
```
which should have the following spec
```yaml
spec:
  mtls:
    mode: STRICT
  selector:
    matchLabels:
      kuadrant.io/managed: "true"
```

* Verify that the limitador  deployment has the expected labels
```
kubectl get deployment limitador-limitador -n kuadrant-system -o yaml | yq e '.spec.template.metadata.labels'
```
Which should return
```
app: limitador
kuadrant.io/managed: "true"
limitador-resource: limitador
sidecar.istio.io/inject: "true"
```

* Verify that the authorino  deployment does not have istio injected as there is no effective auth policy in place.
```
kubectl get deployment authorino -n kuadrant-system -o yaml | yq e '.spec.template.metadata.labels'
```
Which should return
```
authorino-resource: authorino
control-plane: controller-manager
kuadrant.io/managed: "true"
sidecar.istio.io/inject: "false"
```
* When policy is deleted, even though the kuadrant CR has `mTLS` enabled, `mTLS` is not active.
```
kubectl  delete ratelimitpolicy toystore
```
* Verify that the Peer Authentication is gone
```bash
kubectl get peerauthentication default -n kuadrant-system -o yaml
```
which should return NotFound
```shell
Error from server (NotFound): peerauthentications.security.istio.io "default" not found
```

* Verify that the limitador  deployment's pod template label has istio disabled
```
kubectl get deployment limitador-limitador -n kuadrant-system -o yaml | yq e '.spec.template.metadata.labels'
```
Which should return
```
app: limitador
kuadrant.io/managed: "true"
limitador-resource: limitador
sidecar.istio.io/inject: "false"
```

* Verify that the authorino  deployment's pod template label has istio disabled
```
kubectl get deployment authorino -n kuadrant-system -o yaml | yq e '.spec.template.metadata.labels'
```
Which should return
```
authorino-resource: authorino
control-plane: controller-manager
kuadrant.io/managed: "true"
sidecar.istio.io/inject: "false"
```

