### PR TITLE
feat: allow cel optional syntax

### DIFF
--- a/internal/cel/validator.go
+++ b/internal/cel/validator.go
@@ -94,8 +94,10 @@ func (b *ValidatorBuilder) Build() (*Validator, error) {
 	for _, policy := range b.policies {
 		var env *cel.Env
 		var err error
-		var opts []cel.EnvOption
-		opts = []cel.EnvOption{ext.Strings()}
+		opts := []cel.EnvOption{
+			ext.Strings(),
+			cel.OptionalTypes(),
+		}
 
 		for _, binding := range b.baseBindings {
 			opts = append(opts, cel.Variable(binding.name, binding.t))

--- a/internal/cel/validator_test.go
+++ b/internal/cel/validator_test.go
@@ -224,3 +224,36 @@ func TestValidatorSupportsStringExtensions(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatorSupportsOptionalExpression(t *testing.T) {
+	builder := NewValidatorBuilder()
+	if _, err := builder.AddPolicyBindingAfter(nil, "foo", "first", cel.AnyType); err != nil {
+		t.Fatal(err)
+	}
+
+	validator, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		expr string
+	}{
+		{name: "optional syntax", expr: "first.?randomField"},
+		{name: "optional orValue", expr: "first.?randomField.orValue('none')"},
+		{name: "optional of", expr: "optional.of(10)"},
+		{name: "optional ofNonZeroValue", expr: "optional.ofNonZeroValue([])"},
+		{name: "optional hasValue", expr: "optional.of(first.randomField).hasValue()"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if ast, err := validator.Validate("foo", tc.expr); err != nil {
+				t.Fatalf("unexpected error validating expr '%s': %v", tc.expr, err)
+			} else if ast == nil {
+				t.Fatalf("expected non-nil AST for expr '%s'", tc.expr)
+			}
+		})
+	}
+}

--- a/pkg/cel/ext/kuadrant.go
+++ b/pkg/cel/ext/kuadrant.go
@@ -33,7 +33,9 @@ type kuadrantLib struct {
 }
 
 func (l kuadrantLib) CompileOptions() []cel.EnvOption {
-	opts := []cel.EnvOption{}
+	opts := []cel.EnvOption{
+		cel.OptionalTypes(),
+	}
 
 	constVersion := "0"
 

--- a/pkg/cel/ext/kuadrant_test.go
+++ b/pkg/cel/ext/kuadrant_test.go
@@ -28,6 +28,7 @@ var tests = []struct {
 	{expr: `self.findAuthPolicies()[0].targetRefs[0].group == "gateway.networking.k8s.io"`},
 	{expr: `self.findAuthPolicies()[0].targetRefs[0].name == "kuadrant-gw"`},
 	{expr: `self.findAuthPolicies()[0].targetRefs[0].namespace == "some-ns"`},
+	{expr: `self.findGateways()[?0].spec.listeners[0].hostname.hasValue()`},
 }
 
 func TestKuadrantExt(t *testing.T) {


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/1561

Enable CEL optional syntax for CEL expressions evaluated by Kuadrant Operator. This does not enable the same for limitador, wasm-shim or authorino and must be done in their own corresponding source code.

