### PR TITLE
Update sail-operator and istio to v1.27.1

### DIFF
--- a/config/dependencies/istio/sail/istio.yaml
+++ b/config/dependencies/istio/sail/istio.yaml
@@ -1,10 +1,32 @@
-apiVersion: sailoperator.io/v1alpha1
+apiVersion: sailoperator.io/v1
 kind: Istio
 metadata:
   name: default
 spec:
-  # Supported values for sail-operator v0.1.0 are [v1.22.4,v1.23.0]
-  version: v1.23.0
+  # Supported values for sail-operator v1.27.1 are:
+  # - v1.27-latest
+  # - v1.27.1
+  # - v1.27.0
+  # - v1.26-latest
+  # - v1.26.4
+  # - v1.26.3
+  # - v1.26.2
+  # - v1.26.0
+  # - v1.25-latest
+  # - v1.25.5
+  # - v1.25.4
+  # - v1.25.3
+  # - v1.25.2
+  # - v1.25.1
+  # - v1.24-latest
+  # - v1.24.6
+  # - v1.24.5
+  # - v1.24.4
+  # - v1.24.3
+  # - v1.24.2
+  # - v1.24.1
+  # - v1.24.0
+  version: v1.27.1
   namespace: istio-system
   # Disable autoscaling to reduce dev resources
   values:

--- a/make/istio.mk
+++ b/make/istio.mk
@@ -15,7 +15,7 @@ endif
 
 # istioctl tool
 ISTIOCTL=$(shell pwd)/bin/istioctl
-ISTIOVERSION = 1.22.5
+ISTIOVERSION = 1.27.1
 $(ISTIOCTL):
 	mkdir -p $(shell pwd)/bin
 	$(eval TMP := $(shell mktemp -d))
@@ -28,18 +28,13 @@ istioctl: $(ISTIOCTL) ## Download istioctl locally if necessary.
 
 .PHONY: istioctl-install
 istioctl-install: istioctl ## Install istio.
-	$(ISTIOCTL) operator init --operatorNamespace $(ISTIO_NAMESPACE) --watchedNamespaces $(ISTIO_NAMESPACE)
-	kubectl apply -f $(ISTIO_INSTALL_DIR)/istio-operator.yaml
+	$(ISTIOCTL) install -f $(ISTIO_INSTALL_DIR)/istio-operator.yaml -y
 
 .PHONY: istioctl-uninstall
 istioctl-uninstall: istioctl ## Uninstall istio.
-	$(ISTIOCTL) x uninstall -y --purge
+	$(ISTIOCTL) uninstall -y --purge
 
-.PHONY: istioctl-verify-install
-istioctl-verify-install: istioctl ## Verify istio installation.
-	$(ISTIOCTL) verify-install -i $(ISTIO_NAMESPACE)
-
-SAIL_VERSION = 0.1.0
+SAIL_VERSION = 1.27.1
 .PHONY: sail-install
 sail-install: helm
 	$(HELM) install sail-operator \


### PR DESCRIPTION
I noticed that the version of sail-operator we're deploying locally is still the first GA v0.1.0 release; I think it might be time we update to a newer one.

I opted to also update our istio version to the matching latest release but open to opinions here as it's jumping quite a few versions!