### PR TITLE
tests: add -race flag to unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ test-unit: VERBOSE_FLAG = -v
 endif
 test-unit: clean-cov generate fmt vet ## Run Unit tests.
 	mkdir -p $(PROJECT_PATH)/coverage/unit
-	go test $(UNIT_DIRS) -coverprofile $(PROJECT_PATH)/coverage/unit/cover.out -tags unit $(VERBOSE_FLAG) -timeout 0 $(TEST_PATTERN)
+	go test $(UNIT_DIRS) -coverprofile $(PROJECT_PATH)/coverage/unit/cover.out -tags unit $(VERBOSE_FLAG) -timeout 0 -race $(TEST_PATTERN)
 
 ##@ Build
 


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/1559
Needs https://github.com/Kuadrant/kuadrant-operator/issues/1732

Due to found data races this PR should be merged after https://github.com/Kuadrant/kuadrant-operator/issues/1732 is fixed