### PR TITLE
Resilient Deployment set counter storage

### DIFF
--- a/internal/controller/resilient_deployment_workflow.go
+++ b/internal/controller/resilient_deployment_workflow.go
@@ -1,0 +1,201 @@
+package controllers
+
+// TODO: When feature complete, remove all experimental code references.
+
+import (
+	"context"
+	"sync"
+
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+)
+
+// WARNING: level varible is only here for the basic dev work and should not end up in the finished feature
+// FIXME: don't merge to main with value of zero, set to one.
+var level = 1
+
+const (
+	ExperimentalResilienceFeature = "ExperimentalResilienceFeature"
+	ResilienceFeatureAnnotation   = "kuadrant.io/experimental-dont-use-resilient-data-plane"
+)
+
+func NewResilienceDeploymentWorkflow() *controller.Workflow {
+	return &controller.Workflow{
+		Precondition:  NewResilienceDeploymentPrecondition().Subscription().Reconcile,
+		Tasks:         NewResilienceDeploymentTasks(),
+		Postcondition: NewResilienceDeploymentPostcondition().Subscription().Reconcile,
+	}
+}
+
+// INFO: Precontion Section
+
+func NewResilienceDeploymentPrecondition() *ResilienceDeploymentPrecondition {
+	return &ResilienceDeploymentPrecondition{}
+}
+
+type ResilienceDeploymentPrecondition struct{}
+
+func (r *ResilienceDeploymentPrecondition) Subscription() controller.Subscription {
+	return controller.Subscription{
+		ReconcileFunc: r.run,
+		Events: []controller.ResourceEventMatcher{
+			{Kind: &kuadrantv1beta1.KuadrantGroupKind},
+		},
+	}
+}
+
+func (r *ResilienceDeploymentPrecondition) run(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
+	logger := controller.LoggerFromContext(ctx).WithName("ResilienceDeploymentPrecondition")
+	logger.V(level).Info("ResilienceDeployment Precondition", "status", "started")
+	defer logger.V(level).Info("ResilienceDeployment Precondition", "status", "completed")
+
+	state.Store(ExperimentalResilienceFeature, isExperimentalFeatureEnabled(topology))
+
+	return nil
+}
+
+// INFO: Task Section
+
+func NewResilienceDeploymentTasks() []controller.ReconcileFunc {
+	return []controller.ReconcileFunc{
+		NewResilienceAuthorizationReconciler().Subscription().Reconcile,
+		NewResilienceCounterStorageReconciler().Subscription().Reconcile,
+		NewResilienceRateLimitingReconciler().Subscription().Reconcile,
+	}
+}
+
+func NewResilienceAuthorizationReconciler() *ResilienceAuthorizationReconciler {
+	return &ResilienceAuthorizationReconciler{}
+}
+
+type ResilienceAuthorizationReconciler struct{}
+
+func (r *ResilienceAuthorizationReconciler) Subscription() controller.Subscription {
+	return controller.Subscription{
+		ReconcileFunc: r.reconcile,
+		Events: []controller.ResourceEventMatcher{
+			{Kind: &kuadrantv1beta1.KuadrantGroupKind},
+		},
+	}
+}
+
+func (r *ResilienceAuthorizationReconciler) reconcile(ctx context.Context, _ []controller.ResourceEvent, _ *machinery.Topology, _ error, state *sync.Map) error {
+	logger := controller.LoggerFromContext(ctx).WithName("ResilienceAuthorizationReconciler")
+
+	logger.V(level).Info("ResilienceAuthorizationReconciler Task", "status", "started")
+	defer logger.V(level).Info("ResilienceAuthorizationReconciler Task", "status", "completed")
+	if !experimentalFeatureEnabledSate(state) {
+		logger.V(level).Info("Experimental resilience feature is not enabled, early exit", "status", "exiting")
+		return nil
+	}
+	logger.V(level).Info("Experimental resilience feature is enabled", "status", "processing")
+
+	return nil
+}
+
+func NewResilienceRateLimitingReconciler() *ResilienceRateLimitingReconciler {
+	return &ResilienceRateLimitingReconciler{}
+}
+
+type ResilienceRateLimitingReconciler struct{}
+
+func (r *ResilienceRateLimitingReconciler) Subscription() controller.Subscription {
+	return controller.Subscription{
+		ReconcileFunc: r.reconcile,
+		Events: []controller.ResourceEventMatcher{
+			{Kind: &kuadrantv1beta1.KuadrantGroupKind},
+		},
+	}
+}
+
+func (r *ResilienceRateLimitingReconciler) reconcile(ctx context.Context, _ []controller.ResourceEvent, _ *machinery.Topology, _ error, state *sync.Map) error {
+	logger := controller.LoggerFromContext(ctx).WithName("ResilienceRateLimitingReconciler")
+
+	logger.V(level).Info("ResilienceRateLimitingReconciler Task", "status", "started")
+	defer logger.V(level).Info("ResilienceRateLimitingReconciler Task", "status", "completed")
+	if !experimentalFeatureEnabledSate(state) {
+		logger.V(level).Info("Experimental resilience feature is not enabled, early exit", "status", "exiting")
+		return nil
+	}
+	logger.V(level).Info("Experimental resilience feature is enabled", "status", "processing")
+
+	return nil
+}
+
+func NewResilienceCounterStorageReconciler() *ResilienceCounterStorageReconciler {
+	return &ResilienceCounterStorageReconciler{}
+}
+
+type ResilienceCounterStorageReconciler struct{}
+
+func (r *ResilienceCounterStorageReconciler) Subscription() controller.Subscription {
+	return controller.Subscription{
+		ReconcileFunc: r.reconcile,
+		Events: []controller.ResourceEventMatcher{
+			{Kind: &kuadrantv1beta1.KuadrantGroupKind},
+		},
+	}
+}
+
+func (r *ResilienceCounterStorageReconciler) reconcile(ctx context.Context, _ []controller.ResourceEvent, _ *machinery.Topology, _ error, state *sync.Map) error {
+	logger := controller.LoggerFromContext(ctx).WithName("ResilienceCounterStorageReconciler")
+
+	logger.V(level).Info("ResilienceCounterStorageReconciler Task", "status", "started")
+	defer logger.V(level).Info("ResilienceCounterStorageReconciler Task", "status", "completed")
+	if !experimentalFeatureEnabledSate(state) {
+		logger.V(level).Info("Experimental resilience feature is not enabled, early exit", "status", "exiting")
+		return nil
+	}
+	logger.V(level).Info("Experimental resilience feature is enabled", "status", "processing")
+
+	return nil
+}
+
+// INFO: Postconditon Section
+
+func NewResilienceDeploymentPostcondition() *ResilienceDeploymentPostcondition {
+	return &ResilienceDeploymentPostcondition{}
+}
+
+type ResilienceDeploymentPostcondition struct{}
+
+func (r *ResilienceDeploymentPostcondition) Subscription() controller.Subscription {
+	return controller.Subscription{
+		ReconcileFunc: r.run,
+		Events: []controller.ResourceEventMatcher{
+			{Kind: &kuadrantv1beta1.KuadrantGroupKind},
+		},
+	}
+}
+
+func (r *ResilienceDeploymentPostcondition) run(ctx context.Context, _ []controller.ResourceEvent, _ *machinery.Topology, _ error, _ *sync.Map) error {
+	logger := controller.LoggerFromContext(ctx).WithName("ResilienceDeploymentPrecondition")
+
+	logger.V(level).Info("ResilienceDeployment Postcondition", "status", "started")
+	defer logger.V(level).Info("ResilienceDeployment Postcondition", "status", "completed")
+	return nil
+}
+
+// INFO: Local Functions
+
+func isExperimentalFeatureEnabled(topology *machinery.Topology) bool {
+	k := GetKuadrantFromTopology(topology)
+	if k == nil {
+		return false
+	}
+
+	if val, exists := k.GetAnnotations()[ResilienceFeatureAnnotation]; exists {
+		return val == "true"
+	}
+	return false
+}
+
+func experimentalFeatureEnabledSate(state *sync.Map) bool {
+	value, ok := state.Load(ExperimentalResilienceFeature)
+	if ok {
+		return value.(bool)
+	}
+	return false
+}

--- a/internal/controller/resilient_deployment_workflow.go
+++ b/internal/controller/resilient_deployment_workflow.go
@@ -139,7 +139,7 @@ func (r *ResilienceCounterStorageReconciler) Subscription() controller.Subscript
 	}
 }
 
-func (r *ResilienceCounterStorageReconciler) reconcile(ctx context.Context, _ []controller.ResourceEvent, _ *machinery.Topology, _ error, state *sync.Map) error {
+func (r *ResilienceCounterStorageReconciler) reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
 	logger := controller.LoggerFromContext(ctx).WithName("ResilienceCounterStorageReconciler")
 
 	logger.V(level).Info("ResilienceCounterStorageReconciler Task", "status", "started")
@@ -150,7 +150,27 @@ func (r *ResilienceCounterStorageReconciler) reconcile(ctx context.Context, _ []
 	}
 	logger.V(level).Info("Experimental resilience feature is enabled", "status", "processing")
 
+	kObj := GetKuadrantFromTopology(topology)
+	if !r.isConfigured(kObj) {
+		logger.V(level).Info("CounterStorage not configured", "status", "exiting")
+		return nil
+	}
+	logger.V(level).Info("CounterStorage configured", "status", "contiune")
+
 	return nil
+}
+
+func (r *ResilienceCounterStorageReconciler) isConfigured(kObj *kuadrantv1beta1.Kuadrant) bool {
+	if kObj == nil {
+		return false
+	}
+	if resilience := kObj.Spec.Resilience; resilience == nil {
+		return false
+	}
+	if configuration := kObj.Spec.Resilience.CounterStorage; configuration != nil {
+		return true
+	}
+	return false
 }
 
 // INFO: Postconditon Section

--- a/internal/controller/resilient_deployment_workflow_test.go
+++ b/internal/controller/resilient_deployment_workflow_test.go
@@ -1,0 +1,50 @@
+//go:build unit
+
+package controllers
+
+import (
+	"testing"
+
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+)
+
+func TestResilienceCounterStorageReconciler_isConfigured(t *testing.T) {
+	testCases := []struct {
+		name     string
+		kObj     *kuadrantv1beta1.Kuadrant
+		expected bool
+	}{
+
+		{
+			name:     "expected, isConfigured=true",
+			kObj:     &kuadrantv1beta1.Kuadrant{Spec: kuadrantv1beta1.KuadrantSpec{Resilience: &kuadrantv1beta1.Resilience{CounterStorage: &limitadorv1alpha1.Storage{}}}},
+			expected: true,
+		},
+		{
+			name:     "expected, isConfigured=false, no storage object",
+			kObj:     &kuadrantv1beta1.Kuadrant{Spec: kuadrantv1beta1.KuadrantSpec{Resilience: &kuadrantv1beta1.Resilience{}}},
+			expected: false,
+		},
+		{
+			name:     "expected, isConfigured=false, no reilience object",
+			kObj:     &kuadrantv1beta1.Kuadrant{Spec: kuadrantv1beta1.KuadrantSpec{}},
+			expected: false,
+		},
+		{
+			name:     "expected, isConfigured=false, kObj is nil",
+			kObj:     nil,
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(subT *testing.T) {
+			rcsr := NewResilienceCounterStorageReconciler(nil)
+			result := rcsr.isConfigured(tc.kObj)
+			if result != tc.expected {
+				subT.Fatalf("isConfigured result not as expected. Expected: %v, Actual: %v", tc.expected, result)
+			}
+		})
+	}
+}

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -576,7 +576,7 @@ func (b *BootOptionsBuilder) Reconciler() controller.ReconcileFunc {
 			NewDataPlanePoliciesWorkflow(b.manager, b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled, b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Run,
 			NewKuadrantStatusUpdater(b.client, b.isGatewayAPIInstalled, b.isGatewayProviderInstalled(), b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Subscription().Reconcile,
 			NewObservabilityReconciler(b.client, b.manager, operatorNamespace).Subscription().Reconcile,
-			NewResilienceDeploymentWorkflow().Run,
+			NewResilienceDeploymentWorkflow(b.client).Run,
 		},
 		Postcondition: finalStepsWorkflow(b.client, b.isGatewayAPIInstalled, b.isUsingExtensions).Run,
 	}

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -576,6 +576,7 @@ func (b *BootOptionsBuilder) Reconciler() controller.ReconcileFunc {
 			NewDataPlanePoliciesWorkflow(b.manager, b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled, b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Run,
 			NewKuadrantStatusUpdater(b.client, b.isGatewayAPIInstalled, b.isGatewayProviderInstalled(), b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Subscription().Reconcile,
 			NewObservabilityReconciler(b.client, b.manager, operatorNamespace).Subscription().Reconcile,
+			NewResilienceDeploymentWorkflow().Run,
 		},
 		Postcondition: finalStepsWorkflow(b.client, b.isGatewayAPIInstalled, b.isUsingExtensions).Run,
 	}


### PR DESCRIPTION
Closes: #1318

Requires: 
- #1327 
- #1346

Base Branch: https://github.com/Boomatang/kuadrant-operator/tree/Resilient_Deployment

- **ADD: Resilient Deployment Workflow Structure**
- **ADD: isConfigured (counter storage)**
- **ADD: mirror counterStorage to limitador storage**

Allow the configuration of limitadors `spec.storage` from the kuadrant CR.
The change will maintain the configuration defined in the kuadrant CR.

As this is a work in progress area the experimental annotation is required.

Example kaudrant CR
```yaml
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
  annotations:
    kuadrant.io/experimental-dont-use-resilient-data-plane: "true"
spec:
  resilience:
    counterStorage:
      disk: {}
```
