### PR TITLE
ci: add verify-manifests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -361,12 +361,29 @@ jobs:
         run: |
           make verify-go-mod
 
+  verify-manifests:
+    name: Verify manifests
+    if: needs.pre-job.outputs.should_skip != 'true'
+    needs: pre-job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+        id: go
+      - name: Verify manifests
+        run: |
+          make verify-manifests
+
   required-checks:
     name: Test Required Checks
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ unit-tests, controllers-integration-tests, bare-k8s-integration-tests, gatewayapi-integration-tests, gatewayapi-provider-integration-tests, verify-fmt, test-scripts, verify-generate, verify-go-mod ]
+    needs: [ unit-tests, controllers-integration-tests, bare-k8s-integration-tests, gatewayapi-integration-tests, gatewayapi-provider-integration-tests, verify-fmt, test-scripts, verify-generate, verify-go-mod, verify-manifests ]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds a `verify-manifests` CI job to the test workflow
- Ensures CRD bases (`./config`), bundle manifests (`./bundle`), and helm charts (`./charts`) are verified against generated output on every PR
- Wired into `required-checks` so PRs cannot merge with stale manifests

## Context
The `verify-manifests` make target already existed but was only available locally via `make pre-commit`. This gap allowed the ThreatPolicy extension rename (#1846) to merge without its generated bundle manifest (`bundle/manifests/extensions.kuadrant.io_threatpolicies.yaml`), which went undetected.

## Notes
- This PR will fail `verify-manifests` until #1883 is merged, which adds the missing ThreatPolicy bundle manifest
- This is expected and demonstrates the check working correctly — detecting that manifests are out of sync with the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated manifest verification as a new quality assurance checkpoint in the continuous integration pipeline, ensuring enhanced build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->