### PR TITLE
[make] Disabling extensions on `run` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,7 @@ build: generate fmt vet ## Build manager binary.
 
 run: export LOG_LEVEL = debug
 run: export LOG_MODE = development
+run: export WITH_EXTENSIONS = false
 run: export OPERATOR_NAMESPACE := $(OPERATOR_NAMESPACE)
 run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 run: DIRTY=$(shell $(PROJECT_PATH)/utils/check-git-dirty.sh || echo "unknown")


### PR DESCRIPTION
Because it currently doesn't work with multiple processes. We need to implement the target to run the multiple extensions and don't leave them unattended when crashing/killing/etc 