### PR TITLE
Add new kustomize for openshift specific observability installs

### DIFF
--- a/config/install/configure/observability/openshift/kustomization.yaml
+++ b/config/install/configure/observability/openshift/kustomization.yaml
@@ -28,3 +28,9 @@ patches:
         kind: ServiceMonitor
         name: istiod
         namespace: gateway-system
+    - patch: |-
+        - op: replace
+          path: /metadata/namespace
+          value: openshift-operators
+      target:
+        namespace: kuadrant-system


### PR DESCRIPTION
closes [CONNLINK-548](https://issues.redhat.com/browse/CONNLINK-548)

Adds a new kustomize file to be used when installing on OpenShift. Replaces gateway-system with openshift-ingress.

Verification:
1.  kubectl kustomize config/install/configure/observability should generate CRDs using gateway-system namespace for some of the observability resources

2.  kubectl kustomize config/install/configure/observability/openshift should generate CRDs using othe penshift-ingress namespace for the same observability resources.

Note: if kuadrant is installed in custom namespace follow steps below.
```
CUSTOM_NAMESPACE=YOUR_CUSTOM_NS 
kubectl kustomize config/install/configure/observability/openshift | \
    yq '(select(.kind == "ServiceMonitor" and .metadata.namespace == "openshift-operators") | .metadata.namespace) = env(CUSTOM_NAMESPACE)' | \
    kubectl apply -f -
 ```