### PR TITLE
fix: clear stale trace annotations before injecting fresh ones on resource updates

### DIFF
--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -186,7 +186,7 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 	}
 
 	// update
-	applyAuthConfigUpdate(existingAuthConfig, desiredAuthConfig)
+	applyAuthConfigUpdate(spanCtx, existingAuthConfig, desiredAuthConfig)
 	existingAuthConfigUnstructured, err := controller.Destruct(existingAuthConfig)
 	if err != nil {
 		msg := "failed to destruct authconfig object"
@@ -361,7 +361,7 @@ func authConfigAnnotationKeyForRouteType(routeType kuadrantpolicymachinery.Route
 
 // applyAuthConfigUpdate applies the desired state to an existing AuthConfig.
 // It updates the spec, labels, and route-rule annotations while preserving other annotations.
-func applyAuthConfigUpdate(existing, desired *authorinov1beta3.AuthConfig) {
+func applyAuthConfigUpdate(ctx context.Context, existing, desired *authorinov1beta3.AuthConfig) {
 	existing.Spec = desired.Spec
 	existing.Labels = desired.Labels
 
@@ -379,4 +379,9 @@ func applyAuthConfigUpdate(existing, desired *authorinov1beta3.AuthConfig) {
 			delete(existing.Annotations, key)
 		}
 	}
+
+	// Clear stale trace annotations then inject fresh ones (no-op if tracing is disabled)
+	delete(existing.Annotations, "traceparent")
+	delete(existing.Annotations, "tracestate")
+	otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(existing.Annotations))
 }

--- a/internal/controller/authconfigs_reconciler_test.go
+++ b/internal/controller/authconfigs_reconciler_test.go
@@ -3,6 +3,7 @@
 package controllers
 
 import (
+	"context"
 	"testing"
 
 	authorinov1beta3 "github.com/kuadrant/authorino/api/v1beta3"
@@ -306,7 +307,7 @@ func TestApplyAuthConfigUpdate(t *testing.T) {
 			}
 
 			// Apply the update
-			applyAuthConfigUpdate(tt.existing, tt.desired)
+			applyAuthConfigUpdate(context.Background(), tt.existing, tt.desired)
 
 			// Run validation
 			tt.validate(t, tt.existing, tt.desired)

--- a/internal/controller/limitador_limits_reconciler.go
+++ b/internal/controller/limitador_limits_reconciler.go
@@ -76,6 +76,9 @@ func (r *LimitadorLimitsReconciler) Reconcile(ctx context.Context, _ []controlle
 		attribute.StringSlice("sources", lo.Uniq(sources)),
 	)
 
+	// Clear stale trace annotations then inject fresh ones (no-op if tracing is disabled)
+	delete(limitador.Annotations, "traceparent")
+	delete(limitador.Annotations, "tracestate")
 	otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(limitador.Annotations))
 
 	limitador.Spec.Limits = desiredLimits

--- a/tests/common/authpolicy/authpolicy_controller_test.go
+++ b/tests/common/authpolicy/authpolicy_controller_test.go
@@ -481,6 +481,39 @@ var _ = Describe("AuthPolicy controller", func() {
 			authConfigSpecAsJSON, _ := json.Marshal(authConfig.Spec)
 			Expect(string(authConfigSpecAsJSON)).To(Equal(fmt.Sprintf(`{"hosts":["%s"],"patterns":{"authz-and-rl-required":[{"selector":"source.ip","operator":"neq","value":"192.168.0.10"}],"internal-source":[{"selector":"source.ip","operator":"matches","value":"192\\.168\\..*"}]},"authentication":{"jwt":{"when":[{"selector":"filter_metadata.envoy\\.filters\\.http\\.jwt_authn|verified_jwt","operator":"neq"}],"credentials":{},"plain":{"selector":"filter_metadata.envoy\\.filters\\.http\\.jwt_authn|verified_jwt"}}},"metadata":{"user-groups":{"when":[{"selector":"auth.identity.admin","operator":"neq","value":"true"}],"http":{"url":"http://user-groups/username={auth.identity.username}","method":"GET","contentType":"application/x-www-form-urlencoded","credentials":{}}}},"authorization":{"admin-or-privileged":{"when":[{"patternRef":"authz-and-rl-required"}],"patternMatching":{"patterns":[{"any":[{"selector":"auth.identity.admin","operator":"eq","value":"true"},{"selector":"auth.metadata.user-groups","operator":"incl","value":"privileged"}]}]}}},"response":{"unauthenticated":{"message":{"value":"Missing verified JWT injected by the gateway"}},"unauthorized":{"message":{"value":"User must be admin or member of privileged group"}},"success":{"headers":{"x-username":{"when":[{"selector":"request.headers.x-propagate-username.@case:lower","operator":"matches","value":"1|yes|true"}],"plain":{"value":null,"selector":"auth.identity.username"}}},"dynamicMetadata":{"x-auth-data":{"when":[{"patternRef":"authz-and-rl-required"}],"json":{"properties":{"groups":{"value":null,"selector":"auth.metadata.user-groups"},"username":{"value":null,"selector":"auth.identity.username"}}}}}}},"callbacks":{"unauthorized-attempt":{"when":[{"patternRef":"authz-and-rl-required"},{"selector":"auth.authorization.admin-or-privileged","operator":"neq","value":"true"}],"http":{"url":"http://events/unauthorized","method":"POST","body":{"value":null,"selector":"\\{\"identity\":{auth.identity},\"request-id\":{request.id}\\}"},"contentType":"application/json","credentials":{}}}}}`, authConfig.GetName())))
 		}, testTimeOut)
+
+		It("Clears stale trace annotations from AuthConfig on update when tracing is disabled", func(ctx SpecContext) {
+			policy := policyFactory()
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+			Eventually(tests.IsAuthPolicyAcceptedAndEnforced(ctx, testClient(), policy)).WithContext(ctx).Should(BeTrue())
+
+			authConfig := &authorinov1beta3.AuthConfig{}
+			authConfigKey := authConfigKeyForPath(httpRoute, 0)
+			Eventually(fetchReadyAuthConfig(ctx, httpRoute, 0, authConfig)).WithContext(ctx).Should(BeTrue())
+
+			// Patch AuthConfig with both stale trace annotations and a spurious extra host in a
+			// single update. The extra host makes the reconciler detect a spec diff and take the
+			// update path — where stale annotations are cleared before the desired state is written.
+			// This simulates annotations left over from a previous reconcile when tracing was enabled.
+			Eventually(func(g Gomega) {
+				g.Expect(testClient().Get(ctx, authConfigKey, authConfig)).To(Succeed())
+				original := authConfig.DeepCopy()
+				if authConfig.Annotations == nil {
+					authConfig.Annotations = make(map[string]string)
+				}
+				authConfig.Annotations["traceparent"] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+				authConfig.Annotations["tracestate"] = "rojo=00f067aa0ba902b7"
+				authConfig.Spec.Hosts = append(authConfig.Spec.Hosts, "stale-host")
+				g.Expect(testClient().Patch(ctx, authConfig, client.MergeFrom(original))).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Stale trace annotations must be cleared; no fresh ones injected (tracing disabled in tests).
+			Eventually(func(g Gomega) {
+				g.Expect(testClient().Get(ctx, authConfigKey, authConfig)).To(Succeed())
+				g.Expect(authConfig.Annotations).NotTo(HaveKey("traceparent"))
+				g.Expect(authConfig.Annotations).NotTo(HaveKey("tracestate"))
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
 	})
 
 	Context("Complex HTTPRoute with multiple rules and hostnames", func() {

--- a/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
+++ b/tests/common/ratelimitpolicy/ratelimitpolicy_controller_test.go
@@ -921,6 +921,55 @@ var _ = Describe("RateLimitPolicy controller", func() {
 			)).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
 	})
+
+	Context("Limitador trace annotations", func() {
+		BeforeEach(func(ctx SpecContext) {
+			httpRoute := tests.BuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			Expect(k8sClient.Create(ctx, httpRoute)).To(Succeed())
+			Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
+
+			rlp := policyFactory()
+			Expect(k8sClient.Create(ctx, rlp)).To(Succeed())
+			Eventually(assertPolicyIsAcceptedAndEnforced(ctx, client.ObjectKeyFromObject(rlp))).WithContext(ctx).Should(BeTrue())
+		})
+
+		It("Clears stale trace annotations from Limitador on limits update when tracing is disabled", func(ctx SpecContext) {
+			limitadorKey := client.ObjectKey{Name: kuadrant.LimitadorName, Namespace: kuadrantInstallationNS}
+
+			// Patch Limitador with both stale trace annotations and a spurious extra limit in a
+			// single update. The spurious limit makes the reconciler detect a limits diff and take
+			// the update path — where stale annotations are cleared before the desired state is
+			// written. This simulates annotations left over from a previous reconcile when tracing
+			// was enabled, now being cleaned up after tracing is disabled.
+			Eventually(func(g Gomega) {
+				existing := &limitadorv1alpha1.Limitador{}
+				g.Expect(testClient().Get(ctx, limitadorKey, existing)).To(Succeed())
+				original := existing.DeepCopy()
+				if existing.Annotations == nil {
+					existing.Annotations = make(map[string]string)
+				}
+				existing.Annotations["traceparent"] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+				existing.Annotations["tracestate"] = "rojo=00f067aa0ba902b7"
+				existing.Spec.Limits = append(existing.Spec.Limits, limitadorv1alpha1.RateLimit{
+					Name:       "stale-limit",
+					Namespace:  "stale-namespace",
+					MaxValue:   1,
+					Seconds:    60,
+					Conditions: []string{`descriptors[0]["stale"] == "1"`},
+					Variables:  []string{},
+				})
+				g.Expect(testClient().Patch(ctx, existing, client.MergeFrom(original))).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			// Stale trace annotations must be cleared; no fresh ones injected (tracing disabled in tests).
+			Eventually(func(g Gomega) {
+				existing := &limitadorv1alpha1.Limitador{}
+				g.Expect(testClient().Get(ctx, limitadorKey, existing)).To(Succeed())
+				g.Expect(existing.Annotations).NotTo(HaveKey("traceparent"))
+				g.Expect(existing.Annotations).NotTo(HaveKey("tracestate"))
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+	})
 })
 
 var _ = Describe("RateLimitPolicy CEL Validations", func() {


### PR DESCRIPTION
## Summary

- When control plane tracing is disabled, `traceparent`/`tracestate` annotations previously written to AuthConfig and Limitador resources were not cleared, causing traces to remain linked even after tracing was turned off
- Explicitly delete stale trace annotations before calling the OTel propagator inject (which is a no-op when tracing is disabled), so disabling tracing also cleans up the annotations on the next update reconcile
- Add integration tests that verify stale annotations are cleared when the reconciler takes the update path with tracing disabled

## Test plan

- [ ] `make test-integration GATEWAYAPI_PROVIDER=istio` — includes the new `Clears stale trace annotations from AuthConfig` and `Clears stale trace annotations from Limitador` integration tests
- [ ] `make test-integration GATEWAYAPI_PROVIDER=envoygateway` — AuthConfig test also runs here

**Note:** The fix clears annotations opportunistically during updates triggered by spec changes. If tracing is disabled and no other spec changes occur, stale annotations persist until the next reconcile that reaches the update path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reconcilers now explicitly clear stale OpenTelemetry trace annotations before injecting fresh trace context, preventing old trace headers from persisting across updates.

* **Tests**
  * Added integration and unit tests that verify stale trace annotations are removed during reconciliation in AuthPolicy and RateLimitPolicy/Limitador scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->