### PR TITLE
dns: pin version to v0.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ endif
 LIMITADOR_OPERATOR_BUNDLE_IMG ?= quay.io/kuadrant/limitador-operator-bundle:$(LIMITADOR_OPERATOR_BUNDLE_IMG_TAG)
 
 ## dns
-DNS_OPERATOR_VERSION ?= latest
+DNS_OPERATOR_VERSION ?= v0.15.0
 
 kuadrantdns_bundle_is_semantic := $(call is_semantic_version,$(DNS_OPERATOR_VERSION))
 ifeq (latest,$(DNS_OPERATOR_VERSION))

--- a/config/dependencies/dns/kustomization.yaml
+++ b/config/dependencies/dns/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- github.com/kuadrant/dns-operator/config/default?ref=main
+- github.com/kuadrant/dns-operator/config/default?ref=v0.15.0
 
 patches:
   - path: deployment_patch.yaml


### PR DESCRIPTION
DNS Policy integration tests has been broken since November 19th.
- https://github.com/Kuadrant/kuadrant-operator/actions/workflows/test.yaml?query=branch%3Amain

Let's pin the version to the last release of DNS Operator (v0.15.0)