### PR TITLE
fix: remove ThreatPolicy CRD from kustomization

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -11,7 +11,6 @@ resources:
   - bases/extensions.kuadrant.io_oidcpolicies.yaml
   - bases/extensions.kuadrant.io_planpolicies.yaml
   - bases/extensions.kuadrant.io_telemetrypolicies.yaml
-  - bases/extensions.kuadrant.io_threatpolicies.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:


### PR DESCRIPTION
## Summary
- Removes the ThreatPolicy CRD entry from `config/crd/kustomization.yaml`
- Prevents the ThreatPolicy bundle manifest from being generated as part of the main operator bundle

## Related
- #1882

## Context
The ThreatPolicy extension rename (#1846) added the ThreatPolicy CRD to the main kustomization but did not commit the generated bundle manifest. Rather than committing the missing manifest, this removes the entry from the kustomization as it should not be included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed threat policies Custom Resource Definition from the default installation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->