### PR TITLE
Update github.com/kuadrant/policy-machinery to v0.8.0

### DIFF
--- a/charts/kuadrant-operator/README.md
+++ b/charts/kuadrant-operator/README.md
@@ -7,62 +7,49 @@ This is the Helm Chart to install the official Kuadrant Kubernetes Operator
 ### Install Dependencies
 
 Follow the steps below to install the following dependencies for Kuadrant Operator:
-- [Gateway API](https://gateway-api.sigs.k8s.io/)
 - [cert-manager](https://cert-manager.io/)
-- A Gateway Provider [Istio](https://istio.io/latest/docs/ambient/install/helm/)
+- [Gateway API](https://gateway-api.sigs.k8s.io/)
+- [Istio](https://istio.io/latest/docs/ambient/install/helm/)
 
 [Envoy Gateway](https://gateway.envoyproxy.io/) is also an option as a gateway provider, **Steps Coming soon!**
-
-#### Install Kubernetes Gateway API:
-
- ```sh
- kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
- ```
 
 #### Install cert-manager
 
  ```sh
  helm repo add jetstack https://charts.jetstack.io --force-update
- helm install \
-   cert-manager jetstack/cert-manager \
+ helm install cert-manager jetstack/cert-manager \
    --namespace cert-manager \
    --create-namespace \
-   --version v1.15.3 \
+   --version v1.16.1 \
    --set crds.enabled=true
  ```
 
-#### Install Istio (A Gateway Provider):
+#### Install Kubernetes Gateway API:
 
  ```sh
- helm install sail-operator \
-         --create-namespace \
-         --namespace istio-system \
-         --wait \
-         --timeout=300s \
-         https://github.com/istio-ecosystem/sail-operator/releases/download/0.1.0/sail-operator-0.1.0.tgz
+ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
+ ```
 
- kubectl apply -f -<<EOF
- apiVersion: sailoperator.io/v1alpha1
- kind: Istio
- metadata:
-   name: default
- spec:
-   # Supported values for sail-operator v0.1.0 are [v1.22.4,v1.23.0]
-   version: v1.23.0
-   namespace: istio-system
-   # Disable autoscaling to reduce dev resources
-   values:
-     pilot:
-       autoscaleEnabled: false
- EOF
+#### Install Istio:
+
+ ```sh
+ helm repo add istio https://istio-release.storage.googleapis.com/charts --force-update
+ helm install istio-base istio/base \
+   --set defaultRevision=default \
+   --namespace=istio-system \
+   --create-namespace \
+   --version 1.29.1
+ helm install istiod istio/istiod \
+   --namespace=istio-system \
+   --version 1.29.1 \
+   --wait
  ```
 
 ### Install Kuadrant
 
 ```sh
 helm repo add kuadrant https://kuadrant.io/helm-charts/ --force-update
-helm install \
- kuadrant-operator kuadrant/kuadrant-operator \
+helm install kuadrant-operator kuadrant/kuadrant-operator \
  --create-namespace \
  --namespace kuadrant-system
 ```

--- a/config/dependencies/gateway-api/kustomization.yaml
+++ b/config/dependencies/gateway-api/kustomization.yaml
@@ -1,3 +1,3 @@
 ---
 resources:
-- github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.2.1
+- github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.4.1

--- a/config/install/no-gateway-provider/kustomization.yaml
+++ b/config/install/no-gateway-provider/kustomization.yaml
@@ -5,5 +5,5 @@ kind: Kustomization
 # if you want to install a different released version you can use the patch options below.
 # If you want to install the latest development tag, remove the subscription patch
 resources:
-  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
   - ../../deploy/olm

--- a/config/install/standard/kustomization.yaml
+++ b/config/install/standard/kustomization.yaml
@@ -5,6 +5,6 @@ kind: Kustomization
 # if you want to install a different released version you can use the patch options below.
 # If you want to install the latest development tag, remove the subscription patch
 resources:
-  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.1/standard-install.yaml
   - sail-operator.yaml
   - ../../deploy/olm

--- a/doc/user-guides/auth/anonymous-access.md
+++ b/doc/user-guides/auth/anonymous-access.md
@@ -53,7 +53,8 @@ spec:
   hostnames:
   - api.toystore.com
   rules:
-  - matches: # rule-1
+  - name: cars
+    matches:
     - method: GET
       path:
         type: PathPrefix
@@ -61,7 +62,8 @@ spec:
     backendRefs:
     - name: toystore
       port: 80
-  - matches: # rule-2
+  - name: public
+    matches:
     - method: GET
       path:
         type: PathPrefix
@@ -144,7 +146,7 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: toystore
-    sectionName: rule-2
+    sectionName: public
   defaults:
     rules:
       authentication:

--- a/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+++ b/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
@@ -28,7 +28,7 @@ Topology:
                       ▲                ▲
             ┌─────────┴───────┐ ┌──────┴──────────┐
             | (HTTPRouteRule) | | (HTTPRouteRule) |   ┌─────────────────┐
-            |     rule-1      | |     rule-2      |◄──│   (AuthPolicy)  │
+            |      toys       | |     admins      |◄──│   (AuthPolicy)  │
             |                 | |                 |   │ toystore-admins │
             | - GET /cars*    | | - /admins*      |   └─────────────────┘
             | - GET /dolls*   | └─────────────────┘
@@ -96,7 +96,7 @@ Create the namespace for the toystore API:
 ```bash
 kubectl create ns ${KUADRANT_DEVELOPER_NS}
 ```
-Deploy the Toy store 
+Deploy the Toy store
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/heads/main/examples/toystore/toystore.yaml -n ${KUADRANT_DEVELOPER_NS}
 ```
@@ -119,7 +119,8 @@ spec:
   hostnames:
   - api.toystore.com
   rules:
-  - matches: # rule-1
+  - name: toys
+    matches:
     - method: GET
       path:
         type: PathPrefix
@@ -131,7 +132,8 @@ spec:
     backendRefs:
     - name: toystore
       port: 80
-  - matches: # rule-2
+  - name: admins
+    matches:
     - path:
         type: PathPrefix
         value: "/admin"
@@ -211,7 +213,7 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: toystore
-    sectionName: rule-2
+    sectionName: admins
   rules:
     authorization:
       "only-admins":

--- a/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
+++ b/doc/user-guides/ratelimiting/multi-auth-rlp-same-section.md
@@ -1,6 +1,6 @@
 # Multi authenticated Rate Limiting for an Application
 
-This tutorial walks you through an example of how to configure multiple authenticated rate limiting for an application using Kuadrant. 
+This tutorial walks you through an example of how to configure multiple authenticated rate limiting for an application using Kuadrant.
 
 Authenticated rate limiting, rate limits the traffic directed to an application based on attributes of the client user, who is authenticated by some authentication method. A few examples of authenticated rate limiting use cases are:
 
@@ -92,7 +92,8 @@ spec:
   hostnames:
   - api.toystore.com
   rules:
-  - matches:
+  - name: get-toys
+    matches:
     - path:
         type: Exact
         value: "/toy"
@@ -231,7 +232,7 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: toystore
-    sectionName: rule-1
+    sectionName: get-toys
   defaults:
     strategy: merge
     limits:
@@ -257,7 +258,7 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: toystore
-    sectionName: rule-1
+    sectionName: get-toys
   defaults:
     strategy: merge
     limits:

--- a/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
+++ b/doc/user-guides/ratelimiting/simple-rl-for-app-developers.md
@@ -85,7 +85,8 @@ spec:
   hostnames:
   - api.toystore.com
   rules:
-  - matches:
+  - name: get-toys
+    matches:
     - method: GET
       path:
         type: PathPrefix
@@ -93,7 +94,8 @@ spec:
     backendRefs:
     - name: toystore
       port: 80
-  - matches: # it has to be a separate HTTPRouteRule so we do not rate limit other endpoints
+  - name: create-toy
+    matches: # it has to be a separate HTTPRouteRule so we do not rate limit other endpoints
     - method: POST
       path:
         type: Exact
@@ -148,7 +150,7 @@ spec:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
     name: toystore
-    sectionName: rule-2
+    sectionName: create-toy
   limits:
     "create-toy":
       rates:

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/kuadrant/authorino-operator v0.21.0
 	github.com/kuadrant/dns-operator v0.0.0-20251125201831-f74008dc171c
 	github.com/kuadrant/limitador-operator v0.15.0
-	github.com/kuadrant/policy-machinery v0.7.1-0.20260323164840-c61971597c61
+	github.com/kuadrant/policy-machinery v0.8.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/kuadrant/dns-operator v0.0.0-20251125201831-f74008dc171c h1:4FXlQ+zZE
 github.com/kuadrant/dns-operator v0.0.0-20251125201831-f74008dc171c/go.mod h1:QgQK9JsmEkmaH+en2u2r1oXlbLcgvB+1qRnzilYKExI=
 github.com/kuadrant/limitador-operator v0.15.0 h1:BWgYKV0iasFY3+zKQhLpTdfIlI2pD4MuGr8Hc30ypfg=
 github.com/kuadrant/limitador-operator v0.15.0/go.mod h1:58b5gdSemjXUijd2TBPKBwaQskU7rynHGHD7rTqk2OE=
-github.com/kuadrant/policy-machinery v0.7.1-0.20260323164840-c61971597c61 h1:X1ailZz8LtjDvl/LMfcjSjwTZQ9PYRD7t5ut+CkGlTo=
-github.com/kuadrant/policy-machinery v0.7.1-0.20260323164840-c61971597c61/go.mod h1:79/WTO9FvHfiZ9W5r5YHFXh0ossFL8axu2LeRUcbs8U=
+github.com/kuadrant/policy-machinery v0.8.0 h1:WktikruCgNcNdITDOI80yfRnr4uivCh6bxxfrsf0ibc=
+github.com/kuadrant/policy-machinery v0.8.0/go.mod h1:gAnVskiC8jXk13k56QHUhHvMUkYiDA6IqMpYv2UqOng=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=

--- a/internal/controller/effective_auth_policies_reconciler_test.go
+++ b/internal/controller/effective_auth_policies_reconciler_test.go
@@ -100,6 +100,7 @@ func TestCalculateEffectiveAuthPolicies(t *testing.T) {
 			},
 			Rules: []gatewayapiv1.HTTPRouteRule{
 				{
+					Name: ptr.To(gatewayapiv1.SectionName("get-rule")),
 					Matches: []gatewayapiv1.HTTPRouteMatch{
 						{
 							Method: ptr.To(gatewayapiv1.HTTPMethod("GET")),
@@ -116,6 +117,7 @@ func TestCalculateEffectiveAuthPolicies(t *testing.T) {
 					},
 				},
 				{
+					Name: ptr.To(gatewayapiv1.SectionName("post-rule")),
 					Matches: []gatewayapiv1.HTTPRouteMatch{
 						{
 							Method: ptr.To(gatewayapiv1.HTTPMethod("POST")),
@@ -226,7 +228,7 @@ func TestCalculateEffectiveAuthPolicies(t *testing.T) {
 				Kind:  gatewayapiv1alpha2.Kind(machinery.HTTPRouteGroupKind.Kind),
 				Name:  routeName,
 			},
-			SectionName: ptr.To(gatewayapiv1.SectionName("rule-1")),
+			SectionName: ptr.To(gatewayapiv1.SectionName("get-rule")),
 		}
 		p.Spec.AuthPolicySpecProper = kuadrantv1.AuthPolicySpecProper{
 			AuthScheme: &kuadrantv1.AuthSchemeSpec{
@@ -282,31 +284,31 @@ func TestCalculateEffectiveAuthPolicies(t *testing.T) {
 		t.Fatalf("expected 2 effective auth policies, got %d", len(effectiveAuthPolicies))
 	}
 
-	// rule-1
+	// get-rule
 	effectivePolicy, found := lo.Find(lo.Values(effectiveAuthPolicies), func(ep EffectiveAuthPolicy) bool {
-		return len(ep.Path) > 0 && ep.Path[len(ep.Path)-1].GetName() == fmt.Sprintf("%s#rule-1", routeName)
+		return len(ep.Path) > 0 && ep.Path[len(ep.Path)-1].GetName() == fmt.Sprintf("%s#get-rule", routeName)
 	})
 	if !found {
-		t.Fatalf("expected effective policy for rule-1, got none")
+		t.Fatalf("expected effective policy for get-rule, got none")
 	}
 	if authn := effectivePolicy.Spec.Spec.Proper().AuthScheme.Authentication; len(authn) == 0 || !lo.HasKey(authn, "jwt") {
-		t.Fatalf("expected effective policy for rule-1 to have authentication 'jwt'")
+		t.Fatalf("expected effective policy for get-rule to have authentication 'jwt'")
 	}
 	if authz := effectivePolicy.Spec.Spec.Proper().AuthScheme.Authorization; len(authz) == 0 || !lo.HasKey(authz, "admins-or-privileged") {
-		t.Fatalf("expected effective policy for rule-1 to have authorization 'admins-or-privileged'")
+		t.Fatalf("expected effective policy for get-rule to have authorization 'admins-or-privileged'")
 	}
 
-	// rule-2
+	// post-rule
 	effectivePolicy, found = lo.Find(lo.Values(effectiveAuthPolicies), func(ep EffectiveAuthPolicy) bool {
-		return len(ep.Path) > 0 && ep.Path[len(ep.Path)-1].GetName() == fmt.Sprintf("%s#rule-2", routeName)
+		return len(ep.Path) > 0 && ep.Path[len(ep.Path)-1].GetName() == fmt.Sprintf("%s#post-rule", routeName)
 	})
 	if !found {
-		t.Fatalf("expected effective policy for rule-2, got none")
+		t.Fatalf("expected effective policy for post-rule, got none")
 	}
 	if authn := effectivePolicy.Spec.Spec.Proper().AuthScheme.Authentication; len(authn) == 0 || !lo.HasKey(authn, "jwt") {
-		t.Fatalf("expected effective policy for rule-2 to have authentication 'jwt'")
+		t.Fatalf("expected effective policy for post-rule to have authentication 'jwt'")
 	}
 	if authz := effectivePolicy.Spec.Spec.Proper().AuthScheme.Authorization; len(authz) == 0 || !lo.HasKey(authz, "admins-only") {
-		t.Fatalf("expected effective policy for rule-2 to have authorization 'admins-only'")
+		t.Fatalf("expected effective policy for post-rule to have authorization 'admins-only'")
 	}
 }

--- a/tests/istio/extension_reconciler_test.go
+++ b/tests/istio/extension_reconciler_test.go
@@ -286,6 +286,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 			httpRoute := tests.BuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.toystore.acme.com", "api.toystore.io"})
 			httpRoute.Spec.Rules = []gatewayapiv1.HTTPRouteRule{
 				{
+					Name: ptr.To(gatewayapiv1.SectionName("rule-1")),
 					Matches: []gatewayapiv1.HTTPRouteMatch{
 						{ // get /toys*
 							Path: &gatewayapiv1.HTTPPathMatch{
@@ -304,6 +305,7 @@ var _ = Describe("Rate Limiting WasmPlugin controller", func() {
 					},
 				},
 				{
+					Name: ptr.To(gatewayapiv1.SectionName("rule-2")),
 					Matches: []gatewayapiv1.HTTPRouteMatch{
 						{ // /assets
 							Path: &gatewayapiv1.HTTPPathMatch{


### PR DESCRIPTION
Update [`github.com/kuadrant/policy-machinery`](https://pkg.go.dev/github.com/kuadrant/policy-machinery) to v0.8.0

- Support for named route rules (Gateway API 1.3+)
- Better support for GRPCRoute - new helper types available

Additionally:
- chore: Update the version of Gateway API used in the tests, local dev env and examples to 1.4.1

> [!WARNING]
> **Breaking change:** All data plane policies currently attached to sections of the HTTPRoute kind using  `rule-<N>` synthetic rule names MUST be updated if the route rule specifies an actual name (`spec.rules.name`) that doesn't match the policy's `spec.targetRef.sectionName`.

## Verification steps

Setup the cluster:

```sh
make local-setup
```

Deploy Kuadrant and sample app:

```
kubectl apply -f examples/x509-authentication/httpbin.yaml
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant-sample
spec: {}
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: httpbin
  namespace: default
  labels:
    app: httpbin
spec:
  parentRefs:
  - name: kuadrant-ingressgateway
    namespace: gateway-system
  hostnames:
  - httpbin.local
  rules:
  - name: ip
    matches:
    - path:
        type: PathPrefix
        value: /ip
    backendRefs:
    - name: httpbin
      port: 80
  - name: headers
    matches:
    - path:
        type: PathPrefix
        value: /headers
    backendRefs:
    - name: httpbin
      port: 80
---
apiVersion: kuadrant.io/v1
kind: AuthPolicy
metadata:
  name: httpbin
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: httpbin
    sectionName: ip
  rules:
    authorization:
      deny-all:
        opa:
          rego: allow = false
EOF
```

Check out the topology graph:

```sh
kubectl get configmap/topology -n kuadrant-system -o jsonpath='{.data.topology}'
```

<img width="1463" height="720" alt="Screenshot 2026-04-10 at 13 23 34" src="https://github.com/user-attachments/assets/10703582-0964-402f-89e9-da2f77912525" />

Send requests to both rules of the HTTPRoute:

```sh
export GATEWAY_IP=$(kubectl get svc -n gateway-system kuadrant-ingressgateway-istio -o jsonpath='{.status.loadBalancer.ingress[0].ip}') && echo "Gateway IP: $GATEWAY_IP"
```

```sh
curl -H 'Host: httpbin.local' http://$GATEWAY_IP:80/ip -i
# HTTP/1.1 403 Forbidden
```

```sh
curl -H 'Host: httpbin.local' http://$GATEWAY_IP:80/headers -i
# HTTP/1.1 200 OK
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a Go dependency to a stable released version.

* **Documentation**
  * Revised installation and Helm instructions for gateway, cert-manager and Istio (updated install commands and versions).
  * Updated user guides and examples to use explicit, named HTTP route sections for clearer configuration and policy targeting.

* **Tests**
  * Adjusted tests to align with the named route-section examples used in documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->