### PR TITLE
[extensions] Getting updates from created resources

### DIFF
--- a/cmd/extensions/oidc-policy/internal/controller/oidcpolicy_reconciler.go
+++ b/cmd/extensions/oidc-policy/internal/controller/oidcpolicy_reconciler.go
@@ -290,11 +290,11 @@ func (r *OIDCPolicyReconciler) reconcileCallbackHTTPRoute(ctx context.Context, p
 }
 
 func (r *OIDCPolicyReconciler) reconcileAuthPolicy(ctx context.Context, desired *kuadrantv1.AuthPolicy, mutatefn types.MutateFn) error {
-	return r.kCtx.ReconcileKuadrantResource(ctx, &kuadrantv1.AuthPolicy{}, desired, mutatefn)
+	return r.kCtx.ReconcileObject(ctx, &kuadrantv1.AuthPolicy{}, desired, mutatefn)
 }
 
 func (r *OIDCPolicyReconciler) reconcileHTTPRoute(ctx context.Context, desired *gatewayapiv1.HTTPRoute, mutatefn types.MutateFn) error {
-	return r.kCtx.ReconcileKuadrantResource(ctx, &gatewayapiv1.HTTPRoute{}, desired, mutatefn)
+	return r.kCtx.ReconcileObject(ctx, &gatewayapiv1.HTTPRoute{}, desired, mutatefn)
 }
 
 func buildMainAuthPolicy(pol *kuadrantv1alpha1.OIDCPolicy, igw *ingressGatewayInfo) (*kuadrantv1.AuthPolicy, error) {

--- a/cmd/extensions/oidc-policy/main.go
+++ b/cmd/extensions/oidc-policy/main.go
@@ -35,6 +35,8 @@ func main() {
 		WithScheme(scheme).
 		WithReconciler(oidcPolicyReconciler.Reconcile).
 		For(&kuadrantv1alpha1.OIDCPolicy{}).
+		Owns(&kuadrantv1.AuthPolicy{}).
+		Owns(&gatewayapiv1.HTTPRoute{}).
 		Build()
 	if err != nil {
 		logger.Error(err, "unable to create controller")

--- a/cmd/extensions/plan-policy/internal/controller/planpolicy_reconciler.go
+++ b/cmd/extensions/plan-policy/internal/controller/planpolicy_reconciler.go
@@ -65,7 +65,7 @@ func (r *PlanPolicyReconciler) Reconcile(ctx context.Context, request reconcile.
 		r.Logger.Error(err, "failed to set controller reference")
 		return reconcile.Result{}, err
 	}
-	if err := kuadrantCtx.ReconcileKuadrantResource(ctx, &kuadrantv1.RateLimitPolicy{}, desiredRateLimitPolicy, rlpSpecMutator); err != nil {
+	if err := kuadrantCtx.ReconcileObject(ctx, &kuadrantv1.RateLimitPolicy{}, desiredRateLimitPolicy, rlpSpecMutator); err != nil {
 		r.Logger.Error(err, "failed to reconcile desired ratelimitpolicy")
 		return reconcile.Result{}, err
 	}

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -242,14 +242,12 @@ func (ec *ExtensionController) AddDataTo(ctx context.Context, requester exttypes
 	return err
 }
 
-func (ec *ExtensionController) ReconcileKuadrantResource(ctx context.Context, obj, desired client.Object, mutateFn exttypes.MutateFn) error {
-	// reconcile
+func (ec *ExtensionController) ReconcileObject(ctx context.Context, obj, desired client.Object, mutateFn exttypes.MutateFn) error {
 	err := ec.ReconcileResource(ctx, obj, desired, basereconciler.MutateFn(mutateFn)) // TODO(didierofrivia): Next iteration, use policy machinery
 	if err != nil {
 		return err
 	}
 	return nil
-	// TODO(didierofrivia): Subscribe
 }
 
 func (ec *ExtensionController) ClearPolicy(ctx context.Context, namespace, name, kind string) error {

--- a/pkg/extension/controller/controller_test.go
+++ b/pkg/extension/controller/controller_test.go
@@ -91,7 +91,7 @@ func (m *mockKuadrantCtx) GetScheme() *runtime.Scheme {
 	return &runtime.Scheme{}
 }
 
-func (m *mockKuadrantCtx) ReconcileKuadrantResource(ctx context.Context, obj, desired client.Object, mutateFn exttypes.MutateFn) error {
+func (m *mockKuadrantCtx) ReconcileObject(ctx context.Context, obj, desired client.Object, mutateFn exttypes.MutateFn) error {
 	return nil
 }
 

--- a/pkg/extension/types/types.go
+++ b/pkg/extension/types/types.go
@@ -26,7 +26,7 @@ type KuadrantCtx interface {
 	Resolve(context.Context, Policy, string, bool) (celref.Val, error)
 	ResolvePolicy(context.Context, Policy, string, bool) (Policy, error)
 	AddDataTo(context.Context, Policy, Policy, string, string) error
-	ReconcileKuadrantResource(context.Context, client.Object, client.Object, MutateFn) error
+	ReconcileObject(context.Context, client.Object, client.Object, MutateFn) error
 }
 
 type ReconcileFn func(ctx context.Context, request reconcile.Request, kuadrant KuadrantCtx) (reconcile.Result, error)


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/1443 with a different approach (maybe?)

This PR adds a simplified `Owns` method to the extensions controller in order to the extensions can receive events when the objects they create are updated.

**Verification steps:**


1. Local cluster with Kuadrant `LOG_LEVEL` set to "debug"
```sh
LOG_LEVEL="debug"  make local-setup
```

2. Apply Kuadrant CR

```sh
kubectl create -n kuadrant-system -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```

3. Configure default ingress gateway

```sh
export INGRESS_IP=$(kubectl get gateway/kuadrant-ingressgateway -n gateway-system -o jsonpath='{.status.addresses[0].value}')
```

```sh
kubectl apply -n gateway-system -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: kuadrant-ingressgateway
spec:
  gatewayClassName: istio
  listeners:
  - allowedRoutes:
      namespaces:
        from: All
    name: http
    hostname: bakery.$INGRESS_IP.nip.io
    port: 80
    protocol: HTTP
EOF
```


4. Deploy the demo app

```sh
kubectl apply -f - <<EOF
apiVersion: apps/v1
kind: Deployment
metadata:
  name: baker
spec:
  selector:
    matchLabels:
      app: baker
  template:
    metadata:
      labels:
        app: baker
    spec:
      containers:
      - name: baker-app
        image: quay.io/kuadrant/authorino-examples:baker-app
        imagePullPolicy: IfNotPresent
        ports:
        - containerPort: 8000
  replicas: 1
---
apiVersion: v1
kind: Service
metadata:
  name: baker
spec:
  selector:
    app: baker
  ports:
    - port: 8000
      protocol: TCP
EOF
```

5. Attach Route to the ingress GW

```sh
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: baker-route
spec:
  parentRefs:
  - kind: Gateway
    name: kuadrant-ingressgateway
    namespace: gateway-system
  rules:
  - matches:
    - path:
        value: /baker
    backendRefs:
    - kind: Service
      name: baker
      port: 8000
EOF
```

6. Apply the OIDC Policy

```sh
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1alpha1
kind: OIDCPolicy
metadata:
  name: baker-auth
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: baker-route
  provider:
    issuerURL: "https://gitlab.com"
    clientID: "e1628246f292c90068d6307a631c17a9fec533b718a162c94c03c5a7db07e0d8"
EOF
```

7. Watch the logs of the Kuadrant Operator:
```sh
kubectl logs -f deployments/kuadrant-operator-controller-manager -n kuadrant-system
```
8. In another terminal, edit the callback `HTTPRoute` created. I.E: Change the `spec.rules[0].matches[0].path.value` to "foo"
```sh
kubectl edit httproute/baker-auth-callback
```

10. You should see in the Kuadrant Operator logs that the reconciliation of the OIDC Policy triggered.
11. If you check the `HTTPRoute` the change should've been reverted
```sh
 kubectl get httproute/baker-auth-callback -o yaml | grep value
        value: /auth/callback
```