### PR TITLE
Cel Validating auth for Policies

### DIFF
--- a/internal/cel/kuadrant_validator.go
+++ b/internal/cel/kuadrant_validator.go
@@ -1,0 +1,58 @@
+package cel
+
+import (
+	"github.com/google/cel-go/cel"
+
+	"github.com/kuadrant/kuadrant-operator/internal/wasm"
+)
+
+const (
+	AuthPolicyKind           = "AuthPolicy"
+	RateLimitPolicyKind      = "RateLimitPolicy"
+	TokenRateLimitPolicyKind = "TokenRateLimitPolicy"
+
+	AuthPolicyName = "auth"
+	RateLimitName  = "ratelimit"
+)
+
+func NewRootValidatorBuilder() *ValidatorBuilder {
+	builder := NewValidatorBuilder()
+	// TODO: correct cel types
+	builder.AddBinding("request", cel.AnyType)
+	builder.AddBinding("source", cel.AnyType)
+	builder.AddBinding("destination", cel.AnyType)
+	builder.AddBinding("connection", cel.AnyType)
+	return builder
+}
+
+func ValidateWasmAction(action wasm.Action, validator *Validator) error {
+	pol := policyKindFromWasmServiceName(action.ServiceName)
+	for _, predicate := range action.Predicates {
+		if _, err := validator.Validate(pol, predicate); err != nil {
+			return err
+		}
+	}
+	for _, conditionalData := range action.ConditionalData {
+		for _, predicate := range conditionalData.Predicates {
+			if _, err := validator.Validate(pol, predicate); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func policyKindFromWasmServiceName(serviceName string) string {
+	switch serviceName {
+	case wasm.AuthServiceName:
+		return AuthPolicyKind
+	case wasm.RateLimitServiceName:
+		return RateLimitPolicyKind
+	case wasm.RateLimitCheckServiceName:
+		return TokenRateLimitPolicyKind
+	case wasm.RateLimitReportServiceName:
+		return TokenRateLimitPolicyKind
+	default:
+		return RateLimitPolicyKind
+	}
+}

--- a/internal/cel/kuadrant_validator.go
+++ b/internal/cel/kuadrant_validator.go
@@ -15,6 +15,57 @@ const (
 	RateLimitName  = "ratelimit"
 )
 
+var StateCELValidationErrors = "CELValidationErrors"
+
+type Issue struct {
+	policyKind string
+	pathID     string
+	err        error
+}
+
+func NewIssue(action wasm.Action, pathID string, err error) *Issue {
+	return &Issue{
+		policyKind: policyKindFromWasmServiceName(action.ServiceName),
+		pathID:     pathID,
+		err:        err,
+	}
+}
+
+func (i *Issue) GetError() error {
+	return i.err
+}
+
+type IssueCollection struct {
+	issues map[string]map[string][]*Issue
+}
+
+func NewIssueCollection() *IssueCollection {
+	return &IssueCollection{
+		issues: make(map[string]map[string][]*Issue),
+	}
+}
+
+func (c *IssueCollection) IsEmpty() bool {
+	return len(c.issues) == 0
+}
+
+func (c *IssueCollection) GetByPolicyKind(policyKind string) (map[string][]*Issue, bool) {
+	issues := c.issues[policyKind]
+	return issues, len(issues) > 0
+}
+
+func (c *IssueCollection) Add(issue *Issue) {
+	if _, exists := c.issues[issue.policyKind]; !exists {
+		c.issues[issue.policyKind] = make(map[string][]*Issue)
+	}
+
+	if _, exists := c.issues[issue.policyKind][issue.pathID]; !exists {
+		c.issues[issue.policyKind][issue.pathID] = make([]*Issue, 0)
+	}
+
+	c.issues[issue.policyKind][issue.pathID] = append(c.issues[issue.policyKind][issue.pathID], issue)
+}
+
 func NewRootValidatorBuilder() *ValidatorBuilder {
 	builder := NewValidatorBuilder()
 	// TODO: correct cel types

--- a/internal/cel/kuadrant_validator_test.go
+++ b/internal/cel/kuadrant_validator_test.go
@@ -1,0 +1,90 @@
+package cel
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"gotest.tools/assert"
+
+	"github.com/kuadrant/kuadrant-operator/internal/wasm"
+)
+
+func TestNewRootValidatorBuilder(t *testing.T) {
+	builder := NewRootValidatorBuilder()
+	pol := "foo"
+	builder.PushPolicyBinding(pol, "foo", cel.AnyType)
+	if validator, err := builder.Build(); err != nil {
+		t.Fatal(err)
+	} else {
+		if ast, err := validator.Validate("foo", "other == 1"); ast != nil {
+			t.Fatal("No ast should have returned for not known root expression")
+		} else if err == nil {
+			t.Fatal("Should have returned an error")
+		}
+		if ast, err := validator.Validate("foo", "request.id == 1"); ast == nil {
+			t.Fatal("Should have return a valid ast")
+		} else if err != nil {
+			t.Fatalf("Should not have returned an error %v", err)
+		}
+	}
+}
+
+func TestValidateWasmActionInvalidNoAuth(t *testing.T) {
+	wasmAction := wasm.Action{
+		ServiceName: wasm.RateLimitServiceName,
+		Scope:       "scope",
+		Predicates:  []string{"request.id == 1"},
+		ConditionalData: []wasm.ConditionalData{
+			{
+				Predicates: []string{"auth.identity == 'anonymous'"},
+			},
+		},
+	}
+	builder := NewRootValidatorBuilder()
+	builder.PushPolicyBinding(RateLimitPolicyKind, RateLimitName, cel.AnyType)
+	validator, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.ErrorContains(t, ValidateWasmAction(wasmAction, validator), "undeclared reference to 'auth'")
+}
+
+func TestValidateWasmActionInvalidWrongDependency(t *testing.T) {
+	wasmAction := wasm.Action{
+		ServiceName: wasm.RateLimitServiceName,
+		Scope:       "scope",
+		Predicates:  []string{"auth == 'something'"},
+	}
+	builder := NewRootValidatorBuilder()
+	builder.PushPolicyBinding(RateLimitPolicyKind, RateLimitName, cel.AnyType)
+	builder.PushPolicyBinding(AuthPolicyKind, AuthPolicyName, cel.AnyType)
+	validator, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.ErrorContains(t, ValidateWasmAction(wasmAction, validator), "undeclared reference to 'auth'")
+}
+
+func TestValidateWasmActionValid(t *testing.T) {
+	wasmAction := wasm.Action{
+		ServiceName: wasm.RateLimitServiceName,
+		Scope:       "scope",
+		Predicates:  []string{"request.id == 1"},
+		ConditionalData: []wasm.ConditionalData{
+			{
+				Predicates: []string{"auth.identity == 'anonymous'"},
+			},
+		},
+	}
+	builder := NewRootValidatorBuilder()
+	builder.PushPolicyBinding(AuthPolicyKind, AuthPolicyName, cel.AnyType)
+	builder.PushPolicyBinding(RateLimitPolicyKind, RateLimitName, cel.AnyType)
+	validator, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NilError(t, ValidateWasmAction(wasmAction, validator))
+}

--- a/internal/cel/validator.go
+++ b/internal/cel/validator.go
@@ -59,6 +59,19 @@ func (b *ValidatorBuilder) AddPolicyBindingAfter(after *string, policy string, n
 	return b, nil
 }
 
+func (b *ValidatorBuilder) PushPolicyBinding(policy string, name string, t *cel.Type) *ValidatorBuilder {
+	p := policyBinding{
+		policy: policy,
+		binding: binding{
+			name: name,
+			t:    t,
+		},
+	}
+
+	b.policies = append(b.policies, p)
+	return b
+}
+
 func (b *ValidatorBuilder) Build() (*Validator, error) {
 	var envs = make(map[string]*cel.Env)
 

--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -188,9 +188,6 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 	wasmActionSets := kuadrantgatewayapi.GrouppedHTTPRouteMatchConfigs{}
 	validatorBuilder := celvalidator.NewRootValidatorBuilder()
 
-	// clear the stored wasm action errors state
-	state.Delete(celvalidator.StateCELValidationErrors)
-
 	// build the wasm policies for each topological path that contains an effective rate limit policy affecting an envoy gateway gateway
 	for i := range paths {
 		pathID := paths[i].Key

--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -188,6 +188,9 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 	wasmActionSets := kuadrantgatewayapi.GrouppedHTTPRouteMatchConfigs{}
 	validatorBuilder := celvalidator.NewRootValidatorBuilder()
 
+	// clear the stored wasm action errors state
+	state.Delete(celvalidator.StateCELValidationErrors)
+
 	// build the wasm policies for each topological path that contains an effective rate limit policy affecting an envoy gateway gateway
 	for i := range paths {
 		pathID := paths[i].Key
@@ -245,14 +248,19 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 			return nil, fmt.Errorf("failed to build validator for path %s: %w", pathID, err)
 		}
 		var validatedActions []wasm.Action
+		celValidationIssues := celvalidator.NewIssueCollection()
 
 		for _, action := range actions {
-			if err = celvalidator.ValidateWasmAction(action, validator); err != nil {
+			if err := celvalidator.ValidateWasmAction(action, validator); err != nil {
 				logger.V(1).Info("WASM action is invalid", "action", action, "path", pathID, "error", err)
-				// Dag set a state information
+				celValidationIssues.Add(celvalidator.NewIssue(action, pathID, err))
 			} else {
 				validatedActions = append(validatedActions, action)
 			}
+		}
+
+		if !celValidationIssues.IsEmpty() {
+			state.Store(celvalidator.StateCELValidationErrors, celValidationIssues)
 		}
 
 		if len(validatedActions) == 0 {

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -239,9 +239,6 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, state *
 	wasmActionSets := kuadrantgatewayapi.GrouppedHTTPRouteMatchConfigs{}
 	validatorBuilder := celvalidator.NewRootValidatorBuilder()
 
-	// clear the stored wasm action errors state
-	state.Delete(celvalidator.StateCELValidationErrors)
-
 	// build the wasm policies for each topological path that contains an effective rate limit policy affecting an istio gateway
 	for i := range paths {
 		pathID := paths[i].Key

--- a/internal/kuadrant/conditions.go
+++ b/internal/kuadrant/conditions.go
@@ -14,11 +14,12 @@ import (
 const (
 	PolicyConditionEnforced gatewayapiv1alpha2.PolicyConditionType = "Enforced"
 
-	PolicyReasonEnforced          gatewayapiv1alpha2.PolicyConditionReason = "Enforced"
-	PolicyReasonOverridden        gatewayapiv1alpha2.PolicyConditionReason = "Overridden"
-	PolicyReasonUnknown           gatewayapiv1alpha2.PolicyConditionReason = "Unknown"
-	PolicyReasonMissingDependency gatewayapiv1alpha2.PolicyConditionReason = "MissingDependency"
-	PolicyReasonMissingResource   gatewayapiv1alpha2.PolicyConditionReason = "MissingResource"
+	PolicyReasonEnforced             gatewayapiv1alpha2.PolicyConditionReason = "Enforced"
+	PolicyReasonOverridden           gatewayapiv1alpha2.PolicyConditionReason = "Overridden"
+	PolicyReasonUnknown              gatewayapiv1alpha2.PolicyConditionReason = "Unknown"
+	PolicyReasonMissingDependency    gatewayapiv1alpha2.PolicyConditionReason = "MissingDependency"
+	PolicyReasonMissingResource      gatewayapiv1alpha2.PolicyConditionReason = "MissingResource"
+	PolicyReasonInvalidCelExpression gatewayapiv1alpha2.PolicyConditionReason = "InvalidCelExpression"
 )
 
 // ConditionMarshal marshals the set of conditions as a JSON array, sorted by condition type.

--- a/internal/kuadrant/errors.go
+++ b/internal/kuadrant/errors.go
@@ -259,3 +259,21 @@ func (e ErrSystemResource) Error() string {
 func (e ErrSystemResource) Reason() gatewayapiv1alpha2.PolicyConditionReason {
 	return PolicyReasonMissingResource
 }
+
+type ErrCelValidation struct {
+	issues []error
+}
+
+func NewErrCelValidation(issues []error) ErrCelValidation {
+	return ErrCelValidation{
+		issues: issues,
+	}
+}
+
+func (e ErrCelValidation) Error() string {
+	return fmt.Sprintf("validation issues: %v", e.issues)
+}
+
+func (e ErrCelValidation) Reason() gatewayapiv1alpha2.PolicyConditionReason {
+	return PolicyReasonInvalidCelExpression
+}

--- a/tests/common/authpolicy/authpolicy_controller_test.go
+++ b/tests/common/authpolicy/authpolicy_controller_test.go
@@ -273,7 +273,7 @@ var _ = Describe("AuthPolicy controller", func() {
 				}
 				policy.Spec.Proper().MergeableWhenPredicates = kuadrantv1.MergeableWhenPredicates{
 					Predicates: kuadrantv1.WhenPredicates{
-						{Predicate: `source.ip.matches("^192\.168\..*")`},
+						{Predicate: `source.ip.matches("^192\\.168\\..*")`},
 					},
 				}
 				policy.Spec.Proper().AuthScheme = &kuadrantv1.AuthSchemeSpec{


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/1499

This PR introduces the validation of cel expressions in Policies, and the reporting in the Status (RLP at the moment).

**Verification Steps**:

1. Create kind cluster with Kuadrant

2. Apply Kuadrant CR
```sh
kubectl create -n kuadrant-system -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```
3. Follow the steps of the ["Authenticated RL for app devs"](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/ratelimiting/authenticated-rl-for-app-developers.md) but don't create the AuthPolicy nor the secrets

4. Check the status of the RLP:
```sh
kubectl get ratelimitpolicy/toystore -n toystore -o yaml | yq .status
```

It should show:

```yaml
conditions:
  - lastTransitionTime: "2025-08-21T14:37:02Z"
    message: RateLimitPolicy has been accepted
    reason: Accepted
    status: "True"
    type: Accepted
  - lastTransitionTime: "2025-08-21T14:37:02Z"
    message: |-
      validation issues: [ERROR: <input>:1:1: undeclared reference to 'auth' (in container '')
       | auth.identity.userid == 'alice'
       | ^]
    reason: InvalidCelExpression
    status: "False"
    type: Enforced
```
5. Apply the guide example `AuthPolicy`

6. Check the status of the RLP again:
```sh
kubectl get ratelimitpolicy/toystore -n toystore -o yaml | yq .status
```

and this time would look similar to:

```yaml
conditions:
  - lastTransitionTime: "2025-08-21T14:37:02Z"
    message: RateLimitPolicy has been accepted
    reason: Accepted
    status: "True"
    type: Accepted
  - lastTransitionTime: "2025-08-21T16:03:13Z"
    message: RateLimitPolicy has been successfully enforced
    reason: Enforced
    status: "True"
    type: Enforced
observedGeneration: 1
```

Notes:
- It's prepared to validate other policies, even if the RLP Status is been updated
- The root validator should have the correct cel types, future work.
