### PR TITLE
fix: olm.bundle image/relatedImages stricter format validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,9 +182,9 @@ WASM_SHIM_VERSION ?= latest
 shim_version_is_semantic := $(call is_semantic_version,$(WASM_SHIM_VERSION))
 
 ifeq (true,$(shim_version_is_semantic))
-RELATED_IMAGE_WASMSHIM ?= oci://quay.io/kuadrant/wasm-shim:v$(WASM_SHIM_VERSION)
+RELATED_IMAGE_WASMSHIM ?= quay.io/kuadrant/wasm-shim:v$(WASM_SHIM_VERSION)
 else
-RELATED_IMAGE_WASMSHIM ?= oci://quay.io/kuadrant/wasm-shim:$(WASM_SHIM_VERSION)
+RELATED_IMAGE_WASMSHIM ?= quay.io/kuadrant/wasm-shim:$(WASM_SHIM_VERSION)
 endif
 
 ## developer-portal-controller

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2026-01-21T11:20:16Z"
+    createdAt: "2026-03-04T13:41:08Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -742,7 +742,7 @@ spec:
                 - name: EXTENSIONS_DIR
                   value: /extensions
                 - name: RELATED_IMAGE_WASMSHIM
-                  value: oci://quay.io/kuadrant/wasm-shim:latest
+                  value: quay.io/kuadrant/wasm-shim:latest
                 - name: RELATED_IMAGE_DEVELOPERPORTAL
                   value: quay.io/kuadrant/developer-portal-controller:latest
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN_LATEST
@@ -898,7 +898,7 @@ spec:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
   relatedImages:
-  - image: oci://quay.io/kuadrant/wasm-shim:latest
+  - image: quay.io/kuadrant/wasm-shim:latest
     name: wasmshim
   - image: quay.io/kuadrant/developer-portal-controller:latest
     name: developerportal

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14048,7 +14048,7 @@ spec:
         - name: EXTENSIONS_DIR
           value: /extensions
         - name: RELATED_IMAGE_WASMSHIM
-          value: oci://quay.io/kuadrant/wasm-shim:latest
+          value: quay.io/kuadrant/wasm-shim:latest
         - name: RELATED_IMAGE_DEVELOPERPORTAL
           value: quay.io/kuadrant/developer-portal-controller:latest
         - name: RELATED_IMAGE_CONSOLE_PLUGIN_LATEST

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,7 +34,7 @@ spec:
             - name: EXTENSIONS_DIR
               value: "/extensions"
             - name: RELATED_IMAGE_WASMSHIM
-              value: "oci://quay.io/kuadrant/wasm-shim:latest"
+              value: "quay.io/kuadrant/wasm-shim:latest"
             - name: RELATED_IMAGE_DEVELOPERPORTAL
               value: "quay.io/kuadrant/developer-portal-controller:latest"
             - name: RELATED_IMAGE_CONSOLE_PLUGIN_LATEST

--- a/doc/overviews/development.md
+++ b/doc/overviews/development.md
@@ -165,9 +165,9 @@ The `make bundle` target accepts the following variables:
 | `LIMITADOR_OPERATOR_BUNDLE_IMG` | Limitador operator bundle URL | `quay.io/kuadrant/limitador-operator-bundle:latest` | `LIMITADOR_OPERATOR_VERSION` var could be used to build this, defaults to _latest_ if not provided |
 | `AUTHORINO_OPERATOR_BUNDLE_IMG` | Authorino operator bundle URL | `quay.io/kuadrant/authorino-operator-bundle:latest` | `AUTHORINO_OPERATOR_VERSION` var could be used to build this, defaults to _latest_ if not provided |
 | `DNS_OPERATOR_BUNDLE_IMG`       | DNS operator bundle URL       | `quay.io/kuadrant/dns-operator-bundle:latest`       | `DNS_OPERATOR_BUNDLE_IMG` var could be used to build this, defaults to _latest_ if not provided    |
-| `RELATED_IMAGE_WASMSHIM`        | WASM shim image URL           | `oci://quay.io/kuadrant/wasm-shim:latest`           | `WASM_SHIM_VERSION` var could be used to build this, defaults to _latest_ if not provided          |
-| `CHANNELS`                      | Bundle channels used in the bundle, comma separated  | `alpha`           |                                                                                                               |
-| `DEFAULT_CHANNEL`               | The default channel used in the bundle               | `alpha`           |                                                                                                               |
+| `RELATED_IMAGE_WASMSHIM`        | WASM shim image URL           | `quay.io/kuadrant/wasm-shim:latest`                 | `WASM_SHIM_VERSION` var could be used to build this, defaults to _latest_ if not provided          |
+| `CHANNELS`                      | Bundle channels used in the bundle, comma separated  | `alpha`                                             |                                                                                                               |
+| `DEFAULT_CHANNEL`               | The default channel used in the bundle               | `alpha`                                             |                                                                                                               |
 
 *Note:* The console plugin image is configured via two `RELATED_IMAGE` environment variables based on OpenShift version:
 - `RELATED_IMAGE_CONSOLE_PLUGIN_LATEST`: Used for OpenShift versions >= 4.20 (PatternFly 6 compatible)
@@ -184,7 +184,7 @@ make bundle [IMG=quay.io/kuadrant/kuadrant-operator:latest] \
             [LIMITADOR_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/limitador-operator-bundle:latest] \
             [AUTHORINO_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/authorino-operator-bundle:latest] \
             [DNS_OPERATOR_BUNDLE_IMG=quay.io/kuadrant/dns-operator-bundle:latest] \
-            [RELATED_IMAGE_WASMSHIM=oci://quay.io/kuadrant/wasm-shim:latest] \
+            [RELATED_IMAGE_WASMSHIM=quay.io/kuadrant/wasm-shim:latest] \
             [CHANNELS=alpha] \
             [DEFAULT_CHANNEL=alpha]
 ```

--- a/doc/overviews/rate-limiting.md
+++ b/doc/overviews/rate-limiting.md
@@ -308,5 +308,5 @@ spec:
     group: gateway.networking.k8s.io
     kind: Gateway
     name: kuadrant-ingressgateway
-  url: oci://quay.io/kuadrant/wasm-shim:latest
+  url: quay.io/kuadrant/wasm-shim:latest
 ```

--- a/internal/controller/data_plane_policies_workflow.go
+++ b/internal/controller/data_plane_policies_workflow.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	WASMFilterImageURL = env.GetString("RELATED_IMAGE_WASMSHIM", "oci://quay.io/kuadrant/wasm-shim:latest")
+	WASMFilterImageURL = env.GetString("RELATED_IMAGE_WASMSHIM", "quay.io/kuadrant/wasm-shim:latest")
 	// protectedRegistry this defines a default protected registry. If this is in the wasm image URL we add a pull secret name to the WASMPLugin resource
 	ProtectedRegistry = env.GetString("PROTECTED_REGISTRY", "registry.redhat.io")
 

--- a/internal/controller/extenstion_reconciler_test.go
+++ b/internal/controller/extenstion_reconciler_test.go
@@ -17,7 +17,7 @@ import (
 var (
 	defaultWasmImage  = WASMFilterImageURL
 	registry          = "protected.registry.io"
-	protectedRegImage = fmt.Sprintf("oci://%s/kuadrant/wasm-shim:latest", registry)
+	protectedRegImage = fmt.Sprintf("%s/kuadrant/wasm-shim:latest", registry)
 	testGateway       = &machinery.Gateway{
 		Gateway: &v1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{

--- a/utils/release/operator/make_bundles.sh
+++ b/utils/release/operator/make_bundles.sh
@@ -17,7 +17,7 @@ cd $env
 
 # Set desired Wasm-shim image
 wasm_shim=$(mod_version $WASM_SHIM_VERSION)
-wasm_shim_image="oci://quay.io/kuadrant/wasm-shim:$wasm_shim"
+wasm_shim_image="quay.io/kuadrant/wasm-shim:$wasm_shim"
 
 # Set desired developer-portal-controller image
 developerportal_version=$(mod_version $DEVELOPERPORTAL_VERSION)

--- a/utils/release/operator/make_chart.sh
+++ b/utils/release/operator/make_chart.sh
@@ -11,7 +11,7 @@ mod_version() {
 
 # Set desired Wasm-shim image
 wasm_shim_version=$(mod_version $(yq '.dependencies.wasm-shim' $env/release.yaml))
-wasm_shim_image="oci://quay.io/kuadrant/wasm-shim:$wasm_shim_version"
+wasm_shim_image="quay.io/kuadrant/wasm-shim:$wasm_shim_version"
 V=$wasm_shim_image \
 yq eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_WASMSHIM").value) = strenv(V)' --inplace $env/config/manager/manager.yaml
 


### PR DESCRIPTION
This fixes nightly catalogue builds which fail with `invalid image pull spec \"oci://quay.io/kuadrant/wasm-shim:7b8d036770cac858334e121abd1b0eaccf960b8d\": invalid reference format` last few days: https://github.com/Kuadrant/kuadrant-operator/actions/runs/22651093520/job/65651387421

This error was introduced by the image format validation in the latest opm version v1.64.0 https://github.com/operator-framework/operator-registry/pull/1905