### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Global owners
-*       @Kuadrant/Developers


### PR DESCRIPTION
Removing teamwide noise as the majority of PRs tend to be targeted reviews (likely via other channels like slack)