### PR TITLE
Console plugin PF6 - version aware deployment

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -156,7 +156,6 @@ jobs:
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
             DNS_OPERATOR_VERSION=${{ inputs.dnsOperatorVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
-            RELATED_IMAGE_CONSOLEPLUGIN=${{ inputs.consolePluginImageURL }} \
             DEFAULT_CHANNEL=${{ inputs.defaultChannel }} \
             CHANNELS=${{ inputs.channels }}
       - name: Set up Docker Buildx
@@ -205,7 +204,6 @@ jobs:
             LIMITADOR_OPERATOR_VERSION=${{ inputs.limitadorOperatorVersion }} \
             DNS_OPERATOR_VERSION=${{ inputs.dnsOperatorVersion }} \
             WASM_SHIM_VERSION=${{ inputs.wasmShimVersion }} \
-            RELATED_IMAGE_CONSOLEPLUGIN=${{ inputs.consolePluginImageURL }} \
             CHANNEL=${{ inputs.defaultChannel }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/Makefile
+++ b/Makefile
@@ -390,17 +390,12 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
-RELATED_IMAGE_CONSOLEPLUGIN ?= quay.io/kuadrant/console-plugin:latest
-
 .PHONY: bundle
 bundle: $(OPM) $(YQ) manifests dependencies-manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	# Set desired Wasm-shim image
 	V="$(RELATED_IMAGE_WASMSHIM)" \
 	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_WASMSHIM").value) = strenv(V)' -i config/manager/manager.yaml
-	# Set desired ConsolePlugin image
-	V="$(RELATED_IMAGE_CONSOLEPLUGIN)" \
-	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_CONSOLEPLUGIN").value) = strenv(V)' -i config/manager/manager.yaml
 	# Set desired operator image
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	# Update CSV

--- a/bundle/manifests/kuadrant-operator-console-plugin-images_v1_configmap.yaml
+++ b/bundle/manifests/kuadrant-operator-console-plugin-images_v1_configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data:
+  "4.16": quay.io/kuadrant/console-plugin:v0.1.5
+  "4.17": quay.io/kuadrant/console-plugin:v0.1.5
+  "4.18": quay.io/kuadrant/console-plugin:v0.1.5
+  "4.19": quay.io/kuadrant/console-plugin:v0.1.5
+  "4.20": quay.io/kuadrant/console-plugin:latest
+  default: quay.io/kuadrant/console-plugin:latest
+kind: ConfigMap
+metadata:
+  labels:
+    app: kuadrant
+    kuadrant-operator-console-plugin-images: "true"
+  name: kuadrant-operator-console-plugin-images

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -325,6 +325,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - console.openshift.io
           resources:
           - consoleplugins
@@ -581,8 +589,6 @@ spec:
                   value: "true"
                 - name: RELATED_IMAGE_WASMSHIM
                   value: oci://quay.io/kuadrant/wasm-shim:latest
-                - name: RELATED_IMAGE_CONSOLEPLUGIN
-                  value: quay.io/kuadrant/console-plugin:latest
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -691,6 +697,4 @@ spec:
   relatedImages:
   - image: oci://quay.io/kuadrant/wasm-shim:latest
     name: wasmshim
-  - image: quay.io/kuadrant/console-plugin:latest
-    name: consoleplugin
   version: 0.0.0

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -10096,6 +10096,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - console.openshift.io
   resources:
   - consoleplugins
@@ -10410,6 +10418,23 @@ subjects:
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: v1
+data:
+  "4.16": quay.io/kuadrant/console-plugin:v0.1.5
+  "4.17": quay.io/kuadrant/console-plugin:v0.1.5
+  "4.18": quay.io/kuadrant/console-plugin:v0.1.5
+  "4.19": quay.io/kuadrant/console-plugin:v0.1.5
+  "4.20": quay.io/kuadrant/console-plugin:latest
+  default: quay.io/kuadrant/console-plugin:latest
+kind: ConfigMap
+metadata:
+  labels:
+    app: kuadrant
+    app.kubernetes.io/managed-by: helm
+    kuadrant-operator-console-plugin-images: "true"
+  name: kuadrant-operator-console-plugin-images
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -10459,8 +10484,6 @@ spec:
           value: "true"
         - name: RELATED_IMAGE_WASMSHIM
           value: oci://quay.io/kuadrant/wasm-shim:latest
-        - name: RELATED_IMAGE_CONSOLEPLUGIN
-          value: quay.io/kuadrant/console-plugin:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,6 +30,7 @@ import (
 	authorinoapi "github.com/kuadrant/authorino/api/v1beta3"
 	kuadrantdnsv1alpha1 "github.com/kuadrant/dns-operator/api/v1alpha1"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	istioextensionv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
@@ -82,6 +83,7 @@ func init() {
 	utilruntime.Must(kuadrantdnsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(certmanv1.AddToScheme(scheme))
 	utilruntime.Must(egv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(configv1.AddToScheme(scheme))
 	utilruntime.Must(consolev1.AddToScheme(scheme))
 	utilruntime.Must(monitoringv1.AddToScheme(scheme))
 	utilruntime.Must(istiosecurity.AddToScheme(scheme))

--- a/config/manager/console-plugin-images.yaml
+++ b/config/manager/console-plugin-images.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: console-plugin-images
+  namespace: system
+  labels:
+    kuadrant-operator-console-plugin-images: "true"
+data:
+  "4.16": "quay.io/kuadrant/console-plugin:v0.1.5"
+  "4.17": "quay.io/kuadrant/console-plugin:v0.1.5"
+  "4.18": "quay.io/kuadrant/console-plugin:v0.1.5"
+  "4.19": "quay.io/kuadrant/console-plugin:v0.1.5"
+  "4.20": "quay.io/kuadrant/console-plugin:latest"
+  "default": "quay.io/kuadrant/console-plugin:latest"

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - manager.yaml
 - metrics_service.yaml
+- console-plugin-images.yaml
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,8 +32,6 @@ spec:
               value: "true"
             - name: RELATED_IMAGE_WASMSHIM
               value: "oci://quay.io/kuadrant/wasm-shim:latest"
-            - name: RELATED_IMAGE_CONSOLEPLUGIN
-              value: "quay.io/kuadrant/console-plugin:latest"
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -80,6 +80,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - console.openshift.io
   resources:
   - consoleplugins

--- a/doc/overviews/development.md
+++ b/doc/overviews/development.md
@@ -120,9 +120,11 @@ The `make bundle` target accepts the following variables:
 | `AUTHORINO_OPERATOR_BUNDLE_IMG` | Authorino operator bundle URL | `quay.io/kuadrant/authorino-operator-bundle:latest` | `AUTHORINO_OPERATOR_VERSION` var could be used to build this, defaults to _latest_ if not provided |
 | `DNS_OPERATOR_BUNDLE_IMG`       | DNS operator bundle URL       | `quay.io/kuadrant/dns-operator-bundle:latest`       | `DNS_OPERATOR_BUNDLE_IMG` var could be used to build this, defaults to _latest_ if not provided    |
 | `RELATED_IMAGE_WASMSHIM`        | WASM shim image URL           | `oci://quay.io/kuadrant/wasm-shim:latest`           | `WASM_SHIM_VERSION` var could be used to build this, defaults to _latest_ if not provided          |
-| `RELATED_IMAGE_CONSOLEPLUGIN`   | ConsolePlugin image URL       | `quay.io/kuadrant/console-plugin:latest`            |                                                                                                  |
 | `CHANNELS`                      | Bundle channels used in the bundle, comma separated  | `alpha`           |                                                                                                               |
 | `DEFAULT_CHANNEL`               | The default channel used in the bundle               | `alpha`           |                                                                                                               |
+
+*Note:* The `RELATED_IMAGE_CONSOLEPLUGIN` variable is not used anymore. The console plugin now relies on a `kuadrant-operator-console-plugin-images` configmap that stores the images to be used for different openshift versions. 
+This configmap is only created during OLM or Helm installation. To manually override the consoleplugin image edit the configmap manually.
 
 * Build the bundle manifests
 
@@ -134,7 +136,6 @@ make bundle [IMG=quay.io/kuadrant/kuadrant-operator:latest] \
             [AUTHORINO_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/authorino-operator-bundle:latest] \
             [DNS_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:latest] \
             [RELATED_IMAGE_WASMSHIM=oci://quay.io/kuadrant/wasm-shim:latest] \
-            [RELATED_IMAGE_CONSOLEPLUGIN=quay.io/kuadrant/console-plugin:latest] \
             [CHANNELS=alpha] \
             [DEFAULT_CHANNEL=alpha]
 ```

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kuadrant/kuadrant-operator
 go 1.24.0
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/cert-manager/cert-manager v1.16.2
 	github.com/elliotchance/orderedmap/v2 v2.2.0
 	github.com/envoyproxy/gateway v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.19.1 h1:NciYrtDRIR0lNCnH1LFJegdjspNx9fI59O7TWcua/W4=
 cel.dev/expr v0.19.1/go.mod h1:MrpN08Q+lEBs+bGYdLxxHkZoUSsCp0nSKTs0nTymJgw=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/openshift/consoleplugin/common.go
+++ b/internal/openshift/consoleplugin/common.go
@@ -1,7 +1,8 @@
 package consoleplugin
 
 const (
-	KuadrantConsoleName = "kuadrant-console-plugin"
+	KuadrantConsoleName              = "kuadrant-console-plugin"
+	KuadrantConsolePluginImagesLabel = "kuadrant-operator-console-plugin-images"
 )
 
 var (

--- a/internal/openshift/utils.go
+++ b/internal/openshift/utils.go
@@ -1,7 +1,12 @@
 package openshift
 
 import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	configv1 "github.com/openshift/api/config/v1"
 	consolev1 "github.com/openshift/api/console/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -9,14 +14,53 @@ import (
 )
 
 var (
-	ConsolePluginGVK schema.GroupVersionKind = schema.GroupVersionKind{
+	ConsolePluginGVK = schema.GroupVersionKind{
 		Group:   consolev1.GroupName,
 		Version: consolev1.GroupVersion.Version,
 		Kind:    "ConsolePlugin",
 	}
 	ConsolePluginsResource = consolev1.SchemeGroupVersion.WithResource("consoleplugins")
+
+	ClusterVersionGroupKind = schema.GroupVersionKind{
+		Group:   configv1.GroupName,
+		Version: configv1.GroupVersion.Version,
+		Kind:    "ClusterVersion",
+	}
+	ClusterVersionResource = configv1.SchemeGroupVersion.WithResource("clusterversions")
 )
 
 func IsConsolePluginInstalled(restMapper meta.RESTMapper) (bool, error) {
 	return utils.IsCRDInstalled(restMapper, ConsolePluginGVK.Group, ConsolePluginGVK.Kind, ConsolePluginGVK.Version)
+}
+
+func IsClusterVersionInstalled(restMapper meta.RESTMapper) (bool, error) {
+	return utils.IsCRDInstalled(restMapper, ClusterVersionGroupKind.Group, ClusterVersionGroupKind.Kind, ClusterVersionGroupKind.Version)
+}
+
+// GetConsolePluginImageFromConfigMap returns the appropriate console plugin image from ConfigMap based on OpenShift version
+func GetConsolePluginImageFromConfigMap(configMap *corev1.ConfigMap, clusterVersion *configv1.ClusterVersion) (string, error) {
+	openshiftVersion := clusterVersion.Status.Desired.Version
+
+	if configMap == nil || configMap.Data == nil {
+		return "", fmt.Errorf("console plugin ConfigMap is nil or has no data")
+	}
+
+	var majorMinorVersion string
+	if openshiftVersion != "" {
+		version, err := semver.NewVersion(openshiftVersion)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse OpenShift version %q: %w", openshiftVersion, err)
+		}
+		majorMinorVersion = fmt.Sprintf("%d.%d", version.Major(), version.Minor())
+
+		if image, exists := configMap.Data[majorMinorVersion]; exists {
+			return image, nil
+		}
+	}
+
+	if image, exists := configMap.Data["default"]; exists {
+		return image, nil
+	}
+
+	return "", fmt.Errorf("no console plugin image found for OpenShift version %q (major.minor: %q)", openshiftVersion, majorMinorVersion)
 }

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -10,9 +10,6 @@ helm-build: $(YQ) kustomize manifests ## Build the helm chart from kustomize man
 	# Set desired Wasm-shim image
 	V="$(RELATED_IMAGE_WASMSHIM)" \
 	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_WASMSHIM").value) = strenv(V)' -i config/manager/manager.yaml
-	# Set desired ConsolePlugin image
-	V="$(RELATED_IMAGE_CONSOLEPLUGIN)" \
-	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_CONSOLEPLUGIN").value) = strenv(V)' -i config/manager/manager.yaml
 	# Set desired operator image
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	# Build the helm chart templates from kustomize manifests

--- a/utils/release/operator/make_bundles.sh
+++ b/utils/release/operator/make_bundles.sh
@@ -21,11 +21,6 @@ wasm_shim=$(mod_version $WASM_SHIM_VERSION)
 V="oci://quay.io/kuadrant/wasm-shim:$wasm_shim" \
 yq eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_WASMSHIM").value) = strenv(V)' --inplace config/manager/manager.yaml
 
-# Set desired ConsolePlugin image
-console_plugin=$(mod_version $CONSOLEPLUGIN_VERSION)
-V="quay.io/kuadrant/console-plugin:$console_plugin" \
-yq eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_CONSOLEPLUGIN").value) = strenv(V)' --inplace config/manager/manager.yaml
-
 # Set desired operator image
 cd $env/config/manager
 # FIX: for the minute the values for the org and registry are hardcoded into the operator image.

--- a/utils/release/operator/make_chart.sh
+++ b/utils/release/operator/make_chart.sh
@@ -15,12 +15,6 @@ wasm_shim_image="oci://quay.io/kuadrant/wasm-shim:$wasm_shim_version"
 V=$wasm_shim_image \
 yq eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_WASMSHIM").value) = strenv(V)' --inplace $env/config/manager/manager.yaml
 
-# Set desired ConsolePlugin image
-consoleplugin_version=$(mod_version $(yq '.dependencies.console-plugin' $env/release.yaml))
-consoleplugin_image="quay.io/kuadrant/console-plugin:$consoleplugin_version"
-V=$consoleplugin_image \
-yq eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_CONSOLEPLUGIN").value) = strenv(V)' --inplace $env/config/manager/manager.yaml
-
 # Set desired operator image
 cd $env/config/manager
 operator_version=$(mod_version $(yq '.kuadrant-operator.version' $env/release.yaml))


### PR DESCRIPTION
closes #1405 

Expectations
 -  kuadrant-operator-console-plugin-images CM is created by Helm and OLM
 -  for local development we don’t create this configmap as most of local development happens on kind where console plugin doesn’t exist
 -  we don’t watch the cluster version resource for updates as we only want the image to reconcile on upgrades. On upgrades the operator will restart which will reconcile the console plugin image
 - Updating  the  cluster version won’t reconcile the console plugin image.
 - Changes to the configmap will cause a reconciliation
 - Removal of the configmap will remove the console-plugin deployment and will log a warning about it.

Allows for the kuadrant operator to dynamically change the image of the console plugin based on the OpenShift version 

# Verification Steps
1. Create a 4.19 openshift aws cluster, can be done with clusterbot `launch 4.19 aws`
2. Install Kuadrant [through OLM ](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/overviews/development.md#deploy-kuadrant-operator-using-olm) using custom catalog source `   quay.io/pstefans/kuadrant-operator-catalog:1405`
3. The configmap `kuadrant-operator-console-plugin-images` with the console plugin images should exist.
4. Console plugin deployment should use the 4.19 image `quay.io/kuadrant/console-plugin:v0.1.5`
5. Upgrade the openshift cluster to 4.20  `oc adm upgrade --force --allow-explicit-upgrade --to-image=<4.20 image>`
6. Console plugin deployment should use the 4.20 image `quay.io/kuadrant/console-plugin:latest`


