### PR TITLE
GH action release job uses KUADRANT_DEV_PAT to trigger other workflows

### DIFF
--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -47,3 +47,4 @@ jobs:
           generate_release_notes: false
           target_commitish: ${{ env.releaseBranch }}
           prerelease: ${{ env.prerelease }}
+          token: '${{ secrets.KUADRANT_DEV_PAT }}'


### PR DESCRIPTION
### What

GH releases were created using GITHUB_TOKEN. This prevented the trigger of the helm chart workflow. From GH doc https://docs.github.com/actions/using-workflows/triggering-a-workflow

```
When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run.
```

