### PR TITLE
Extension mutator updates trigger reconcile

### DIFF
--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -576,7 +576,7 @@ func (b *BootOptionsBuilder) getExtensionsOptions() []controller.ControllerOptio
 	var opts []controller.ControllerOption
 	extensionsDir := env.GetString("EXTENSIONS_DIR", "/extensions")
 
-	extManager, err := extension.NewManager(extensionsDir, b.logger.WithName("extensions"), log.Sync)
+	extManager, err := extension.NewManager(extensionsDir, b.logger.WithName("extensions"), log.Sync, b.client)
 	if err != nil {
 		if errors.Is(err, extension.ErrNoExtensionsFound) {
 			b.logger.Info("No extensions found, skipping extension manager", "directory", extensionsDir)
@@ -585,6 +585,7 @@ func (b *BootOptionsBuilder) getExtensionsOptions() []controller.ControllerOptio
 		b.logger.Error(err, "failed to create extension manager")
 		return opts
 	}
+	extManager.SetChangeNotifier(extManager.TriggerReconciliation)
 
 	b.isUsingExtensions = true
 	opts = append(opts, controller.WithRunnable(

--- a/internal/extension/oop_test.go
+++ b/internal/extension/oop_test.go
@@ -33,7 +33,7 @@ func TestOOPExtensionManagesExternalProcess(t *testing.T) {
 		name:       "test",
 		executable: "/bin/sleep",
 		socket:     "1d",
-		service:    newExtensionService(nil),
+		service:    newExtensionService(nil, logr.Discard()),
 		logger:     logr.Discard(),
 		sync:       nil,
 	}
@@ -75,7 +75,7 @@ func TestOOPExtensionForwardsLog(t *testing.T) {
 		name:       "testErrorLog",
 		executable: "/bin/ps",
 		socket:     "--foobar",
-		service:    newExtensionService(nil),
+		service:    newExtensionService(nil, logger),
 		logger:     logger,
 		sync:       writer,
 	}


### PR DESCRIPTION
### Changes

Currently, the mutators are evaluated and applied to an `AuthConfig` when the state of the world workflows run. This works great if a change that takes place to apply the mutator _also_ triggers the state of the world workflow, however if an edit/update/change to a mutator _does not_ impact the state of the world, the mutator is not applied. Ideally there would be some way to do this within policy-machinery, to re-trigger/build affected parts of the workflow, but this is currently not possible.

* Updated the manager to allow the setting of a `ChangeNotifier` callback function which takes a `reason` which is called when the mutator updates are applied
* There's a default implementation called `TriggerReconciliation` which sets annotations on the `Kuadrant` resource to ensure the mutator updates are applied

### Verification

From this branch, deploy a cluster with extensions:
```sh
make local-setup local-apply-extensions apply-extensions-manifests
```

Deploy `Kuadrant` and the `Gateway`:
```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
  namespace: kuadrant-system
EOF
export KUADRANT_GATEWAY_NS=api-gateway # Namespace for the example Gateway
export KUADRANT_GATEWAY_NAME=external # Name for the example Gateway
export KUADRANT_DEVELOPER_NS=toystore # Namespace for an example toystore app
kubectl create ns ${KUADRANT_GATEWAY_NS}
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: ${KUADRANT_GATEWAY_NAME}
  namespace: ${KUADRANT_GATEWAY_NS}
  labels:
    kuadrant.io/gateway: "true"
spec:
  gatewayClassName: istio
  listeners:
    - name: http
      protocol: HTTP
      port: 80
      allowedRoutes:
        namespaces:
          from: All
EOF
```

Deploy toystore and the `HTTPRoute`:
```sh
kubectl create ns ${KUADRANT_DEVELOPER_NS}
kubectl apply -f https://raw.githubusercontent.com/Kuadrant/Kuadrant-operator/main/examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: toystore
  namespace: ${KUADRANT_DEVELOPER_NS}
spec:
  parentRefs:
  - name: ${KUADRANT_GATEWAY_NAME}
    namespace: ${KUADRANT_GATEWAY_NS}
  hostnames:
  - api.toystore.com
  rules:
  - matches:
    - path:
        type: Exact
        value: "/toy"
      method: GET
    backendRefs:
    - name: toystore
      port: 80
EOF
export KUADRANT_INGRESS_HOST=$(kubectl get gtw ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o jsonpath='{.status.addresses[0].value}')
export KUADRANT_INGRESS_PORT=$(kubectl get gtw ${KUADRANT_GATEWAY_NAME} -n ${KUADRANT_GATEWAY_NS} -o jsonpath='{.spec.listeners[?(@.name=="http")].port}')
export KUADRANT_GATEWAY_URL=${KUADRANT_INGRESS_HOST}:${KUADRANT_INGRESS_PORT}
kubectl -n ${KUADRANT_DEVELOPER_NS} wait --for=condition=Available deployments toystore --timeout=90s
```

Test the `HTTPRoute`:
```sh
curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy -i
# HTTP/1.1 200 OK
```

Deploy an `AuthPolicy` (targeting the `Gateway`):
```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1
kind: AuthPolicy
metadata:
  name: toystore
  namespace: ${KUADRANT_GATEWAY_NS}
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: ${KUADRANT_GATEWAY_NAME}
  rules:
    authentication:
      "api-key-plan":
        apiKey:
          selector:
            matchLabels:
              app: toystore
          allNamespaces: true
        credentials:
          authorizationHeader:
            prefix: APIKEY
EOF
kubectl apply -f - <<EOF
apiVersion: v1
kind: Secret
metadata:
  name: gold-key
  labels:
    authorino.kuadrant.io/managed-by: authorino
    app: toystore
  annotations:
    secret.kuadrant.io/plan-id: gold
stringData:
  api_key: IAMGOLD
type: Opaque
---
apiVersion: v1
kind: Secret
metadata:
  name: silver-key
  labels:
    authorino.kuadrant.io/managed-by: authorino
    app: toystore
  annotations:
    secret.kuadrant.io/plan-id: silver
stringData:
  api_key: IAMSILVER
type: Opaque
---
apiVersion: v1
kind: Secret
metadata:
  name: bronze-key
  labels:
    authorino.kuadrant.io/managed-by: authorino
    app: toystore
  annotations:
    secret.kuadrant.io/plan-id: bronze
stringData:
  api_key: IAMBRONZE
type: Opaque
EOF
```

Check it's working:
```sh
curl -H 'Host: api.toystore.com' http://$KUADRANT_GATEWAY_URL/toy -i
# HTTP/1.1 401 Unauthorized
# www-authenticate: APIKEY realm="api-key-plan"
# x-ext-auth-reason: "credential not found"
```
```sh
curl -H 'Host: api.toystore.com' -H 'Authorization: APIKEY IAMGOLD' http://$KUADRANT_GATEWAY_URL/toy -i
# HTTP/1.1 200 OK
```

Deploy a `PlanPolicy` targeting the `HTTPRoute`:
```sh
export KUADRANT_DEVELOPER_NS=toystore # Namespace for an example toystore app
kubectl apply -f - <<EOF
apiVersion: extensions.kuadrant.io/v1alpha1
kind: PlanPolicy
metadata:
  name: my-toystore-plan
  namespace: ${KUADRANT_DEVELOPER_NS}
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: toystore
  plans:
    - tier: gold
      predicate: |
        has(auth.identity) && auth.identity.metadata.annotations["secret.kuadrant.io/plan-id"] == "gold"
      limits:
        daily: 5
    - tier: silver
      predicate: |
        has(auth.identity) && auth.identity.metadata.annotations["secret.kuadrant.io/plan-id"] == "silver"
      limits:
        daily: 2
    - tier: bronze
      predicate: |
        has(auth.identity) && auth.identity.metadata.annotations["secret.kuadrant.io/plan-id"] == "bronze"
      limits:
        daily: 1
EOF
```

Verify the `AuthConfig` was updated with the `plan` data:
```sh
kubectl get -n kuadrant-system authconfig -o yaml
```

Edit this `PlanPolicy` (i.e. remove one of the limits, or update the CEL expression) and re-check the authconfig data binding was updated to reflect the change

Resolves #1433
