### PR TITLE
ci: adjust nightlies cron to build earlier

### DIFF
--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -2,7 +2,10 @@ name: Build nightly images
 
 on:
   schedule:
-    - cron: "0 2 * * *"
+    # Runs at 01:07 UTC
+    # Local Winter (CET): 02:07 AM
+    # Local Summer (CEST): 03:07 AM
+    - cron: "7 1 * * *"
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
With the change to [summer time](https://en.wikipedia.org/wiki/Daylight_saving_time) a couple of days ago, and also, probably, because of the downtime issues happening with github currently, nightly kuadrant builds are now getting to the quay registry as late as 5:30 AM. With QE also having nightly pipelines and tasks that utilize nightly kuadrant image being built, these pipelines are mistimed now, and are being executed before image manages to get uploaded to quay.io. 

With this PR, I'm making nightlies build a bit earlier in the night, so we can have a working build as earlier as possible for any other existing and future nightly tasks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted the nightly build schedule to run at 01:07 UTC (updated accompanying local time notes for CET/CEST).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->