### PR TITLE
Makefile deploy target does not deploy dependencies

### DIFF
--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -2,4 +2,3 @@ namespace: kuadrant-system
 
 resources:
   - ../default
-  - ../dependencies

--- a/make/development-environments.mk
+++ b/make/development-environments.mk
@@ -35,10 +35,10 @@ uninstall-olm:
 
 deploy-dependencies: kustomize dependencies-manifests ## Deploy dependencies to the K8s cluster specified in ~/.kube/config.
 	$(MAKE) namespace
-	$(KUSTOMIZE) build config/dependencies | kubectl apply -f -
+	$(KUSTOMIZE) build config/dependencies | kubectl apply --server-side -f -
 	kubectl -n "$(KUADRANT_NAMESPACE)" wait --timeout=300s --for=condition=Available deployments --all
 
-deploy: manifests dependencies-manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/deploy | kubectl apply --server-side -f -
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_BASE):latest


### PR DESCRIPTION
### What

When I run `make local-setup` I get the following error:
```
error: Apply failed with 1 conflict: conflict with "kubectl-client-side-apply" using apps/v1: .spec.template.spec.containers[name="manager"].env[name="CLUSTER_SECRET_NAMESPACE"].valueFrom.fieldRef
Please review the fields above--they currently have other managers. Here
```
Tried with kubectl 1.31.1 and 1.29.7 with the same result. 

It turns out that dependencies are applied twice when running `make local-setup`. First time from `deploy-dependencies` target, then from `deploy` target. The first one uses `kubectl apply -f`, whereas the second one uses `kubectl apply --server-side -f -`,  that causes `managedFields` to have two different "managers" of the same fields, raising conflict issue.

The fix is twofold: 
* deploy kuadrant dependencies just once when running `make local-setup`
* be consistent and apply with the same approach: `kubectl apply --server-side -f -`