### PR TITLE
Release v1.3.0 GA

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -161,14 +161,14 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.3.0-rc2
-    createdAt: "2025-10-07T12:45:04Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.3.0
+    createdAt: "2025-10-09T15:51:16Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.3.0-rc2
+  name: kuadrant-operator.v1.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -593,7 +593,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.3.0-rc2
+                image: quay.io/kuadrant/kuadrant-operator:v1.3.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -707,4 +707,4 @@ spec:
   relatedImages:
   - image: oci://quay.io/kuadrant/wasm-shim:v0.11.0
     name: wasmshim
-  version: 1.3.0-rc2
+  version: 1.3.0

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.3.0-rc2"
-appVersion: "1.3.0-rc2"
+version: "1.3.0"
+appVersion: "1.3.0"
 dependencies:
   - name: authorino-operator
     version: 0.22.0

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -10810,7 +10810,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.3.0-rc2
+        image: quay.io/kuadrant/kuadrant-operator:v1.3.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.3.0-rc2
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.3.0
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,4 +11,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.3.0-rc2
+  newTag: v1.3.0

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -5,13 +5,13 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Integration & Delivery
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.3.0-rc2
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.3.0
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.3.0-rc2
+  name: kuadrant-operator.v1.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -87,4 +87,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.3.0-rc2
+  version: 1.3.0

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.3.0-rc2"
+  version: "1.3.0"
 olm:
   channels:
     - "stable"


### PR DESCRIPTION
The following PR for the release candidate of Kuadrant Operator version 1.3.0 includes:
- Authorino Operator version 0.22.0
- DNS Operator version 0.15.0
- Limitador Operator version 0.16.0
- Console Plugin version 0.2.2
- WASM Shim version 0.11.0