### PR TITLE
Enable s390x (IBM Z/Linux) support

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -119,7 +119,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: true
           provenance: false
           tags: |
@@ -172,7 +172,7 @@ jobs:
         with:
           context: .
           file: ./bundle.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: true
           provenance: false
           tags: |
@@ -219,7 +219,7 @@ jobs:
         with:
           context: ./catalog
           file: ./catalog/kuadrant-operator-catalog.Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: true
           provenance: false
           tags: |

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}
           tags: ${{ github.ref_name }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           build-args: |
             GIT_SHA=${{ github.sha }}
             DIRTY=false
@@ -102,7 +102,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-bundle
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           dockerfiles: |
             ./bundle.Dockerfile
 
@@ -181,7 +181,7 @@ jobs:
         with:
           image: ${{ env.OPERATOR_NAME }}-catalog
           tags: ${{ needs.build.outputs.build-tags }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           context: ./catalog
           dockerfiles: ./catalog/${{ env.OPERATOR_NAME }}-catalog.Dockerfile
 

--- a/make/envoy-gateway.mk
+++ b/make/envoy-gateway.mk
@@ -22,6 +22,10 @@ endif
 ifeq ($(ARCH),aarch64)
 	EG_ARCH = arm64
 endif
+ifeq ($(ARCH),s390x)
+	# Envoy Gateway may not publish egctl for s390x; download will fail if not available
+	EG_ARCH = s390x
+endif
 ifneq ($(filter armv5%,$(ARCH)),)
 	EG_ARCH = armv5
 endif


### PR DESCRIPTION
## Summary

Adds **linux/s390x** to the set of platforms we build and publish so the operator and its OLM bundle/catalog images are available on IBM Z and LinuxONE (s390x).

## Changes

### CI – multi-arch image builds

- **`.github/workflows/build-images-for-tag-release.yaml`**
  - Added `linux/s390x` to the `platforms` list for:
    - Kuadrant operator image
    - Operator bundle image
    - Operator catalog image

- **`.github/workflows/build-images-base.yaml`**
  - Same change: `linux/s390x` added to `platforms` for the operator, bundle, and catalog build steps.

### Makefile – Envoy Gateway / egctl

- **`make/envoy-gateway.mk`**
  - Set `EG_ARCH = s390x` when building on s390x so the Makefile does not leave `EG_ARCH` unset.
  - Added a comment that Envoy Gateway may not yet publish egctl for s390x; if they do in the future, `make egctl` will work without further changes.

## Technical notes

- Dockerfiles already use `TARGETARCH` and `CGO_ENABLED=0`; no code changes were required for s390x.
- Base images in use (`gcr.io/distroless/static:nonroot`, UBI in the extension Dockerfile) support s390x.
- CI uses QEMU user emulation for multi-arch builds, so s390x is built via emulation on the current runners.

## Out of scope for this PR

- **Dependency operators** (Authorino, Limitador, DNS operator, etc.) must provide their own s390x images for a full stack on s390x; that is tracked in their respective projects.
- **egctl** on s390x: Envoy Gateway does not currently publish egctl binaries for s390x; the Makefile change only ensures correct `EG_ARCH` and a clear path if they add support later.

## Testing

- No change to unit or integration test commands; existing test targets remain unchanged.
- To validate s390x builds locally:
  ```bash
  docker buildx build --platform linux/s390x -f Dockerfile .
  ```
