### PR TITLE
feat(extension): Guard the DAG in a blocking atomic ref

### DIFF
--- a/internal/extension/reconciler.go
+++ b/internal/extension/reconciler.go
@@ -4,12 +4,97 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/kuadrant/policy-machinery/controller"
 	"github.com/kuadrant/policy-machinery/machinery"
 )
 
-var DAG *atomic.Pointer[StateAwareDAG]
+// nilGuardedPointer is an atomic pointer that provides blocking behavior
+// until the pointer is set to a non-nil value.
+type nilGuardedPointer[T any] struct {
+	ptr  atomic.Pointer[T]
+	mu   sync.Mutex
+	cond *sync.Cond
+}
+
+// newNilGuardedPointer creates a new nilGuardedPointer.
+func newNilGuardedPointer[T any]() *nilGuardedPointer[T] {
+	cgp := &nilGuardedPointer[T]{}
+	cgp.cond = sync.NewCond(&cgp.mu)
+	return cgp
+}
+
+// set sets the pointer to x and signals any goroutines waiting for a non-nil value.
+func (c *nilGuardedPointer[T]) set(x T) {
+	c.ptr.Store(&x)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cond.Broadcast()
+}
+
+// get returns the current value of the pointer without blocking.
+func (c *nilGuardedPointer[T]) get() *T {
+	return c.ptr.Load()
+}
+
+// getWait blocks until the pointer is set to a non-nil value and then returns that value.
+func (c *nilGuardedPointer[T]) getWait() T {
+	// First try a quick non-blocking check
+	if val := c.ptr.Load(); val != nil {
+		return *c.ptr.Load()
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for c.ptr.Load() == nil {
+		c.cond.Wait()
+	}
+
+	return *c.ptr.Load()
+}
+
+// getWaitWithTimeout blocks until the pointer is set to a non-nil value or until the timeout is reached.
+// Returns the current value of the pointer and a boolean indicating whether the value was set before the timeout.
+func (c *nilGuardedPointer[T]) getWaitWithTimeout(timeout time.Duration) (*T, bool) {
+	// First try a quick non-blocking check
+	if val := c.ptr.Load(); val != nil {
+		return c.ptr.Load(), true
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	done := make(chan struct{})
+	var result *T
+	var success bool
+
+	go func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+
+		for c.ptr.Load() == nil {
+			c.cond.Wait()
+		}
+
+		result = c.ptr.Load()
+		success = true
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return result, success
+	case <-timer.C:
+		return c.ptr.Load(), false
+	}
+}
+
+// BlockingDAG is a condition variable guarded atomic pointer that blocks until the pointer is set to a non-nil value
+var BlockingDAG = newNilGuardedPointer[StateAwareDAG]()
 
 type StateAwareDAG struct {
 	topology *machinery.Topology
@@ -21,6 +106,6 @@ func Reconcile(_ context.Context, _ []controller.ResourceEvent, topology *machin
 		topology: topology,
 		state:    state,
 	}
-	DAG.Store(&newDag)
+	BlockingDAG.set(newDag)
 	return nil
 }

--- a/internal/extension/reconciler_test.go
+++ b/internal/extension/reconciler_test.go
@@ -1,0 +1,137 @@
+package extension
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNilGuardedPointer(t *testing.T) {
+	t.Run("set and get", func(t *testing.T) {
+		ptr := newNilGuardedPointer[string]()
+
+		if ptr.get() != nil {
+			t.Errorf("Expected initial value to be nil, got %v", ptr.get())
+		}
+
+		value := "test"
+		ptr.set(value)
+
+		loaded := ptr.get()
+		if loaded == nil {
+			t.Error("Expected loaded value to be non-nil")
+		} else if *loaded != value {
+			t.Errorf("Expected loaded value to be %s, got %s", value, *loaded)
+		}
+	})
+
+	t.Run("getWait blocks until value is set", func(t *testing.T) {
+		ptr := newNilGuardedPointer[string]()
+
+		done := make(chan struct{})
+		var loaded string
+
+		go func() {
+			loaded = ptr.getWait()
+			close(done)
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		value := "test"
+		ptr.set(value)
+
+		select {
+		case <-done:
+			if loaded != value {
+				t.Errorf("Expected loaded value to be %s, got %s", value, loaded)
+			}
+		case <-time.After(1 * time.Second):
+			t.Error("Timed out waiting for getWait to return")
+		}
+	})
+
+	t.Run("getWait returns immediately if value is already set", func(t *testing.T) {
+		ptr := newNilGuardedPointer[string]()
+
+		value := "test"
+		ptr.set(value)
+
+		start := time.Now()
+		loaded := ptr.getWait()
+		elapsed := time.Since(start)
+
+		if elapsed > 100*time.Millisecond {
+			t.Errorf("Expected getWait to return immediately, took %v", elapsed)
+		}
+
+		if loaded != value {
+			t.Errorf("Expected loaded value to be %s, got %s", value, loaded)
+		}
+	})
+
+	t.Run("getWaitWithTimeout returns false on timeout", func(t *testing.T) {
+		ptr := newNilGuardedPointer[string]()
+
+		start := time.Now()
+		_, success := ptr.getWaitWithTimeout(100 * time.Millisecond)
+		elapsed := time.Since(start)
+
+		if elapsed < 100*time.Millisecond {
+			t.Errorf("Expected getWaitWithTimeout to wait for at least the timeout duration, took %v", elapsed)
+		}
+
+		if success {
+			t.Error("Expected success to be false on timeout")
+		}
+	})
+
+	t.Run("getWaitWithTimeout returns true when value is set before timeout", func(t *testing.T) {
+		ptr := newNilGuardedPointer[string]()
+
+		done := make(chan bool)
+		var loaded string
+
+		go func() {
+			var success bool
+			l, success := ptr.getWaitWithTimeout(1 * time.Second)
+			loaded = *l
+			done <- success
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+
+		value := "test"
+		ptr.set(value)
+
+		select {
+		case success := <-done:
+			if !success {
+				t.Error("Expected success to be true when value is set before timeout")
+			}
+			if loaded != value {
+				t.Errorf("Expected loaded value to be %s, got %s", value, loaded)
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("Timed out waiting for getWaitWithTimeout to return")
+		}
+	})
+
+	t.Run("BlockingDAG variable", func(t *testing.T) {
+		if BlockingDAG.get() != nil {
+			t.Error("Expected initial BlockingDAG to be nil")
+		}
+
+		dag := StateAwareDAG{
+			topology: nil,
+			state:    &sync.Map{},
+		}
+
+		BlockingDAG.set(dag)
+
+		loaded := BlockingDAG.get()
+		if loaded == nil {
+			t.Error("Expected loaded BlockingDAG to be non-nil")
+		}
+	})
+}


### PR DESCRIPTION
Replaced the DAG "static" with a "Blocking version"