### PR TITLE
feat: configure wasm with tracing config

### DIFF
--- a/internal/controller/auth_workflow_helpers.go
+++ b/internal/controller/auth_workflow_helpers.go
@@ -63,75 +63,7 @@ func AuthClusterName(gatewayName string) string {
 }
 
 func authClusterPatch(host string, port int, mTLS bool) map[string]any {
-	patch := map[string]any{
-		"name":                   kuadrant.KuadrantAuthClusterName,
-		"type":                   "STRICT_DNS",
-		"connect_timeout":        "1s",
-		"lb_policy":              "ROUND_ROBIN",
-		"http2_protocol_options": map[string]any{},
-		"load_assignment": map[string]any{
-			"cluster_name": kuadrant.KuadrantAuthClusterName,
-			"endpoints": []map[string]any{
-				{
-					"lb_endpoints": []map[string]any{
-						{
-							"endpoint": map[string]any{
-								"address": map[string]any{
-									"socket_address": map[string]any{
-										"address":    host,
-										"port_value": port,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	if mTLS {
-		patch["transport_socket"] = map[string]interface{}{
-			"name": "envoy.transport_sockets.tls",
-			"typed_config": map[string]interface{}{
-				"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
-				"common_tls_context": map[string]interface{}{
-					"tls_certificate_sds_secret_configs": []interface{}{
-						map[string]interface{}{
-							"name": "default",
-							"sds_config": map[string]interface{}{
-								"api_config_source": map[string]interface{}{
-									"api_type": "GRPC",
-									"grpc_services": []interface{}{
-										map[string]interface{}{
-											"envoy_grpc": map[string]interface{}{
-												"cluster_name": "sds-grpc",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					"validation_context_sds_secret_config": map[string]interface{}{
-						"name": "ROOTCA",
-						"sds_config": map[string]interface{}{
-							"api_config_source": map[string]interface{}{
-								"api_type": "GRPC",
-								"grpc_services": []interface{}{
-									map[string]interface{}{
-										"envoy_grpc": map[string]interface{}{
-											"cluster_name": "sds-grpc",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-	return patch
+	return buildClusterPatch(kuadrant.KuadrantAuthClusterName, host, port, mTLS, true)
 }
 
 type authorinoServiceInfo struct {

--- a/internal/controller/cluster_patch_helpers.go
+++ b/internal/controller/cluster_patch_helpers.go
@@ -1,0 +1,86 @@
+package controllers
+
+// buildClusterPatch creates an Envoy cluster configuration patch with optional mTLS and HTTP/2 support
+func buildClusterPatch(clusterName, host string, port int, mTLS bool, useHTTP2 bool) map[string]any {
+	base := map[string]any{
+		"name":            clusterName,
+		"type":            "STRICT_DNS",
+		"connect_timeout": "1s",
+		"lb_policy":       "ROUND_ROBIN",
+		"load_assignment": map[string]any{
+			"cluster_name": clusterName,
+			"endpoints": []map[string]any{
+				{
+					"lb_endpoints": []map[string]any{
+						{
+							"endpoint": map[string]any{
+								"address": map[string]any{
+									"socket_address": map[string]any{
+										"address":    host,
+										"port_value": port,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Add HTTP/2 protocol options if needed
+	if useHTTP2 {
+		base["http2_protocol_options"] = map[string]any{}
+	}
+
+	// Add mTLS configuration if needed
+	if mTLS {
+		base["transport_socket"] = buildMTLSTransportSocket()
+	}
+
+	return base
+}
+
+// buildMTLSTransportSocket creates the mTLS transport socket configuration using SDS
+func buildMTLSTransportSocket() map[string]interface{} {
+	return map[string]interface{}{
+		"name": "envoy.transport_sockets.tls",
+		"typed_config": map[string]interface{}{
+			"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+			"common_tls_context": map[string]interface{}{
+				"tls_certificate_sds_secret_configs": []interface{}{
+					map[string]interface{}{
+						"name": "default",
+						"sds_config": map[string]interface{}{
+							"api_config_source": map[string]interface{}{
+								"api_type": "GRPC",
+								"grpc_services": []interface{}{
+									map[string]interface{}{
+										"envoy_grpc": map[string]interface{}{
+											"cluster_name": "sds-grpc",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"validation_context_sds_secret_config": map[string]interface{}{
+					"name": "ROOTCA",
+					"sds_config": map[string]interface{}{
+						"api_config_source": map[string]interface{}{
+							"api_type": "GRPC",
+							"grpc_services": []interface{}{
+								map[string]interface{}{
+									"envoy_grpc": map[string]interface{}{
+										"cluster_name": "sds-grpc",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/data_plane_policies_workflow.go
+++ b/internal/controller/data_plane_policies_workflow.go
@@ -101,6 +101,8 @@ func NewDataPlanePoliciesWorkflow(mgr controllerruntime.Manager, client *dynamic
 		effectiveDataPlanePoliciesWorkflow.Tasks = append(effectiveDataPlanePoliciesWorkflow.Tasks,
 			traceReconcileFunc("reconciler.istio_ratelimit_cluster", (&IstioRateLimitClusterReconciler{client: client}).Subscription().Reconcile))
 		effectiveDataPlanePoliciesWorkflow.Tasks = append(effectiveDataPlanePoliciesWorkflow.Tasks,
+			traceReconcileFunc("reconciler.istio_tracing_cluster", (&IstioTracingClusterReconciler{client: client}).Subscription().Reconcile))
+		effectiveDataPlanePoliciesWorkflow.Tasks = append(effectiveDataPlanePoliciesWorkflow.Tasks,
 			traceReconcileFunc("reconciler.istio_extension", (&IstioExtensionReconciler{client: client}).Subscription().Reconcile))
 	}
 
@@ -109,6 +111,8 @@ func NewDataPlanePoliciesWorkflow(mgr controllerruntime.Manager, client *dynamic
 			traceReconcileFunc("reconciler.envoy_gateway_auth_cluster", (&EnvoyGatewayAuthClusterReconciler{client: client}).Subscription().Reconcile))
 		effectiveDataPlanePoliciesWorkflow.Tasks = append(effectiveDataPlanePoliciesWorkflow.Tasks,
 			traceReconcileFunc("reconciler.envoy_gateway_ratelimit_cluster", (&EnvoyGatewayRateLimitClusterReconciler{client: client}).Subscription().Reconcile))
+		effectiveDataPlanePoliciesWorkflow.Tasks = append(effectiveDataPlanePoliciesWorkflow.Tasks,
+			traceReconcileFunc("reconciler.envoy_gateway_tracing_cluster", (&EnvoyGatewayTracingClusterReconciler{client: client}).Subscription().Reconcile))
 		effectiveDataPlanePoliciesWorkflow.Tasks = append(effectiveDataPlanePoliciesWorkflow.Tasks,
 			traceReconcileFunc("reconciler.envoy_gateway_extension", (&EnvoyGatewayExtensionReconciler{client: client}).Subscription().Reconcile))
 	}

--- a/internal/controller/envoy_gateway_tracing_cluster_reconciler.go
+++ b/internal/controller/envoy_gateway_tracing_cluster_reconciler.go
@@ -1,0 +1,223 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	envoygatewayv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/ptr"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	kuadrantenvoygateway "github.com/kuadrant/kuadrant-operator/internal/envoygateway"
+	"github.com/kuadrant/kuadrant-operator/internal/wasm"
+)
+
+//+kubebuilder:rbac:groups=gateway.envoyproxy.io,resources=envoypatchpolicies,verbs=get;list;watch;create;update;patch;delete
+
+// EnvoyGatewayTracingClusterReconciler reconciles Envoy Gateway EnvoyPatchPolicy custom resources for tracing
+type EnvoyGatewayTracingClusterReconciler struct {
+	client *dynamic.DynamicClient
+}
+
+// Subscription subscribes to events with potential impact on the Envoy Gateway EnvoyPatchPolicy custom resources for tracing
+func (r *EnvoyGatewayTracingClusterReconciler) Subscription() controller.Subscription {
+	return controller.Subscription{
+		ReconcileFunc: r.Reconcile,
+		Events: []controller.ResourceEventMatcher{
+			{Kind: &kuadrantv1beta1.KuadrantGroupKind},
+			{Kind: &machinery.GatewayClassGroupKind},
+			{Kind: &machinery.GatewayGroupKind},
+			{Kind: &kuadrantenvoygateway.EnvoyPatchPolicyGroupKind},
+		},
+	}
+}
+
+func (r *EnvoyGatewayTracingClusterReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
+	logger := controller.LoggerFromContext(ctx).WithName("EnvoyGatewayTracingClusterReconciler").WithValues("context", ctx)
+
+	logger.V(1).Info("building envoy gateway tracing clusters")
+	defer logger.V(1).Info("finished building envoy gateway tracing clusters")
+
+	kuadrant := GetKuadrantFromTopology(topology)
+	if kuadrant == nil {
+		logger.V(1).Info("kuadrant CR not found")
+		return nil
+	}
+
+	var gateways []*machinery.Gateway
+
+	// Only build tracing clusters if tracing is configured
+	if kuadrant.Spec.Observability.Tracing != nil && kuadrant.Spec.Observability.Tracing.DefaultEndpoint != "" {
+		// Get all envoy gateway gateways
+		gateways = lo.FilterMap(
+			topology.Targetables().Items(func(o machinery.Object) bool {
+				return o.GroupVersionKind().GroupKind() == machinery.GatewayGroupKind
+			}),
+			func(t machinery.Targetable, _ int) (*machinery.Gateway, bool) {
+				gateway := t.(*machinery.Gateway)
+				gatewayClass, found := lo.Find(topology.Targetables().Parents(gateway), func(t machinery.Targetable) bool {
+					return t.GroupVersionKind().GroupKind() == machinery.GatewayClassGroupKind
+				})
+				if !found {
+					return nil, false
+				}
+				return gateway, lo.Contains(envoyGatewayGatewayControllerNames, gatewayClass.(*machinery.GatewayClass).Spec.ControllerName)
+			},
+		)
+	} else {
+		logger.V(1).Info("tracing not configured")
+	}
+
+	desiredEnvoyPatchPolicies := make(map[k8stypes.NamespacedName]struct{})
+	var modifiedGateways []string
+
+	if len(gateways) == 0 {
+		logger.V(1).Info("no envoy gateway gateways found")
+	}
+
+	// Reconcile tracing cluster for each gateway
+	for _, gateway := range gateways {
+		gatewayKey := k8stypes.NamespacedName{Name: gateway.GetName(), Namespace: gateway.GetNamespace()}
+
+		desiredEnvoyPatchPolicy, err := r.buildDesiredEnvoyPatchPolicy(kuadrant, gateway)
+		if err != nil {
+			logger.Error(err, "failed to build desired envoy patch policy", "gateway", gatewayKey.String())
+			continue
+		}
+		desiredEnvoyPatchPolicies[k8stypes.NamespacedName{Name: desiredEnvoyPatchPolicy.GetName(), Namespace: desiredEnvoyPatchPolicy.GetNamespace()}] = struct{}{}
+
+		resource := r.client.Resource(kuadrantenvoygateway.EnvoyPatchPoliciesResource).Namespace(desiredEnvoyPatchPolicy.GetNamespace())
+
+		existingEnvoyPatchPolicyObj, found := lo.Find(topology.Objects().Children(gateway), func(child machinery.Object) bool {
+			return child.GroupVersionKind().GroupKind() == kuadrantenvoygateway.EnvoyPatchPolicyGroupKind &&
+				child.GetName() == desiredEnvoyPatchPolicy.GetName() &&
+				child.GetNamespace() == desiredEnvoyPatchPolicy.GetNamespace() &&
+				labels.Set(child.(*controller.RuntimeObject).GetLabels()).AsSelector().Matches(labels.Set(desiredEnvoyPatchPolicy.GetLabels()))
+		})
+
+		// Create
+		if !found {
+			modifiedGateways = append(modifiedGateways, gateway.GetLocator())
+			desiredEnvoyPatchPolicyUnstructured, err := controller.Destruct(desiredEnvoyPatchPolicy)
+			if err != nil {
+				logger.Error(err, "failed to destruct envoypatchpolicy object", "gateway", gatewayKey.String(), "envoypatchpolicy", desiredEnvoyPatchPolicy)
+				continue
+			}
+			if _, err = resource.Create(ctx, desiredEnvoyPatchPolicyUnstructured, metav1.CreateOptions{}); err != nil {
+				logger.Error(err, "failed to create envoypatchpolicy object", "gateway", gatewayKey.String(), "envoypatchpolicy", desiredEnvoyPatchPolicyUnstructured.Object)
+				// TODO: handle error
+			}
+			continue
+		}
+
+		existingEnvoyPatchPolicy := existingEnvoyPatchPolicyObj.(*controller.RuntimeObject).Object.(*envoygatewayv1alpha1.EnvoyPatchPolicy)
+
+		if kuadrantenvoygateway.EqualEnvoyPatchPolicies(existingEnvoyPatchPolicy, desiredEnvoyPatchPolicy) {
+			logger.V(1).Info("envoypatchpolicy object is up to date, nothing to do")
+			continue
+		}
+
+		// Update
+		existingEnvoyPatchPolicy.Spec = envoygatewayv1alpha1.EnvoyPatchPolicySpec{
+			TargetRef:   desiredEnvoyPatchPolicy.Spec.TargetRef,
+			Type:        desiredEnvoyPatchPolicy.Spec.Type,
+			JSONPatches: desiredEnvoyPatchPolicy.Spec.JSONPatches,
+			Priority:    desiredEnvoyPatchPolicy.Spec.Priority,
+		}
+
+		existingEnvoyPatchPolicyUnstructured, err := controller.Destruct(existingEnvoyPatchPolicy)
+		if err != nil {
+			logger.Error(err, "failed to destruct envoypatchpolicy object", "gateway", gatewayKey.String(), "envoypatchpolicy", existingEnvoyPatchPolicy)
+			continue
+		}
+		if _, err = resource.Update(ctx, existingEnvoyPatchPolicyUnstructured, metav1.UpdateOptions{}); err != nil {
+			logger.Error(err, "failed to update envoypatchpolicy object", "gateway", gatewayKey.String(), "envoypatchpolicy", existingEnvoyPatchPolicyUnstructured.Object)
+			// TODO: handle error
+		}
+	}
+
+	state.Store(StateEnvoyGatewayTracingClustersModified, modifiedGateways)
+
+	// Cleanup tracing clusters for gateways that no longer need them
+	staleEnvoyPatchPolicies := topology.Objects().Items(func(o machinery.Object) bool {
+		_, desired := desiredEnvoyPatchPolicies[k8stypes.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}]
+		return o.GroupVersionKind().GroupKind() == kuadrantenvoygateway.EnvoyPatchPolicyGroupKind &&
+			labels.Set(o.(*controller.RuntimeObject).GetLabels()).AsSelector().Matches(TracingObjectLabels()) &&
+			!desired
+	})
+
+	for _, envoyPatchPolicy := range staleEnvoyPatchPolicies {
+		if err := r.client.Resource(kuadrantenvoygateway.EnvoyPatchPoliciesResource).Namespace(envoyPatchPolicy.GetNamespace()).Delete(ctx, envoyPatchPolicy.GetName(), metav1.DeleteOptions{}); err != nil {
+			logger.Error(err, "failed to delete envoypatchpolicy object", "envoypatchpolicy", fmt.Sprintf("%s/%s", envoyPatchPolicy.GetNamespace(), envoyPatchPolicy.GetName()))
+			// TODO: handle error
+		}
+	}
+
+	return nil
+}
+
+func (r *EnvoyGatewayTracingClusterReconciler) buildDesiredEnvoyPatchPolicy(kuadrant *kuadrantv1beta1.Kuadrant, gateway *machinery.Gateway) (*envoygatewayv1alpha1.EnvoyPatchPolicy, error) {
+	envoyPatchPolicy := &envoygatewayv1alpha1.EnvoyPatchPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kuadrantenvoygateway.EnvoyPatchPolicyGroupKind.Kind,
+			APIVersion: envoygatewayv1alpha1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TracingClusterName(gateway.GetName()),
+			Namespace: gateway.GetNamespace(),
+			Labels:    TracingObjectLabels(),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         gateway.GroupVersionKind().GroupVersion().String(),
+					Kind:               gateway.GroupVersionKind().Kind,
+					Name:               gateway.Name,
+					UID:                gateway.UID,
+					BlockOwnerDeletion: ptr.To(true),
+					Controller:         ptr.To(true),
+				},
+			},
+		},
+		Spec: envoygatewayv1alpha1.EnvoyPatchPolicySpec{
+			TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReference{
+				Group: gatewayapiv1alpha2.Group(machinery.GatewayGroupKind.Group),
+				Kind:  gatewayapiv1alpha2.Kind(machinery.GatewayGroupKind.Kind),
+				Name:  gatewayapiv1alpha2.ObjectName(gateway.GetName()),
+			},
+			Type: envoygatewayv1alpha1.JSONPatchEnvoyPatchType,
+		},
+	}
+
+	tracingEndpoint := kuadrant.Spec.Observability.Tracing.DefaultEndpoint
+
+	// Parse the tracing endpoint to extract host and port
+	host, port, err := parseTracingEndpoint(tracingEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse tracing endpoint: %w", err)
+	}
+
+	// Use mTLS unless explicitly set to insecure
+	mTLS := !kuadrant.Spec.Observability.Tracing.Insecure
+
+	jsonPatches, err := kuadrantenvoygateway.BuildEnvoyPatchPolicyClusterPatch(
+		wasm.TracingServiceName,
+		host,
+		port,
+		mTLS,
+		tracingClusterPatch,
+	)
+	if err != nil {
+		return nil, err
+	}
+	envoyPatchPolicy.Spec.JSONPatches = jsonPatches
+
+	return envoyPatchPolicy, nil
+}

--- a/internal/controller/istio_tracing_cluster_reconciler.go
+++ b/internal/controller/istio_tracing_cluster_reconciler.go
@@ -1,0 +1,217 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	"github.com/samber/lo"
+	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
+	istiov1beta1 "istio.io/api/type/v1beta1"
+	istioclientgonetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/ptr"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	kuadrantistio "github.com/kuadrant/kuadrant-operator/internal/istio"
+)
+
+//+kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;update;patch;delete
+
+// IstioTracingClusterReconciler reconciles Istio EnvoyFilter custom resources for tracing
+type IstioTracingClusterReconciler struct {
+	client *dynamic.DynamicClient
+}
+
+// Subscription subscribes to events with potential impact on the Istio EnvoyFilter custom resources for tracing
+func (r *IstioTracingClusterReconciler) Subscription() controller.Subscription {
+	return controller.Subscription{
+		ReconcileFunc: r.Reconcile,
+		Events: []controller.ResourceEventMatcher{
+			{Kind: &kuadrantv1beta1.KuadrantGroupKind},
+			{Kind: &machinery.GatewayClassGroupKind},
+			{Kind: &machinery.GatewayGroupKind},
+			{Kind: &kuadrantistio.EnvoyFilterGroupKind},
+		},
+	}
+}
+
+func (r *IstioTracingClusterReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
+	logger := controller.LoggerFromContext(ctx).WithName("IstioTracingClusterReconciler").WithValues("context", ctx)
+
+	logger.V(1).Info("building istio tracing clusters")
+	defer logger.V(1).Info("finished building istio tracing clusters")
+
+	kuadrant := GetKuadrantFromTopology(topology)
+	if kuadrant == nil {
+		logger.V(1).Info("kuadrant CR not found")
+		return nil
+	}
+
+	var gateways []*machinery.Gateway
+
+	// Only build tracing clusters if tracing is configured
+	if kuadrant.Spec.Observability.Tracing != nil && kuadrant.Spec.Observability.Tracing.DefaultEndpoint != "" {
+		// Get all istio gateways
+		gateways = lo.FilterMap(
+			topology.Targetables().Items(func(o machinery.Object) bool {
+				return o.GroupVersionKind().GroupKind() == machinery.GatewayGroupKind
+			}),
+			func(t machinery.Targetable, _ int) (*machinery.Gateway, bool) {
+				gateway := t.(*machinery.Gateway)
+				gatewayClass, found := lo.Find(topology.Targetables().Parents(gateway), func(t machinery.Targetable) bool {
+					return t.GroupVersionKind().GroupKind() == machinery.GatewayClassGroupKind
+				})
+				if !found {
+					return nil, false
+				}
+				return gateway, lo.Contains(istioGatewayControllerNames, gatewayClass.(*machinery.GatewayClass).Spec.ControllerName)
+			},
+		)
+	} else {
+		logger.V(1).Info("tracing not configured")
+	}
+
+	desiredEnvoyFilters := make(map[k8stypes.NamespacedName]struct{})
+	var modifiedGateways []string
+
+	if len(gateways) == 0 {
+		logger.V(1).Info("no istio gateways found")
+	}
+
+	// Reconcile tracing cluster for each gateway
+	for _, gateway := range gateways {
+		gatewayKey := k8stypes.NamespacedName{Name: gateway.GetName(), Namespace: gateway.GetNamespace()}
+
+		desiredEnvoyFilter, err := r.buildDesiredEnvoyFilter(kuadrant, gateway)
+		if err != nil {
+			logger.Error(err, "failed to build desired envoy filter", "gateway", gatewayKey.String())
+			continue
+		}
+		desiredEnvoyFilters[k8stypes.NamespacedName{Name: desiredEnvoyFilter.GetName(), Namespace: desiredEnvoyFilter.GetNamespace()}] = struct{}{}
+
+		resource := r.client.Resource(kuadrantistio.EnvoyFiltersResource).Namespace(desiredEnvoyFilter.GetNamespace())
+
+		existingEnvoyFilterObj, found := lo.Find(topology.Objects().Children(gateway), func(child machinery.Object) bool {
+			return child.GroupVersionKind().GroupKind() == kuadrantistio.EnvoyFilterGroupKind &&
+				child.GetName() == desiredEnvoyFilter.GetName() &&
+				child.GetNamespace() == desiredEnvoyFilter.GetNamespace() &&
+				labels.Set(child.(*controller.RuntimeObject).GetLabels()).AsSelector().Matches(labels.Set(desiredEnvoyFilter.GetLabels()))
+		})
+
+		// Create
+		if !found {
+			modifiedGateways = append(modifiedGateways, gateway.GetLocator())
+			desiredEnvoyFilterUnstructured, err := controller.Destruct(desiredEnvoyFilter)
+			if err != nil {
+				logger.Error(err, "failed to destruct envoyfilter object", "gateway", gatewayKey.String(), "envoyfilter", desiredEnvoyFilter)
+				continue
+			}
+			if _, err = resource.Create(ctx, desiredEnvoyFilterUnstructured, metav1.CreateOptions{}); err != nil {
+				logger.Error(err, "failed to create envoyfilter object", "gateway", gatewayKey.String(), "envoyfilter", desiredEnvoyFilterUnstructured.Object)
+				// TODO: handle error
+			}
+			continue
+		}
+
+		existingEnvoyFilter := existingEnvoyFilterObj.(*controller.RuntimeObject).Object.(*istioclientgonetworkingv1alpha3.EnvoyFilter)
+
+		if kuadrantistio.EqualEnvoyFilters(existingEnvoyFilter, desiredEnvoyFilter) {
+			logger.V(1).Info("envoyfilter object is up to date, nothing to do")
+			continue
+		}
+
+		// Update
+		existingEnvoyFilter.Spec = istioapinetworkingv1alpha3.EnvoyFilter{
+			TargetRefs:    desiredEnvoyFilter.Spec.TargetRefs,
+			ConfigPatches: desiredEnvoyFilter.Spec.ConfigPatches,
+			Priority:      desiredEnvoyFilter.Spec.Priority,
+		}
+
+		existingEnvoyFilterUnstructured, err := controller.Destruct(existingEnvoyFilter)
+		if err != nil {
+			logger.Error(err, "failed to destruct envoyfilter object", "gateway", gatewayKey.String(), "envoyfilter", existingEnvoyFilter)
+			continue
+		}
+		if _, err = resource.Update(ctx, existingEnvoyFilterUnstructured, metav1.UpdateOptions{}); err != nil {
+			logger.Error(err, "failed to update envoyfilter object", "gateway", gatewayKey.String(), "envoyfilter", existingEnvoyFilterUnstructured.Object)
+			// TODO: handle error
+		}
+	}
+
+	state.Store(StateIstioTracingClustersModified, modifiedGateways)
+
+	// Cleanup tracing clusters for gateways that no longer need them
+	staleEnvoyFilters := topology.Objects().Items(func(o machinery.Object) bool {
+		_, desired := desiredEnvoyFilters[k8stypes.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}]
+		return o.GroupVersionKind().GroupKind() == kuadrantistio.EnvoyFilterGroupKind &&
+			labels.Set(o.(*controller.RuntimeObject).GetLabels()).AsSelector().Matches(TracingObjectLabels()) &&
+			!desired
+	})
+
+	for _, envoyFilter := range staleEnvoyFilters {
+		if err := r.client.Resource(kuadrantistio.EnvoyFiltersResource).Namespace(envoyFilter.GetNamespace()).Delete(ctx, envoyFilter.GetName(), metav1.DeleteOptions{}); err != nil {
+			logger.Error(err, "failed to delete envoyfilter object", "envoyfilter", fmt.Sprintf("%s/%s", envoyFilter.GetNamespace(), envoyFilter.GetName()))
+			// TODO: handle error
+		}
+	}
+
+	return nil
+}
+
+func (r *IstioTracingClusterReconciler) buildDesiredEnvoyFilter(kuadrant *kuadrantv1beta1.Kuadrant, gateway *machinery.Gateway) (*istioclientgonetworkingv1alpha3.EnvoyFilter, error) {
+	envoyFilter := &istioclientgonetworkingv1alpha3.EnvoyFilter{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kuadrantistio.EnvoyFilterGroupKind.Kind,
+			APIVersion: istioclientgonetworkingv1alpha3.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TracingClusterName(gateway.GetName()),
+			Namespace: gateway.GetNamespace(),
+			Labels:    TracingObjectLabels(),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         gateway.GroupVersionKind().GroupVersion().String(),
+					Kind:               gateway.GroupVersionKind().Kind,
+					Name:               gateway.Name,
+					UID:                gateway.UID,
+					BlockOwnerDeletion: ptr.To(true),
+					Controller:         ptr.To(true),
+				},
+			},
+		},
+		Spec: istioapinetworkingv1alpha3.EnvoyFilter{
+			TargetRefs: []*istiov1beta1.PolicyTargetReference{
+				{
+					Group: machinery.GatewayGroupKind.Group,
+					Kind:  machinery.GatewayGroupKind.Kind,
+					Name:  gateway.GetName(),
+				},
+			},
+		},
+	}
+
+	tracingEndpoint := kuadrant.Spec.Observability.Tracing.DefaultEndpoint
+
+	// Parse the tracing endpoint to extract host and port
+	host, port, err := parseTracingEndpoint(tracingEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse tracing endpoint: %w", err)
+	}
+
+	// Use mTLS unless explicitly set to insecure
+	mTLS := !kuadrant.Spec.Observability.Tracing.Insecure
+
+	configPatches, err := kuadrantistio.BuildEnvoyFilterClusterPatch(host, port, mTLS, tracingClusterPatch)
+	if err != nil {
+		return nil, err
+	}
+	envoyFilter.Spec.ConfigPatches = configPatches
+
+	return envoyFilter, nil
+}

--- a/internal/controller/ratelimit_workflow_helpers.go
+++ b/internal/controller/ratelimit_workflow_helpers.go
@@ -102,75 +102,7 @@ func RateLimitClusterName(gatewayName string) string {
 }
 
 func rateLimitClusterPatch(host string, port int, mTLS bool) map[string]any {
-	base := map[string]any{
-		"name":                   kuadrant.KuadrantRateLimitClusterName,
-		"type":                   "STRICT_DNS",
-		"connect_timeout":        "1s",
-		"lb_policy":              "ROUND_ROBIN",
-		"http2_protocol_options": map[string]any{},
-		"load_assignment": map[string]any{
-			"cluster_name": kuadrant.KuadrantRateLimitClusterName,
-			"endpoints": []map[string]any{
-				{
-					"lb_endpoints": []map[string]any{
-						{
-							"endpoint": map[string]any{
-								"address": map[string]any{
-									"socket_address": map[string]any{
-										"address":    host,
-										"port_value": port,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	if mTLS {
-		base["transport_socket"] = map[string]interface{}{
-			"name": "envoy.transport_sockets.tls",
-			"typed_config": map[string]interface{}{
-				"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
-				"common_tls_context": map[string]interface{}{
-					"tls_certificate_sds_secret_configs": []interface{}{
-						map[string]interface{}{
-							"name": "default",
-							"sds_config": map[string]interface{}{
-								"api_config_source": map[string]interface{}{
-									"api_type": "GRPC",
-									"grpc_services": []interface{}{
-										map[string]interface{}{
-											"envoy_grpc": map[string]interface{}{
-												"cluster_name": "sds-grpc",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					"validation_context_sds_secret_config": map[string]interface{}{
-						"name": "ROOTCA",
-						"sds_config": map[string]interface{}{
-							"api_config_source": map[string]interface{}{
-								"api_type": "GRPC",
-								"grpc_services": []interface{}{
-									map[string]interface{}{
-										"envoy_grpc": map[string]interface{}{
-											"cluster_name": "sds-grpc",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-	}
-	return base
+	return buildClusterPatch(kuadrant.KuadrantRateLimitClusterName, host, port, mTLS, true)
 }
 
 // wasmActionFromLimit builds a wasm rate-limit action for a given limit.

--- a/internal/controller/tracing_workflow_helpers.go
+++ b/internal/controller/tracing_workflow_helpers.go
@@ -1,0 +1,72 @@
+package controllers
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
+)
+
+const (
+	tracingObjectLabelKey = "kuadrant.io/tracing"
+
+	// State keys
+	StateEnvoyGatewayTracingClustersModified = "EnvoyGatewayTracingClustersModified"
+	StateIstioTracingClustersModified        = "IstioTracingClustersModified"
+)
+
+// TracingObjectLabels returns labels for tracing-related objects
+func TracingObjectLabels() labels.Set {
+	m := KuadrantManagedObjectLabels()
+	m[tracingObjectLabelKey] = "true"
+	return m
+}
+
+// TracingClusterName returns the name for the tracing cluster EnvoyFilter/EnvoyPatchPolicy
+func TracingClusterName(gatewayName string) string {
+	return fmt.Sprintf("kuadrant-tracing-%s", gatewayName)
+}
+
+// tracingClusterPatch returns the Envoy cluster configuration for the tracing service
+func tracingClusterPatch(host string, port int, mTLS bool) map[string]any {
+	return buildClusterPatch(kuadrant.KuadrantTracingClusterName, host, port, mTLS, true)
+}
+
+// parseTracingEndpoint parses a tracing endpoint URL and returns host and port
+func parseTracingEndpoint(endpoint string) (string, int, error) {
+	parsedURL, err := url.Parse(endpoint)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid URL: %w", err)
+	}
+
+	host := parsedURL.Hostname()
+	if host == "" {
+		return "", 0, fmt.Errorf("no host found in URL")
+	}
+
+	// Default ports based on scheme
+	var port int
+	portStr := parsedURL.Port()
+	if portStr != "" {
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			return "", 0, fmt.Errorf("invalid port: %w", err)
+		}
+	} else {
+		// Use common default ports for tracing
+		switch parsedURL.Scheme {
+		case "https":
+			port = 443
+		case "http":
+			port = 80
+		default:
+			// For OTLP gRPC (common default)
+			port = 4317
+		}
+	}
+
+	return host, port, nil
+}

--- a/internal/kuadrant/kuadrant.go
+++ b/internal/kuadrant/kuadrant.go
@@ -11,6 +11,7 @@ const (
 	DeveloperPortalLabel         = "kuadrant.io/developerportal"
 	KuadrantRateLimitClusterName = "kuadrant-ratelimit-service"
 	KuadrantAuthClusterName      = "kuadrant-auth-service"
+	KuadrantTracingClusterName   = "kuadrant-tracing-service"
 	LimitadorName                = "limitador"
 )
 

--- a/internal/wasm/utils.go
+++ b/internal/wasm/utils.go
@@ -143,7 +143,7 @@ func BuildObservabilityConfig(serviceBuilder *ServiceBuilder, observabilitySpec 
 			Service: TracingServiceName,
 		}
 
-		serviceBuilder.WithTracing(observabilitySpec.Tracing.DefaultEndpoint)
+		serviceBuilder.WithTracing()
 	}
 
 	return &Observability{
@@ -193,10 +193,10 @@ func NewServiceBuilder(logger *logr.Logger) *ServiceBuilder {
 }
 
 // WithTracing adds a tracing service with the specified endpoint
-func (sb *ServiceBuilder) WithTracing(endpoint string) *ServiceBuilder {
+func (sb *ServiceBuilder) WithTracing() *ServiceBuilder {
 	sb.services[TracingServiceName] = Service{
 		Type:        TracingServiceType,
-		Endpoint:    endpoint,
+		Endpoint:    kuadrant.KuadrantTracingClusterName,
 		FailureMode: TracingServiceFailureMode(sb.logger),
 		Timeout:     ptr.To(TracingServiceTimeout()),
 	}

--- a/tests/envoygateway/tracing_cluster_reconciler_test.go
+++ b/tests/envoygateway/tracing_cluster_reconciler_test.go
@@ -1,0 +1,231 @@
+//go:build integration
+
+package envoygateway_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	egv1alpha1 "github.com/envoyproxy/gateway/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	controllers "github.com/kuadrant/kuadrant-operator/internal/controller"
+	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
+	"github.com/kuadrant/kuadrant-operator/tests"
+)
+
+var _ = Describe("tracing cluster controller", Serial, func() {
+	const (
+		testTimeOut      = SpecTimeout(2 * time.Minute)
+		afterEachTimeOut = NodeTimeout(3 * time.Minute)
+	)
+	var (
+		testNamespace string
+		gwHost        = fmt.Sprintf("*.toystore-%s.com", rand.String(4))
+		gateway       *gatewayapiv1.Gateway
+	)
+
+	BeforeEach(func(ctx SpecContext) {
+		testNamespace = tests.CreateNamespace(ctx, testClient())
+		gateway = tests.NewGatewayBuilder(TestGatewayName, tests.GatewayClassName, testNamespace).
+			WithHTTPListener("test-listener", gwHost).
+			Gateway
+		err := testClient().Create(ctx, gateway)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(tests.GatewayIsReady(ctx, testClient(), gateway)).WithContext(ctx).Should(BeTrue())
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		// Clean up tracing configuration
+		kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+		kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+		Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+		original := kuadrantObj.DeepCopy()
+		kuadrantObj.Spec.Observability.Tracing = nil
+		Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+
+		tests.DeleteNamespace(ctx, testClient(), testNamespace)
+	}, afterEachTimeOut)
+
+	randomHostFromGWHost := func() string {
+		return strings.Replace(gwHost, "*", rand.String(4), 1)
+	}
+
+	Context("Tracing configuration on Kuadrant CR", func() {
+		var gwRoute *gatewayapiv1.HTTPRoute
+
+		BeforeEach(func(ctx SpecContext) {
+			gwRoute = tests.BuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{randomHostFromGWHost()})
+			err := testClient().Create(ctx, gwRoute)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(gwRoute))).WithContext(ctx).Should(BeTrue())
+		})
+
+		It("Creates envoypatchpolicy for tracing cluster with insecure connection", func(ctx SpecContext) {
+			// Configure tracing with insecure connection
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+			kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original := kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = &kuadrantv1beta1.Tracing{
+				DefaultEndpoint: "http://jaeger-collector.observability.svc:14268/api/traces",
+				Insecure:        true,
+			}
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+
+			patchKey := client.ObjectKey{
+				Name:      controllers.TracingClusterName(TestGatewayName),
+				Namespace: testNamespace,
+			}
+
+			Eventually(IsEnvoyPatchPolicyAccepted).
+				WithContext(ctx).
+				WithArguments(testClient(), patchKey, client.ObjectKeyFromObject(gateway)).
+				Should(Succeed())
+
+			envoyPatch := &egv1alpha1.EnvoyPatchPolicy{}
+			err := testClient().Get(ctx, patchKey, envoyPatch)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(envoyPatch.Spec.TargetRef.Group).To(Equal(gatewayapiv1.Group("gateway.networking.k8s.io")))
+			Expect(envoyPatch.Spec.TargetRef.Kind).To(Equal(gatewayapiv1.Kind("Gateway")))
+			Expect(envoyPatch.Spec.TargetRef.Name).To(Equal(gatewayapiv1.ObjectName(TestGatewayName)))
+
+			// Verify patch contains cluster configuration
+			Expect(envoyPatch.Spec.JSONPatches).NotTo(BeEmpty())
+			Expect(envoyPatch.Spec.JSONPatches[0].Type).To(Equal(egv1alpha1.EnvoyResourceType("type.googleapis.com/envoy.config.cluster.v3.Cluster")))
+			Expect(envoyPatch.Spec.JSONPatches[0].Operation.Op).To(Equal(egv1alpha1.JSONPatchOperationType("add")))
+
+			// Verify cluster details
+			var clusterConfig map[string]interface{}
+			err = json.Unmarshal(envoyPatch.Spec.JSONPatches[0].Operation.Value.Raw, &clusterConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clusterConfig["name"]).To(Equal(kuadrant.KuadrantTracingClusterName))
+
+			// Verify endpoint configuration
+			loadAssignment := clusterConfig["load_assignment"].(map[string]interface{})
+			endpoints := loadAssignment["endpoints"].([]interface{})[0].(map[string]interface{})
+			lbEndpoints := endpoints["lb_endpoints"].([]interface{})[0].(map[string]interface{})
+			endpoint := lbEndpoints["endpoint"].(map[string]interface{})
+			address := endpoint["address"].(map[string]interface{})
+			socketAddress := address["socket_address"].(map[string]interface{})
+			Expect(socketAddress["address"]).To(Equal("jaeger-collector.observability.svc"))
+			Expect(socketAddress["port_value"]).To(BeNumerically("==", 14268))
+
+			// No mTLS when insecure: true
+			Expect(clusterConfig).NotTo(HaveKey("transport_socket"))
+		}, testTimeOut)
+
+		It("Creates envoypatchpolicy for tracing cluster with mTLS", func(ctx SpecContext) {
+			// Configure tracing with mTLS
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+			kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original := kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = &kuadrantv1beta1.Tracing{
+				DefaultEndpoint: "https://secure-collector.observability.svc:443",
+				Insecure:        false, // mTLS enabled
+			}
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+
+			patchKey := client.ObjectKey{
+				Name:      controllers.TracingClusterName(TestGatewayName),
+				Namespace: testNamespace,
+			}
+
+			Eventually(IsEnvoyPatchPolicyAccepted).
+				WithContext(ctx).
+				WithArguments(testClient(), patchKey, client.ObjectKeyFromObject(gateway)).
+				Should(Succeed())
+
+			envoyPatch := &egv1alpha1.EnvoyPatchPolicy{}
+			err := testClient().Get(ctx, patchKey, envoyPatch)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify cluster details
+			var clusterConfig map[string]interface{}
+			err = json.Unmarshal(envoyPatch.Spec.JSONPatches[0].Operation.Value.Raw, &clusterConfig)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify mTLS configuration is present
+			Expect(clusterConfig).To(HaveKey("transport_socket"))
+			transportSocket := clusterConfig["transport_socket"].(map[string]interface{})
+			Expect(transportSocket["name"]).To(Equal("envoy.transport_sockets.tls"))
+
+			typedConfig := transportSocket["typed_config"].(map[string]interface{})
+			Expect(typedConfig["@type"]).To(Equal("type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"))
+
+			commonTLS := typedConfig["common_tls_context"].(map[string]interface{})
+			Expect(commonTLS).To(HaveKey("tls_certificate_sds_secret_configs"))
+			Expect(commonTLS).To(HaveKey("validation_context_sds_secret_config"))
+		}, testTimeOut)
+
+		It("Does not create envoypatchpolicy when tracing is not configured", func(ctx SpecContext) {
+			// Ensure tracing is not configured
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+			kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original := kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = nil
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+
+			patchKey := client.ObjectKey{
+				Name:      controllers.TracingClusterName(TestGatewayName),
+				Namespace: testNamespace,
+			}
+
+			// Verify patch is not created
+			Consistently(func(g Gomega) {
+				patch := &egv1alpha1.EnvoyPatchPolicy{}
+				err := testClient().Get(ctx, patchKey, patch)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+
+		It("Deletes envoypatchpolicy when tracing config is removed", func(ctx SpecContext) {
+			// First, configure tracing
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+			kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original := kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = &kuadrantv1beta1.Tracing{
+				DefaultEndpoint: "http://jaeger:14268",
+				Insecure:        true,
+			}
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+
+			patchKey := client.ObjectKey{
+				Name:      controllers.TracingClusterName(TestGatewayName),
+				Namespace: testNamespace,
+			}
+
+			// Verify patch is created
+			Eventually(IsEnvoyPatchPolicyAccepted).
+				WithContext(ctx).
+				WithArguments(testClient(), patchKey, client.ObjectKeyFromObject(gateway)).
+				Should(Succeed())
+
+			// Remove tracing configuration
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original = kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = nil
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+
+			// Verify patch is deleted
+			Eventually(func(g Gomega) {
+				patch := &egv1alpha1.EnvoyPatchPolicy{}
+				err := testClient().Get(ctx, patchKey, patch)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+	})
+})

--- a/tests/istio/istio_tracing_cluster_reconciler_test.go
+++ b/tests/istio/istio_tracing_cluster_reconciler_test.go
@@ -1,0 +1,257 @@
+//go:build integration
+
+package istio_test
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	istioclientnetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	controllers "github.com/kuadrant/kuadrant-operator/internal/controller"
+	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
+	"github.com/kuadrant/kuadrant-operator/tests"
+)
+
+var _ = Describe("Tracing Cluster EnvoyFilter controller", Serial, func() {
+	const (
+		testTimeOut      = SpecTimeout(2 * time.Minute)
+		afterEachTimeOut = NodeTimeout(3 * time.Minute)
+	)
+	var (
+		testNamespace string
+	)
+
+	beforeEachCallback := func(ctx SpecContext) {
+		testNamespace = tests.CreateNamespace(ctx, testClient())
+		gateway := tests.BuildBasicGateway(TestGatewayName, testNamespace)
+		err := testClient().Create(ctx, gateway)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(tests.GatewayIsReady(ctx, testClient(), gateway)).WithContext(ctx).Should(BeTrue())
+	}
+
+	BeforeEach(beforeEachCallback)
+	AfterEach(func(ctx SpecContext) {
+		// Clean up tracing configuration
+		kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+		kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+		Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+		original := kuadrantObj.DeepCopy()
+		kuadrantObj.Spec.Observability.Tracing = nil
+		Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+
+		tests.DeleteNamespace(ctx, testClient(), testNamespace)
+	}, afterEachTimeOut)
+
+	Context("Tracing configuration on Kuadrant CR", func() {
+		// tracing with mTLS disabled (insecure: true)
+		BeforeEach(func(ctx SpecContext) {
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+			kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original := kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = &kuadrantv1beta1.Tracing{
+				DefaultEndpoint: "http://jaeger-collector.observability.svc:14268/api/traces",
+				Insecure:        true,
+			}
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+		})
+
+		It("EnvoyFilter created with tracing cluster when gateway exists", func(ctx SpecContext) {
+			// Create a route to ensure gateway is in the topology
+			route := tests.BuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+			Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
+
+			// Check envoy filter has been created
+			existingEF := &istioclientnetworkingv1alpha3.EnvoyFilter{}
+			Eventually(func(g Gomega, ctx context.Context) {
+				efKey := client.ObjectKey{Name: controllers.TracingClusterName(TestGatewayName), Namespace: testNamespace}
+				g.Expect(testClient().Get(ctx, efKey, existingEF)).NotTo(HaveOccurred())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Check envoy filter configuration
+			Expect(existingEF.Spec.ConfigPatches).To(HaveLen(1))
+			Expect(existingEF.Spec.ConfigPatches[0].Patch).NotTo(BeNil())
+			Expect(existingEF.Spec.ConfigPatches[0].Patch.Value).NotTo(BeNil())
+
+			// Verify cluster configuration
+			patchValueRaw, err := json.Marshal(existingEF.Spec.ConfigPatches[0].Patch.Value)
+			Expect(err).ToNot(HaveOccurred())
+			var patchValue map[string]any
+			Expect(json.Unmarshal(patchValueRaw, &patchValue)).ToNot(HaveOccurred())
+			Expect(patchValue).To(HaveKey("name"))
+			Expect(patchValue["name"]).To(Equal(kuadrant.KuadrantTracingClusterName))
+
+			// Check load_assignment has correct host and port
+			Expect(patchValue).To(HaveKey("load_assignment"))
+			loadAssignment := patchValue["load_assignment"].(map[string]interface{})
+			endpoints := loadAssignment["endpoints"].([]interface{})[0].(map[string]interface{})
+			lbEndpoints := endpoints["lb_endpoints"].([]interface{})[0].(map[string]interface{})
+			endpoint := lbEndpoints["endpoint"].(map[string]interface{})
+			address := endpoint["address"].(map[string]interface{})
+			socketAddress := address["socket_address"].(map[string]interface{})
+			Expect(socketAddress["address"]).To(Equal("jaeger-collector.observability.svc"))
+			Expect(socketAddress["port_value"]).To(BeNumerically("==", 14268))
+
+			// transport_socket should NOT be present when insecure: true
+			Expect(patchValue).NotTo(HaveKey("transport_socket"))
+		}, testTimeOut)
+	})
+
+	Context("when tracing mTLS is enabled", func() {
+		BeforeEach(func(ctx SpecContext) {
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+			kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original := kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = &kuadrantv1beta1.Tracing{
+				DefaultEndpoint: "https://secure-collector.observability.svc:443",
+				Insecure:        false, // mTLS enabled
+			}
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+		})
+
+		It("envoy filter has transport configured with mTLS", func(ctx SpecContext) {
+			route := tests.BuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+			Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
+
+			existingEF := &istioclientnetworkingv1alpha3.EnvoyFilter{}
+			Eventually(func(g Gomega, ctx context.Context) {
+				efKey := client.ObjectKey{Name: controllers.TracingClusterName(TestGatewayName), Namespace: testNamespace}
+				g.Expect(testClient().Get(ctx, efKey, existingEF)).NotTo(HaveOccurred())
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(existingEF.Spec.ConfigPatches).To(HaveLen(1))
+			Expect(existingEF.Spec.ConfigPatches[0].Patch).NotTo(BeNil())
+			Expect(existingEF.Spec.ConfigPatches[0].Patch.Value).NotTo(BeNil())
+
+			patchValueRaw, err := json.Marshal(existingEF.Spec.ConfigPatches[0].Patch.Value)
+			Expect(err).ToNot(HaveOccurred())
+			var patchValue map[string]any
+			Expect(json.Unmarshal(patchValueRaw, &patchValue)).ToNot(HaveOccurred())
+			Expect(patchValue).To(HaveKey("name"))
+
+			// transport_socket config should be present when insecure: false
+			Expect(patchValue).To(HaveKey("transport_socket"))
+			Expect(patchValue["transport_socket"]).To(Equal(map[string]interface{}{
+				"name": "envoy.transport_sockets.tls",
+				"typed_config": map[string]interface{}{
+					"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
+					"common_tls_context": map[string]interface{}{
+						"tls_certificate_sds_secret_configs": []interface{}{
+							map[string]interface{}{
+								"name": "default",
+								"sds_config": map[string]interface{}{
+									"api_config_source": map[string]interface{}{
+										"api_type": "GRPC",
+										"grpc_services": []interface{}{
+											map[string]interface{}{
+												"envoy_grpc": map[string]interface{}{
+													"cluster_name": "sds-grpc",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"validation_context_sds_secret_config": map[string]interface{}{
+							"name": "ROOTCA",
+							"sds_config": map[string]interface{}{
+								"api_config_source": map[string]interface{}{
+									"api_type": "GRPC",
+									"grpc_services": []interface{}{
+										map[string]interface{}{
+											"envoy_grpc": map[string]interface{}{
+												"cluster_name": "sds-grpc",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}))
+		}, testTimeOut)
+	})
+
+	Context("when tracing is not configured", func() {
+		BeforeEach(func(ctx SpecContext) {
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+			kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original := kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = nil
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+		})
+
+		It("EnvoyFilter is not created", func(ctx SpecContext) {
+			route := tests.BuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+			Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
+
+			// Check envoy filter has not been created
+			Eventually(func(g Gomega, ctx context.Context) {
+				existingEF := &istioclientnetworkingv1alpha3.EnvoyFilter{}
+				efKey := client.ObjectKey{Name: controllers.TracingClusterName(TestGatewayName), Namespace: testNamespace}
+				err := testClient().Get(ctx, efKey, existingEF)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+	})
+
+	Context("when tracing is removed", func() {
+		BeforeEach(func(ctx SpecContext) {
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+			Eventually(tests.KuadrantIsReady(testClient(), kuadrantKey)).WithContext(ctx).Should(Succeed())
+			kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original := kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = &kuadrantv1beta1.Tracing{
+				DefaultEndpoint: "http://jaeger:14268",
+				Insecure:        true,
+			}
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+		})
+
+		It("EnvoyFilter is deleted when tracing config is removed", func(ctx SpecContext) {
+			route := tests.BuildBasicHttpRoute(TestHTTPRouteName, TestGatewayName, testNamespace, []string{"*.toystore.com"})
+			Expect(k8sClient.Create(ctx, route)).To(Succeed())
+			Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(route))).WithContext(ctx).Should(BeTrue())
+
+			// Verify EnvoyFilter is created
+			efKey := client.ObjectKey{Name: controllers.TracingClusterName(TestGatewayName), Namespace: testNamespace}
+			existingEF := &istioclientnetworkingv1alpha3.EnvoyFilter{}
+			Eventually(func(g Gomega, ctx context.Context) {
+				g.Expect(testClient().Get(ctx, efKey, existingEF)).NotTo(HaveOccurred())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Remove tracing configuration
+			kuadrantKey := client.ObjectKey{Name: "kuadrant-sample", Namespace: kuadrantInstallationNS}
+			kuadrantObj := &kuadrantv1beta1.Kuadrant{}
+			Eventually(testClient().Get).WithContext(ctx).WithArguments(kuadrantKey, kuadrantObj).Should(Succeed())
+			original := kuadrantObj.DeepCopy()
+			kuadrantObj.Spec.Observability.Tracing = nil
+			Expect(testClient().Patch(ctx, kuadrantObj, client.MergeFrom(original))).To(Succeed())
+
+			// Verify EnvoyFilter is deleted
+			Eventually(func(g Gomega, ctx context.Context) {
+				err := testClient().Get(ctx, efKey, existingEF)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+	})
+})


### PR DESCRIPTION
# Description
Closes: https://github.com/Kuadrant/kuadrant-operator/issues/1705

Adds a `EnvoyFilter` for tracing service and update the wasm config to point to this service

# Verification
* Deploy
```
make local-setup
```
* Install Kuadrant with tracing enabled
```
kubectl apply -f - <<EOF       
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant       
metadata:
  name: kuadrant-sample
  namespace: kuadrant-system         
spec:
  observability:
    enable: true                    
    tracing:       
       defaultEndpoint: "http://jaeger-collector.observability.svc.cluster.local:14268/api/traces"
    dataPlane:
      defaultLevels:
        - debug: "true"
      httpHeaderIdentifier: "x-kuadrant-trace-id"
EOF                
```
* Check envoyfilter (has tls config also)
```
kubectl get envoyfilter -A -o yaml | yq '.items[0].spec'
```
<img width="891" height="881" alt="image" src="https://github.com/user-attachments/assets/d8362eca-0963-4b4d-9b0e-02e5cf5ec8ab" />

* Disable tls
```
kubectl apply -f - <<EOF       
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant       
metadata:
  name: kuadrant-sample
  namespace: kuadrant-system         
spec:
  observability:
    enable: true                    
    tracing:       
       defaultEndpoint: "http://jaeger-collector.observability.svc.cluster.local:14268/api/traces"
       insecure: true
    dataPlane:
      defaultLevels:
        - debug: "true"
      httpHeaderIdentifier: "x-kuadrant-trace-id"
EOF
```
* Check envoyfilter (does not have tls config)
```
kubectl get envoyfilter -A -o yaml | yq '.items[0].spec'
```
<img width="838" height="519" alt="image" src="https://github.com/user-attachments/assets/18d08060-9637-4610-9c3b-2e78847485d8" />