### PR TITLE
Allows for validating expressions, making sure they only use root bindings (and types) introduced by a policy

### DIFF
--- a/api/v1/ratelimitpolicy_types.go
+++ b/api/v1/ratelimitpolicy_types.go
@@ -19,7 +19,7 @@ package v1
 import (
 	"time"
 
-	transformer "github.com/kuadrant/kuadrant-operator/internal/cel"
+	"github.com/kuadrant/kuadrant-operator/internal/cel"
 
 	"github.com/kuadrant/policy-machinery/machinery"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -241,7 +241,7 @@ func (l Limit) CountersAsStringList() []string {
 	}
 	return utils.Map(l.Counters, func(counter Counter) string {
 		str := string(counter.Expression)
-		if exp, err := transformer.TransformCounterVariable(str, false); err == nil {
+		if exp, err := cel.TransformCounterVariable(str, false); err == nil {
 			return *exp
 		}
 		return str

--- a/internal/cel/transformer.go
+++ b/internal/cel/transformer.go
@@ -1,4 +1,4 @@
-package transformer
+package cel
 
 import (
 	"errors"

--- a/internal/cel/transformer_test.go
+++ b/internal/cel/transformer_test.go
@@ -1,4 +1,4 @@
-package transformer
+package cel
 
 import (
 	"testing"

--- a/internal/cel/validator.go
+++ b/internal/cel/validator.go
@@ -62,43 +62,46 @@ func (b *ValidatorBuilder) AddPolicyBindingAfter(after *string, policy string, n
 }
 
 func (b *ValidatorBuilder) Build() (*Validator, error) {
+	var envs = make(map[string]*cel.Env)
+
+	for _, policy := range b.policies {
+		var env *cel.Env
+		var err error
+		var opts []cel.EnvOption
+
+		for _, binding := range b.baseBindings {
+			opts = append(opts, cel.Variable(binding.name, binding.t))
+		}
+
+		for _, p := range b.policies {
+			opts = append(opts,
+				cel.Types(p.binding.t),
+				cel.Variable(p.binding.name, p.binding.t),
+			)
+			if p.policy == policy.policy {
+				break
+			}
+		}
+
+		if env, err = cel.NewEnv(opts...); err != nil {
+			return nil, err
+		}
+
+		envs[policy.policy] = env
+	}
+
 	return &Validator{
-		baseBindings: b.baseBindings,
-		policies:     b.policies,
+		envs: envs,
 	}, nil
 }
 
 type Validator struct {
-	baseBindings map[string]binding
-	policies     []policyBinding
+	envs map[string]*cel.Env
 }
 
 func (v *Validator) Validate(policy string, expr string) (*cel.Ast, error) {
-	var env *cel.Env
-	var err error
-	opts := []cel.EnvOption{}
-	found := false
-
-	for _, binding := range v.baseBindings {
-		opts = append(opts, cel.Variable(binding.name, binding.t))
-	}
-
-	for _, p := range v.policies {
-		opts = append(opts,
-			cel.Types(p.binding.t),
-			cel.Variable(p.binding.name, p.binding.t),
-		)
-		if p.policy == policy {
-			found = true
-			break
-		}
-	}
-
-	if env, err = cel.NewEnv(opts...); err != nil {
-		return nil, err
-	}
-
-	if !found {
+	env := v.envs[policy]
+	if env == nil {
 		return nil, fmt.Errorf("no policy matching `%s`", policy)
 	}
 

--- a/internal/cel/validator.go
+++ b/internal/cel/validator.go
@@ -2,6 +2,7 @@ package cel
 
 import (
 	"fmt"
+
 	"github.com/google/cel-go/cel"
 )
 

--- a/internal/cel/validator.go
+++ b/internal/cel/validator.go
@@ -1,0 +1,92 @@
+package cel
+
+import (
+	"fmt"
+	"github.com/google/cel-go/cel"
+)
+
+type ValidatorBuilder struct {
+	baseBindings []binding
+	policies     []policyBinding
+}
+
+type policyBinding struct {
+	policy  string
+	binding binding
+}
+
+type binding struct {
+	name string
+}
+
+func NewValidatorBuilder() *ValidatorBuilder {
+	return &ValidatorBuilder{}
+}
+
+func (b *ValidatorBuilder) AddBinding(name string) *ValidatorBuilder {
+	return b
+}
+
+func (b *ValidatorBuilder) AddPolicyBindingAfter(after *string, policy string, name string) (*ValidatorBuilder, error) {
+	p := policyBinding{
+		policy:  policy,
+		binding: binding{name: name},
+	}
+	if after == nil {
+		b.policies = append([]policyBinding{p}, b.policies...)
+	} else {
+		idx := -1
+		for i, p := range b.policies {
+			if p.policy == *after {
+				idx = i
+			}
+		}
+		if idx < 0 {
+			return nil, fmt.Errorf("policy %s not found", *after)
+		} else {
+			suffix := append([]policyBinding{p}, b.policies[idx+1:]...)
+			b.policies = append(b.policies[:idx], suffix...)
+		}
+	}
+	return b, nil
+}
+
+func (b *ValidatorBuilder) Build() (*Validator, error) {
+	return &Validator{
+		baseBindings: b.baseBindings,
+		policies:     b.policies,
+	}, nil
+}
+
+type Validator struct {
+	baseBindings []binding
+	policies     []policyBinding
+}
+
+func (v *Validator) Validate(policy string, ast *cel.Ast) (*cel.Ast, error) {
+	if ast == nil {
+		return nil, fmt.Errorf("AST is nil")
+	}
+	var env *cel.Env
+	var err error
+	if env, err = cel.NewEnv(); err != nil {
+		return nil, err
+	}
+
+	found := false
+	for _, p := range v.policies {
+		if p.policy == policy {
+			found = true
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("no policy matching `%s`", policy)
+	}
+
+	if cAst, iss := env.Check(ast); iss.Err() != nil {
+		return nil, iss.Err()
+	} else {
+		return cAst, nil
+	}
+}

--- a/internal/cel/validator.go
+++ b/internal/cel/validator.go
@@ -54,7 +54,7 @@ func (b *ValidatorBuilder) AddPolicyBindingAfter(after *string, policy string, n
 			return nil, fmt.Errorf("policy %s not found", *after)
 		}
 		suffix := append([]policyBinding{p}, b.policies[idx+1:]...)
-		b.policies = append(b.policies[:idx], suffix...)
+		b.policies = append(b.policies[:idx+1], suffix...)
 	}
 	return b, nil
 }

--- a/internal/cel/validator.go
+++ b/internal/cel/validator.go
@@ -2,6 +2,7 @@ package cel
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/google/cel-go/cel"
 )
@@ -46,12 +47,9 @@ func (b *ValidatorBuilder) AddPolicyBindingAfter(after *string, policy string, n
 	if after == nil {
 		b.policies = append([]policyBinding{p}, b.policies...)
 	} else {
-		idx := -1
-		for i, p := range b.policies {
-			if p.policy == *after {
-				idx = i
-			}
-		}
+		idx := slices.IndexFunc(b.policies, func(pb policyBinding) bool {
+			return pb.policy == *after
+		})
 		if idx < 0 {
 			return nil, fmt.Errorf("policy %s not found", *after)
 		}

--- a/internal/cel/validator.go
+++ b/internal/cel/validator.go
@@ -54,10 +54,9 @@ func (b *ValidatorBuilder) AddPolicyBindingAfter(after *string, policy string, n
 		}
 		if idx < 0 {
 			return nil, fmt.Errorf("policy %s not found", *after)
-		} else {
-			suffix := append([]policyBinding{p}, b.policies[idx+1:]...)
-			b.policies = append(b.policies[:idx], suffix...)
 		}
+		suffix := append([]policyBinding{p}, b.policies[idx+1:]...)
+		b.policies = append(b.policies[:idx], suffix...)
 	}
 	return b, nil
 }
@@ -106,13 +105,16 @@ func (v *Validator) Validate(policy string, expr string) (*cel.Ast, error) {
 		return nil, fmt.Errorf("no policy matching `%s`", policy)
 	}
 
-	if ast, iss := env.Parse(expr); iss.Err() != nil {
+	var ast *cel.Ast
+	var iss *cel.Issues
+
+	if ast, iss = env.Parse(expr); iss.Err() != nil {
 		return nil, iss.Err()
-	} else {
-		if cAst, iss := env.Check(ast); iss.Err() != nil {
-			return nil, iss.Err()
-		} else {
-			return cAst, nil
-		}
 	}
+
+	if ast, iss = env.Check(ast); iss.Err() != nil {
+		return nil, iss.Err()
+	}
+
+	return ast, nil
 }

--- a/internal/cel/validator_test.go
+++ b/internal/cel/validator_test.go
@@ -33,19 +33,6 @@ func TestAddPolicyAfter(t *testing.T) {
 	}
 }
 
-func TestPolicyNoDependency(t *testing.T) {
-	builder := NewValidatorBuilder()
-	if validator, err := builder.Build(); err != nil {
-		t.Fatal(err)
-	} else {
-		if ast, err := validator.Validate("foo", "1 == 1"); ast != nil {
-			t.Fatal("No ast should have returned for no matching policy")
-		} else if err == nil {
-			t.Fatal("Should have returned an error")
-		}
-	}
-}
-
 func TestPolicyWithUnknownBinding(t *testing.T) {
 	builder := NewValidatorBuilder()
 	if validator, err := builder.Build(); err != nil {

--- a/internal/cel/validator_test.go
+++ b/internal/cel/validator_test.go
@@ -117,3 +117,18 @@ func TestPolicyWithNotYetKnownPolicyBinding(t *testing.T) {
 		}
 	}
 }
+
+func TestPolicyWithAnyKnownPolicyBinding(t *testing.T) {
+	builder := NewValidatorBuilder()
+	builder.AddBinding("nope", cel.StringType)
+	builder, _ = builder.AddPolicyBindingAfter(nil, "foo", "first", cel.AnyType)
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("foo", "!first.randomField"); err != nil {
+			t.Fatalf("Should have not returned an error: %v", err)
+		} else if ast == nil {
+			t.Fatal("Ast should have returned for known policy binding")
+		}
+	}
+}

--- a/internal/cel/validator_test.go
+++ b/internal/cel/validator_test.go
@@ -1,8 +1,9 @@
 package cel
 
 import (
-	"github.com/google/cel-go/cel"
 	"testing"
+
+	"github.com/google/cel-go/cel"
 )
 
 func TestNoPolicy(t *testing.T) {

--- a/internal/cel/validator_test.go
+++ b/internal/cel/validator_test.go
@@ -126,11 +126,24 @@ func TestPolicyWithNotYetKnownPolicyBinding(t *testing.T) {
 func TestPolicyWithAnyKnownPolicyBinding(t *testing.T) {
 	builder := NewValidatorBuilder()
 	builder.AddBinding("nope", cel.StringType)
-	builder, _ = builder.AddPolicyBindingAfter(nil, "foo", "first", cel.AnyType)
+	first := "foo"
+	second := "bar"
+	builder, _ = builder.AddPolicyBindingAfter(nil, first, "first", cel.AnyType)
+	builder, _ = builder.AddPolicyBindingAfter(&first, second, "second", cel.AnyType)
 	if validator, err := builder.Build(); err != nil {
 		t.Fatal(err)
 	} else {
-		if ast, err := validator.Validate("foo", "!first.randomField"); err != nil {
+		if ast, err := validator.Validate(first, "!first.randomField"); err != nil {
+			t.Fatalf("Should have not returned an error: %v", err)
+		} else if ast == nil {
+			t.Fatal("Ast should have returned for known policy binding")
+		}
+		if ast, err := validator.Validate(second, "!first.randomField"); err != nil {
+			t.Fatalf("Should have not returned an error: %v", err)
+		} else if ast == nil {
+			t.Fatal("Ast should have returned for known policy binding")
+		}
+		if ast, err := validator.Validate(second, "!second.randomField"); err != nil {
 			t.Fatalf("Should have not returned an error: %v", err)
 		} else if ast == nil {
 			t.Fatal("Ast should have returned for known policy binding")

--- a/internal/cel/validator_test.go
+++ b/internal/cel/validator_test.go
@@ -72,6 +72,7 @@ func TestPolicyWithKnownRootBinding(t *testing.T) {
 		}
 	}
 }
+
 func TestPolicyWithUnknownRootBinding(t *testing.T) {
 	builder := NewValidatorBuilder()
 	builder.AddBinding("nope", cel.StringType)
@@ -86,6 +87,22 @@ func TestPolicyWithUnknownRootBinding(t *testing.T) {
 		}
 	}
 }
+
+func TestPolicyWithUnknownPolicyBinding(t *testing.T) {
+	builder := NewValidatorBuilder()
+	builder.AddBinding("nope", cel.StringType)
+	builder, _ = builder.AddPolicyBindingAfter(nil, "foo", "first", cel.BoolType)
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("fo", "!first"); ast != nil {
+			t.Fatal("No ast should have returned for unknown policy")
+		} else if err == nil {
+			t.Fatal("Should have returned an error")
+		}
+	}
+}
+
 func TestPolicyWithKnownPolicyBinding(t *testing.T) {
 	builder := NewValidatorBuilder()
 	builder.AddBinding("nope", cel.StringType)

--- a/internal/cel/validator_test.go
+++ b/internal/cel/validator_test.go
@@ -5,25 +5,12 @@ import (
 	"testing"
 )
 
-func TestNoAST(t *testing.T) {
-	builder := NewValidatorBuilder()
-	if validator, err := builder.Build(); err != nil {
-		t.Fatal(err)
-	} else {
-		if ast, err := validator.Validate("foo", nil); ast != nil {
-			t.Fatal("No ast should have returned for no matching policy")
-		} else if err == nil {
-			t.Fatal("Should have returned an error")
-		}
-	}
-}
-
 func TestNoPolicy(t *testing.T) {
 	builder := NewValidatorBuilder()
 	if validator, err := builder.Build(); err != nil {
 		t.Fatal(err)
 	} else {
-		if ast, err := validator.Validate("foo", astFor("1 == 1")); ast != nil {
+		if ast, err := validator.Validate("foo", "1 == 1"); ast != nil {
 			t.Fatal("No ast should have returned for no matching policy")
 		} else if err == nil {
 			t.Fatal("Should have returned an error")
@@ -33,13 +20,13 @@ func TestNoPolicy(t *testing.T) {
 
 func TestAddPolicyAfter(t *testing.T) {
 	start := "foo"
-	if _, err := NewValidatorBuilder().AddPolicyBindingAfter(&start, "bar", "second"); err == nil {
+	if _, err := NewValidatorBuilder().AddPolicyBindingAfter(&start, "bar", "second", cel.BoolType); err == nil {
 		t.Fatal("Should have returned an error")
 	}
-	if builder, err := NewValidatorBuilder().AddPolicyBindingAfter(nil, start, "first"); err != nil {
+	if builder, err := NewValidatorBuilder().AddPolicyBindingAfter(nil, start, "first", cel.BoolType); err != nil {
 		t.Fatal(err)
 	} else {
-		if _, err := builder.AddPolicyBindingAfter(&start, "bar", "second"); err != nil {
+		if _, err := builder.AddPolicyBindingAfter(&start, "bar", "second", cel.BoolType); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -50,7 +37,7 @@ func TestPolicyNoDependency(t *testing.T) {
 	if validator, err := builder.Build(); err != nil {
 		t.Fatal(err)
 	} else {
-		if ast, err := validator.Validate("foo", astFor("1 == 1")); ast != nil {
+		if ast, err := validator.Validate("foo", "1 == 1"); ast != nil {
 			t.Fatal("No ast should have returned for no matching policy")
 		} else if err == nil {
 			t.Fatal("Should have returned an error")
@@ -58,8 +45,75 @@ func TestPolicyNoDependency(t *testing.T) {
 	}
 }
 
-func astFor(expr string) *cel.Ast {
-	env, _ := cel.NewEnv()
-	ast, _ := env.Parse(expr)
-	return ast
+func TestPolicyWithUnknownBinding(t *testing.T) {
+	builder := NewValidatorBuilder()
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("foo", "first == 1"); ast != nil {
+			t.Fatal("No ast should have returned for no matching policy")
+		} else if err == nil {
+			t.Fatal("Should have returned an error")
+		}
+	}
+}
+
+func TestPolicyWithKnownRootBinding(t *testing.T) {
+	builder := NewValidatorBuilder()
+	builder.AddBinding("base", cel.StringType)
+	builder, _ = builder.AddPolicyBindingAfter(nil, "foo", "first", cel.BoolType)
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("foo", "base == 'value'"); err != nil {
+			t.Fatalf("Should have not returned an error: %v", err)
+		} else if ast == nil {
+			t.Fatal("We should have a valid AST!")
+		}
+	}
+}
+func TestPolicyWithUnknownRootBinding(t *testing.T) {
+	builder := NewValidatorBuilder()
+	builder.AddBinding("nope", cel.StringType)
+	builder, _ = builder.AddPolicyBindingAfter(nil, "foo", "first", cel.BoolType)
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("foo", "base == 'value'"); ast != nil {
+			t.Fatal("No ast should have returned for no known base")
+		} else if err == nil {
+			t.Fatal("Should have returned an error")
+		}
+	}
+}
+func TestPolicyWithKnownPolicyBinding(t *testing.T) {
+	builder := NewValidatorBuilder()
+	builder.AddBinding("nope", cel.StringType)
+	builder, _ = builder.AddPolicyBindingAfter(nil, "foo", "first", cel.BoolType)
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("foo", "!first"); err != nil {
+			t.Fatalf("Should have not returned an error: %v", err)
+		} else if ast == nil {
+			t.Fatal("Ast should have returned for known policy binding")
+		}
+	}
+}
+
+func TestPolicyWithNotYetKnownPolicyBinding(t *testing.T) {
+	builder := NewValidatorBuilder()
+	builder.AddBinding("nope", cel.StringType)
+	first := "foo"
+	builder, _ = builder.AddPolicyBindingAfter(nil, first, "first", cel.BoolType)
+	builder, _ = builder.AddPolicyBindingAfter(&first, "bar", "second", cel.BoolType)
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate(first, "!second"); ast != nil {
+			t.Fatalf("Should have not returned an ast: %v", ast)
+		} else if err == nil {
+			t.Fatal("Should have returned an error")
+		}
+	}
 }

--- a/internal/cel/validator_test.go
+++ b/internal/cel/validator_test.go
@@ -1,0 +1,65 @@
+package cel
+
+import (
+	"github.com/google/cel-go/cel"
+	"testing"
+)
+
+func TestNoAST(t *testing.T) {
+	builder := NewValidatorBuilder()
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("foo", nil); ast != nil {
+			t.Fatal("No ast should have returned for no matching policy")
+		} else if err == nil {
+			t.Fatal("Should have returned an error")
+		}
+	}
+}
+
+func TestNoPolicy(t *testing.T) {
+	builder := NewValidatorBuilder()
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("foo", astFor("1 == 1")); ast != nil {
+			t.Fatal("No ast should have returned for no matching policy")
+		} else if err == nil {
+			t.Fatal("Should have returned an error")
+		}
+	}
+}
+
+func TestAddPolicyAfter(t *testing.T) {
+	start := "foo"
+	if _, err := NewValidatorBuilder().AddPolicyBindingAfter(&start, "bar", "second"); err == nil {
+		t.Fatal("Should have returned an error")
+	}
+	if builder, err := NewValidatorBuilder().AddPolicyBindingAfter(nil, start, "first"); err != nil {
+		t.Fatal(err)
+	} else {
+		if _, err := builder.AddPolicyBindingAfter(&start, "bar", "second"); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestPolicyNoDependency(t *testing.T) {
+	builder := NewValidatorBuilder()
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("foo", astFor("1 == 1")); ast != nil {
+			t.Fatal("No ast should have returned for no matching policy")
+		} else if err == nil {
+			t.Fatal("Should have returned an error")
+		}
+	}
+}
+
+func astFor(expr string) *cel.Ast {
+	env, _ := cel.NewEnv()
+	ast, _ := env.Parse(expr)
+	return ast
+}


### PR DESCRIPTION
Closes Issue #1365 