### PR TITLE
Bring cel evalution errors to TRLP status

### DIFF
--- a/internal/controller/tokenratelimitpolicy_status_updater.go
+++ b/internal/controller/tokenratelimitpolicy_status_updater.go
@@ -24,6 +24,7 @@ import (
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1alpha1 "github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/kuadrant-operator/internal/cel"
 	kuadrantenvoygateway "github.com/kuadrant/kuadrant-operator/internal/envoygateway"
 	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/internal/gatewayapi"
 	kuadrantistio "github.com/kuadrant/kuadrant-operator/internal/istio"
@@ -135,10 +136,28 @@ func (r *TokenRateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1
 	policyRuleKeys := lo.Keys(policy.Rules())
 	overridingPolicies := map[string][]string{}      // policyRuleKey → locators of policies overriding the policy rule
 	affectedGateways := map[string]affectedGateway{} // Gateway locator → {GatewayClass, Gateway}
+
+	var rateLimitCelValidationErrors []error
+	var rateLimitIssuesByPathID map[string][]*cel.Issue
+	var ratelimitIssuesFound bool
+	stateCelValErrors, stateCelValErrorsFound := state.Load(cel.StateCELValidationErrors)
+	if stateCelValErrorsFound {
+		celIssuesCollection := stateCelValErrors.(*cel.IssueCollection)
+		rateLimitIssuesByPathID, ratelimitIssuesFound = celIssuesCollection.GetByPolicyKind(policyKind)
+	}
+
 	for _, effectivePolicy := range effectivePolicies.(EffectiveTokenRateLimitPolicies) {
 		if len(kuadrantv1.PoliciesInPath(effectivePolicy.Path, func(p machinery.Policy) bool { return p.GetLocator() == policy.GetLocator() })) == 0 {
 			continue
 		}
+
+		if ratelimitIssuesFound {
+			storedValidationIssuesForPathID, storedValidationIssuesForPathIDFound := rateLimitIssuesByPathID[kuadrantv1.PathID(effectivePolicy.Path)]
+			if storedValidationIssuesForPathIDFound {
+				rateLimitCelValidationErrors = append(rateLimitCelValidationErrors, lo.Map(storedValidationIssuesForPathID, func(i *cel.Issue, _ int) error { return i.GetError() })...)
+			}
+		}
+
 		gatewayClass, gateway, listener, httpRoute, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(effectivePolicy.Path)
 		if !kuadrantgatewayapi.IsListenerReady(listener.Listener, gateway.Gateway) || !kuadrantgatewayapi.IsHTTPRouteReady(httpRoute.HTTPRoute, gateway.Gateway, gatewayClass.Spec.ControllerName) {
 			continue
@@ -242,6 +261,10 @@ func (r *TokenRateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1
 		default:
 			componentsToSync = append(componentsToSync, fmt.Sprintf("%s (%s/%s)", machinery.GatewayGroupKind.Kind, g.gateway.GetNamespace(), g.gateway.GetName()))
 		}
+	}
+
+	if len(rateLimitCelValidationErrors) > 0 {
+		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrCelValidation(rateLimitCelValidationErrors), false)
 	}
 
 	if len(componentsToSync) > 0 {


### PR DESCRIPTION
**Verification Steps**:

1. Create kind cluster with Kuadrant

2. Apply Kuadrant CR
```sh
kubectl create -n kuadrant-system -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```
3. Follow the steps of the ["Token-based Rate Limiting for Large Language Model APIs"](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/tokenratelimitpolicy/authenticated-token-ratelimiting-tutorial.md) but don't create the AuthPolicy nor the secrets

4. Check the status of the TRLP:
```sh
kubectl get tokenratelimitpolicy trlp-tutorial-token-limits -n gateway-system -o jsonpath='{.status}'  |  yq e -P
```

It should show:

```yaml
conditions:
  - lastTransitionTime: "2025-09-04T16:29:06Z"
    message: TokenRateLimitPolicy has been accepted
    reason: Accepted
    status: "True"
    type: Accepted
  - lastTransitionTime: "2025-09-04T16:32:19Z"
    message: |-
      validation issues: [ERROR: <input>:1:1: undeclared reference to 'auth' (in container '')
       | auth.identity.groups.split(",").exists(g, g == "free")
       | ^ ERROR: <input>:1:1: undeclared reference to 'auth' (in container '')
       | auth.identity.groups.split(",").exists(g, g == "free")
       | ^ ERROR: <input>:1:1: undeclared reference to 'auth' (in container '')
       | auth.identity.groups.split(",").exists(g, g == "gold")
       | ^ ERROR: <input>:1:1: undeclared reference to 'auth' (in container '')
       | auth.identity.groups.split(",").exists(g, g == "gold")
       | ^]
    reason: InvalidCelExpression
    status: "False"
    type: Enforced
observedGeneration: 1
```
5. Apply the guide example `AuthPolicy`

6. Check the status of the TRLP again:
```sh
kubectl get tokenratelimitpolicy trlp-tutorial-token-limits -n gateway-system -o jsonpath='{.status}'  |  yq e -P
```

and this time would look similar to:

```yaml
conditions:
  - lastTransitionTime: "2025-09-04T16:34:41Z"
    message: TokenRateLimitPolicy has been accepted
    reason: Accepted
    status: "True"
    type: Accepted
  - lastTransitionTime: "2025-09-04T16:34:41Z"
    message: TokenRateLimitPolicy has been successfully enforced
    reason: Enforced
    status: "True"
    type: Enforced
observedGeneration: 1
```