### PR TITLE
fix: ensure limitador limits span attributes appear consistently

### DIFF
--- a/internal/controller/limitador_limits_reconciler.go
+++ b/internal/controller/limitador_limits_reconciler.go
@@ -56,7 +56,7 @@ func (r *LimitadorLimitsReconciler) Reconcile(ctx context.Context, _ []controlle
 		return nil
 	}
 
-	desiredLimits := r.buildLimitadorLimits(ctx, state)
+	desiredLimits, sources := r.buildLimitadorLimits(ctx, state)
 
 	if ratelimit.LimitadorRateLimits(limitador.Spec.Limits).EqualTo(desiredLimits) {
 		logger.Info("limitador object is up to date, nothing to do", "status", "skipping")
@@ -73,6 +73,7 @@ func (r *LimitadorLimitsReconciler) Reconcile(ctx context.Context, _ []controlle
 	span.SetAttributes(
 		attribute.String("namespace", limitador.Namespace),
 		attribute.String("name", limitador.Name),
+		attribute.StringSlice("sources", lo.Uniq(sources)),
 	)
 
 	otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(limitador.Annotations))
@@ -97,20 +98,20 @@ func (r *LimitadorLimitsReconciler) Reconcile(ctx context.Context, _ []controlle
 	return nil
 }
 
-func (r *LimitadorLimitsReconciler) buildLimitadorLimits(ctx context.Context, state *sync.Map) []limitadorv1alpha1.RateLimit {
+func (r *LimitadorLimitsReconciler) buildLimitadorLimits(ctx context.Context, state *sync.Map) ([]limitadorv1alpha1.RateLimit, []string) {
 	logger := controller.LoggerFromContext(ctx).WithName("LimitadorLimitsReconciler").WithName("buildLimitadorLimits").WithValues("context", ctx)
 
 	rateLimitIndex := ratelimit.NewIndex()
 
 	// both RateLimitPolicies and TokenRateLimitPolicies together
-	r.processEffectivePolicies(ctx, state, rateLimitIndex)
+	sources := r.processEffectivePolicies(ctx, state, rateLimitIndex)
 
 	logger.V(1).Info("finished building limitador limits", "limits", rateLimitIndex.Len())
 
-	return rateLimitIndex.ToRateLimits()
+	return rateLimitIndex.ToRateLimits(), sources
 }
 
-func (r *LimitadorLimitsReconciler) processEffectivePolicies(ctx context.Context, state *sync.Map, rateLimitIndex *ratelimit.Index) {
+func (r *LimitadorLimitsReconciler) processEffectivePolicies(ctx context.Context, state *sync.Map, rateLimitIndex *ratelimit.Index) []string {
 	logger := controller.LoggerFromContext(ctx).WithName("LimitadorLimitsReconciler").WithName("processEffectivePolicies").WithValues("context", ctx)
 	var sources []string
 	// RateLimitPolicies
@@ -133,10 +134,7 @@ func (r *LimitadorLimitsReconciler) processEffectivePolicies(ctx context.Context
 		}
 	}
 
-	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(
-		attribute.StringSlice("sources", lo.Uniq(sources)),
-	)
+	return sources
 }
 
 func (r *LimitadorLimitsReconciler) processPolicyRules(ctx context.Context, pathID string, path []machinery.Targetable, rules map[string]kuadrantv1.MergeableRule, state *sync.Map, rateLimitIndex *ratelimit.Index) {


### PR DESCRIPTION
# Description

Fixes #1866

This PR implements the fix for the tracing attribute inconsistency issue in the limitador limits reconciler.

## Problem

Following PR #1768, span attributes (`namespace`, `name`, `sources`) were only appearing on the first reconciliation iteration in the limitador limits reconciler. This was inconsistent with the authconfigs reconciler implementation.

## Solution

Aligned the limitador limits reconciler with the authconfigs reconciler pattern:
- Create a dedicated span using `controller.TracerFromContext(ctx).Start(ctx, "limits")`
- Modified `buildLimitadorLimits()` to return both limits and sources
- Modified `processEffectivePolicies()` to return the collected sources
- Set all span attributes together in one place
- Use the span context for trace propagation

## Changes

- `Reconcile()`: Creates dedicated span and sets all attributes together
- `buildLimitadorLimits()`: Now returns `([]limitadorv1alpha1.RateLimit, []string)`
- `processEffectivePolicies()`: Now returns `[]string` with collected sources

## Verification

Follow the verification steps from PR #1768:
\`\`\`bash
make local-setup
make install-jaeger deploy-tracing jaeger-port-forward
\`\`\`

Check http://localhost:16686 and confirm all three attributes appear consistently on limitador limit spans in every reconciliation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal observability: tracing now collects and attributes policy source information more reliably, with clearer propagation of span attributes across operations. This enhances diagnostic fidelity and monitoring accuracy for system behaviour and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->