### PR TITLE
refactor: cel validation for tlspolicy issuer kind

### DIFF
--- a/api/v1/tlspolicy_types.go
+++ b/api/v1/tlspolicy_types.go
@@ -57,6 +57,7 @@ type CertificateSpec struct {
 	// If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
 	// provided name will be used.
 	// The `name` field in this stanza is required at all times.
+	// +kubebuilder:validation:XValidation:rule="!has(self.kind) || self.kind in ['Issuer', 'ClusterIssuer']",message="Invalid issuerRef.kind. The only supported values are blank, 'Issuer' and 'ClusterIssuer'"
 	IssuerRef certmanmetav1.ObjectReference `json:"issuerRef"`
 
 	// CommonName is a common name to be used on the Certificate.

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -109,7 +109,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2025-04-23T14:42:57Z"
+    createdAt: "2025-06-23T14:58:26Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kuadrant.io_tlspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_tlspolicies.yaml
@@ -110,6 +110,10 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
               privateKey:
                 description: Options to control private keys used for the Certificate.
                 properties:

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -8804,6 +8804,10 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
               privateKey:
                 description: Options to control private keys used for the Certificate.
                 properties:

--- a/config/crd/bases/kuadrant.io_tlspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_tlspolicies.yaml
@@ -109,6 +109,10 @@ spec:
                 required:
                 - name
                 type: object
+                x-kubernetes-validations:
+                - message: Invalid issuerRef.kind. The only supported values are blank,
+                    'Issuer' and 'ClusterIssuer'
+                  rule: '!has(self.kind) || self.kind in [''Issuer'', ''ClusterIssuer'']'
               privateKey:
                 description: Options to control private keys used for the Certificate.
                 properties:

--- a/internal/controller/tlspolicies_validator.go
+++ b/internal/controller/tlspolicies_validator.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"reflect"
 	"sync"
 
@@ -67,11 +66,6 @@ func (r *TLSPoliciesValidator) Validate(ctx context.Context, _ []controller.Reso
 			return p.GetLocator(), err
 		}
 
-		// Validate IssuerRef kind is correct
-		if err := r.isValidIssuerKind(policy); err != nil {
-			return p.GetLocator(), err
-		}
-
 		// Validate Issuer is present on cluster through the topology
 		if err := r.isIssuerFound(topology, policy); err != nil {
 			return p.GetLocator(), err
@@ -125,16 +119,6 @@ func (r *TLSPoliciesValidator) isConflict(policies []machinery.Policy, p *kuadra
 
 	if ok {
 		return kuadrant.NewErrConflict(kuadrantv1.TLSPolicyGroupKind.Kind, client.ObjectKeyFromObject(conflictingP.(*kuadrantv1.TLSPolicy)).String(), errors.New("conflicting policy"))
-	}
-
-	return nil
-}
-
-// isValidIssuerKind Validates that the Issuer Ref kind is either empty, Issuer or ClusterIssuer
-func (r *TLSPoliciesValidator) isValidIssuerKind(p *kuadrantv1.TLSPolicy) error {
-	if !lo.Contains([]string{"", certmanv1.IssuerKind, certmanv1.ClusterIssuerKind}, p.Spec.IssuerRef.Kind) {
-		return kuadrant.NewErrInvalid(kuadrantv1.TLSPolicyGroupKind.Kind, fmt.Errorf(`invalid value %q for issuerRef.kind. Must be empty, %q or %q`,
-			p.Spec.IssuerRef.Kind, certmanv1.IssuerKind, certmanv1.ClusterIssuerKind))
 	}
 
 	return nil


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/1390

Refactors issuer kind validation to CEL

# Verification
* Passing e2e tests should be sufficient