### PR TITLE
ADD: integration test for counter storage

### DIFF
--- a/tests/common/kuadrant/kuadrant_resource_test.go
+++ b/tests/common/kuadrant/kuadrant_resource_test.go
@@ -1,0 +1,196 @@
+//go:build integration
+
+package kuadrant
+
+import (
+	"reflect"
+	"time"
+
+	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
+	"github.com/kuadrant/kuadrant-operator/tests"
+)
+
+var _ = Describe("Resilience counterStorage", Serial, func() {
+	const (
+		testTimeOut                 = SpecTimeout(1 * time.Minute)
+		afterEachTimeOut            = NodeTimeout(2 * time.Minute)
+		kuatrantResource            = "kuadrant-sample"
+		ResilienceFeatureAnnotation = "kuadrant.io/experimental-dont-use-resilient-data-plane"
+	)
+
+	var testNamespace string
+
+	BeforeEach(func(ctx SpecContext) {
+		testNamespace = tests.CreateNamespace(ctx, testClient())
+
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		tests.DeleteNamespace(ctx, testClient(), testNamespace)
+	}, afterEachTimeOut)
+
+	Context("User configures counterStorage", Serial, func() {
+		It("limitador resource is configured", func(ctx SpecContext) {
+			By("Set up the initail kuadrant counterStorage configuration")
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: testNamespace}
+			spec := &limitadorv1alpha1.Storage{
+				Disk: &limitadorv1alpha1.DiskSpec{},
+			}
+			tests.ApplyKuadrantCRWithName(ctx, testClient(), testNamespace, kuatrantResource, func(k *kuadrantv1beta1.Kuadrant) {
+				k.Annotations = map[string]string{ResilienceFeatureAnnotation: "true"}
+				k.Spec = kuadrantv1beta1.KuadrantSpec{
+					Resilience: &kuadrantv1beta1.Resilience{
+						CounterStorage: spec,
+					},
+				}
+			})
+
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+			Eventually(func(g Gomega) {
+				limitadorKey := client.ObjectKey{Name: kuadrant.LimitadorName, Namespace: testNamespace}
+
+				existingLimitador := &limitadorv1alpha1.Limitador{}
+				err := k8sClient.Get(ctx, limitadorKey, existingLimitador)
+				g.Expect(err).ToNot(HaveOccurred())
+				result := reflect.DeepEqual(existingLimitador.Spec.Storage,  spec)
+				g.Expect(result).To(BeTrue()) 
+
+			}).WithContext(ctx).Should(Succeed())
+
+			By("Update kuadrant counterStorage configuration")
+
+			existingKuadrant := &kuadrantv1beta1.Kuadrant{}
+			err := k8sClient.Get(ctx, kuadrantKey, existingKuadrant)
+			Expect(err).ToNot(HaveOccurred())
+			existingKuadrant.Spec.Resilience.CounterStorage = &limitadorv1alpha1.Storage{}
+			
+			err = k8sClient.Update(ctx, existingKuadrant)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+			Eventually(func(g Gomega) {
+				limitadorKey := client.ObjectKey{Name: kuadrant.LimitadorName, Namespace: testNamespace}
+
+				existingLimitador := &limitadorv1alpha1.Limitador{}
+				err := k8sClient.Get(ctx, limitadorKey, existingLimitador)
+				g.Expect(err).ToNot(HaveOccurred())
+				result := reflect.DeepEqual(existingLimitador.Spec.Storage,  &limitadorv1alpha1.Storage{})
+				g.Expect(result).To(BeTrue()) 
+
+			}).WithContext(ctx).Should(Succeed())
+
+			By("kuadrant counterStorage configuration removed")
+
+			err = k8sClient.Get(ctx, kuadrantKey, existingKuadrant)
+			Expect(err).ToNot(HaveOccurred())
+			existingKuadrant.Spec.Resilience.CounterStorage = nil
+			
+			err = k8sClient.Update(ctx, existingKuadrant)
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+			Eventually(func(g Gomega) {
+				limitadorKey := client.ObjectKey{Name: kuadrant.LimitadorName, Namespace: testNamespace}
+
+				existingLimitador := &limitadorv1alpha1.Limitador{}
+				err := k8sClient.Get(ctx, limitadorKey, existingLimitador)
+				g.Expect(err).ToNot(HaveOccurred())
+				result := (existingLimitador.Spec.Storage == nil)
+				g.Expect(result).To(BeTrue()) 
+
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+	})
+
+
+	Context("User set the Storage configuration directly in the limitador resource", Serial, func() {
+		It("not reverting of chanages happen", func(ctx SpecContext) {
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: testNamespace}
+			limitadorKey := client.ObjectKey{Name: kuadrant.LimitadorName, Namespace: testNamespace}
+
+			By("Setup the basic kuadrant installation")
+			tests.ApplyKuadrantCR(ctx, testClient(), testNamespace)
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+			
+			By("Configure the storage in the limitador resource")
+			existingLimitador := &limitadorv1alpha1.Limitador{}
+			err := k8sClient.Get(ctx, limitadorKey, existingLimitador)
+			Expect(err).ToNot(HaveOccurred())
+
+			existingLimitador.Spec.Storage = &limitadorv1alpha1.Storage{Disk: &limitadorv1alpha1.DiskSpec{}}
+			err = k8sClient.Update(ctx, existingLimitador)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check that kuadrant and limitador are ready")
+			Eventually(tests.LimitadorIsReady(testClient(), limitadorKey)).WithContext(ctx).Should(Succeed())
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+			
+
+			By("Check that the limitador resource is still configured as expected.")
+			Eventually(func(g Gomega) {
+				limitadorKey := client.ObjectKey{Name: kuadrant.LimitadorName, Namespace: testNamespace}
+
+				existingLimitador := &limitadorv1alpha1.Limitador{}
+				err := k8sClient.Get(ctx, limitadorKey, existingLimitador)
+				g.Expect(err).ToNot(HaveOccurred())
+				result := reflect.DeepEqual(existingLimitador.Spec.Storage,  &limitadorv1alpha1.Storage{Disk: &limitadorv1alpha1.DiskSpec{}})
+				g.Expect(result).To(BeTrue()) 
+
+			}).WithContext(ctx).Should(Succeed())
+
+
+		}, testTimeOut)
+	})
+
+	Context("counterStorage is configured", Serial, func() {
+		It("user modifies the storage configuration in the limitador resource", func(ctx SpecContext) {
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: testNamespace}
+			limitadorKey := client.ObjectKey{Name: kuadrant.LimitadorName, Namespace: testNamespace}
+
+			By("Apply kurdrant resouce with counterStorage configured")
+			tests.ApplyKuadrantCRWithName(ctx, testClient(), testNamespace, kuatrantResource, func(k *kuadrantv1beta1.Kuadrant) {
+				k.Annotations = map[string]string{ResilienceFeatureAnnotation: "true"}
+				k.Spec = kuadrantv1beta1.KuadrantSpec{
+					Resilience: &kuadrantv1beta1.Resilience{
+						CounterStorage: &limitadorv1alpha1.Storage{
+							Disk: &limitadorv1alpha1.DiskSpec{},
+						},
+					},
+				}
+			})
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+
+			By("Modify the storage in the limitador resource")
+			existingLimitador := &limitadorv1alpha1.Limitador{}
+			err := k8sClient.Get(ctx, limitadorKey, existingLimitador)
+			Expect(err).ToNot(HaveOccurred())
+
+			existingLimitador.Spec.Storage = &limitadorv1alpha1.Storage{}
+			err = k8sClient.Update(ctx, existingLimitador)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Check for everything to be come ready")
+			Eventually(tests.LimitadorIsReady(testClient(), limitadorKey)).WithContext(ctx).Should(Succeed())
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+
+			By("Check the limitador resource is still equal to the kuadrant resource")
+			Eventually(func(g Gomega) {
+				limitadorKey := client.ObjectKey{Name: kuadrant.LimitadorName, Namespace: testNamespace}
+
+				existingLimitador := &limitadorv1alpha1.Limitador{}
+				err := k8sClient.Get(ctx, limitadorKey, existingLimitador)
+				g.Expect(err).ToNot(HaveOccurred())
+				result := reflect.DeepEqual(existingLimitador.Spec.Storage,  &limitadorv1alpha1.Storage{Disk: &limitadorv1alpha1.DiskSpec{}})
+				g.Expect(result).To(BeTrue()) 
+
+			}).WithContext(ctx).Should(Succeed())
+
+		}, testTimeOut)
+	})
+})

--- a/tests/common/kuadrant/suite_test.go
+++ b/tests/common/kuadrant/suite_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuadrant
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	controllers "github.com/kuadrant/kuadrant-operator/internal/controller"
+	"github.com/kuadrant/kuadrant-operator/internal/log"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+// This test suite will be run on k8s env with GatewayAPI CRDs, Istio and Kuadrant CRDs installed
+
+var k8sClient client.Client
+var testEnv *envtest.Environment
+
+func testClient() client.Client { return k8sClient }
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "kuadrant resource Suite")
+}
+
+var _ = SynchronizedBeforeSuite(func() []byte {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		UseExistingCluster: &[]bool{true}[0],
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	controllers.SetupKuadrantOperatorForTest(controllers.BootstrapScheme(), cfg)
+
+	data := controllers.MarshalConfig(cfg)
+
+	return data
+}, func(data []byte) {
+	// Unmarshal the shared configuration struct
+	var sharedCfg controllers.SharedConfig
+	Expect(json.Unmarshal(data, &sharedCfg)).To(Succeed())
+
+	// Create the rest.Config object from the shared configuration
+	cfg := &rest.Config{
+		Host: sharedCfg.Host,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: sharedCfg.TLSClientConfig.Insecure,
+			CertData: sharedCfg.TLSClientConfig.CertData,
+			KeyData:  sharedCfg.TLSClientConfig.KeyData,
+			CAData:   sharedCfg.TLSClientConfig.CAData,
+		},
+	}
+
+	// Create new scheme for each client
+	s := controllers.BootstrapScheme()
+
+	// Set the shared configuration
+	var err error
+	k8sClient, err = client.New(cfg, client.Options{Scheme: s})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+})
+
+var _ = SynchronizedAfterSuite(func() {}, func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+func TestMain(m *testing.M) {
+	logger := log.NewLogger(
+		log.SetLevel(log.DebugLevel),
+		log.SetMode(log.ModeDev),
+		log.WriteTo(GinkgoWriter),
+	).WithName("kuadrant_resource_test")
+	log.SetLogger(logger)
+	os.Exit(m.Run())
+}

--- a/tests/commons.go
+++ b/tests/commons.go
@@ -141,6 +141,27 @@ func ApplyKuadrantCRWithName(ctx context.Context, cl client.Client, namespace, n
 	Expect(err).ToNot(HaveOccurred())
 }
 
+func UpdateKuadrantCRWithName(ctx context.Context, cl client.Client, namespace, name string, mutateFns ...func(*kuadrantv1beta1.Kuadrant)) {
+	kuadrantCR := &kuadrantv1beta1.Kuadrant{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Kuadrant",
+			APIVersion: kuadrantv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    CommonLabels,
+		},
+	}
+
+	for _, mutateFn := range mutateFns {
+		mutateFn(kuadrantCR)
+	}
+
+	err := cl.Update(ctx, kuadrantCR)
+	Expect(err).ToNot(HaveOccurred())
+}
+
 func GatewayIsReady(ctx context.Context, cl client.Client, gateway *gatewayapiv1.Gateway) func() bool {
 	return func() bool {
 		existingGateway := &gatewayapiv1.Gateway{}


### PR DESCRIPTION

Requires:
- #1347
- #1348

This adds integration tests for counter storage configuration
in the kuadrant resource. As there is interaction with the kuadrant
resource the test can **NOT** be run in parallel.

