### PR TITLE
CEL validator builder per path

### DIFF
--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -186,7 +186,6 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 	paths := lo.UniqBy(allPaths, func(e lo.Entry[string, []machinery.Targetable]) string { return e.Key })
 
 	wasmActionSets := kuadrantgatewayapi.GrouppedHTTPRouteMatchConfigs{}
-	validatorBuilder := celvalidator.NewRootValidatorBuilder()
 	celValidationIssues := celvalidator.NewIssueCollection()
 
 	// build the wasm policies for each topological path that contains an effective rate limit policy affecting an envoy gateway gateway
@@ -195,6 +194,8 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 		path := paths[i].Value
 
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(path)
+
+		validatorBuilder := celvalidator.NewRootValidatorBuilder()
 
 		// ignore if not an envoy gateway gateway
 		if !lo.Contains(envoyGatewayGatewayControllerNames, gatewayClass.Spec.ControllerName) {

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -237,7 +237,6 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, state *
 	paths := lo.UniqBy(allPaths, func(e lo.Entry[string, []machinery.Targetable]) string { return e.Key })
 
 	wasmActionSets := kuadrantgatewayapi.GrouppedHTTPRouteMatchConfigs{}
-	validatorBuilder := celvalidator.NewRootValidatorBuilder()
 	celValidationIssues := celvalidator.NewIssueCollection()
 
 	// build the wasm policies for each topological path that contains an effective rate limit policy affecting an istio gateway
@@ -246,6 +245,8 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, state *
 		path := paths[i].Value
 
 		gatewayClass, gateway, _, _, _, _ := kuadrantpolicymachinery.ObjectsInRequestPath(path)
+
+		validatorBuilder := celvalidator.NewRootValidatorBuilder()
 
 		// ignore if not an istio gateway
 		if !lo.Contains(istioGatewayControllerNames, gatewayClass.Spec.ControllerName) {


### PR DESCRIPTION
When having "global" cel validator builder, one RLP policy having dependency on "auth" could be falsely "Enforced" when in any previous gateway API path an Authpolicy existed.  This PR builds a cel validator builder per path. 

**Verification Steps**:

1. Run local environment 
```sh
make local-setup
```

2. Apply Kuadrant CR
```sh
kubectl create -n kuadrant-system -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
spec: {}
EOF
```

3. Create HTTPRoute `a` and `b`

```yaml
kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: a
spec:
  hostnames:
    - a.example.com
  parentRefs:
    - name: kuadrant-ingressgateway
      namespace: gateway-system
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: "/"
      backendRefs:
        - name: trlp-tutorial-llm-sim
          port: 80
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: b
spec:
  hostnames:
    - b.example.com
  parentRefs:
    - name: kuadrant-ingressgateway
      namespace: gateway-system
  rules:
    - matches:
        - path:
            type: PathPrefix
            value: "/"
      backendRefs:
        - name: trlp-tutorial-llm-sim
          port: 80
EOF
```

4. Add AuthPolicy and TRLP targeting HTTPRoute `a`
```yaml
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1
kind: AuthPolicy
metadata:
  name: a
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: a
  rules:
    authentication:
      api-key-users:
        apiKey:
          selector:
            matchLabels:
              app: my-llm
        credentials:
          authorizationHeader:
            prefix: APIKEY
    response:
      success:
        filters:
          identity:
            json:
              properties:
                groups:
                  selector: auth.identity.metadata.annotations.kuadrant\.io/groups
                userid:
                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
---
apiVersion: kuadrant.io/v1alpha1
kind: TokenRateLimitPolicy
metadata:
  name: a
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: a
  limits:
    limit-a:
      rates:
        - limit: 50 # 50 tokens per minute for free users (small for testing)
          window: 1m
      when:
        - predicate: auth.identity.userid == "user1"
EOF
```

5. Add TRLP targeting HTTPRoute `b`
```yaml
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1alpha1
kind: TokenRateLimitPolicy
metadata:
  name: b
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: b
  limits:
    limit-a:
      rates:
        - limit: 50 # 50 tokens per minute for free users (small for testing)
          window: 1m
      when:
        - predicate: auth.identity.userid == "user1"
EOF
```
This policy has data dependency on `auth` but there is no authpolicy at the same path that can provide such data. Hence, cel validator should report error and the policy should be flagged as not "Enforced".

```
kubectl get tokenratelimitpolicy b -o jsonpath='{.status.conditions[?(@.type=="Accepted")].message}{"\n"}{.status.conditions[?(@.type=="Enforced")].message}{"\n"}'
```
returns
```
TokenRateLimitPolicy has been accepted
validation issues: [ERROR: <input>:1:1: undeclared reference to 'auth' (in container '')
 | auth.identity.userid == "user1"
 | ^ ERROR: <input>:1:1: undeclared reference to 'auth' (in container '')
 | auth.identity.userid == "user1"
 | ^]
```