### PR TITLE
Optional provider ref in DNSPolicy

### DIFF
--- a/api/v1/dnspolicy_types.go
+++ b/api/v1/dnspolicy_types.go
@@ -60,7 +60,7 @@ type DNSPolicySpec struct {
 
 	// providerRefs is a list of references to provider secrets. Max is one but intention is to allow this to be more in the future
 	// +kubebuilder:validation:MaxItems=1
-	// +kubebuilder:validation:MinItems=1
+	// +optional
 	ProviderRefs []dnsv1alpha1.ProviderRef `json:"providerRefs"`
 
 	// ExcludeAddresses is a list of addresses (either hostnames, CIDR or IPAddresses) that DNSPolicy should not use as values in the configured DNS provider records. The default is to allow all addresses configured in the Gateway DNSPolicy is targeting

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -189,7 +189,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2025-07-15T15:05:41Z"
+    createdAt: "2025-07-23T14:49:01Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -182,13 +182,11 @@ spec:
                 items:
                   properties:
                     name:
-                      minLength: 1
                       type: string
                   required:
                   - name
                   type: object
                 maxItems: 1
-                minItems: 1
                 type: array
               targetRef:
                 description: targetRef identifies an API object to apply policy to.
@@ -237,7 +235,6 @@ spec:
                 - message: Invalid targetRef.kind. The only supported values are 'Gateway'
                   rule: self.kind == 'Gateway'
             required:
-            - providerRefs
             - targetRef
             type: object
           status:

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -7715,13 +7715,11 @@ spec:
                 items:
                   properties:
                     name:
-                      minLength: 1
                       type: string
                   required:
                   - name
                   type: object
                 maxItems: 1
-                minItems: 1
                 type: array
               targetRef:
                 description: targetRef identifies an API object to apply policy to.
@@ -7770,7 +7768,6 @@ spec:
                 - message: Invalid targetRef.kind. The only supported values are 'Gateway'
                   rule: self.kind == 'Gateway'
             required:
-            - providerRefs
             - targetRef
             type: object
           status:

--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -181,13 +181,11 @@ spec:
                 items:
                   properties:
                     name:
-                      minLength: 1
                       type: string
                   required:
                   - name
                   type: object
                 maxItems: 1
-                minItems: 1
                 type: array
               targetRef:
                 description: targetRef identifies an API object to apply policy to.
@@ -236,7 +234,6 @@ spec:
                 - message: Invalid targetRef.kind. The only supported values are 'Gateway'
                   rule: self.kind == 'Gateway'
             required:
-            - providerRefs
             - targetRef
             type: object
           status:

--- a/doc/overviews/dns.md
+++ b/doc/overviews/dns.md
@@ -29,6 +29,8 @@ A DNSPolicy acts against a target Gateway by processing its listeners for hostna
 In order for it to do this, it must know about the dns provider.
 This is done through the creation of dns provider secrets containing the credentials and configuration for the dns provider account.
 
+The policy can use a specific provider secret by referencing it in the `ProviderRefs`. Alternatively, if no reference is provided, the secret with `kuadrant.io/default-provider=true` label will be chosen as a default option.
+
 If for example a Gateway is created with a listener with a hostname of `echo.apps.hcpapps.net`:
 
 ```yaml

--- a/doc/reference/dnspolicy.md
+++ b/doc/reference/dnspolicy.md
@@ -21,12 +21,12 @@
 
 ## DNSPolicySpec
 
-| **Field**        | **Type**                                                                                                                          |     **Required**      | **Description**                                            |
-|------------------|-----------------------------------------------------------------------------------------------------------------------------------|:---------------------:|------------------------------------------------------------|
-| `targetRef`      | [Gateway API LocalPolicyTargetReferenceWithSectionName](https://gateway-api.sigs.k8s.io/reference/spec/#localpolicytargetreferencewithsectionname)   |          Yes          | Reference to a Kubernetes resource that the policy attaches to |
-| `healthCheck`    | [HealthCheckSpec](#healthcheckspec)                                                                                               |          No           | HealthCheck spec                                           |
-| `loadBalancing`  | [LoadBalancingSpec](#loadbalancingspec)                                                                                           | No | LoadBalancing Spec       |
-| `providerRefs`   | [ProviderRefs](#providerrefs)                                                                                                         |          Yes          | array of references to providers. (currently limited to max 1) |
+| **Field**        | **Type**                                                                                                                          | **Required** | **Description**                                            |
+|------------------|-----------------------------------------------------------------------------------------------------------------------------------|:------------:|------------------------------------------------------------|
+| `targetRef`      | [Gateway API LocalPolicyTargetReferenceWithSectionName](https://gateway-api.sigs.k8s.io/reference/spec/#localpolicytargetreferencewithsectionname)   |     Yes      | Reference to a Kubernetes resource that the policy attaches to |
+| `healthCheck`    | [HealthCheckSpec](#healthcheckspec)                                                                                               |      No      | HealthCheck spec                                           |
+| `loadBalancing`  | [LoadBalancingSpec](#loadbalancingspec)                                                                                           |      No      | LoadBalancing Spec       |
+| `providerRefs`   | [ProviderRefs](#providerrefs)                                                                                                         |      No      | array of references to providers. (currently limited to max 1) |
 
 ## ProviderRefs
 

--- a/doc/user-guides/dns/load-balanced-dns.md
+++ b/doc/user-guides/dns/load-balanced-dns.md
@@ -18,7 +18,7 @@ It is most useful to use the load balancing options when targeting multiple gate
 
 ## DNS Provider Setup
 
-A DNSPolicy acts against a target Gateway or a target listener within a gateway by processing the hostnames on the targeted listeners. Using these it can create dns records using the address exposed in the Gateway's status block. In order for Kuadrant's DNS component to do this, it must be able to access and know which DNS provider to use. This is done through the creation of a dns provider secret containing the needed credentials and the provider identifier.
+A DNSPolicy acts against a target Gateway or a target listener within a gateway by processing the hostnames on the targeted listeners. Using these it can create dns records using the address exposed in the Gateway's status block. In order for Kuadrant's DNS component to do this, it must be able to access and know which DNS provider to use. This is done through the creation of a dns provider secret containing the needed credentials and the provider identifier and either adding the secret in `spec.providerRef` array or labeling the secret with `kuadrant.io/default-provider=true` label.
 
 [Learn more about how to setup a DNS Provider](https://docs.kuadrant.io/latest/dns-operator/docs/provider/)
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/kuadrant/authorino v0.20.0
 	github.com/kuadrant/authorino-operator v0.11.1
-	github.com/kuadrant/dns-operator v0.10.0
+	github.com/kuadrant/dns-operator v0.0.0-20250723135023-9a5f87880460
 	github.com/kuadrant/limitador-operator v0.9.0
 	github.com/kuadrant/policy-machinery v0.6.4
 	github.com/martinlindhe/base36 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/kuadrant/authorino v0.20.0 h1:fDq8b5valsBjhW9vMySx/+y/zKphMrVsWEMR8JG
 github.com/kuadrant/authorino v0.20.0/go.mod h1:J9B/8aZMSyim6CxdmSlS2kRfQt3xMrZub2V/qHnkNeA=
 github.com/kuadrant/authorino-operator v0.11.1 h1:jndTZhiHMU+2Dk0NU+KP2+MUSfvclrn+YtTCQDJj+1s=
 github.com/kuadrant/authorino-operator v0.11.1/go.mod h1:TeFFdX477vUTMushCojaHpvwPLga4DpErGI2oQbqFIs=
-github.com/kuadrant/dns-operator v0.10.0 h1:3NfHauZ7bnldfNPcd5rlreU9vVV9yKTGl8M0O+k1cKk=
-github.com/kuadrant/dns-operator v0.10.0/go.mod h1:7JmHQZJC9JUwzb0ZCZRml6qy6oDkOGU+lMeX2+2cgu0=
+github.com/kuadrant/dns-operator v0.0.0-20250723135023-9a5f87880460 h1:Rr9gN2xm+/5/1tvgft8vmHAh2dgB6TJUi8AOUa3Viaw=
+github.com/kuadrant/dns-operator v0.0.0-20250723135023-9a5f87880460/go.mod h1:Y9Djb29EkSWaSgkRmtBrhyJSTg7UQLRm3wBzUgcL/jU=
 github.com/kuadrant/limitador-operator v0.9.0 h1:hTQ6CFPayf/sL7cIzwWjCoU8uTn6fzWdsJgKbDlnFts=
 github.com/kuadrant/limitador-operator v0.9.0/go.mod h1:DQOlg9qFOcnWPrwO529JRCMLLOEXJQxkmOes952S/Hw=
 github.com/kuadrant/policy-machinery v0.6.4 h1:UMdZ2p7WyUdOKcWlJA2w2MzJnB8/Nn4dT6hE9cUcbeg=

--- a/internal/controller/dnspolicy_dnsrecords.go
+++ b/internal/controller/dnspolicy_dnsrecords.go
@@ -37,6 +37,11 @@ func desiredDNSRecord(gateway *gatewayapiv1.Gateway, clusterID string, dnsPolicy
 			AdditionalHeadersRef: dnsPolicy.Spec.HealthCheck.AdditionalHeadersRef,
 		}
 	}
+	var providerRef *kuadrantdnsv1alpha1.ProviderRef
+	// Currently we only allow a single providerRef to be added. When that changes, we will need to update this to deal with multiple records.
+	if len(dnsPolicy.Spec.ProviderRefs) > 0 {
+		providerRef = &dnsPolicy.Spec.ProviderRefs[0]
+	}
 	dnsRecord := &kuadrantdnsv1alpha1.DNSRecord{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dnsRecordName(gateway.Name, string(targetListener.Name)),
@@ -48,11 +53,8 @@ func desiredDNSRecord(gateway *gatewayapiv1.Gateway, clusterID string, dnsPolicy
 			APIVersion: kuadrantdnsv1alpha1.GroupVersion.String(),
 		},
 		Spec: kuadrantdnsv1alpha1.DNSRecordSpec{
-			RootHost: rootHost,
-			ProviderRef: kuadrantdnsv1alpha1.ProviderRef{
-				// Currently we only allow a single providerRef to be added. When that changes, we will need to update this to deal with multiple records.
-				Name: dnsPolicy.Spec.ProviderRefs[0].Name,
-			},
+			RootHost:    rootHost,
+			ProviderRef: providerRef,
 			HealthCheck: healthCheckSpec,
 		},
 	}


### PR DESCRIPTION
Making provider ref optional to allow for the dns-operator [side](https://github.com/Kuadrant/dns-operator/pull/488) of the change. 

The code will now check if we have refs, and if not, we will have an empty ref in the policy. 

Adjusting tests and docs for it.  