### PR TITLE
Extension Status

### DIFF
--- a/cmd/extensions/oidc-policy/internal/controller/oidcpolicy_reconciler.go
+++ b/cmd/extensions/oidc-policy/internal/controller/oidcpolicy_reconciler.go
@@ -290,11 +290,13 @@ func (r *OIDCPolicyReconciler) reconcileCallbackHTTPRoute(ctx context.Context, p
 }
 
 func (r *OIDCPolicyReconciler) reconcileAuthPolicy(ctx context.Context, desired *kuadrantv1.AuthPolicy, mutatefn types.MutateFn) error {
-	return r.kCtx.ReconcileObject(ctx, &kuadrantv1.AuthPolicy{}, desired, mutatefn)
+	_, err := r.kCtx.ReconcileObject(ctx, &kuadrantv1.AuthPolicy{}, desired, mutatefn)
+	return err
 }
 
 func (r *OIDCPolicyReconciler) reconcileHTTPRoute(ctx context.Context, desired *gatewayapiv1.HTTPRoute, mutatefn types.MutateFn) error {
-	return r.kCtx.ReconcileObject(ctx, &gatewayapiv1.HTTPRoute{}, desired, mutatefn)
+	_, err := r.kCtx.ReconcileObject(ctx, &gatewayapiv1.HTTPRoute{}, desired, mutatefn)
+	return err
 }
 
 func buildMainAuthPolicy(pol *kuadrantv1alpha1.OIDCPolicy, igw *ingressGatewayInfo) (*kuadrantv1.AuthPolicy, error) {

--- a/cmd/extensions/oidc-policy/internal/controller/oidcpolicy_reconciler.go
+++ b/cmd/extensions/oidc-policy/internal/controller/oidcpolicy_reconciler.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"slices"
 	"strings"
 
 	authorinov1beta3 "github.com/kuadrant/authorino/api/v1beta3"
-	"github.com/kuadrant/limitador-operator/pkg/helpers"
 	"github.com/kuadrant/policy-machinery/machinery"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -191,7 +191,7 @@ func (r *OIDCPolicyReconciler) calculateStatus(pol *kuadrantv1alpha1.OIDCPolicy,
 	newStatus := &kuadrantv1alpha1.OIDCPolicyStatus{
 		ObservedGeneration: pol.Generation,
 		// Copy initial conditions. Otherwise, status will always be updated
-		Conditions: helpers.DeepCopyConditions(pol.Status.Conditions),
+		Conditions: slices.Clone(pol.Status.Conditions),
 	}
 
 	availableCond := r.readyCondition(specErr)

--- a/cmd/extensions/plan-policy/internal/controller/planpolicy_reconciler.go
+++ b/cmd/extensions/plan-policy/internal/controller/planpolicy_reconciler.go
@@ -65,7 +65,7 @@ func (r *PlanPolicyReconciler) Reconcile(ctx context.Context, request reconcile.
 		r.Logger.Error(err, "failed to set controller reference")
 		return reconcile.Result{}, err
 	}
-	if err := kuadrantCtx.ReconcileObject(ctx, &kuadrantv1.RateLimitPolicy{}, desiredRateLimitPolicy, rlpSpecMutator); err != nil {
+	if _, err := kuadrantCtx.ReconcileObject(ctx, &kuadrantv1.RateLimitPolicy{}, desiredRateLimitPolicy, rlpSpecMutator); err != nil {
 		r.Logger.Error(err, "failed to reconcile desired ratelimitpolicy")
 		return reconcile.Result{}, err
 	}

--- a/internal/controller/consoleplugin_reconciler.go
+++ b/internal/controller/consoleplugin_reconciler.go
@@ -107,7 +107,7 @@ func (r *ConsolePluginReconciler) Run(eventCtx context.Context, _ []controller.R
 	if !topologyExists || !consolePluginConfigMapExists || !clusterVersionExists {
 		utils.TagObjectToDelete(service)
 	}
-	err := r.ReconcileResource(ctx, &corev1.Service{}, service, reconcilers.CreateOnlyMutator)
+	_, err := r.ReconcileResource(ctx, &corev1.Service{}, service, reconcilers.CreateOnlyMutator)
 	if err != nil {
 		logger.Error(err, "reconciling service")
 		return err
@@ -131,7 +131,7 @@ func (r *ConsolePluginReconciler) Run(eventCtx context.Context, _ []controller.R
 	if !topologyExists || !consolePluginConfigMapExists || !clusterVersionExists {
 		utils.TagObjectToDelete(deployment)
 	}
-	err = r.ReconcileResource(ctx, &appsv1.Deployment{}, deployment, reconcilers.DeploymentMutator(deploymentMutators...))
+	_, err = r.ReconcileResource(ctx, &appsv1.Deployment{}, deployment, reconcilers.DeploymentMutator(deploymentMutators...))
 	if err != nil {
 		logger.Error(err, "reconciling deployment")
 		return err
@@ -142,7 +142,7 @@ func (r *ConsolePluginReconciler) Run(eventCtx context.Context, _ []controller.R
 	if !topologyExists || !consolePluginConfigMapExists || !clusterVersionExists {
 		utils.TagObjectToDelete(nginxConfigMap)
 	}
-	err = r.ReconcileResource(ctx, &corev1.ConfigMap{}, nginxConfigMap, reconcilers.CreateOnlyMutator)
+	_, err = r.ReconcileResource(ctx, &corev1.ConfigMap{}, nginxConfigMap, reconcilers.CreateOnlyMutator)
 	if err != nil {
 		logger.Error(err, "reconciling nginx configmap")
 		return err
@@ -154,7 +154,7 @@ func (r *ConsolePluginReconciler) Run(eventCtx context.Context, _ []controller.R
 		utils.TagObjectToDelete(consolePlugin)
 	}
 	consolePluginMutator := reconcilers.Mutator[*consolev1.ConsolePlugin](consoleplugin.ServiceMutator)
-	err = r.ReconcileResource(ctx, &consolev1.ConsolePlugin{}, consolePlugin, consolePluginMutator)
+	_, err = r.ReconcileResource(ctx, &consolev1.ConsolePlugin{}, consolePlugin, consolePluginMutator)
 	if err != nil {
 		logger.Error(err, "reconciling consoleplugin")
 		return err

--- a/internal/controller/istio_peerauthentication_reconciler.go
+++ b/internal/controller/istio_peerauthentication_reconciler.go
@@ -118,7 +118,7 @@ func (p *PeerAuthenticationReconciler) Run(baseCtx context.Context, _ []controll
 		return err
 	}
 
-	err := p.ReconcileResource(ctx, &istiosecurityv1.PeerAuthentication{}, peerAuth, reconcilers.CreateOnlyMutator)
+	_, err := p.ReconcileResource(ctx, &istiosecurityv1.PeerAuthentication{}, peerAuth, reconcilers.CreateOnlyMutator)
 	if err != nil {
 		logger.Error(err, "failed to create peer authentication resource", "status", "error")
 		return err

--- a/internal/controller/observability_reconciler.go
+++ b/internal/controller/observability_reconciler.go
@@ -399,7 +399,7 @@ func (r *ObservabilityReconciler) createServiceMonitor(ctx context.Context, moni
 
 	// Only create, do not mutate if exists.
 	// Effectively the controlller does not revert back external changes
-	err := r.ReconcileResource(ctx, &monitoringv1.ServiceMonitor{}, monitor, reconcilers.CreateOnlyMutator)
+	_, err := r.ReconcileResource(ctx, &monitoringv1.ServiceMonitor{}, monitor, reconcilers.CreateOnlyMutator)
 	if err != nil {
 		logger.Error(err, "reconciling service monitor", "key", client.ObjectKeyFromObject(monitor))
 		return err
@@ -417,7 +417,7 @@ func (r *ObservabilityReconciler) createPodMonitor(ctx context.Context, monitor 
 
 	// Only create, do not mutate if exists.
 	// Effectively the controlller does not revert back external changes
-	err := r.ReconcileResource(ctx, &monitoringv1.PodMonitor{}, monitor, reconcilers.CreateOnlyMutator)
+	_, err := r.ReconcileResource(ctx, &monitoringv1.PodMonitor{}, monitor, reconcilers.CreateOnlyMutator)
 	if err != nil {
 		logger.Error(err, "reconciling pod monitor", "key", client.ObjectKeyFromObject(monitor))
 		return err

--- a/internal/reconcilers/base_reconciler_test.go
+++ b/internal/reconcilers/base_reconciler_test.go
@@ -93,7 +93,7 @@ func TestBaseReconcilerCreate(t *testing.T) {
 		},
 	}
 
-	err = baseReconciler.ReconcileResource(ctx, &v1.ConfigMap{}, desiredConfigmap, CreateOnlyMutator)
+	_, err = baseReconciler.ReconcileResource(ctx, &v1.ConfigMap{}, desiredConfigmap, CreateOnlyMutator)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +171,7 @@ func TestBaseReconcilerUpdateNeeded(t *testing.T) {
 		return true, nil
 	}
 
-	err = baseReconciler.ReconcileResource(ctx, &v1.ConfigMap{}, desiredConfigmap, customMutator)
+	_, err = baseReconciler.ReconcileResource(ctx, &v1.ConfigMap{}, desiredConfigmap, customMutator)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestBaseReconcilerDelete(t *testing.T) {
 	}
 	utils.TagObjectToDelete(desired)
 
-	err = baseReconciler.ReconcileResource(ctx, &v1.ConfigMap{}, desired, CreateOnlyMutator)
+	_, err = baseReconciler.ReconcileResource(ctx, &v1.ConfigMap{}, desired, CreateOnlyMutator)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -242,12 +242,12 @@ func (ec *ExtensionController) AddDataTo(ctx context.Context, requester exttypes
 	return err
 }
 
-func (ec *ExtensionController) ReconcileObject(ctx context.Context, obj, desired client.Object, mutateFn exttypes.MutateFn) error {
-	err := ec.ReconcileResource(ctx, obj, desired, basereconciler.MutateFn(mutateFn)) // TODO(didierofrivia): Next iteration, use policy machinery
+func (ec *ExtensionController) ReconcileObject(ctx context.Context, obj client.Object, desired client.Object, mutateFn exttypes.MutateFn) (client.Object, error) {
+	obj, err := ec.ReconcileResource(ctx, obj, desired, basereconciler.MutateFn(mutateFn)) // TODO(didierofrivia): Next iteration, use policy machinery
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return obj, nil
 }
 
 func (ec *ExtensionController) ClearPolicy(ctx context.Context, namespace, name, kind string) error {

--- a/pkg/extension/controller/controller_test.go
+++ b/pkg/extension/controller/controller_test.go
@@ -91,8 +91,8 @@ func (m *mockKuadrantCtx) GetScheme() *runtime.Scheme {
 	return &runtime.Scheme{}
 }
 
-func (m *mockKuadrantCtx) ReconcileObject(ctx context.Context, obj, desired client.Object, mutateFn exttypes.MutateFn) error {
-	return nil
+func (m *mockKuadrantCtx) ReconcileObject(ctx context.Context, obj, desired client.Object, mutateFn exttypes.MutateFn) (client.Object, error) {
+	return nil, nil
 }
 
 func TestGenericResolveSuccess(t *testing.T) {

--- a/pkg/extension/controller/utils.go
+++ b/pkg/extension/controller/utils.go
@@ -2,9 +2,14 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
 	extpb "github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v1"
 	exttypes "github.com/kuadrant/kuadrant-operator/pkg/extension/types"
 )
@@ -53,4 +58,56 @@ func Resolve[T any](ctx context.Context, kuadrantCtx exttypes.KuadrantCtx, polic
 		return zero, fmt.Errorf("value is not type: %T", zero)
 	}
 	return result, nil
+}
+
+func AcceptedCondition(p exttypes.Policy, err error) *metav1.Condition {
+	policyKind := fmt.Sprintf("%s", p.GetObjectKind())
+	cond := &metav1.Condition{
+		Type:    string(gatewayapiv1alpha2.PolicyConditionAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayapiv1alpha2.PolicyReasonAccepted),
+		Message: fmt.Sprintf("%s has been accepted", policyKind),
+	}
+	if err == nil {
+		return cond
+	}
+
+	policyErr := intoPolicyError(err, policyKind)
+
+	cond.Status = metav1.ConditionFalse
+	cond.Message = policyErr.Error()
+	cond.Reason = string(policyErr.Reason())
+
+	return cond
+}
+
+func EnforcedCondition(p exttypes.Policy, err error, fully bool) *metav1.Condition {
+	policyKind := fmt.Sprintf("%s", p.GetObjectKind())
+	message := fmt.Sprintf("%s has been successfully enforced", policyKind)
+	if !fully {
+		message = fmt.Sprintf("%s has been partially enforced", policyKind)
+	}
+	cond := &metav1.Condition{
+		Type:    string(kuadrant.PolicyConditionEnforced),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(kuadrant.PolicyReasonEnforced),
+		Message: message,
+	}
+	if err == nil {
+		return cond
+	}
+	policyErr := intoPolicyError(err, policyKind)
+	cond.Status = metav1.ConditionFalse
+	cond.Message = err.Error()
+	cond.Reason = string(policyErr.Reason())
+
+	return cond
+}
+
+func intoPolicyError(err error, policyKind string) kuadrant.PolicyError {
+	var policyErr kuadrant.PolicyError
+	if !errors.As(err, &policyErr) {
+		policyErr = kuadrant.NewErrUnknown(policyKind, err)
+	}
+	return policyErr
 }

--- a/pkg/extension/controller/utils_test.go
+++ b/pkg/extension/controller/utils_test.go
@@ -1,0 +1,199 @@
+package controller
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
+	exttypes "github.com/kuadrant/kuadrant-operator/pkg/extension/types"
+)
+
+type policyObjectKind struct {
+	group   string
+	kind    string
+	version string
+}
+
+func (p policyObjectKind) SetGroupVersionKind(_ schema.GroupVersionKind) {
+
+}
+
+func (p policyObjectKind) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Group:   p.group,
+		Version: p.version,
+		Kind:    p.kind,
+	}
+}
+
+type fakePolicy struct {
+	kind string
+}
+
+func (f *fakePolicy) GetName() string {
+	return f.kind
+}
+
+func (f *fakePolicy) GetNamespace() string {
+	return ""
+}
+
+func (f *fakePolicy) GetTargetRefs() []gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName {
+	return nil
+}
+
+func (f *fakePolicy) GetObjectKind() schema.ObjectKind {
+	return &policyObjectKind{
+		group:   "",
+		version: "",
+		kind:    f.kind,
+	}
+}
+
+func TestAcceptedCondition(t *testing.T) {
+	testCases := []struct {
+		name           string
+		policy         exttypes.Policy
+		errorInput     error
+		expectedStatus metav1.ConditionStatus
+		expectedType   string
+		expectedReason string
+	}{
+		{
+			name: "nil error creates accepted condition",
+			policy: &fakePolicy{
+				kind: "MyPolicy",
+			},
+			errorInput:     nil,
+			expectedStatus: metav1.ConditionTrue,
+			expectedType:   string(gatewayapiv1alpha2.PolicyConditionAccepted),
+			expectedReason: string(gatewayapiv1alpha2.PolicyReasonAccepted),
+		},
+		{
+			name: "error creates false condition",
+			policy: &fakePolicy{
+				kind: "MyPolicy",
+			},
+			errorInput:     fmt.Errorf("test error"),
+			expectedStatus: metav1.ConditionFalse,
+			expectedType:   string(gatewayapiv1alpha2.PolicyConditionAccepted),
+			expectedReason: "Unknown",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			condition := AcceptedCondition(tc.policy, tc.errorInput)
+
+			if condition.Type != tc.expectedType {
+				t.Errorf("condition Type mismatch: got %q, want %q",
+					condition.Type, tc.expectedType)
+			}
+
+			if condition.Status != tc.expectedStatus {
+				t.Errorf("condition Status mismatch: got %q, want %q",
+					condition.Status, tc.expectedStatus)
+			}
+
+			if condition.Reason != tc.expectedReason {
+				t.Errorf("condition Reason mismatch: got %q, want %q",
+					condition.Reason, tc.expectedReason)
+			}
+
+			if tc.errorInput == nil {
+				expectedMessage := fmt.Sprintf("%s has been accepted",
+					tc.policy.GetObjectKind())
+				if condition.Message != expectedMessage {
+					t.Errorf("message mismatch: got %q, want %q",
+						condition.Message, expectedMessage)
+				}
+			} else {
+				if !strings.Contains(condition.Message, tc.errorInput.Error()) {
+					t.Errorf("message does not contain error: got %q, want %q",
+						condition.Message, tc.errorInput.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestEnforcedCondition(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		policy                  exttypes.Policy
+		errorInput              error
+		fullyEnforced           bool
+		expectedStatus          metav1.ConditionStatus
+		expectedType            string
+		expectedReason          string
+		expectedMessageContains string
+	}{
+		{
+			name: "fully enforced with no error",
+			policy: &fakePolicy{
+				kind: "MyPolicy",
+			},
+			errorInput:              nil,
+			fullyEnforced:           true,
+			expectedStatus:          metav1.ConditionTrue,
+			expectedType:            string(kuadrant.PolicyConditionEnforced),
+			expectedReason:          string(kuadrant.PolicyReasonEnforced),
+			expectedMessageContains: "has been successfully enforced",
+		},
+		{
+			name: "partially enforced with no error",
+			policy: &fakePolicy{
+				kind: "MyPolicy",
+			},
+			errorInput:              nil,
+			fullyEnforced:           false,
+			expectedStatus:          metav1.ConditionTrue,
+			expectedType:            string(kuadrant.PolicyConditionEnforced),
+			expectedReason:          string(kuadrant.PolicyReasonEnforced),
+			expectedMessageContains: "has been partially enforced",
+		},
+		{
+			name: "error condition",
+			policy: &fakePolicy{
+				kind: "MyPolicy",
+			},
+			errorInput:              fmt.Errorf("test error"),
+			fullyEnforced:           true,
+			expectedStatus:          metav1.ConditionFalse,
+			expectedType:            string(kuadrant.PolicyConditionEnforced),
+			expectedReason:          "Unknown",
+			expectedMessageContains: "test error",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			condition := EnforcedCondition(tc.policy, tc.errorInput, tc.fullyEnforced)
+
+			if condition.Type != tc.expectedType {
+				t.Errorf("condition Type mismatch: got %q, want %q",
+					condition.Type, tc.expectedType)
+			}
+
+			if condition.Status != tc.expectedStatus {
+				t.Errorf("condition Status mismatch: got %q, want %q",
+					condition.Status, tc.expectedStatus)
+			}
+
+			if condition.Reason != tc.expectedReason {
+				t.Errorf("condition Reason mismatch: got %q, want %q",
+					condition.Reason, tc.expectedReason)
+			}
+
+			if !strings.Contains(condition.Message, tc.expectedMessageContains) {
+				t.Errorf("message does not contain expected text: got %q, want to contain %q",
+					condition.Message, tc.expectedMessageContains)
+			}
+		})
+	}
+}

--- a/pkg/extension/types/types.go
+++ b/pkg/extension/types/types.go
@@ -26,7 +26,7 @@ type KuadrantCtx interface {
 	Resolve(context.Context, Policy, string, bool) (celref.Val, error)
 	ResolvePolicy(context.Context, Policy, string, bool) (Policy, error)
 	AddDataTo(context.Context, Policy, Policy, string, string) error
-	ReconcileObject(context.Context, client.Object, client.Object, MutateFn) error
+	ReconcileObject(context.Context, client.Object, client.Object, MutateFn) (client.Object, error)
 }
 
 type ReconcileFn func(ctx context.Context, request reconcile.Request, kuadrant KuadrantCtx) (reconcile.Result, error)


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/1483

This PR provides a set of functions to make it possible to communicate Kuadrant like status conditions for the extensions. It also refactors the `BaseReconciler.CreateResource` to also return the reconciled obj in order to be use for later reconciliation decisions.