### PR TITLE
Extension bind permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o extensions/oidc
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
-COPY --from=builder --chown=65532:65532 /workspace/extensions /extensions
-USER 65532:65532
+COPY --from=builder /workspace/extensions /extensions
 
 # Quay image expiry
 ARG QUAY_IMAGE_EXPIRY

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ endif
 ## gatewayapi-provider
 GATEWAYAPI_PROVIDER ?= istio
 
-WITH_EXTENSIONS ?= false
+WITH_EXTENSIONS ?= true
 
 all: build
 

--- a/internal/extension/oop.go
+++ b/internal/extension/oop.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -58,7 +59,7 @@ func NewOOPExtension(name string, location string, service extpb.ExtensionServic
 
 	return OOPExtension{
 		name:       name,
-		socket:     fmt.Sprintf("%s/%s/%s", location, name, defaultUnixSocket),
+		socket:     fmt.Sprintf("/tmp/kuadrant/%s/%s", name, defaultUnixSocket),
 		executable: executable,
 		service:    service,
 		logger:     logger.WithName(name),
@@ -151,6 +152,10 @@ func (p *OOPExtension) Stop() error {
 
 func (p *OOPExtension) startServer() error {
 	if p.server == nil {
+		if err := os.MkdirAll(filepath.Dir(p.socket), 0755); err != nil {
+			return fmt.Errorf("failed to create socket directory: %w", err)
+		}
+
 		ln, err := net.Listen("unix", p.socket)
 		if err != nil {
 			return err

--- a/make/development-environments.mk
+++ b/make/development-environments.mk
@@ -52,7 +52,7 @@ namespace: ## Creates a namespace where to deploy Kuadrant Operator
 
 .PHONY: local-deploy
 local-deploy: ## Deploy Kuadrant Operator from the current code
-	$(MAKE) $(DOCKER_BUILD) IMG=$(IMAGE_TAG_BASE):dev
+	$(MAKE) docker-build IMG=$(IMAGE_TAG_BASE):dev
 	$(MAKE) kind-load-image IMG=$(IMAGE_TAG_BASE):dev
 
 	$(MAKE) deploy IMG=$(IMAGE_TAG_BASE):dev


### PR DESCRIPTION
Couple bugs regarding enabling extensions by default.

In OpenShift the default SCC runs the container as a random `USER` ID, so our solution to set ownership via the `USER` does not work. This new solution instead uses `/tmp` and creates folders beneath it owned by the running kuadrant operator user to bind the socket within