### PR TITLE
internal/controller: return stale AuthConfig deletion errors so the controller retries

### DIFF
--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -93,14 +93,16 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 		_, desired := desiredAuthConfigs[k8stypes.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}]
 		return o.GroupVersionKind().GroupKind() == kuadrantauthorino.AuthConfigGroupKind && labels.Set(o.(*controller.RuntimeObject).GetLabels()).AsSelector().Matches(AuthObjectLabels()) && !desired
 	})
+	var deleteErrors []error
 	for _, authConfig := range staleAuthConfigs {
 		if err := r.client.Resource(kuadrantauthorino.AuthConfigsResource).Namespace(authConfig.GetNamespace()).Delete(ctx, authConfig.GetName(), metav1.DeleteOptions{}); err != nil {
 			logger.Error(err, "failed to delete authconfig object", "authconfig", fmt.Sprintf("%s/%s", authConfig.GetNamespace(), authConfig.GetName()))
-			// TODO: handle error
+			deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete stale authconfig %s/%s: %w",
+				authConfig.GetNamespace(), authConfig.GetName(), err))
 		}
 	}
 
-	return nil
+	return errors.Join(deleteErrors...)
 }
 
 // reconcileAuthConfigForPath reconciles the AuthConfig for a single effective policy path.

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -96,6 +97,12 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 	var deleteErrors []error
 	for _, authConfig := range staleAuthConfigs {
 		if err := r.client.Resource(kuadrantauthorino.AuthConfigsResource).Namespace(authConfig.GetNamespace()).Delete(ctx, authConfig.GetName(), metav1.DeleteOptions{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Already gone - idempotent success, matching the pattern
+				// used in effective_dnspolicies_reconciler.go:311 and
+				// effective_tls_policies_reconciler.go:131.
+				continue
+			}
 			logger.Error(err, "failed to delete authconfig object", "authconfig", fmt.Sprintf("%s/%s", authConfig.GetNamespace(), authConfig.GetName()))
 			deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete stale authconfig %s/%s: %w",
 				authConfig.GetNamespace(), authConfig.GetName(), err))

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -98,9 +98,6 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 	for _, authConfig := range staleAuthConfigs {
 		if err := r.client.Resource(kuadrantauthorino.AuthConfigsResource).Namespace(authConfig.GetNamespace()).Delete(ctx, authConfig.GetName(), metav1.DeleteOptions{}); err != nil {
 			if apierrors.IsNotFound(err) {
-				// Already gone - idempotent success, matching the pattern
-				// used in effective_dnspolicies_reconciler.go:311 and
-				// effective_tls_policies_reconciler.go:131.
 				continue
 			}
 			logger.Error(err, "failed to delete authconfig object", "authconfig", fmt.Sprintf("%s/%s", authConfig.GetNamespace(), authConfig.GetName()))


### PR DESCRIPTION
## What

`AuthConfigsReconciler.Reconcile` in `internal/controller/authconfigs_reconciler.go` sweeps out stale `AuthConfig` objects but swallows the error:

```go
for _, authConfig := range staleAuthConfigs {
    if err := r.client.Resource(...).Delete(ctx, authConfig.GetName(), metav1.DeleteOptions{}); err != nil {
        logger.Error(err, "failed to delete authconfig object", "authconfig", ...)
        // TODO: handle error
    }
}
return nil
```

The controller runtime only re-queues a reconcile when `Reconcile` returns a non-nil error. So a failed delete was a one-shot log line and the stale resource was left in-cluster until some *other* event happened to trigger another reconcile pass. Under API-server pressure, a transient permission glitch, or a brief conflict, that's long enough for stale AuthConfigs to accumulate, and for Authorino to keep enforcing policy fragments the operator already tried to remove.

Per #1867.

## Fix

Collect per-delete failures and return them through `errors.Join` at the end of the function:

```go
var deleteErrors []error
for _, authConfig := range staleAuthConfigs {
    if err := r.client.Resource(...).Delete(...); err != nil {
        logger.Error(err, "failed to delete authconfig object", "authconfig", ...)
        deleteErrors = append(deleteErrors, fmt.Errorf("failed to delete stale authconfig %s/%s: %w",
            authConfig.GetNamespace(), authConfig.GetName(), err))
    }
}

return errors.Join(deleteErrors...)
```

- Successful deletes in the same loop still complete; only the failed ones are surfaced.
- The existing per-object `logger.Error(...)` call is kept so the operator log still has the structured context.
- `errors.Is`/`errors.As` in any upstream error handlers continue to work because we wrap the original error with `%w`.

`errors.Join(nil...)` returns `nil`, so the success path is unchanged from the previous `return nil`.

Fixes #1867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during stale configuration cleanup: deletion errors encountered while removing obsolete AuthConfig resources are now accumulated and reported collectively, while not-found cases are ignored. As a result, cleanup failures are surfaced instead of being silently skipped, and the reconciler may now return an error when stale configuration deletions fail for reasons other than not-found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->