### PR TITLE
Disable e2e smoke tests when merging from fork branches

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -23,7 +23,7 @@ jobs:
 
   smoke-tests:
     name: Smoke Tests
-    if: needs.pre-job.outputs.should_skip != 'true'
+    if: needs.pre-job.outputs.should_skip != 'true' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     needs: pre-job
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
Upstream project action variables are not used if you're merging changes from your fork, making e2e smoke tests fail if executed on forked branch. I'm adding the condition to not run the action if branch is forked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified smoke test execution conditions in the continuous integration pipeline. Smoke tests now run only when the pull request source repository matches the base repository, in addition to existing skip condition checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->