### PR TITLE
OOP Logging - Round 2

### DIFF
--- a/cmd/extension/main.go
+++ b/cmd/extension/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 
+	"k8s.io/utils/env"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
@@ -19,11 +21,13 @@ import (
 )
 
 var (
-	scheme = k8sruntime.NewScheme()
-	logger = zap.New(
-		zap.Level(zapcore.DebugLevel),
-		zap.UseDevMode(false),
-		zap.WriteTo(os.Stdout),
+	scheme      = k8sruntime.NewScheme()
+	logLevel, _ = zapcore.ParseLevel(env.GetString("LOG_LEVEL", "info"))
+	logMode     = env.GetString("LOG_MODE", "production") != "production"
+	logger      = zap.New(
+		zap.Level(logLevel),
+		zap.UseDevMode(logMode),
+		zap.WriteTo(os.Stderr),
 	).WithName("test-extension")
 )
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"runtime"
 
+	"go.uber.org/zap/zapcore"
+
 	certmanv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	egv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
 	authorinoopapi "github.com/kuadrant/authorino-operator/api/v1beta1"
@@ -86,12 +88,15 @@ func init() {
 	utilruntime.Must(istiosecurity.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 
+	sync := zapcore.Lock(zapcore.AddSync(os.Stdout))
+
 	logger := log.NewLogger(
 		log.SetLevel(log.ToLevel(logLevel)),
 		log.SetMode(log.ToMode(logMode)),
-		log.WriteTo(os.Stdout),
+		log.WriteTo(sync),
 	).WithName("kuadrant-operator")
 	log.SetLogger(logger)
+	log.SetSync(sync)
 }
 
 func printControllerMetaInfo() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -164,7 +164,7 @@ func main() {
 
 	if withExtensions {
 		// start extension manager
-		extManager, err := extension.NewManager([]string{"myextension"}, "/extensions", log.Log)
+		extManager, err := extension.NewManager([]string{"myextension"}, "/extensions", log.Log, log.Sync)
 		if err != nil {
 			setupLog.Error(err, "unable to create extension manager")
 			os.Exit(1)

--- a/extension.Dockerfile
+++ b/extension.Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/zap/zapcore"
+
 	extpb "github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v0"
 
 	"github.com/go-logr/logr"
@@ -31,6 +33,7 @@ type Manager struct {
 	extensions []Extension
 	service    extpb.ExtensionServiceServer
 	logger     logr.Logger
+	sync       zapcore.WriteSyncer
 }
 
 type Extension interface {
@@ -39,7 +42,7 @@ type Extension interface {
 	Name() string
 }
 
-func NewManager(names []string, location string, logger logr.Logger) (Manager, error) {
+func NewManager(names []string, location string, logger logr.Logger, sync zapcore.WriteSyncer) (Manager, error) {
 	var extensions []Extension
 	var err error
 
@@ -47,7 +50,7 @@ func NewManager(names []string, location string, logger logr.Logger) (Manager, e
 	logger = logger.WithName("extension")
 
 	for _, name := range names {
-		if oopExtension, e := NewOOPExtension(name, location, service, logger); e == nil {
+		if oopExtension, e := NewOOPExtension(name, location, service, logger, sync); e == nil {
 			extensions = append(extensions, &oopExtension)
 		} else {
 			if err == nil {
@@ -59,9 +62,10 @@ func NewManager(names []string, location string, logger logr.Logger) (Manager, e
 	}
 
 	return Manager{
-		extensions: extensions,
-		service:    service,
-		logger:     logger,
+		extensions,
+		service,
+		logger,
+		sync,
 	}, err
 }
 

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -19,9 +19,8 @@ package extension
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
-
-	"go.uber.org/zap/zapcore"
 
 	extpb "github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v0"
 
@@ -33,7 +32,7 @@ type Manager struct {
 	extensions []Extension
 	service    extpb.ExtensionServiceServer
 	logger     logr.Logger
-	sync       zapcore.WriteSyncer
+	sync       io.Writer
 }
 
 type Extension interface {
@@ -42,7 +41,7 @@ type Extension interface {
 	Name() string
 }
 
-func NewManager(names []string, location string, logger logr.Logger, sync zapcore.WriteSyncer) (Manager, error) {
+func NewManager(names []string, location string, logger logr.Logger, sync io.Writer) (Manager, error) {
 	var extensions []Extension
 	var err error
 

--- a/internal/extension/oop.go
+++ b/internal/extension/oop.go
@@ -26,6 +26,8 @@ import (
 	"syscall"
 	"time"
 
+	"go.uber.org/zap/zapcore"
+
 	extpb "github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v0"
 
 	"github.com/go-logr/logr"
@@ -49,9 +51,10 @@ type OOPExtension struct {
 	server     *grpc.Server
 	service    extpb.ExtensionServiceServer
 	logger     logr.Logger
+	sync       zapcore.WriteSyncer
 }
 
-func NewOOPExtension(name string, location string, service extpb.ExtensionServiceServer, logger logr.Logger) (OOPExtension, error) {
+func NewOOPExtension(name string, location string, service extpb.ExtensionServiceServer, logger logr.Logger, sync zapcore.WriteSyncer) (OOPExtension, error) {
 	var err error
 	var stat os.FileInfo
 
@@ -68,6 +71,7 @@ func NewOOPExtension(name string, location string, service extpb.ExtensionServic
 		executable: executable,
 		service:    service,
 		logger:     logger.WithName(name),
+		sync:       sync,
 	}, err
 }
 

--- a/internal/extension/oop.go
+++ b/internal/extension/oop.go
@@ -196,6 +196,8 @@ func (p *OOPExtension) monitorStderr(stderr io.ReadCloser, stopChan <-chan struc
 			}
 
 			if scanner.Scan() {
+				// TODO (didierofrivia): Check output of scanner.Bytes() to see if it's sink compatible, otherwise log
+				// instead of directly write.
 				if _, err := p.sync.Write(append(scanner.Bytes(), []byte("\n")...)); err != nil {
 					p.logger.Error(err, "failed to write to logger")
 				}

--- a/internal/extension/oop_test.go
+++ b/internal/extension/oop_test.go
@@ -21,9 +21,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samber/lo"
-
 	"github.com/go-logr/logr/funcr"
+	"github.com/samber/lo"
 	"gotest.tools/assert"
 
 	"github.com/go-logr/logr"
@@ -56,11 +55,20 @@ func TestOOPExtensionManagesExternalProcess(t *testing.T) {
 	}
 }
 
+type writerMock struct {
+	messages []string
+}
+
+func (w *writerMock) Write(p []byte) (n int, err error) {
+	w.messages = append(w.messages, string(p))
+	return len(p), nil
+}
+
 func TestOOPExtensionForwardsLog(t *testing.T) {
-	var messages []string
+	writer := &writerMock{}
 
 	logger := funcr.New(func(_, args string) {
-		messages = append(messages, args)
+		writer.Write([]byte(args))
 	}, funcr.Options{})
 
 	oopErrorLog := OOPExtension{
@@ -69,7 +77,7 @@ func TestOOPExtensionForwardsLog(t *testing.T) {
 		socket:     "--foobar",
 		service:    newExtensionService(),
 		logger:     logger,
-		sync:       nil,
+		sync:       writer,
 	}
 
 	if err := oopErrorLog.Start(); err != nil {
@@ -80,31 +88,8 @@ func TestOOPExtensionForwardsLog(t *testing.T) {
 		time.Sleep(5 * time.Millisecond) // wait for the command to return
 	}
 
-	logAsString := strings.Join(messages, "\n")
-	assert.Assert(t, strings.Contains(strings.ToLower(logAsString), "is not a valid log level range 0-1. log:"))
-
 	_ = oopErrorLog.Stop() // gracefully kill the process/server
-	assert.Assert(t, lo.Contains(messages, "\"msg\"=\"Extension \\\"testErrorLog\\\" finished with an error\" \"error\"=\"exit status 1\""))
-}
-
-func TestOOPExtensionParseStderr(t *testing.T) {
-	lvl, text, err := parseStderr(append([]byte{0}, []byte("Info")...))
-	assert.Equal(t, lvl, LogLevelInfo)
-	assert.Equal(t, text, "Info")
-	assert.Equal(t, err, nil)
-
-	lvl, text, err = parseStderr(append([]byte{1}, []byte("Error")...))
-	assert.Equal(t, lvl, LogLevelError)
-	assert.Equal(t, text, "Error")
-	assert.Equal(t, err, nil)
-
-	lvl, text, err = parseStderr(append([]byte{5}, []byte("not valid log level")...))
-	assert.Equal(t, lvl, LogLevelError)
-	assert.Equal(t, text, "")
-	assert.Error(t, err, "first byte is not a valid log level range 0-1. log: \"\\x05not valid log level\"")
-
-	lvl, text, err = parseStderr([]byte{})
-	assert.Equal(t, lvl, LogLevelError)
-	assert.Equal(t, text, "")
-	assert.Error(t, err, "input byte slice is empty")
+	assert.Assert(t, lo.Contains(writer.messages, "\"msg\"=\"Extension \\\"testErrorLog\\\" finished with an error\" \"error\"=\"exit status 1\""))
+	logAsString := strings.Join(writer.messages, "\n")
+	assert.Assert(t, strings.Contains(strings.ToLower(logAsString), "usage:"))
 }

--- a/internal/extension/oop_test.go
+++ b/internal/extension/oop_test.go
@@ -36,6 +36,7 @@ func TestOOPExtensionManagesExternalProcess(t *testing.T) {
 		socket:     "1d",
 		service:    newExtensionService(),
 		logger:     logr.Discard(),
+		sync:       nil,
 	}
 
 	if oop.IsAlive() {
@@ -68,6 +69,7 @@ func TestOOPExtensionForwardsLog(t *testing.T) {
 		socket:     "--foobar",
 		service:    newExtensionService(),
 		logger:     logger,
+		sync:       nil,
 	}
 
 	if err := oopErrorLog.Start(); err != nil {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -32,7 +32,8 @@ import (
 
 var (
 	// Log is the base logger
-	Log logr.Logger = logr.New(ctrllog.NullLogSink{})
+	Log  logr.Logger = logr.New(ctrllog.NullLogSink{})
+	Sync             = zapcore.WriteSyncer(nil)
 )
 
 // Level configures the verbosity of the logging.
@@ -114,6 +115,11 @@ func SetLogger(logger logr.Logger) {
 
 	ctrl.SetLogger(logger) // fulfills `logger` as the de facto logger used by controller-runtime
 	klog.SetLogger(logger)
+}
+
+// SetSync sets the zapcore.WriterSyncer used to write the logs.
+func SetSync(sync zapcore.WriteSyncer) {
+	Sync = sync
 }
 
 // WriteTo configures the logger to write to the given io.Writer, instead of standard error.

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -33,7 +33,7 @@ import (
 var (
 	// Log is the base logger
 	Log  logr.Logger = logr.New(ctrllog.NullLogSink{})
-	Sync             = zapcore.WriteSyncer(nil)
+	Sync io.Writer
 )
 
 // Level configures the verbosity of the logging.
@@ -118,7 +118,7 @@ func SetLogger(logger logr.Logger) {
 }
 
 // SetSync sets the zapcore.WriterSyncer used to write the logs.
-func SetSync(sync zapcore.WriteSyncer) {
+func SetSync(sync io.Writer) {
 	Sync = sync
 }
 

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package log
 
 import (
+	"fmt"
 	"testing"
 
 	// In this package there is no ginkgo tests
@@ -60,4 +61,17 @@ func TestToMode(t *testing.T) {
 		// should panic
 		ToMode("invalid")
 	}()
+}
+
+type writerMock struct{}
+
+func (w *writerMock) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func TestSetSync(t *testing.T) {
+	assert.Equal(t, Sync, nil)
+
+	SetSync(&writerMock{})
+	assert.Equal(t, fmt.Sprintf("%T", Sync), "*log.writerMock")
 }


### PR DESCRIPTION
This PR changes the way the child out of process forwards its logs to the parent (kuadrant operator). The logging of the child OOP is written to the `stderr` which the parent will read and write directly using a _syncer writer_.

The messages are logged as shown below:

![Screenshot 2025-04-18 at 16 10 50](https://github.com/user-attachments/assets/82508c54-2425-45f5-9b40-9fb0a9e2868b)

