### PR TITLE
equate not set delegate field to false in CR validation

### DIFF
--- a/api/v1/dnspolicy_types.go
+++ b/api/v1/dnspolicy_types.go
@@ -46,8 +46,8 @@ var (
 )
 
 // DNSPolicySpec defines the desired state of DNSPolicy
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.delegate) || has(self.delegate)", message="Delegate can't be unset if it was previously set"
-// +kubebuilder:validation:XValidation:rule="has(oldSelf.delegate) || !has(self.delegate)", message="Delegate can't be set if it was previously unset"
+// +kubebuilder:validation:XValidation:rule="has(oldSelf.delegate) || !has(self.delegate) || self.delegate == false", message="delegate can't be set to true if unset"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)", message="delegate can't be unset if true"
 // +kubebuilder:validation:XValidation:rule="!(has(self.providerRefs) && has(self.delegate) && self.delegate == true)", message="delegate=true and providerRefs are mutually exclusive"
 type DNSPolicySpec struct {
 	// targetRef identifies an API object to apply policy to.

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -162,7 +162,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2025-09-15T12:23:41Z"
+    createdAt: "2025-09-23T10:59:18Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kuadrant.io_dnspolicies.yaml
+++ b/bundle/manifests/kuadrant.io_dnspolicies.yaml
@@ -243,10 +243,11 @@ spec:
             - targetRef
             type: object
             x-kubernetes-validations:
-            - message: Delegate can't be unset if it was previously set
-              rule: '!has(oldSelf.delegate) || has(self.delegate)'
-            - message: Delegate can't be set if it was previously unset
-              rule: has(oldSelf.delegate) || !has(self.delegate)
+            - message: delegate can't be set to true if unset
+              rule: has(oldSelf.delegate) || !has(self.delegate) || self.delegate
+                == false
+            - message: delegate can't be unset if true
+              rule: '!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)'
             - message: delegate=true and providerRefs are mutually exclusive
               rule: '!(has(self.providerRefs) && has(self.delegate) && self.delegate
                 == true)'

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -7836,10 +7836,11 @@ spec:
             - targetRef
             type: object
             x-kubernetes-validations:
-            - message: Delegate can't be unset if it was previously set
-              rule: '!has(oldSelf.delegate) || has(self.delegate)'
-            - message: Delegate can't be set if it was previously unset
-              rule: has(oldSelf.delegate) || !has(self.delegate)
+            - message: delegate can't be set to true if unset
+              rule: has(oldSelf.delegate) || !has(self.delegate) || self.delegate
+                == false
+            - message: delegate can't be unset if true
+              rule: '!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)'
             - message: delegate=true and providerRefs are mutually exclusive
               rule: '!(has(self.providerRefs) && has(self.delegate) && self.delegate
                 == true)'

--- a/config/crd/bases/kuadrant.io_dnspolicies.yaml
+++ b/config/crd/bases/kuadrant.io_dnspolicies.yaml
@@ -242,10 +242,11 @@ spec:
             - targetRef
             type: object
             x-kubernetes-validations:
-            - message: Delegate can't be unset if it was previously set
-              rule: '!has(oldSelf.delegate) || has(self.delegate)'
-            - message: Delegate can't be set if it was previously unset
-              rule: has(oldSelf.delegate) || !has(self.delegate)
+            - message: delegate can't be set to true if unset
+              rule: has(oldSelf.delegate) || !has(self.delegate) || self.delegate
+                == false
+            - message: delegate can't be unset if true
+              rule: '!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)'
             - message: delegate=true and providerRefs are mutually exclusive
               rule: '!(has(self.providerRefs) && has(self.delegate) && self.delegate
                 == true)'

--- a/tests/common/dnspolicy/suite_test.go
+++ b/tests/common/dnspolicy/suite_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"github.com/onsi/gomega/types"
+	"k8s.io/client-go/dynamic"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -48,9 +49,14 @@ import (
 // This test suite will be run on k8s env with GatewayAPI CRDs, Istio and Kuadrant CRDs installed
 
 var k8sClient client.Client
+var dynClient *dynamic.DynamicClient
 var testEnv *envtest.Environment
 
 func testClient() client.Client { return k8sClient }
+
+func testDynamicClient() *dynamic.DynamicClient {
+	return dynClient
+}
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -99,6 +105,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: s})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	dynClient, err = dynamic.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(dynClient).NotTo(BeNil())
 })
 
 var _ = SynchronizedAfterSuite(func() {}, func() {

--- a/tests/commons.go
+++ b/tests/commons.go
@@ -39,6 +39,7 @@ import (
 )
 
 const (
+	TimeoutShort         = time.Second * 5
 	TimeoutMedium        = time.Second * 10
 	TimeoutLongerMedium  = time.Second * 15
 	TimeoutLong          = time.Second * 30


### PR DESCRIPTION
a copy of the same [PR](https://github.com/Kuadrant/dns-operator/pull/580) from dns-operator 