### PR TITLE
Extensions: fix subscription response trigger

### DIFF
--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -103,13 +103,11 @@ func (ec *ExtensionController) Subscribe(ctx context.Context, reconcileChan chan
 			return
 		}
 		trigger := &unstructured.Unstructured{}
-		if response.Event != nil {
-			if response.Event.Metadata == nil {
-				trigger.SetName(response.Event.Metadata.Name)
-				trigger.SetNamespace(response.Event.Metadata.Namespace)
-				trigger.SetKind(response.Event.Metadata.Kind)
-				reconcileChan <- ctrlruntimeevent.GenericEvent{Object: trigger}
-			}
+		if response.Event != nil && response.Event.Metadata != nil {
+			trigger.SetName(response.Event.Metadata.Name)
+			trigger.SetNamespace(response.Event.Metadata.Namespace)
+			trigger.SetKind(response.Event.Metadata.Kind)
+			reconcileChan <- ctrlruntimeevent.GenericEvent{Object: trigger}
 		}
 	})
 	if err != nil {


### PR DESCRIPTION
Minor bug, inverted logic of the `response.Event.Metadata != nil`