### PR TITLE
Prepare release v1.4.0 GA

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -224,14 +224,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.0-rc1
-    createdAt: "2026-02-05T17:14:12Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.0
+    createdAt: "2026-02-05T17:52:41Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.0-rc1
+  name: kuadrant-operator.v1.4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -753,7 +753,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.4.0-rc1
+                image: quay.io/kuadrant/kuadrant-operator:v1.4.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -906,4 +906,4 @@ spec:
     name: console-plugin-latest
   - image: quay.io/kuadrant/console-plugin:v0.1.5
     name: console-plugin-pf5
-  version: 1.4.0-rc1
+  version: 1.4.0

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.4.0-rc1"
-appVersion: "1.4.0-rc1"
+version: "1.4.0"
+appVersion: "1.4.0"
 dependencies:
   - name: authorino-operator
     version: 0.23.0

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14059,7 +14059,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.4.0-rc1
+        image: quay.io/kuadrant/kuadrant-operator:v1.4.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.0-rc1
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.0
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.4.0-rc1
+  newTag: v1.4.0

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.0-rc1
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.0
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.0-rc1
+  name: kuadrant-operator.v1.4.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,4 +88,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.4.0-rc1
+  version: 1.4.0

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.4.0-rc1"
+  version: "1.4.0"
 olm:
   channels:
     - "stable"


### PR DESCRIPTION
The following PR for the release of Kuadrant Operator version 1.4.0 includes:
- Authorino Operator version 0.23.0
- DNS Operator version 0.16.0
- Limitador Operator version 0.17.0
- Console Plugin version 0.3.4
- WASM Shim version 0.12.0
- Developer Portal Controller version 0.1.0