### PR TITLE
observability: scope auto-created Pod/ServiceMonitors to the install namespace

### DIFF
--- a/internal/controller/observability_reconciler.go
+++ b/internal/controller/observability_reconciler.go
@@ -100,6 +100,9 @@ func dnsOpMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
 					"control-plane": "dns-operator-controller-manager",
 				},
 			},
+			NamespaceSelector: monitoringv1.NamespaceSelector{
+				MatchNames: []string{ns},
+			},
 		},
 	}
 }
@@ -129,6 +132,9 @@ func authOpMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
 					"control-plane": "authorino-operator",
 				},
 			},
+			NamespaceSelector: monitoringv1.NamespaceSelector{
+				MatchNames: []string{ns},
+			},
 		},
 	}
 }
@@ -157,6 +163,9 @@ func limitOpMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
 				MatchLabels: map[string]string{
 					"control-plane": "controller-manager",
 				},
+			},
+			NamespaceSelector: monitoringv1.NamespaceSelector{
+				MatchNames: []string{ns},
 			},
 		},
 	}
@@ -238,6 +247,9 @@ func istioPodMonitorBuild(ns string) *monitoringv1.PodMonitor {
 					},
 				},
 			},
+			NamespaceSelector: monitoringv1.NamespaceSelector{
+				MatchNames: []string{ns},
+			},
 		},
 	}
 }
@@ -310,6 +322,9 @@ func authorinoMonitorBuild(ns string) *monitoringv1.ServiceMonitor {
 					"app.kubernetes.io/part-of":   "authorino",
 				},
 			},
+			NamespaceSelector: monitoringv1.NamespaceSelector{
+				MatchNames: []string{ns},
+			},
 		},
 	}
 }
@@ -336,6 +351,9 @@ func envoyStatsMonitorBuild(ns string) *monitoringv1.PodMonitor {
 				MatchLabels: map[string]string{
 					"app": "kuadrant-ingressgateway",
 				},
+			},
+			NamespaceSelector: monitoringv1.NamespaceSelector{
+				MatchNames: []string{ns},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #1920.

`kOpMonitorBuild()` (line 65) and `limitMonitorBuild()` (line 273) already set `NamespaceSelector.MatchNames = []string{ns}`, so Prometheus only scrapes the Kuadrant install namespace. The other six builders (`dnsOpMonitorBuild`, `authOpMonitorBuild`, `limitOpMonitorBuild`, `istioPodMonitorBuild`, `authorinoMonitorBuild`, `envoyStatsMonitorBuild`) omit `NamespaceSelector` entirely, which prometheus-operator treats as the cluster-wide empty selector `{}`.

On OpenShift with user-workload monitoring this causes user-workload Prometheus to pick up the monitors but fail to scrape anything in cluster-monitoring namespaces (blocked by `podMonitorNamespaceSelector`), producing persistent `TargetDown` alerts.

## Fix

Attach `NamespaceSelector: monitoringv1.NamespaceSelector{ MatchNames: []string{ns} }` to all six builders, matching the pattern already used by the two correctly-scoped ones. No field removals or label changes, no behaviour change in environments where the monitors were already being scraped correctly (selector `{}` is a superset of `{ns}` for the install-namespace targets).

## Test plan

- [x] `go build ./internal/controller/...` clean
- [x] `go vet ./internal/controller/...` clean
- [x] `go test ./internal/controller/...` green
- [ ] Manual: install Kuadrant with `spec.observability.enable: true` on OpenShift with user-workload monitoring; no more `TargetDown` alerts from monitors scraping cluster-monitoring namespaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted monitoring to specific namespaces so metrics are now collected only from intended targets, reducing cross-namespace noise and improving observability accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->