### PR TITLE
feat: runtime trace provider enablement via config map

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -269,12 +269,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = controllers.NewTracingConfigMapReconciler(mgr, env.GetString("OPERATOR_NAMESPACE", ""), dynTraceProvider).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to setup tracing configmap reconciler")
-		os.Exit(1)
-	}
-
-	stateOfTheWorld, err := controllers.NewPolicyMachineryController(mgr, client, log.Log, opts...)
+	stateOfTheWorld, err := controllers.NewPolicyMachineryController(mgr, client, log.Log, dynTraceProvider, opts...)
 	if err != nil {
 		setupLog.Error(err, "unable to setup policy controller")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -160,38 +160,38 @@ func main() {
 		}
 	}
 
-	// Setup OTel tracing if endpoint is configured
-	if otelConfig.TracesEndpoint() != "" {
-		traceProvider, err := trace.NewProvider(context.Background(), otelConfig)
-		if err != nil {
-			log.Log.Error(err, "Failed to setup OpenTelemetry tracing, continuing without traces")
-		} else {
-			log.Log.Info("OpenTelemetry tracing enabled",
-				"endpoint", otelConfig.TracesEndpoint(),
-				"sampler", "AlwaysSample",
-			)
-
-			// Set global propagator for distributed tracing
-			otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
-				propagation.TraceContext{},
-				propagation.Baggage{},
-			))
-
-			// Set as global tracer provider
-			otel.SetTracerProvider(traceProvider.TracerProvider())
-
-			// Ensure OTel tracing is shut down gracefully on exit
-			defer func() {
-				shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer shutdownCancel()
-				if err := traceProvider.Shutdown(shutdownCtx); err != nil {
-					log.Log.Error(err, "Failed to shutdown OpenTelemetry tracing")
-				}
-			}()
-
-			opts = append(opts, controller.WithTracer(traceProvider.TracerProvider().Tracer(otelConfig.ServiceName)))
-		}
+	// Setup OTel tracing. DynamicProvider initializes from env vars and can be
+	// reconfigured at runtime via the kuadrant-tracing ConfigMap.
+	// NewDynamicProvider always returns a usable provider: initial endpoint failure
+	// is non-fatal so the ConfigMap reconciler can still reconfigure it later.
+	dynTraceProvider, err := trace.NewDynamicProvider(context.Background(), otelConfig)
+	if err != nil {
+		log.Log.Error(err, "Failed to connect to OTel traces endpoint from env vars, tracing disabled until ConfigMap is applied")
+	} else if otelConfig.TracesEndpoint() != "" {
+		log.Log.Info("OpenTelemetry tracing enabled",
+			"endpoint", otelConfig.TracesEndpoint(),
+			"sampler", "AlwaysSample",
+		)
 	}
+
+	// Set global propagator unconditionally so it is in place when tracing
+	// is enabled later via the kuadrant-tracing ConfigMap.
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	// GlobalTracer always delegates to the current global provider, so spans
+	// are automatically routed to the updated exporter after a ConfigMap change.
+	opts = append(opts, controller.WithTracer(dynTraceProvider.GlobalTracer(otelConfig.ServiceName)))
+
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := dynTraceProvider.Shutdown(shutdownCtx); err != nil {
+			log.Log.Error(err, "Failed to shutdown OpenTelemetry tracing")
+		}
+	}()
 
 	printControllerMetaInfo()
 
@@ -201,7 +201,6 @@ func main() {
 		metricsAddr          string
 		enableLeaderElection bool
 		probeAddr            string
-		err                  error
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -267,6 +266,11 @@ func main() {
 	client, err := dynamic.NewForConfig(mgr.GetConfig())
 	if err != nil {
 		setupLog.Error(err, "unable to create client")
+		os.Exit(1)
+	}
+
+	if err = controllers.NewTracingConfigMapReconciler(mgr, env.GetString("OPERATOR_NAMESPACE", ""), dynTraceProvider).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to setup tracing configmap reconciler")
 		os.Exit(1)
 	}
 

--- a/internal/controller/test_common.go
+++ b/internal/controller/test_common.go
@@ -23,8 +23,11 @@ limitations under the License.
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 
+	kuadrantOtel "github.com/kuadrant/kuadrant-operator/internal/otel"
+	"github.com/kuadrant/kuadrant-operator/internal/trace"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -64,7 +67,11 @@ func SetupKuadrantOperatorForTest(s *runtime.Scheme, cfg *rest.Config) {
 	dClient, err := dynamic.NewForConfig(mgr.GetConfig())
 	Expect(err).NotTo(HaveOccurred())
 
-	stateOfTheWorld, err := NewPolicyMachineryController(mgr, dClient, log.Log)
+	otelConfig := kuadrantOtel.NewConfig("dev", "true", "dev")
+	dynTraceProvider, err := trace.NewDynamicProvider(context.Background(), otelConfig)
+	Expect(err).ToNot(HaveOccurred())
+
+	stateOfTheWorld, err := NewPolicyMachineryController(mgr, dClient, log.Log, dynTraceProvider)
 	Expect(err).NotTo(HaveOccurred())
 
 	go func() {

--- a/internal/controller/tracing_configmap_reconciler.go
+++ b/internal/controller/tracing_configmap_reconciler.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kuadrant/kuadrant-operator/internal/log"
+	"github.com/kuadrant/kuadrant-operator/internal/trace"
+)
+
+// TracingConfigMapName is the name of the ConfigMap that controls the operator's
+// control-plane trace exporter at runtime. Creating or updating this ConfigMap
+// reconfigures the trace provider without restarting the operator. Deleting it
+// reverts to the env var configuration captured at startup.
+const TracingConfigMapName = "kuadrant-tracing"
+
+const (
+	tracingEndpointKey = "endpoint"
+	tracingInsecureKey = "insecure"
+)
+
+// TracingConfigMapReconciler watches the kuadrant-tracing ConfigMap and
+// reconfigures the operator's OTEL trace provider whenever it changes.
+//
+// ConfigMap data keys:
+//   - endpoint: OTLP collector URL (e.g. "rpc://otel-collector:4317" or "http://…")
+//   - insecure: "true" to skip TLS verification (optional, defaults to false)
+//
+// This reconciler uses a plain controller-runtime reconcile loop rather than the
+// policy machinery subscription pattern, because it configures the operator itself
+// rather than reconciling cluster resources.
+type TracingConfigMapReconciler struct {
+	client    client.Client
+	namespace string
+	provider  *trace.DynamicProvider
+}
+
+func NewTracingConfigMapReconciler(mgr ctrl.Manager, namespace string, provider *trace.DynamicProvider) *TracingConfigMapReconciler {
+	return &TracingConfigMapReconciler{
+		client:    mgr.GetClient(),
+		namespace: namespace,
+		provider:  provider,
+	}
+}
+
+func (r *TracingConfigMapReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	logger := log.Log.WithName("TracingConfigMapReconciler").WithValues("configmap", req.NamespacedName)
+
+	cm := &corev1.ConfigMap{}
+	if err := r.client.Get(ctx, req.NamespacedName, cm); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("tracing configmap deleted, reverting to env var config")
+			if revertErr := r.provider.RevertToFallback(ctx); revertErr != nil {
+				logger.Error(revertErr, "failed to revert trace provider to fallback")
+				return reconcile.Result{}, revertErr
+			}
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	endpoint := cm.Data[tracingEndpointKey]
+	insecure, _ := strconv.ParseBool(cm.Data[tracingInsecureKey])
+
+	logger.Info("reconfiguring trace provider", "endpoint", endpoint, "insecure", insecure)
+	if err := r.provider.Reconfigure(ctx, endpoint, insecure); err != nil {
+		logger.Error(err, "failed to reconfigure trace provider")
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *TracingConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("tracing-configmap").
+		For(&corev1.ConfigMap{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			return obj.GetName() == TracingConfigMapName && obj.GetNamespace() == r.namespace
+		}))).
+		Complete(r)
+}

--- a/internal/controller/tracing_configmap_reconciler.go
+++ b/internal/controller/tracing_configmap_reconciler.go
@@ -19,16 +19,15 @@ package controllers
 import (
 	"context"
 	"strconv"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	"k8s.io/utils/ptr"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kuadrant/kuadrant-operator/internal/log"
 	"github.com/kuadrant/kuadrant-operator/internal/trace"
 )
 
@@ -36,6 +35,11 @@ import (
 // control-plane trace exporter at runtime. Creating or updating this ConfigMap
 // reconfigures the trace provider without restarting the operator. Deleting it
 // reverts to the env var configuration captured at startup.
+//
+// This is a shared convention: other Kuadrant operators (limitador-operator,
+// authorino-operator, dns-operator) watch the same ConfigMap name in their
+// namespace, allowing a single ConfigMap to configure tracing across all
+// control-plane operators without introducing cross-operator CRD dependencies.
 const TracingConfigMapName = "kuadrant-tracing"
 
 const (
@@ -49,57 +53,67 @@ const (
 // ConfigMap data keys:
 //   - endpoint: OTLP collector URL (e.g. "rpc://otel-collector:4317" or "http://…")
 //   - insecure: "true" to skip TLS verification (optional, defaults to false)
-//
-// This reconciler uses a plain controller-runtime reconcile loop rather than the
-// policy machinery subscription pattern, because it configures the operator itself
-// rather than reconciling cluster resources.
 type TracingConfigMapReconciler struct {
-	client    client.Client
 	namespace string
 	provider  *trace.DynamicProvider
 }
 
-func NewTracingConfigMapReconciler(mgr ctrl.Manager, namespace string, provider *trace.DynamicProvider) *TracingConfigMapReconciler {
+func NewTracingConfigMapReconciler(provider *trace.DynamicProvider, namespace string) *TracingConfigMapReconciler {
 	return &TracingConfigMapReconciler{
-		client:    mgr.GetClient(),
 		namespace: namespace,
 		provider:  provider,
 	}
 }
 
-func (r *TracingConfigMapReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	logger := log.Log.WithName("TracingConfigMapReconciler").WithValues("configmap", req.NamespacedName)
-
-	cm := &corev1.ConfigMap{}
-	if err := r.client.Get(ctx, req.NamespacedName, cm); err != nil {
-		if errors.IsNotFound(err) {
-			logger.Info("tracing configmap deleted, reverting to env var config")
-			if revertErr := r.provider.RevertToFallback(ctx); revertErr != nil {
-				logger.Error(revertErr, "failed to revert trace provider to fallback")
-				return reconcile.Result{}, revertErr
-			}
-			return reconcile.Result{}, nil
-		}
-		return reconcile.Result{}, err
+func (r *TracingConfigMapReconciler) Subscription() *controller.Subscription {
+	return &controller.Subscription{
+		ReconcileFunc: r.Run,
+		Events: []controller.ResourceEventMatcher{
+			{
+				Kind:            ptr.To(ConfigMapGroupKind),
+				ObjectNamespace: r.namespace,
+				ObjectName:      TracingConfigMapName,
+			},
+		},
 	}
-
-	endpoint := cm.Data[tracingEndpointKey]
-	insecure, _ := strconv.ParseBool(cm.Data[tracingInsecureKey])
-
-	logger.Info("reconfiguring trace provider", "endpoint", endpoint, "insecure", insecure)
-	if err := r.provider.Reconfigure(ctx, endpoint, insecure); err != nil {
-		logger.Error(err, "failed to reconfigure trace provider")
-		return reconcile.Result{}, err
-	}
-
-	return reconcile.Result{}, nil
 }
 
-func (r *TracingConfigMapReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		Named("tracing-configmap").
-		For(&corev1.ConfigMap{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-			return obj.GetName() == TracingConfigMapName && obj.GetNamespace() == r.namespace
-		}))).
-		Complete(r)
+func (r *TracingConfigMapReconciler) Run(eventCtx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
+	logger := controller.LoggerFromContext(eventCtx).WithName("TracingConfigMapReconciler")
+	ctx := logr.NewContext(eventCtx, logger)
+
+	cmObjs := topology.Objects().Items(func(object machinery.Object) bool {
+		return object.GetName() == TracingConfigMapName &&
+			object.GetNamespace() == r.namespace &&
+			object.GroupVersionKind().Kind == ConfigMapGroupKind.Kind
+	})
+
+	if len(cmObjs) == 0 {
+		logger.V(1).Info("tracing configmap not found, reverting to env var config")
+		if err := r.provider.RevertToFallback(ctx); err != nil {
+			logger.Error(err, "failed to revert trace provider to fallback")
+			return err
+		}
+		return nil
+	}
+
+	cm := cmObjs[0].(*controller.RuntimeObject).Object.(*corev1.ConfigMap)
+	endpoint, ok := cm.Data[tracingEndpointKey]
+	if !ok || endpoint == "" {
+		logger.Info("tracing configmap found but missing endpoint key, reverting to env var config")
+		if err := r.provider.RevertToFallback(ctx); err != nil {
+			logger.Error(err, "failed to revert trace provider to fallback")
+			return err
+		}
+		return nil
+	}
+	insecure, _ := strconv.ParseBool(cm.Data[tracingInsecureKey])
+
+	logger.V(1).Info("reconfiguring trace provider", "endpoint", endpoint, "insecure", insecure)
+	if err := r.provider.Reconfigure(ctx, endpoint, insecure); err != nil {
+		logger.Error(err, "failed to reconfigure trace provider")
+		return err
+	}
+
+	return nil
 }

--- a/internal/trace/dynamic_provider.go
+++ b/internal/trace/dynamic_provider.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2025 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trace
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	otelapi "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+	"go.opentelemetry.io/otel/trace/noop" // used for noop.NewTracerProvider() in Reconfigure
+
+	kuadrantotel "github.com/kuadrant/kuadrant-operator/internal/otel"
+)
+
+// DynamicProvider wraps a trace Provider and supports runtime reconfiguration
+// without restarting the operator. The underlying exporter is hot-swapped by
+// replacing the global OTEL tracer provider.
+//
+// Precedence: ConfigMap endpoint > env var endpoint > disabled (noop).
+// Deleting the ConfigMap reverts to the env var config captured at startup.
+type DynamicProvider struct {
+	mu               sync.Mutex
+	current          *Provider
+	otelConfig       *kuadrantotel.Config
+	fallbackEndpoint string
+	fallbackInsecure bool
+}
+
+// NewDynamicProvider creates a DynamicProvider initialized from env var config.
+// If a traces endpoint is set via env vars, it attempts to start exporting immediately.
+// The env var values are stored as fallback for when a ConfigMap is later deleted.
+//
+// Failure to connect to the initial endpoint is non-fatal: the provider is always
+// returned so the tracing ConfigMap reconciler can still reconfigure it at runtime.
+// The error is returned alongside the provider so callers can log it.
+func NewDynamicProvider(ctx context.Context, otelConfig *kuadrantotel.Config) (*DynamicProvider, error) {
+	dp := &DynamicProvider{
+		otelConfig:       otelConfig,
+		fallbackEndpoint: otelConfig.TracesEndpoint(),
+		fallbackInsecure: otelConfig.Insecure,
+	}
+
+	if dp.fallbackEndpoint != "" {
+		p, err := NewProviderWithEndpoint(ctx, otelConfig, dp.fallbackEndpoint, dp.fallbackInsecure)
+		if err != nil {
+			return dp, err
+		}
+		dp.current = p
+		otel.SetTracerProvider(p.TracerProvider())
+	}
+
+	return dp, nil
+}
+
+// Reconfigure hot-swaps the trace provider to export to the given endpoint.
+// Passing an empty endpoint disables tracing (sets a noop provider).
+// The previous provider is shut down gracefully before the new one starts.
+func (d *DynamicProvider) Reconfigure(ctx context.Context, endpoint string, insecure bool) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	_ = d.shutdownCurrent(ctx)
+
+	if endpoint == "" {
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		return nil
+	}
+
+	p, err := NewProviderWithEndpoint(ctx, d.otelConfig, endpoint, insecure)
+	if err != nil {
+		// Ensure a consistent state even on failure: no partial provider.
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		return err
+	}
+
+	d.current = p
+	otel.SetTracerProvider(p.TracerProvider())
+	return nil
+}
+
+// RevertToFallback restores the trace provider to the env var configuration
+// captured at startup. Used when the tracing ConfigMap is deleted.
+// If no env var endpoint was set, this disables tracing.
+func (d *DynamicProvider) RevertToFallback(ctx context.Context) error {
+	return d.Reconfigure(ctx, d.fallbackEndpoint, d.fallbackInsecure)
+}
+
+// Shutdown gracefully shuts down the current provider, flushing any pending spans.
+// The caller is responsible for setting an appropriate deadline on ctx.
+func (d *DynamicProvider) Shutdown(ctx context.Context) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.shutdownCurrent(ctx)
+}
+
+// GlobalTracer returns a tracer that always delegates to the current global tracer
+// provider. This ensures that after a Reconfigure call, spans are routed to the
+// updated provider without needing to update every call site.
+func (d *DynamicProvider) GlobalTracer(name string) otelapi.Tracer {
+	return &globalTracerProxy{name: name}
+}
+
+// shutdownCurrent shuts down the current provider using the caller's context.
+// Must be called with d.mu held.
+func (d *DynamicProvider) shutdownCurrent(ctx context.Context) error {
+	if d.current == nil {
+		return nil
+	}
+	err := d.current.Shutdown(ctx)
+	d.current = nil
+	return err
+}
+
+// globalTracerProxy implements otelapi.Tracer by delegating every call to the
+// current global tracer provider. This makes the tracer resilient to provider
+// swaps performed by DynamicProvider.Reconfigure.
+// embedded.Tracer satisfies the unexported embedded interface requirement of otelapi.Tracer.
+type globalTracerProxy struct {
+	embedded.Tracer
+	name string
+}
+
+func (t *globalTracerProxy) Start(ctx context.Context, spanName string, opts ...otelapi.SpanStartOption) (context.Context, otelapi.Span) {
+	return otel.Tracer(t.name).Start(ctx, spanName, opts...)
+}


### PR DESCRIPTION
# Description
  Part of: https://github.com/Kuadrant/kuadrant-operator/issues/1750                                                                                                                                             

  Allows for:
  - Runtime enabling/disabling of tracing export via a kuadrant-tracing ConfigMap (keys: endpoint, insecure), without restarting the operator
  - Env var configuration continues to work as before; the ConfigMap takes precedence over env vars, and deleting the ConfigMap reverts to the env var configuration

# Verification
* Create cluster and run
```
make local-env-setup run
```
* Run jaegar
```
podman run --rm --name jaeger \                         
  -p 16686:16686 \
  -p 4317:4317 \
  -p 4318:4318 \
  -p 5778:5778 \
  -p 9411:9411 \
  cr.jaegertracing.io/jaegertracing/jaeger:2.14.0
```
* Create config map
```
kubectl apply -n kuadrant-system -f -<<EOF              
  apiVersion: v1
  kind: ConfigMap
  metadata:
    name: kuadrant-tracing
    namespace: kuadrant-system
  data:
    endpoint: "http://localhost:4318"
    insecure: "true"
EOF
```
* Create Kuadrant CR
```
kubectl apply -f - <<EOF                                
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant   
metadata:  
  name: kuadrant          
  namespace: kuadrant-system  
spec:  
  observability: {}                  
EOF
```
* Verify logs now has trace and span ids
* Verify trace is not exported to jaeger at http://localhost:16686/search
* Delete config map
```
kubectl delete configmap kuadrant-tracing -n kuadrant-system
```
* Delete kuadrant cr
```
kubectl delete kuadrant kuadrant  -n kuadrant-system
```
* Verify logs no longer have trace and span ids
* Verify main reconcile trace is no longer exported to jaegar instance