### PR TITLE
temporarly change ratelimit-check service type to rate limit

### DIFF
--- a/internal/wasm/types.go
+++ b/internal/wasm/types.go
@@ -79,9 +79,9 @@ func (s Service) EqualTo(other Service) bool {
 type ServiceType string
 
 const (
-	RateLimitServiceType      ServiceType = "ratelimit"
-	RateLimitCheckServiceType ServiceType = "ratelimit-check"
-	AuthServiceType           ServiceType = "auth"
+	RateLimitServiceType ServiceType = "ratelimit"
+	//RateLimitCheckServiceType ServiceType = "ratelimit-check"
+	AuthServiceType ServiceType = "auth"
 )
 
 // +kubebuilder:validation:Enum:=deny;allow

--- a/internal/wasm/utils.go
+++ b/internal/wasm/utils.go
@@ -89,7 +89,7 @@ func BuildConfigForActionSet(actionSets []ActionSet, logger *logr.Logger) Config
 				Timeout:     ptr.To(RatelimitServiceTimeout()),
 			},
 			RateLimitCheckServiceName: {
-				Type:        RateLimitCheckServiceType,
+				Type:        RateLimitServiceType,
 				Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 				FailureMode: RatelimitCheckServiceFailureMode(logger),
 				Timeout:     ptr.To(RatelimitCheckServiceTimeout()),

--- a/tests/envoygateway/extension_reconciler_test.go
+++ b/tests/envoygateway/extension_reconciler_test.go
@@ -180,7 +180,7 @@ var _ = Describe("wasm controller", func() {
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -352,7 +352,7 @@ var _ = Describe("wasm controller", func() {
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),

--- a/tests/istio/extension_reconciler_test.go
+++ b/tests/istio/extension_reconciler_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -797,7 +797,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -1028,7 +1028,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -1246,7 +1246,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -1382,7 +1382,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -1592,7 +1592,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -1691,7 +1691,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -1876,7 +1876,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -1993,7 +1993,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -2214,7 +2214,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -2328,7 +2328,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.RateLimitServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -2503,7 +2503,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
@@ -2589,7 +2589,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.RateLimitServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),


### PR DESCRIPTION
changing the new ratelimit-check service to normal rate limit service type until https://github.com/Kuadrant/wasm-shim/pull/194 is merged , this fixes https://github.com/Kuadrant/wasm-shim/issues/197
