### PR TITLE
Extensions OOP Logging round 2

### DIFF
--- a/cmd/extension/main.go
+++ b/cmd/extension/main.go
@@ -23,7 +23,7 @@ var (
 	logger = zap.New(
 		zap.Level(zapcore.DebugLevel),
 		zap.UseDevMode(false),
-		zap.WriteTo(os.Stdout),
+		zap.WriteTo(os.Stderr),
 	).WithName("test-extension")
 )
 


### PR DESCRIPTION
![Screenshot 2025-04-16 at 15 55 37](https://github.com/user-attachments/assets/e8e025d4-1efb-411c-9db3-3b3a380b22fb)

Notes:
* Is not possible to feed the `logr.LogSink` directly with Bytes or a JSON string, since it doesn't have anything to write to it. Its interface defines Info and Error similar to the logr wrapper, but with an extra log level int
* Since at the time we are not discerning the log level from the kuadrant-operator, the OOP extensions will use the same log level, thus I've decided to use the _logr_ instance methods to log, instead of directly its _sink_
* I've found that Unmarshalling the bytes coming from the OOP extension Stderr Pipe was necessary to correctly interact with the `logr` instance, and thus later to add extra info in our future SDK bits.
