### PR TITLE
using JSON Pointer in responseBodyJSON() CEL function

### DIFF
--- a/internal/controller/ratelimit_workflow_helpers.go
+++ b/internal/controller/ratelimit_workflow_helpers.go
@@ -342,7 +342,7 @@ func wasmActionsFromTokenLimit(tokenLimit *kuadrantv1alpha1.TokenLimit, limitIde
 		Value: &wasm.Expression{
 			ExpressionItem: wasm.ExpressionItem{
 				Key:   "ratelimit.hits_addend",
-				Value: "responseBodyJSON(\"usage.total_tokens\")",
+				Value: "responseBodyJSON(\"/usage/total_tokens\")",
 			},
 		},
 	})

--- a/internal/controller/tokenratelimit_workflow_test.go
+++ b/internal/controller/tokenratelimit_workflow_test.go
@@ -108,7 +108,7 @@ func TestWasmActionsFromTokenLimit(t *testing.T) {
 							Value: &wasm.Expression{
 								ExpressionItem: wasm.ExpressionItem{
 									Key:   "ratelimit.hits_addend",
-									Value: `responseBodyJSON("usage.total_tokens")`,
+									Value: `responseBodyJSON("/usage/total_tokens")`,
 								},
 							},
 						},
@@ -184,7 +184,7 @@ func TestWasmActionsFromTokenLimit(t *testing.T) {
 							Value: &wasm.Expression{
 								ExpressionItem: wasm.ExpressionItem{
 									Key:   "ratelimit.hits_addend",
-									Value: `responseBodyJSON("usage.total_tokens")`,
+									Value: `responseBodyJSON("/usage/total_tokens")`,
 								},
 							},
 						},
@@ -263,7 +263,7 @@ func TestWasmActionsFromTokenLimit(t *testing.T) {
 							Value: &wasm.Expression{
 								ExpressionItem: wasm.ExpressionItem{
 									Key:   "ratelimit.hits_addend",
-									Value: `responseBodyJSON("usage.total_tokens")`,
+									Value: `responseBodyJSON("/usage/total_tokens")`,
 								},
 							},
 						},
@@ -324,7 +324,7 @@ func TestWasmActionsFromTokenLimit(t *testing.T) {
 							Value: &wasm.Expression{
 								ExpressionItem: wasm.ExpressionItem{
 									Key:   "ratelimit.hits_addend",
-									Value: `responseBodyJSON("usage.total_tokens")`,
+									Value: `responseBodyJSON("/usage/total_tokens")`,
 								},
 							},
 						},


### PR DESCRIPTION
The [wasm module](https://github.com/Kuadrant/wasm-shim?tab=readme-ov-file#requestbodyjsonjson_pointer) looks up a value from the json body by a JSON Pointer. JSON Pointer defines a string syntax for identifying a specific value within a JavaScript Object Notation (JSON) document. A Pointer is a Unicode string with the reference tokens separated by /. For more information read [RFC6901](https://datatracker.ietf.org/doc/html/rfc6901).

so, looking up the `usage.total_tokens` json path becomes

```cel
responseBodyJSON("/usage/total_tokens")
```