### PR TITLE
fix: restore TLSPolicy reconciliation on issuer readiness changes

### DIFF
--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -761,25 +761,13 @@ func certManagerControllerOpts() []controller.ControllerOption {
 			&certmanagerv1.Issuer{},
 			CertManagerIssuersResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates(ctrlruntimepredicate.TypedFuncs[*certmanagerv1.Issuer]{
-				UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.Issuer]) bool {
-					oldStatus := e.ObjectOld.GetStatus()
-					newStatus := e.ObjectOld.GetStatus()
-					return !reflect.DeepEqual(oldStatus, newStatus)
-				},
-			})),
+			controller.WithPredicates(issuerStatusChangedPredicate())),
 		),
 		controller.WithRunnable("clusterissuers watcher", controller.Watch(
 			&certmanagerv1.ClusterIssuer{},
 			CertMangerClusterIssuersResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates(ctrlruntimepredicate.TypedFuncs[*certmanagerv1.ClusterIssuer]{
-				UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.ClusterIssuer]) bool {
-					oldStatus := e.ObjectOld.GetStatus()
-					newStatus := e.ObjectOld.GetStatus()
-					return !reflect.DeepEqual(oldStatus, newStatus)
-				},
-			})),
+			controller.WithPredicates(clusterIssuerStatusChangedPredicate())),
 		),
 		controller.WithObjectKinds(
 			CertManagerCertificateKind,
@@ -791,6 +779,26 @@ func certManagerControllerOpts() []controller.ControllerOption {
 			LinkTLSPolicyToIssuerFunc,
 			LinkTLSPolicyToClusterIssuerFunc,
 		),
+	}
+}
+
+func statusChanged[S any, T interface{ GetStatus() S }](oldObj, newObj T) bool {
+	return !reflect.DeepEqual(oldObj.GetStatus(), newObj.GetStatus())
+}
+
+func issuerStatusChangedPredicate() ctrlruntimepredicate.TypedPredicate[*certmanagerv1.Issuer] {
+	return ctrlruntimepredicate.TypedFuncs[*certmanagerv1.Issuer]{
+		UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.Issuer]) bool {
+			return statusChanged(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}
+
+func clusterIssuerStatusChangedPredicate() ctrlruntimepredicate.TypedPredicate[*certmanagerv1.ClusterIssuer] {
+	return ctrlruntimepredicate.TypedFuncs[*certmanagerv1.ClusterIssuer]{
+		UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.ClusterIssuer]) bool {
+			return statusChanged(e.ObjectOld, e.ObjectNew)
+		},
 	}
 }
 

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -761,25 +761,13 @@ func certManagerControllerOpts() []controller.ControllerOption {
 			&certmanagerv1.Issuer{},
 			CertManagerIssuersResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates(ctrlruntimepredicate.TypedFuncs[*certmanagerv1.Issuer]{
-				UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.Issuer]) bool {
-					oldStatus := e.ObjectOld.GetStatus()
-					newStatus := e.ObjectOld.GetStatus()
-					return !reflect.DeepEqual(oldStatus, newStatus)
-				},
-			})),
+			controller.WithPredicates(issuerStatusChangedPredicate())),
 		),
 		controller.WithRunnable("clusterissuers watcher", controller.Watch(
 			&certmanagerv1.ClusterIssuer{},
 			CertMangerClusterIssuersResource,
 			metav1.NamespaceAll,
-			controller.WithPredicates(ctrlruntimepredicate.TypedFuncs[*certmanagerv1.ClusterIssuer]{
-				UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.ClusterIssuer]) bool {
-					oldStatus := e.ObjectOld.GetStatus()
-					newStatus := e.ObjectOld.GetStatus()
-					return !reflect.DeepEqual(oldStatus, newStatus)
-				},
-			})),
+			controller.WithPredicates(clusterIssuerStatusChangedPredicate())),
 		),
 		controller.WithObjectKinds(
 			CertManagerCertificateKind,
@@ -791,6 +779,22 @@ func certManagerControllerOpts() []controller.ControllerOption {
 			LinkTLSPolicyToIssuerFunc,
 			LinkTLSPolicyToClusterIssuerFunc,
 		),
+	}
+}
+
+func issuerStatusChangedPredicate() ctrlruntimepredicate.TypedPredicate[*certmanagerv1.Issuer] {
+	return ctrlruntimepredicate.TypedFuncs[*certmanagerv1.Issuer]{
+		UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.Issuer]) bool {
+			return !reflect.DeepEqual(e.ObjectOld.GetStatus(), e.ObjectNew.GetStatus())
+		},
+	}
+}
+
+func clusterIssuerStatusChangedPredicate() ctrlruntimepredicate.TypedPredicate[*certmanagerv1.ClusterIssuer] {
+	return ctrlruntimepredicate.TypedFuncs[*certmanagerv1.ClusterIssuer]{
+		UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.ClusterIssuer]) bool {
+			return !reflect.DeepEqual(e.ObjectOld.GetStatus(), e.ObjectNew.GetStatus())
+		},
 	}
 }
 

--- a/internal/controller/state_of_the_world_test.go
+++ b/internal/controller/state_of_the_world_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 	"time"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/kuadrant/policy-machinery/machinery"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 )
@@ -105,6 +108,104 @@ func TestGetKuadrant(t *testing.T) {
 			got := GetKuadrantFromTopology(tt.args.topology)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetKuadrantFromTopology() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssuerStatusChangedPredicate(t *testing.T) {
+	ready := certmanagerv1.IssuerStatus{
+		Conditions: []certmanagerv1.IssuerCondition{{
+			Type:   certmanagerv1.IssuerConditionReady,
+			Status: certmanmetav1.ConditionTrue,
+		}},
+	}
+	notReady := certmanagerv1.IssuerStatus{
+		Conditions: []certmanagerv1.IssuerCondition{{
+			Type:   certmanagerv1.IssuerConditionReady,
+			Status: certmanmetav1.ConditionFalse,
+		}},
+	}
+
+	predicate := issuerStatusChangedPredicate()
+
+	tests := []struct {
+		name string
+		old  certmanagerv1.IssuerStatus
+		new  certmanagerv1.IssuerStatus
+		want bool
+	}{
+		{
+			name: "status change triggers reconciliation",
+			old:  notReady,
+			new:  ready,
+			want: true,
+		},
+		{
+			name: "unchanged status is ignored",
+			old:  ready,
+			new:  ready,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := predicate.Update(event.TypedUpdateEvent[*certmanagerv1.Issuer]{
+				ObjectOld: &certmanagerv1.Issuer{Status: tt.old},
+				ObjectNew: &certmanagerv1.Issuer{Status: tt.new},
+			})
+			if got != tt.want {
+				t.Fatalf("issuerStatusChangedPredicate().Update() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterIssuerStatusChangedPredicate(t *testing.T) {
+	ready := certmanagerv1.IssuerStatus{
+		Conditions: []certmanagerv1.IssuerCondition{{
+			Type:   certmanagerv1.IssuerConditionReady,
+			Status: certmanmetav1.ConditionTrue,
+		}},
+	}
+	notReady := certmanagerv1.IssuerStatus{
+		Conditions: []certmanagerv1.IssuerCondition{{
+			Type:   certmanagerv1.IssuerConditionReady,
+			Status: certmanmetav1.ConditionFalse,
+		}},
+	}
+
+	predicate := clusterIssuerStatusChangedPredicate()
+
+	tests := []struct {
+		name string
+		old  certmanagerv1.IssuerStatus
+		new  certmanagerv1.IssuerStatus
+		want bool
+	}{
+		{
+			name: "status change triggers reconciliation",
+			old:  notReady,
+			new:  ready,
+			want: true,
+		},
+		{
+			name: "unchanged status is ignored",
+			old:  ready,
+			new:  ready,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := predicate.Update(event.TypedUpdateEvent[*certmanagerv1.ClusterIssuer]{
+				ObjectOld: &certmanagerv1.ClusterIssuer{Status: tt.old},
+				ObjectNew: &certmanagerv1.ClusterIssuer{Status: tt.new},
+			})
+			if got != tt.want {
+				t.Fatalf("clusterIssuerStatusChangedPredicate().Update() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/controller/state_of_the_world_test.go
+++ b/internal/controller/state_of_the_world_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 	"time"
 
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	certmanmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/kuadrant/policy-machinery/machinery"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 )
@@ -105,6 +108,104 @@ func TestGetKuadrant(t *testing.T) {
 			got := GetKuadrantFromTopology(tt.args.topology, nil)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetKuadrantFromTopology() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssuerStatusChangedPredicate(t *testing.T) {
+	ready := certmanagerv1.IssuerStatus{
+		Conditions: []certmanagerv1.IssuerCondition{{
+			Type:   certmanagerv1.IssuerConditionReady,
+			Status: certmanmetav1.ConditionTrue,
+		}},
+	}
+	notReady := certmanagerv1.IssuerStatus{
+		Conditions: []certmanagerv1.IssuerCondition{{
+			Type:   certmanagerv1.IssuerConditionReady,
+			Status: certmanmetav1.ConditionFalse,
+		}},
+	}
+
+	predicate := issuerStatusChangedPredicate()
+
+	tests := []struct {
+		name string
+		old  certmanagerv1.IssuerStatus
+		new  certmanagerv1.IssuerStatus
+		want bool
+	}{
+		{
+			name: "status change triggers reconciliation",
+			old:  notReady,
+			new:  ready,
+			want: true,
+		},
+		{
+			name: "unchanged status is ignored",
+			old:  ready,
+			new:  ready,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := predicate.Update(event.TypedUpdateEvent[*certmanagerv1.Issuer]{
+				ObjectOld: &certmanagerv1.Issuer{Status: tt.old},
+				ObjectNew: &certmanagerv1.Issuer{Status: tt.new},
+			})
+			if got != tt.want {
+				t.Fatalf("issuerStatusChangedPredicate().Update() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClusterIssuerStatusChangedPredicate(t *testing.T) {
+	ready := certmanagerv1.IssuerStatus{
+		Conditions: []certmanagerv1.IssuerCondition{{
+			Type:   certmanagerv1.IssuerConditionReady,
+			Status: certmanmetav1.ConditionTrue,
+		}},
+	}
+	notReady := certmanagerv1.IssuerStatus{
+		Conditions: []certmanagerv1.IssuerCondition{{
+			Type:   certmanagerv1.IssuerConditionReady,
+			Status: certmanmetav1.ConditionFalse,
+		}},
+	}
+
+	predicate := clusterIssuerStatusChangedPredicate()
+
+	tests := []struct {
+		name string
+		old  certmanagerv1.IssuerStatus
+		new  certmanagerv1.IssuerStatus
+		want bool
+	}{
+		{
+			name: "status change triggers reconciliation",
+			old:  notReady,
+			new:  ready,
+			want: true,
+		},
+		{
+			name: "unchanged status is ignored",
+			old:  ready,
+			new:  ready,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := predicate.Update(event.TypedUpdateEvent[*certmanagerv1.ClusterIssuer]{
+				ObjectOld: &certmanagerv1.ClusterIssuer{Status: tt.old},
+				ObjectNew: &certmanagerv1.ClusterIssuer{Status: tt.new},
+			})
+			if got != tt.want {
+				t.Fatalf("clusterIssuerStatusChangedPredicate().Update() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# Description
Closes: #1876

- compare cert-manager `Issuer` and `ClusterIssuer` update predicates against `ObjectNew` instead of comparing `ObjectOld` to itself
- restore TLSPolicy status reconciliation when issuer readiness changes after the policy already exists
- add regression coverage for both watcher predicates so the status-driven watch path stays protected

# Verification
- `go vet ./...`
- `go test -tags unit ./internal/controller -run 'Test(GetKuadrant|IssuerStatusChangedPredicate|ClusterIssuerStatusChangedPredicate)$'`
- `go test -race -tags unit ./api/... ./internal/... ./pkg/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed an issue where status updates for Issuer and ClusterIssuer were not being reliably detected, ensuring reconciliation triggers correctly when readiness status changes.

* **Tests**
  * Added unit tests covering status-change detection for both Issuer and ClusterIssuer, verifying reconciliation is triggered on readiness transitions and ignored when status is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->