### PR TITLE
Extensions: more wiring

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -24,7 +24,8 @@ comment:
 
 # Find more at https://docs.codecov.com/docs/ignoring-paths
 ignore:
-  - "**/*.deepcopy.go"  # ignore controller-gen generated code
+  - "**/*.deepcopy.go" # ignore controller-gen generated code
+  - "**/*.pb.go"
 
 component_management:
   individual_components:

--- a/Makefile
+++ b/Makefile
@@ -485,7 +485,7 @@ print-operator-image: ## Print operator image
 
 .PHONY: update-catalogsource
 update-catalogsource:
-	@$(YQ) e -i '.spec.image = "${CATALOG_IMG}"' config/deploy/olm/catalogsource.yaml	
+	@$(YQ) e -i '.spec.image = "${CATALOG_IMG}"' config/deploy/olm/catalogsource.yaml
 
 ##@ Code Style
 

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	github.com/prometheus/client_golang v1.20.4
 	github.com/samber/lo v1.47.0
 	go.uber.org/zap v1.27.0
+	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f
 	google.golang.org/grpc v1.71.0
 	google.golang.org/protobuf v1.36.4
 	gotest.tools v2.2.0+incompatible
@@ -88,8 +90,6 @@ require (
 	golang.org/x/time v0.7.0 // indirect
 	golang.org/x/tools v0.26.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/controller/example_extension_reconciler.go
+++ b/internal/controller/example_extension_reconciler.go
@@ -12,10 +12,11 @@ import (
 type ExampleExtensionReconciler struct {
 }
 
-func (e *ExampleExtensionReconciler) Reconcile(ctx context.Context, _ reconcile.Request, _ *types.KuadrantCtx) (reconcile.Result, error) {
+func (e *ExampleExtensionReconciler) Reconcile(ctx context.Context, _ reconcile.Request, _ types.KuadrantCtx) (reconcile.Result, error) {
 	logger := utils.LoggerFromContext(ctx).WithName("ExampleExtensionReconciler")
 	logger.Info("Reconciling ExampleExtension")
 
+	// kuadrantCtx.Resolve()
 	_, err := utils.DynamicClientFromContext(ctx)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/internal/controller/example_extension_reconciler.go
+++ b/internal/controller/example_extension_reconciler.go
@@ -11,7 +11,6 @@ import (
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	"github.com/kuadrant/kuadrant-operator/pkg/extension/types"
 	"github.com/kuadrant/kuadrant-operator/pkg/extension/utils"
-	policymachinery "github.com/kuadrant/policy-machinery/controller"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -22,29 +21,23 @@ type ExampleExtensionReconciler struct {
 func (e *ExampleExtensionReconciler) Reconcile(ctx context.Context, request reconcile.Request, kuadrantCtx types.KuadrantCtx) (reconcile.Result, error) {
 	logger := utils.LoggerFromContext(ctx).WithName("ExampleExtensionReconciler")
 	logger.Info("Reconciling ExampleExtension")
-	dynamicClient, err := utils.DynamicClientFromContext(ctx)
+
+	client, err := utils.ClientFromContext(ctx)
 	if err != nil {
-		return reconcile.Result{}, err
+		logger.Error(err, "Failed to retrieve client")
+		return reconcile.Result{}, nil
 	}
 
-	unstructuredPolicy, err := dynamicClient.Resource(kuadrantv1.AuthPoliciesResource).Namespace(request.Namespace).Get(ctx, request.Name, metav1.GetOptions{})
-	if err != nil {
-		if errors.IsNotFound(err) {
-			logger.Error(nil, "Could not find my policy")
-			return reconcile.Result{}, nil
-		}
+	// instead of registering ExamplePolicy just fake using an AuthPolicy for now
+	authPolicy := &kuadrantv1.AuthPolicy{}
+	err = client.Get(ctx, request.NamespacedName, authPolicy)
+	if errors.IsNotFound(err) {
 		logger.Error(err, "Failed to get my policy")
 		return reconcile.Result{}, err
 	}
 
-	result, err := policymachinery.Restructure[kuadrantv1.AuthPolicy](unstructuredPolicy)
-	if err != nil {
-		logger.Error(err, "Failed to restructure OIDCPolicy")
-		return reconcile.Result{}, err
-	}
-
 	//map it to something that implements the interface
-	myPolicy := newExamplePolicy(result.(kuadrantv1.AuthPolicy))
+	myPolicy := newExamplePolicy(authPolicy)
 
 	out, err := kuadrantCtx.Resolve(ctx, myPolicy, "self.findGateways()[0].metadata.name", true)
 	if err != nil {
@@ -78,7 +71,7 @@ func (e *ExamplePolicy) GetTargetRefs() []gatewayapiv1alpha2.LocalPolicyTargetRe
 	}
 }
 
-func newExamplePolicy(authPolicy kuadrantv1.AuthPolicy) *ExamplePolicy {
+func newExamplePolicy(authPolicy *kuadrantv1.AuthPolicy) *ExamplePolicy {
 	return &ExamplePolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      authPolicy.Name,

--- a/internal/controller/example_extension_reconciler.go
+++ b/internal/controller/example_extension_reconciler.go
@@ -3,8 +3,15 @@ package controllers
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	"github.com/kuadrant/kuadrant-operator/pkg/extension/types"
 	"github.com/kuadrant/kuadrant-operator/pkg/extension/utils"
+	policymachinery "github.com/kuadrant/policy-machinery/controller"
 
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -12,14 +19,73 @@ import (
 type ExampleExtensionReconciler struct {
 }
 
-func (e *ExampleExtensionReconciler) Reconcile(ctx context.Context, _ reconcile.Request, _ types.KuadrantCtx) (reconcile.Result, error) {
+func (e *ExampleExtensionReconciler) Reconcile(ctx context.Context, request reconcile.Request, kuadrantCtx types.KuadrantCtx) (reconcile.Result, error) {
 	logger := utils.LoggerFromContext(ctx).WithName("ExampleExtensionReconciler")
 	logger.Info("Reconciling ExampleExtension")
-
-	// kuadrantCtx.Resolve()
-	_, err := utils.DynamicClientFromContext(ctx)
+	dynamicClient, err := utils.DynamicClientFromContext(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+
+	unstructuredPolicy, err := dynamicClient.Resource(kuadrantv1.AuthPoliciesResource).Namespace(request.Namespace).Get(ctx, request.Name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Error(nil, "Could not find my policy")
+			return reconcile.Result{}, nil
+		}
+		logger.Error(err, "Failed to get my policy")
+		return reconcile.Result{}, err
+	}
+
+	result, err := policymachinery.Restructure[kuadrantv1.AuthPolicy](unstructuredPolicy)
+	if err != nil {
+		logger.Error(err, "Failed to restructure OIDCPolicy")
+		return reconcile.Result{}, err
+	}
+
+	//map it to something that implements the interface
+	myPolicy := newExamplePolicy(result.(kuadrantv1.AuthPolicy))
+
+	out, err := kuadrantCtx.Resolve(ctx, myPolicy, "self.findGateways()[0].metadata.name", true)
+	if err != nil {
+		logger.Error(err, "Failed to resolve")
+		return reconcile.Result{}, err
+	}
+	logger.Info("Resolved", "out", out)
+
 	return reconcile.Result{}, nil
+}
+
+type ExamplePolicy struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec ExamplePolicySpec `json:"spec,omitempty"`
+}
+
+func (e *ExamplePolicy) DeepCopyObject() runtime.Object {
+	//TODO implement me
+	panic("implement me")
+}
+
+type ExamplePolicySpec struct {
+	TargetRef gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName `json:"targetRef"`
+}
+
+func (e *ExamplePolicy) GetTargetRefs() []gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName {
+	return []gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+		e.Spec.TargetRef,
+	}
+}
+
+func newExamplePolicy(authPolicy kuadrantv1.AuthPolicy) *ExamplePolicy {
+	return &ExamplePolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      authPolicy.Name,
+			Namespace: authPolicy.Namespace,
+		},
+		Spec: ExamplePolicySpec{
+			TargetRef: authPolicy.Spec.TargetRef,
+		},
+	}
 }

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -37,7 +37,7 @@ import (
 
 	extpb "github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v0"
 	exttypes "github.com/kuadrant/kuadrant-operator/pkg/extension/types"
-	"github.com/kuadrant/kuadrant-operator/pkg/extension/utils"
+	extutils "github.com/kuadrant/kuadrant-operator/pkg/extension/utils"
 )
 
 var (
@@ -123,7 +123,8 @@ func (ec *ExtensionController) Reconcile(ctx context.Context, request reconcile.
 	//  retrieved by the user in their Reconcile method, or should it just pass them as parameters?
 	// update ctx to hold our logger and client
 	ctx = context.WithValue(ctx, logr.Logger{}, ec.logger)
-	ctx = context.WithValue(ctx, (*dynamic.DynamicClient)(nil), ec.client)
+	ctx = context.WithValue(ctx, extutils.SchemeKey, ec.manager.GetScheme())
+	ctx = context.WithValue(ctx, extutils.ClientKey, ec.manager.GetClient())
 
 	// overrides reconcile method
 	ec.logger.Info("reconciling request", "namespace", request.Namespace, "name", request.Name)
@@ -132,7 +133,7 @@ func (ec *ExtensionController) Reconcile(ctx context.Context, request reconcile.
 
 func (ec *ExtensionController) Resolve(ctx context.Context, policy exttypes.Policy, expression string, subscribe bool) (ref.Val, error) {
 	resp, err := ec.extensionClient.client.Resolve(ctx, &extpb.ResolveRequest{
-		Policy:     utils.MapToExtPolicy(policy),
+		Policy:     extutils.MapToExtPolicy(policy),
 		Expression: expression,
 		Subscribe:  subscribe,
 	})

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -259,6 +259,17 @@ func (b *Builder) Build() (*ExtensionController, error) {
 		return nil, fmt.Errorf("watch sources must be set")
 	}
 
+	// todo(adam-cattermole): we could rework this to be either unix socket path or host etc and configure appropriately
+	if len(os.Args) < 2 {
+		return nil, errors.New("missing socket path argument")
+	}
+	socketPath := os.Args[1]
+
+	extClient, err := newExtensionClient(socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create extension client: %w", err)
+	}
+
 	options := ctrlruntime.Options{
 		Scheme:  b.scheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
@@ -272,17 +283,6 @@ func (b *Builder) Build() (*ExtensionController, error) {
 	dynamicClient, err := dynamic.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		return nil, fmt.Errorf("unable to create client for manager: %w", err)
-	}
-
-	// todo(adam-cattermole): we could rework this to be either unix socket path or host etc and configure appropriately
-	if len(os.Args) < 2 {
-		return nil, errors.New("missing socket path argument")
-	}
-	socketPath := os.Args[1]
-
-	extClient, err := newExtensionClient(socketPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create extension client: %w", err)
 	}
 
 	watchSources := make([]ctrlruntimesrc.Source, 0)

--- a/pkg/extension/controller/controller_test.go
+++ b/pkg/extension/controller/controller_test.go
@@ -1,0 +1,117 @@
+//go:build unit
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	exttypes "github.com/kuadrant/kuadrant-operator/pkg/extension/types"
+)
+
+type mockKuadrantCtx struct {
+	resolveFn func(ctx context.Context, policy exttypes.Policy, expression string, subscribe bool) (ref.Val, error)
+}
+
+func (m *mockKuadrantCtx) Resolve(ctx context.Context, policy exttypes.Policy, expression string, subscribe bool) (ref.Val, error) {
+	return m.resolveFn(ctx, policy, expression, subscribe)
+}
+
+func TestGenericResolveSuccess(t *testing.T) {
+	mockCtx := &mockKuadrantCtx{
+		resolveFn: func(ctx context.Context, policy exttypes.Policy, expression string, subscribe bool) (ref.Val, error) {
+			return celtypes.Int(42), nil
+		},
+	}
+
+	result, err := Resolve[int](context.Background(), mockCtx, nil, "some.expression", false)
+	assert.NilError(t, err)
+	assert.Equal(t, 42, result)
+}
+
+func TestGenericResolveTypeMismatch(t *testing.T) {
+	mockCtx := &mockKuadrantCtx{
+		resolveFn: func(ctx context.Context, policy exttypes.Policy, expression string, subscribe bool) (ref.Val, error) {
+			return celtypes.String("not-an-int"), nil
+		},
+	}
+
+	_, err := Resolve[int](context.Background(), mockCtx, nil, "some.expression", false)
+	assert.ErrorContains(t, err, "unsupported native conversion")
+}
+
+func TestGenericResolveError(t *testing.T) {
+	expectedErr := errors.New("resolve failure")
+	mockCtx := &mockKuadrantCtx{
+		resolveFn: func(ctx context.Context, policy exttypes.Policy, expression string, subscribe bool) (ref.Val, error) {
+			return nil, expectedErr
+		},
+	}
+
+	_, err := Resolve[int](context.Background(), mockCtx, nil, "some.expression", false)
+	assert.Error(t, err, expectedErr.Error())
+}
+
+func mockReconcile(_ context.Context, _ reconcile.Request, _ exttypes.KuadrantCtx) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+func setupFakeArgs(t *testing.T, socketPath string) func() {
+	t.Helper()
+	originalArgs := os.Args
+	os.Args = []string{"my-extension", socketPath}
+	return func() { os.Args = originalArgs }
+}
+
+func TestBuilderMissingName(t *testing.T) {
+	builder := &Builder{}
+	_, err := builder.Build()
+	assert.ErrorContains(t, err, "controller name must be set")
+}
+
+func TestBuilderMissingScheme(t *testing.T) {
+	builder, _ := NewBuilder("test-controller")
+	_, err := builder.Build()
+	assert.ErrorContains(t, err, "scheme must be set")
+}
+
+func TestBuilderBuildMissingReconcile(t *testing.T) {
+	builder, _ := NewBuilder("test-controller")
+	_, err := builder.
+		WithScheme(runtime.NewScheme()).
+		Build()
+	assert.ErrorContains(t, err, "reconcile function must be set")
+}
+
+func TestBuilderMissingWatchTypes(t *testing.T) {
+	builder, _ := NewBuilder("test-controller")
+	_, err := builder.
+		WithScheme(runtime.NewScheme()).
+		WithReconciler(mockReconcile).
+		Build()
+	assert.ErrorContains(t, err, "watch sources must be set")
+}
+
+func TestBuilderMissingSocketPath(t *testing.T) {
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+	os.Args = []string{"my-extension"} // no socket path
+
+	builder, _ := NewBuilder("test-controller")
+	_, err := builder.
+		WithScheme(runtime.NewScheme()).
+		WithReconciler(mockReconcile).
+		Watches(&corev1.Pod{}).
+		Build()
+
+	assert.ErrorContains(t, err, "missing socket path")
+}

--- a/pkg/extension/grpc/v0/kuadrant.pb.go
+++ b/pkg/extension/grpc/v0/kuadrant.pb.go
@@ -8,6 +8,7 @@ package v0
 
 import (
 	v1alpha1 "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
+	status "google.golang.org/genproto/googleapis/rpc/status"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -220,7 +221,58 @@ func (x *ResolveResponse) GetCelResult() *v1alpha1.Value {
 	return nil
 }
 
-// todo: define the message to be streamed back to the client
+type SubscribeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Event         *Event                 `protobuf:"bytes,1,opt,name=event,proto3" json:"event,omitempty"`
+	Error         *status.Status         `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SubscribeResponse) Reset() {
+	*x = SubscribeResponse{}
+	mi := &file_kuadrant_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SubscribeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SubscribeResponse) ProtoMessage() {}
+
+func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kuadrant_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SubscribeResponse.ProtoReflect.Descriptor instead.
+func (*SubscribeResponse) Descriptor() ([]byte, []int) {
+	return file_kuadrant_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *SubscribeResponse) GetEvent() *Event {
+	if x != nil {
+		return x.Event
+	}
+	return nil
+}
+
+func (x *SubscribeResponse) GetError() *status.Status {
+	if x != nil {
+		return x.Error
+	}
+	return nil
+}
+
 type Event struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Metadata      *Metadata              `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
@@ -230,7 +282,7 @@ type Event struct {
 
 func (x *Event) Reset() {
 	*x = Event{}
-	mi := &file_kuadrant_proto_msgTypes[4]
+	mi := &file_kuadrant_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -242,7 +294,7 @@ func (x *Event) String() string {
 func (*Event) ProtoMessage() {}
 
 func (x *Event) ProtoReflect() protoreflect.Message {
-	mi := &file_kuadrant_proto_msgTypes[4]
+	mi := &file_kuadrant_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -255,7 +307,7 @@ func (x *Event) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Event.ProtoReflect.Descriptor instead.
 func (*Event) Descriptor() ([]byte, []int) {
-	return file_kuadrant_proto_rawDescGZIP(), []int{4}
+	return file_kuadrant_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Event) GetMetadata() *Metadata {
@@ -269,7 +321,7 @@ var File_kuadrant_proto protoreflect.FileDescriptor
 
 const file_kuadrant_proto_rawDesc = "" +
 	"\n" +
-	"\x0ekuadrant.proto\x12\vkuadrant.v0\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x11gateway_api.proto\x1a\x1fgoogle/api/cel/expr/value.proto\";\n" +
+	"\x0ekuadrant.proto\x12\vkuadrant.v0\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x11gateway_api.proto\x1a\x1fgoogle/api/cel/expr/value.proto\x1a\x17google/rpc/status.proto\";\n" +
 	"\vPingRequest\x12,\n" +
 	"\x03out\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x03out\":\n" +
 	"\fPongResponse\x12*\n" +
@@ -282,12 +334,15 @@ const file_kuadrant_proto_rawDesc = "" +
 	"\tsubscribe\x18\x03 \x01(\bR\tsubscribe\"Q\n" +
 	"\x0fResolveResponse\x12>\n" +
 	"\n" +
-	"cel_result\x18\x01 \x01(\v2\x1f.google.api.expr.v1alpha1.ValueR\tcelResult\":\n" +
+	"cel_result\x18\x01 \x01(\v2\x1f.google.api.expr.v1alpha1.ValueR\tcelResult\"g\n" +
+	"\x11SubscribeResponse\x12(\n" +
+	"\x05event\x18\x01 \x01(\v2\x12.kuadrant.v0.EventR\x05event\x12(\n" +
+	"\x05error\x18\x02 \x01(\v2\x12.google.rpc.StatusR\x05error\":\n" +
 	"\x05Event\x121\n" +
-	"\bmetadata\x18\x01 \x01(\v2\x15.kuadrant.v0.MetadataR\bmetadata2\xd6\x01\n" +
+	"\bmetadata\x18\x01 \x01(\v2\x15.kuadrant.v0.MetadataR\bmetadata2\xe2\x01\n" +
 	"\x10ExtensionService\x12=\n" +
-	"\x04Ping\x12\x18.kuadrant.v0.PingRequest\x1a\x19.kuadrant.v0.PongResponse\"\x00\x12;\n" +
-	"\tSubscribe\x12\x16.google.protobuf.Empty\x1a\x12.kuadrant.v0.Event\"\x000\x01\x12F\n" +
+	"\x04Ping\x12\x18.kuadrant.v0.PingRequest\x1a\x19.kuadrant.v0.PongResponse\"\x00\x12G\n" +
+	"\tSubscribe\x12\x16.google.protobuf.Empty\x1a\x1e.kuadrant.v0.SubscribeResponse\"\x000\x01\x12F\n" +
 	"\aResolve\x12\x1b.kuadrant.v0.ResolveRequest\x1a\x1c.kuadrant.v0.ResolveResponse\"\x00B=Z;github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v0b\x06proto3"
 
 var (
@@ -302,36 +357,40 @@ func file_kuadrant_proto_rawDescGZIP() []byte {
 	return file_kuadrant_proto_rawDescData
 }
 
-var file_kuadrant_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_kuadrant_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_kuadrant_proto_goTypes = []any{
 	(*PingRequest)(nil),           // 0: kuadrant.v0.PingRequest
 	(*PongResponse)(nil),          // 1: kuadrant.v0.PongResponse
 	(*ResolveRequest)(nil),        // 2: kuadrant.v0.ResolveRequest
 	(*ResolveResponse)(nil),       // 3: kuadrant.v0.ResolveResponse
-	(*Event)(nil),                 // 4: kuadrant.v0.Event
-	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
-	(*Policy)(nil),                // 6: kuadrant.v0.Policy
-	(*v1alpha1.Value)(nil),        // 7: google.api.expr.v1alpha1.Value
-	(*Metadata)(nil),              // 8: kuadrant.v0.Metadata
-	(*emptypb.Empty)(nil),         // 9: google.protobuf.Empty
+	(*SubscribeResponse)(nil),     // 4: kuadrant.v0.SubscribeResponse
+	(*Event)(nil),                 // 5: kuadrant.v0.Event
+	(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
+	(*Policy)(nil),                // 7: kuadrant.v0.Policy
+	(*v1alpha1.Value)(nil),        // 8: google.api.expr.v1alpha1.Value
+	(*status.Status)(nil),         // 9: google.rpc.Status
+	(*Metadata)(nil),              // 10: kuadrant.v0.Metadata
+	(*emptypb.Empty)(nil),         // 11: google.protobuf.Empty
 }
 var file_kuadrant_proto_depIdxs = []int32{
-	5, // 0: kuadrant.v0.PingRequest.out:type_name -> google.protobuf.Timestamp
-	5, // 1: kuadrant.v0.PongResponse.in:type_name -> google.protobuf.Timestamp
-	6, // 2: kuadrant.v0.ResolveRequest.policy:type_name -> kuadrant.v0.Policy
-	7, // 3: kuadrant.v0.ResolveResponse.cel_result:type_name -> google.api.expr.v1alpha1.Value
-	8, // 4: kuadrant.v0.Event.metadata:type_name -> kuadrant.v0.Metadata
-	0, // 5: kuadrant.v0.ExtensionService.Ping:input_type -> kuadrant.v0.PingRequest
-	9, // 6: kuadrant.v0.ExtensionService.Subscribe:input_type -> google.protobuf.Empty
-	2, // 7: kuadrant.v0.ExtensionService.Resolve:input_type -> kuadrant.v0.ResolveRequest
-	1, // 8: kuadrant.v0.ExtensionService.Ping:output_type -> kuadrant.v0.PongResponse
-	4, // 9: kuadrant.v0.ExtensionService.Subscribe:output_type -> kuadrant.v0.Event
-	3, // 10: kuadrant.v0.ExtensionService.Resolve:output_type -> kuadrant.v0.ResolveResponse
-	8, // [8:11] is the sub-list for method output_type
-	5, // [5:8] is the sub-list for method input_type
-	5, // [5:5] is the sub-list for extension type_name
-	5, // [5:5] is the sub-list for extension extendee
-	0, // [0:5] is the sub-list for field type_name
+	6,  // 0: kuadrant.v0.PingRequest.out:type_name -> google.protobuf.Timestamp
+	6,  // 1: kuadrant.v0.PongResponse.in:type_name -> google.protobuf.Timestamp
+	7,  // 2: kuadrant.v0.ResolveRequest.policy:type_name -> kuadrant.v0.Policy
+	8,  // 3: kuadrant.v0.ResolveResponse.cel_result:type_name -> google.api.expr.v1alpha1.Value
+	5,  // 4: kuadrant.v0.SubscribeResponse.event:type_name -> kuadrant.v0.Event
+	9,  // 5: kuadrant.v0.SubscribeResponse.error:type_name -> google.rpc.Status
+	10, // 6: kuadrant.v0.Event.metadata:type_name -> kuadrant.v0.Metadata
+	0,  // 7: kuadrant.v0.ExtensionService.Ping:input_type -> kuadrant.v0.PingRequest
+	11, // 8: kuadrant.v0.ExtensionService.Subscribe:input_type -> google.protobuf.Empty
+	2,  // 9: kuadrant.v0.ExtensionService.Resolve:input_type -> kuadrant.v0.ResolveRequest
+	1,  // 10: kuadrant.v0.ExtensionService.Ping:output_type -> kuadrant.v0.PongResponse
+	4,  // 11: kuadrant.v0.ExtensionService.Subscribe:output_type -> kuadrant.v0.SubscribeResponse
+	3,  // 12: kuadrant.v0.ExtensionService.Resolve:output_type -> kuadrant.v0.ResolveResponse
+	10, // [10:13] is the sub-list for method output_type
+	7,  // [7:10] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_kuadrant_proto_init() }
@@ -346,7 +405,7 @@ func file_kuadrant_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kuadrant_proto_rawDesc), len(file_kuadrant_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   5,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/extension/grpc/v0/kuadrant.pb.go
+++ b/pkg/extension/grpc/v0/kuadrant.pb.go
@@ -7,6 +7,7 @@
 package v0
 
 import (
+	v1alpha1 "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -174,10 +175,10 @@ func (x *ResolveRequest) GetSubscribe() bool {
 	return false
 }
 
-// todo(adam-cattermole): this should return a Cel value not a string
+// Return the result as a cel value
 type ResolveResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	CelResult     string                 `protobuf:"bytes,1,opt,name=cel_result,json=celResult,proto3" json:"cel_result,omitempty"`
+	CelResult     *v1alpha1.Value        `protobuf:"bytes,1,opt,name=cel_result,json=celResult,proto3" json:"cel_result,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -212,11 +213,11 @@ func (*ResolveResponse) Descriptor() ([]byte, []int) {
 	return file_kuadrant_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *ResolveResponse) GetCelResult() string {
+func (x *ResolveResponse) GetCelResult() *v1alpha1.Value {
 	if x != nil {
 		return x.CelResult
 	}
-	return ""
+	return nil
 }
 
 // todo: define the message to be streamed back to the client
@@ -268,7 +269,7 @@ var File_kuadrant_proto protoreflect.FileDescriptor
 
 const file_kuadrant_proto_rawDesc = "" +
 	"\n" +
-	"\x0ekuadrant.proto\x12\vkuadrant.v0\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x11gateway_api.proto\";\n" +
+	"\x0ekuadrant.proto\x12\vkuadrant.v0\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x11gateway_api.proto\x1a\x1fgoogle/api/cel/expr/value.proto\";\n" +
 	"\vPingRequest\x12,\n" +
 	"\x03out\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x03out\":\n" +
 	"\fPongResponse\x12*\n" +
@@ -278,10 +279,10 @@ const file_kuadrant_proto_rawDesc = "" +
 	"\n" +
 	"expression\x18\x02 \x01(\tR\n" +
 	"expression\x12\x1c\n" +
-	"\tsubscribe\x18\x03 \x01(\bR\tsubscribe\"0\n" +
-	"\x0fResolveResponse\x12\x1d\n" +
+	"\tsubscribe\x18\x03 \x01(\bR\tsubscribe\"Q\n" +
+	"\x0fResolveResponse\x12>\n" +
 	"\n" +
-	"cel_result\x18\x01 \x01(\tR\tcelResult\":\n" +
+	"cel_result\x18\x01 \x01(\v2\x1f.google.api.expr.v1alpha1.ValueR\tcelResult\":\n" +
 	"\x05Event\x121\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x15.kuadrant.v0.MetadataR\bmetadata2\xd6\x01\n" +
 	"\x10ExtensionService\x12=\n" +
@@ -310,25 +311,27 @@ var file_kuadrant_proto_goTypes = []any{
 	(*Event)(nil),                 // 4: kuadrant.v0.Event
 	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
 	(*Policy)(nil),                // 6: kuadrant.v0.Policy
-	(*Metadata)(nil),              // 7: kuadrant.v0.Metadata
-	(*emptypb.Empty)(nil),         // 8: google.protobuf.Empty
+	(*v1alpha1.Value)(nil),        // 7: google.api.expr.v1alpha1.Value
+	(*Metadata)(nil),              // 8: kuadrant.v0.Metadata
+	(*emptypb.Empty)(nil),         // 9: google.protobuf.Empty
 }
 var file_kuadrant_proto_depIdxs = []int32{
 	5, // 0: kuadrant.v0.PingRequest.out:type_name -> google.protobuf.Timestamp
 	5, // 1: kuadrant.v0.PongResponse.in:type_name -> google.protobuf.Timestamp
 	6, // 2: kuadrant.v0.ResolveRequest.policy:type_name -> kuadrant.v0.Policy
-	7, // 3: kuadrant.v0.Event.metadata:type_name -> kuadrant.v0.Metadata
-	0, // 4: kuadrant.v0.ExtensionService.Ping:input_type -> kuadrant.v0.PingRequest
-	8, // 5: kuadrant.v0.ExtensionService.Subscribe:input_type -> google.protobuf.Empty
-	2, // 6: kuadrant.v0.ExtensionService.Resolve:input_type -> kuadrant.v0.ResolveRequest
-	1, // 7: kuadrant.v0.ExtensionService.Ping:output_type -> kuadrant.v0.PongResponse
-	4, // 8: kuadrant.v0.ExtensionService.Subscribe:output_type -> kuadrant.v0.Event
-	3, // 9: kuadrant.v0.ExtensionService.Resolve:output_type -> kuadrant.v0.ResolveResponse
-	7, // [7:10] is the sub-list for method output_type
-	4, // [4:7] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	7, // 3: kuadrant.v0.ResolveResponse.cel_result:type_name -> google.api.expr.v1alpha1.Value
+	8, // 4: kuadrant.v0.Event.metadata:type_name -> kuadrant.v0.Metadata
+	0, // 5: kuadrant.v0.ExtensionService.Ping:input_type -> kuadrant.v0.PingRequest
+	9, // 6: kuadrant.v0.ExtensionService.Subscribe:input_type -> google.protobuf.Empty
+	2, // 7: kuadrant.v0.ExtensionService.Resolve:input_type -> kuadrant.v0.ResolveRequest
+	1, // 8: kuadrant.v0.ExtensionService.Ping:output_type -> kuadrant.v0.PongResponse
+	4, // 9: kuadrant.v0.ExtensionService.Subscribe:output_type -> kuadrant.v0.Event
+	3, // 10: kuadrant.v0.ExtensionService.Resolve:output_type -> kuadrant.v0.ResolveResponse
+	8, // [8:11] is the sub-list for method output_type
+	5, // [5:8] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_kuadrant_proto_init() }

--- a/pkg/extension/grpc/v0/kuadrant.proto
+++ b/pkg/extension/grpc/v0/kuadrant.proto
@@ -7,6 +7,7 @@ package kuadrant.v0;
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
 import "gateway_api.proto";
+import "google/api/cel/expr/value.proto";
 
 // The greeting service definition.
 service ExtensionService {
@@ -35,9 +36,9 @@ message ResolveRequest {
   bool subscribe = 3;
 }
 
-// todo(adam-cattermole): this should return a Cel value not a string
+// Return the result as a cel value
 message ResolveResponse {
-  string cel_result = 1;
+  google.api.expr.v1alpha1.Value cel_result = 1;
 }
 
 // todo: define the message to be streamed back to the client

--- a/pkg/extension/grpc/v0/kuadrant.proto
+++ b/pkg/extension/grpc/v0/kuadrant.proto
@@ -8,13 +8,14 @@ import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
 import "gateway_api.proto";
 import "google/api/cel/expr/value.proto";
+import "google/rpc/status.proto";
 
 // The greeting service definition.
 service ExtensionService {
   // Sends a greeting
   rpc Ping (PingRequest) returns (PongResponse) {}
   // Subscribe to a set of Events
-  rpc Subscribe(google.protobuf.Empty) returns (stream Event) {}
+  rpc Subscribe(google.protobuf.Empty) returns (stream SubscribeResponse) {}
   // Resolve the expression for context and subscribe (or not)
   rpc Resolve(ResolveRequest) returns (ResolveResponse) {}
 }
@@ -41,7 +42,11 @@ message ResolveResponse {
   google.api.expr.v1alpha1.Value cel_result = 1;
 }
 
-// todo: define the message to be streamed back to the client
+message SubscribeResponse {
+  Event event = 1;
+  google.rpc.Status error = 2;
+}
+
 message Event {
   Metadata metadata = 1;
 }

--- a/pkg/extension/grpc/v0/kuadrant_grpc.pb.go
+++ b/pkg/extension/grpc/v0/kuadrant_grpc.pb.go
@@ -34,7 +34,7 @@ type ExtensionServiceClient interface {
 	// Sends a greeting
 	Ping(ctx context.Context, in *PingRequest, opts ...grpc.CallOption) (*PongResponse, error)
 	// Subscribe to a set of Events
-	Subscribe(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Event], error)
+	Subscribe(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeResponse], error)
 	// Resolve the expression for context and subscribe (or not)
 	Resolve(ctx context.Context, in *ResolveRequest, opts ...grpc.CallOption) (*ResolveResponse, error)
 }
@@ -57,13 +57,13 @@ func (c *extensionServiceClient) Ping(ctx context.Context, in *PingRequest, opts
 	return out, nil
 }
 
-func (c *extensionServiceClient) Subscribe(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[Event], error) {
+func (c *extensionServiceClient) Subscribe(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SubscribeResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &ExtensionService_ServiceDesc.Streams[0], ExtensionService_Subscribe_FullMethodName, cOpts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &grpc.GenericClientStream[emptypb.Empty, Event]{ClientStream: stream}
+	x := &grpc.GenericClientStream[emptypb.Empty, SubscribeResponse]{ClientStream: stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (c *extensionServiceClient) Subscribe(ctx context.Context, in *emptypb.Empt
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type ExtensionService_SubscribeClient = grpc.ServerStreamingClient[Event]
+type ExtensionService_SubscribeClient = grpc.ServerStreamingClient[SubscribeResponse]
 
 func (c *extensionServiceClient) Resolve(ctx context.Context, in *ResolveRequest, opts ...grpc.CallOption) (*ResolveResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -95,7 +95,7 @@ type ExtensionServiceServer interface {
 	// Sends a greeting
 	Ping(context.Context, *PingRequest) (*PongResponse, error)
 	// Subscribe to a set of Events
-	Subscribe(*emptypb.Empty, grpc.ServerStreamingServer[Event]) error
+	Subscribe(*emptypb.Empty, grpc.ServerStreamingServer[SubscribeResponse]) error
 	// Resolve the expression for context and subscribe (or not)
 	Resolve(context.Context, *ResolveRequest) (*ResolveResponse, error)
 	mustEmbedUnimplementedExtensionServiceServer()
@@ -111,7 +111,7 @@ type UnimplementedExtensionServiceServer struct{}
 func (UnimplementedExtensionServiceServer) Ping(context.Context, *PingRequest) (*PongResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Ping not implemented")
 }
-func (UnimplementedExtensionServiceServer) Subscribe(*emptypb.Empty, grpc.ServerStreamingServer[Event]) error {
+func (UnimplementedExtensionServiceServer) Subscribe(*emptypb.Empty, grpc.ServerStreamingServer[SubscribeResponse]) error {
 	return status.Errorf(codes.Unimplemented, "method Subscribe not implemented")
 }
 func (UnimplementedExtensionServiceServer) Resolve(context.Context, *ResolveRequest) (*ResolveResponse, error) {
@@ -161,11 +161,11 @@ func _ExtensionService_Subscribe_Handler(srv interface{}, stream grpc.ServerStre
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(ExtensionServiceServer).Subscribe(m, &grpc.GenericServerStream[emptypb.Empty, Event]{ServerStream: stream})
+	return srv.(ExtensionServiceServer).Subscribe(m, &grpc.GenericServerStream[emptypb.Empty, SubscribeResponse]{ServerStream: stream})
 }
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type ExtensionService_SubscribeServer = grpc.ServerStreamingServer[Event]
+type ExtensionService_SubscribeServer = grpc.ServerStreamingServer[SubscribeResponse]
 
 func _ExtensionService_Resolve_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ResolveRequest)

--- a/pkg/extension/types/types.go
+++ b/pkg/extension/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 
+	celref "github.com/google/cel-go/common/types/ref"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
@@ -14,7 +15,7 @@ type Policy interface {
 }
 
 type KuadrantCtx interface {
-	Resolve(context.Context, Policy, string, bool) (string, error)
+	Resolve(context.Context, Policy, string, bool) (celref.Val, error)
 }
 
-type ReconcileFn func(ctx context.Context, request reconcile.Request, kuadrant *KuadrantCtx) (reconcile.Result, error)
+type ReconcileFn func(ctx context.Context, request reconcile.Request, kuadrant KuadrantCtx) (reconcile.Result, error)

--- a/pkg/extension/types/types.go
+++ b/pkg/extension/types/types.go
@@ -3,9 +3,18 @@ package types
 import (
 	"context"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-type KuadrantCtx interface{}
+type Policy interface {
+	client.Object
+	GetTargetRefs() []gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName
+}
+
+type KuadrantCtx interface {
+	Resolve(context.Context, Policy, string, bool) (string, error)
+}
 
 type ReconcileFn func(ctx context.Context, request reconcile.Request, kuadrant *KuadrantCtx) (reconcile.Result, error)

--- a/pkg/extension/utils/utils.go
+++ b/pkg/extension/utils/utils.go
@@ -5,8 +5,13 @@ import (
 	"errors"
 
 	"github.com/go-logr/logr"
+	"github.com/samber/lo"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/ptr"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	extpb "github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v0"
+	exttypes "github.com/kuadrant/kuadrant-operator/pkg/extension/types"
 	"github.com/kuadrant/policy-machinery/controller"
 )
 
@@ -20,4 +25,25 @@ func DynamicClientFromContext(ctx context.Context) (*dynamic.DynamicClient, erro
 		return nil, errors.New("failed to retrieve dynamic client from context")
 	}
 	return dynamicClient, nil
+}
+
+func MapToExtPolicy(p exttypes.Policy) *extpb.Policy {
+	targetRefs := lo.Map(p.GetTargetRefs(), func(targetRef gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName, _ int) *extpb.TargetRef {
+		return &extpb.TargetRef{
+			Group:       string(targetRef.Group),
+			Kind:        string(targetRef.Kind),
+			Name:        string(targetRef.Name),
+			SectionName: string(ptr.Deref(targetRef.SectionName, "")),
+		}
+	})
+	return &extpb.Policy{
+		Metadata: &extpb.Metadata{
+			Group:     p.GetObjectKind().GroupVersionKind().Group,
+			Kind:      p.GetObjectKind().GroupVersionKind().Kind,
+			Namespace: p.GetNamespace(),
+			Name:      p.GetName(),
+		},
+		TargetRefs: targetRefs,
+	}
+
 }

--- a/pkg/extension/utils/utils.go
+++ b/pkg/extension/utils/utils.go
@@ -45,5 +45,4 @@ func MapToExtPolicy(p exttypes.Policy) *extpb.Policy {
 		},
 		TargetRefs: targetRefs,
 	}
-
 }

--- a/pkg/extension/utils/utils.go
+++ b/pkg/extension/utils/utils.go
@@ -6,25 +6,41 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
-	"k8s.io/client-go/dynamic"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kuadrant/policy-machinery/controller"
 
 	extpb "github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v0"
 	exttypes "github.com/kuadrant/kuadrant-operator/pkg/extension/types"
-	"github.com/kuadrant/policy-machinery/controller"
 )
+
+type clientKeyType struct{}
+type schemeKeyType struct{}
+
+var ClientKey = clientKeyType{}
+var SchemeKey = schemeKeyType{}
 
 func LoggerFromContext(ctx context.Context) logr.Logger {
 	return controller.LoggerFromContext(ctx)
 }
 
-func DynamicClientFromContext(ctx context.Context) (*dynamic.DynamicClient, error) {
-	dynamicClient, ok := ctx.Value((*dynamic.DynamicClient)(nil)).(*dynamic.DynamicClient)
+func ClientFromContext(ctx context.Context) (client.Client, error) {
+	client, ok := ctx.Value(ClientKey).(client.Client)
 	if !ok {
-		return nil, errors.New("failed to retrieve dynamic client from context")
+		return nil, errors.New("failed to retrieve the client from context")
 	}
-	return dynamicClient, nil
+	return client, nil
+}
+
+func SchemeFromContext(ctx context.Context) (*runtime.Scheme, error) {
+	scheme, ok := ctx.Value(SchemeKey).(*runtime.Scheme)
+	if !ok {
+		return nil, errors.New("failed to retrieve scheme from context")
+	}
+	return scheme, nil
 }
 
 func MapToExtPolicy(p exttypes.Policy) *extpb.Policy {

--- a/pkg/extension/utils/utils_test.go
+++ b/pkg/extension/utils/utils_test.go
@@ -1,0 +1,109 @@
+//go:build unit
+
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/ptr"
+
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+)
+
+func TestDynamicClientFromContext_Success(t *testing.T) {
+	expectedClient := &dynamic.DynamicClient{}
+	ctx := context.WithValue(context.Background(), (*dynamic.DynamicClient)(nil), expectedClient)
+
+	client, err := DynamicClientFromContext(ctx)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if client != expectedClient {
+		t.Errorf("expected client %v, got %v", expectedClient, client)
+	}
+}
+
+func TestDynamicClientFromContext_Missing(t *testing.T) {
+	ctx := context.Background()
+
+	client, err := DynamicClientFromContext(ctx)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if client != nil {
+		t.Errorf("expected nil client, got %v", client)
+	}
+}
+
+type TestPolicy struct {
+	metav1.ObjectMeta
+	GroupVersionKind schema.GroupVersionKind
+	TargetRefs       []gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName
+}
+
+type mockObjectKind struct {
+	gvk schema.GroupVersionKind
+}
+
+func (m *mockObjectKind) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	m.gvk = gvk
+}
+
+func (m *mockObjectKind) GroupVersionKind() schema.GroupVersionKind {
+	return m.gvk
+}
+
+func (tp *TestPolicy) GetObjectKind() schema.ObjectKind {
+	return &mockObjectKind{gvk: tp.GroupVersionKind}
+}
+
+func (tp *TestPolicy) GetTargetRefs() []gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName {
+	return tp.TargetRefs
+}
+
+func (tp *TestPolicy) DeepCopyObject() runtime.Object {
+	copy := *tp
+	return &copy
+}
+
+func TestMapToExtPolicy(t *testing.T) {
+
+	p := &TestPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-policy",
+		},
+		GroupVersionKind: schema.GroupVersionKind{Group: "example.group", Kind: "ExamplePolicy"},
+		TargetRefs: []gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+			gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+					Group: "my.group",
+					Kind:  "MyKind",
+					Name:  "example-name",
+				},
+				SectionName: ptr.To[gatewayapiv1alpha2.SectionName]("some-section"),
+			},
+		},
+	}
+	result := MapToExtPolicy(p)
+
+	assert.Assert(t, result != nil, "expected non-nil result")
+	assert.Assert(t, result.Metadata != nil, "expected metadata to be populated")
+
+	assert.Equal(t, "default", result.Metadata.Namespace)
+	assert.Equal(t, "test-policy", result.Metadata.Name)
+	assert.Equal(t, "example.group", result.Metadata.Group)
+	assert.Equal(t, "ExamplePolicy", result.Metadata.Kind)
+
+	assert.Equal(t, len(result.TargetRefs), 1)
+	assert.Equal(t, "my.group", result.TargetRefs[0].Group)
+	assert.Equal(t, "MyKind", result.TargetRefs[0].Kind)
+	assert.Equal(t, "example-name", result.TargetRefs[0].Name)
+	assert.Equal(t, "some-section", result.TargetRefs[0].SectionName)
+}


### PR DESCRIPTION
Builds on #1360 

* Add support to pass the cel.expr.Value back instead of strings from Resolve
* Fix a couple issues in the manager - we may need to extend the timeout even more on the `getWaitWithTimeout`
* Passing errors back in the subscribe stream, for now these are logged "internally" within the client controller
* Updated the example reconciler with a Policy that matches the interface (we map an AuthPolicy to it for now), and resolve the first gateway name

If you follow the guide here [authenticated rl guide](https://docs.kuadrant.io/1.2.x/kuadrant-operator/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers/) you'll see the following in the logs (the gateway is called `external` in that example):

```
WITH_EXTENSIONS=true make local setup
kubectl set env -n kuadrant-system deployments/kuadrant-operator-controller-manager WITH_EXTENSIONS="true"
```

```
{"level":"info","ts":"2025-05-07T16:43:21Z","logger":"example-extension-controller.ExampleExtensionReconciler","msg":"Reconciling ExampleExtension"}
{"level":"info","ts":"2025-05-07T16:43:21Z","logger":"example-extension-controller.ExampleExtensionReconciler","msg":"Resolved","out":"external"}
```