### PR TITLE
Document X.509 client certificate authentication support

### DIFF
--- a/doc/overviews/auth-x509.md
+++ b/doc/overviews/auth-x509.md
@@ -94,7 +94,7 @@ spec:
         x509:
           # Extract certificate from XFCC header
           source:
-            xfccHeader: "x-forwarded-client-cert"
+            xfccHeader: "x-forwarded-client-cert" # cert in envoy XFCC text format, extracted from the header
           # Select trusted CA certificates using labels
           selector:
             matchLabels:
@@ -159,9 +159,9 @@ spec:
     authentication:
       "client-cert-header":
         x509:
-          # Extract from RFC 9440 Client-Cert header
+          # Extract certificate from RFC 9440 Client-Cert header
           source:
-            clientCertHeader: "client-cert"
+            clientCertHeader: "client-cert" # cert in der format, base64-encoded, extracted from the header
           selector:
             matchLabels:
               tier: trusted-upstream
@@ -184,7 +184,7 @@ The `x509.source` field specifies where to extract the client certificate from:
 ```yaml
 x509:
   source:
-    expression: 'request.http.headers["x-custom-client-cert"]'
+    expression: 'request.http.headers["x-custom-client-cert"]' # cert in pem format, URL-encoded, extracted from a custom header using CEL
   selector:
     matchLabels:
       app: my-service
@@ -240,6 +240,9 @@ kubectl label secret customer-a-ca \
   environment=production
 ```
 
+> [!IMPORTANT] Cross-namespace trust
+> By default, Authorino only trusts CA secrets in the Kuadrant namespace. To allow cross-namespace references, set `allNamespaces: true` in the AuthPolicy, but use this with caution as it expands the trust scope.
+
 ## Certificate requirements and constraints
 
 ### Required certificate attributes
@@ -279,17 +282,17 @@ Client certificates must meet these requirements for Authorino validation to suc
 
 When X.509 authentication succeeds, the identity object (`auth.identity`) contains the certificate subject fields available for use in authorization rules and response transformations:
 
-| Field | Type | Description | Example |
-|-------|------|-------------|---------|
-| `CommonName` | string | Certificate Common Name (CN) | `"api-client.example.com"` |
-| `Country` | array of strings | Country (C) | `["US"]` |
-| `Organization` | array of strings | Organization (O) | `["ACME Corp"]` |
-| `OrganizationalUnit` | array of strings | Organizational Unit (OU) | `["Engineering", "Platform"]` |
-| `Locality` | array of strings | Locality (L) | `["San Francisco"]` |
-| `Province` | array of strings | Province/State (ST) | `["California"]` |
-| `StreetAddress` | array of strings | Street Address | `["123 Main St"]` |
-| `PostalCode` | array of strings | Postal Code | `["94105"]` |
-| `SerialNumber` | string | Certificate serial number | `"01:23:45:67:89:AB:CD:EF"` |
+| Field | Type | OID | Description | Example |
+|-------|------|-----|-------------|---------|
+| `CommonName` | string | 2.5.4.3 | Common Name (CN) | `"api-client.example.com"` |
+| `Country` | array of strings | 2.5.4.6 | Country (C) | `["US"]` |
+| `Organization` | array of strings | 2.5.4.10 | Organization (O) | `["ACME Corp"]` |
+| `OrganizationalUnit` | array of strings | 2.5.4.11 | Organizational Unit (OU) | `["Engineering", "Platform"]` |
+| `Locality` | array of strings | 2.5.4.7 | Locality (L) | `["San Francisco"]` |
+| `Province` | array of strings | 2.5.4.8 | Province/State (ST) | `["California"]` |
+| `StreetAddress` | array of strings | 2.5.4.9 | Street Address | `["123 Main St"]` |
+| `PostalCode` | array of strings | 2.5.4.17 | Postal Code | `["94105"]` |
+| `SerialNumber` | string | 2.5.4.5 | Subject serial number | `"01:23:45:67:89:AB:CD:EF"` |
 
 **Example - Use certificate attributes in authorization:**
 
@@ -380,7 +383,7 @@ Proper CA certificate management is critical for maintaining security:
 - Manage CA certificates in Kubernetes TLS secrets with appropriate labels
 - Rotation requires updating secrets (Authorino watches for changes)
 - Multi-CA trust via label selectors enables fine-grained revocation control
-- Secrets must be in the Kuadrant namespace
+- Secrets must be in the Kuadrant namespace preferably (or use `allNamespaces: true` with caution)
 
 **Key distinction:** Gateway CAs typically represent a single root CA validated at TLS handshake, while Authorino CAs can represent multiple intermediate CAs selected via labels, enabling granular trust management.
 

--- a/doc/overviews/auth-x509.md
+++ b/doc/overviews/auth-x509.md
@@ -1,0 +1,492 @@
+# X.509 Client Certificate Authentication
+
+## Verify cryptographic identity with client certificates
+
+When your organization requires strong cryptographic identity verification—such as for zero-trust architectures, compliance requirements, or machine-to-machine communication with PKI—X.509 client certificate authentication provides defense-in-depth security with validation at both the TLS layer and application layer.
+
+### When to use X.509 authentication
+
+Choose X.509 client certificate authentication when:
+
+- **Zero-trust architecture**: You need cryptographic proof of identity for every request
+- **Compliance requirements**: Security standards (PCI DSS, HIPAA, FedRAMP) mandate mutual TLS (mTLS)
+- **Machine-to-machine communication**: Services authenticate with long-lived certificates from your PKI
+- **Multi-CA trust**: Different clients are issued certificates by different CAs, and you need fine-grained control over which CAs are trusted for which routes
+- **No shared secrets**: You want to avoid the operational burden of rotating and distributing API keys or tokens
+
+## How X.509 authentication works in Kuadrant
+
+Kuadrant's X.509 authentication implements a two-layer validation model for defense-in-depth security:
+
+**Layer 1 (TLS/L4)**: The Gateway validates client certificates during the TLS handshake against CA certificates configured in the Gateway resource. This cryptographically verifies that the client possesses the private key and that the certificate is trusted.
+
+**Layer 2 (Application/L7)**: Authorino validates certificates extracted from the `X-Forwarded-Client-Cert` (XFCC) header using label selectors to support multi-CA trust and fine-grained validation rules.
+
+Both layers must succeed for the request to be authenticated. This defense-in-depth approach provides:
+- **Security**: Invalid, expired, or untrusted certificates are rejected at the TLS layer before reaching the application
+- **Flexibility**: Application-layer validation supports multi-CA trust scenarios where different CAs are trusted for different routes or services
+- **Auditability**: Certificate attributes (CN, Organization, etc.) are available for authorization decisions and request enrichment
+
+## Configuration tiers
+
+Kuadrant supports three configuration tiers for X.509 authentication, each with different security characteristics and requirements. Choose the tier that matches your Gateway API version, gateway provider, and security requirements.
+
+### Tier 1: Gateway API v1.5+ frontend TLS validation (Recommended)
+
+**Use Tier 1 when:** You have Gateway API v1.5+ and a compatible gateway implementation (Istio v1.28+, Envoy Gateway with v1.5 support).
+
+Tier 1 uses the standard Gateway API `spec.tls.frontend.default.validation` field to configure client certificate validation at the Gateway level, providing automatic defense-in-depth security.
+
+**Security characteristics:**
+- ✅ Defense-in-depth: Both L4 (TLS) and L7 (Authorino) validation
+- ✅ Cryptographic proof of private key possession
+- ✅ Standard Gateway API configuration
+- ✅ XFCC header automatically set by gateway after successful TLS validation
+- ✅ Incoming XFCC headers automatically stripped to prevent spoofing
+
+**Gateway configuration:**
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: mtls-gateway
+  namespace: gateway-system
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: https
+    protocol: HTTPS
+    port: 443
+    hostname: "*.example.com"
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: gateway-tls-cert
+  # Frontend TLS validation for client certificates
+  tls:
+    frontend:
+      default:
+        validation:
+          # Reference ConfigMap(s) with trusted CA certificates
+          caCertificateRefs:
+          - name: client-ca-bundle
+            kind: ConfigMap
+          # Require valid client certificates
+          mode: AllowValidOnly  # or AllowInsecureFallback for optional mTLS
+```
+
+**AuthPolicy configuration:**
+
+```yaml
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: x509-auth
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: protected-api
+  rules:
+    authentication:
+      "client-certificate":
+        x509:
+          # Extract certificate from XFCC header
+          source:
+            xfccHeader: "x-forwarded-client-cert"
+          # Select trusted CA certificates using labels
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: trusted-client
+```
+
+See the [X.509 Client Certificate Authentication user guide](../user-guides/auth/x509-client-certificate-authentication.md) for a complete working example.
+
+### Tier 2: Provider-specific resources (Alternative for older Gateway API versions)
+
+**Use Tier 2 when:** You don't have Gateway API v1.5+ but still want defense-in-depth security with L4 TLS validation.
+
+Tier 2 uses provider-specific resources to configure TLS validation at the gateway level:
+- **Istio**: EnvoyFilter resources
+- **Envoy Gateway**: EnvoyPatchPolicy resources
+
+**Security characteristics:**
+- ✅ Defense-in-depth: Both L4 (TLS) and L7 (Authorino) validation
+- ✅ Cryptographic proof of private key possession
+- ✅ XFCC header set by gateway after successful TLS validation
+- ⚠️ Requires provider-specific configuration knowledge
+- ⚠️ Configuration varies by gateway provider
+
+**Trade-offs:**
+- More complex configuration compared to Tier 1
+- Provider-specific knowledge required
+- Same security guarantees as Tier 1
+
+**When to migrate to Tier 1:** When you upgrade to Gateway API v1.5+ and your gateway provider supports frontend TLS validation, migrate from Tier 2 to Tier 1 for standardized configuration.
+
+### Tier 3: Certificate in request header only (Exceptional cases)
+
+**Use Tier 3 only when:** Gateway-level TLS validation is not feasible, and you have a trusted upstream proxy that performs TLS validation and populates the XFCC or Client-Cert header.
+
+Tier 3 extracts certificates from request headers without gateway-level TLS validation. Authorino becomes the sole certificate validator.
+
+**Security characteristics:**
+- ❌ No defense-in-depth (single validation point at L7)
+- ❌ No cryptographic proof of private key possession
+- ❌ Potential spoofing risk if headers originate from untrusted sources
+- ✅ Still validates certificate chain against trusted CAs
+- ✅ Supports multi-CA trust via label selectors
+
+**When Tier 3 is acceptable:**
+- Certificate header originates from a trusted upstream proxy that performed TLS validation
+- Network topology prevents direct client access to the gateway
+- You understand and accept the security trade-offs
+
+**AuthPolicy configuration with Client-Cert header (RFC 9440):**
+
+```yaml
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: x509-header-only
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: api-route
+  rules:
+    authentication:
+      "client-cert-header":
+        x509:
+          # Extract from RFC 9440 Client-Cert header
+          source:
+            clientCertHeader: "client-cert"
+          selector:
+            matchLabels:
+              tier: trusted-upstream
+```
+
+**⚠️ Important:** Use Tier 1 or Tier 2 whenever possible. Only use Tier 3 in exceptional cases where gateway-level TLS validation is not feasible and you have a trusted upstream proxy.
+
+## Certificate source options
+
+The `x509.source` field specifies where to extract the client certificate from:
+
+| Source | Value | When to use | Security |
+|--------|--------|-------------|----------|
+| **`xfccHeader`** | Name of the Envoy `X-Forwarded-Client-Cert` header | Istio, Envoy Gateway (Tier 1 or 2) | ✅ Set by gateway after TLS validation |
+| **`clientCertHeader`** | Name of the RFC 9440 `Client-Cert` header | Trusted upstream proxy implementing RFC 9440 (Tier 3) | ⚠️ Requires trusted source |
+| **`expression`** | CEL expression that evaluates to a certificate | Custom header names or attribute paths (Tier 3) | ⚠️ Requires trusted source |
+
+**Example with custom CEL expression:**
+
+```yaml
+x509:
+  source:
+    expression: 'request.http.headers["x-custom-client-cert"]'
+  selector:
+    matchLabels:
+      app: my-service
+```
+
+## Multi-CA trust with label selectors
+
+Unlike traditional proxy-based client certificate validation that supports only a single CA bundle, Kuadrant's X.509 authentication allows you to trust multiple CAs and select different CA sets for different routes using Kubernetes label selectors.
+
+**Example - Trust CA certificates labeled with specific environment:**
+
+```yaml
+x509:
+  selector:
+    matchLabels:
+      environment: production
+      tier: customer-facing
+```
+
+**Example - More complex selectors:**
+
+```yaml
+x509:
+  selector:
+    matchExpressions:
+    - key: ca-tier
+      operator: In
+      values: ["tier-1", "tier-2"]
+    - key: deprecated
+      operator: DoesNotExist
+```
+
+This enables sophisticated trust models such as:
+- Different CAs for production vs. staging environments
+- Separate CAs for different business units or customers
+- Gradual CA rotation by trusting both old and new CAs during migration
+- Per-route CA trust policies for multi-tenant scenarios
+
+**CA Secret requirements:**
+
+Trusted CA certificates must be stored in Kubernetes TLS secrets in the Kuadrant namespace with appropriate labels:
+
+```bash
+kubectl create secret tls customer-a-ca \
+  -n kuadrant-system \
+  --cert=customer-a-ca.crt \
+  --key=customer-a-ca.key
+
+kubectl label secret customer-a-ca \
+  -n kuadrant-system \
+  authorino.kuadrant.io/managed-by=authorino \
+  customer=customer-a \
+  environment=production
+```
+
+## Certificate requirements and constraints
+
+### Required certificate attributes
+
+Client certificates must meet these requirements for Authorino validation to succeed:
+
+1. **Extended Key Usage (EKU)**: Certificates must include the x509 v3 extension specifying **Client Authentication** (`1.3.6.1.5.5.7.3.2`) extended key usage
+
+   **Example certificate generation with Client Auth EKU:**
+   ```bash
+   # Create X.509 v3 extensions file
+   cat > client-cert-ext.cnf << EOF
+   authorityKeyIdentifier=keyid,issuer
+   basicConstraints=CA:FALSE
+   keyUsage=digitalSignature,nonRepudiation,keyEncipherment,dataEncipherment
+   extendedKeyUsage=clientAuth
+   EOF
+
+   # Generate certificate with Client Auth EKU
+   openssl x509 -req -sha256 \
+     -days 365 \
+     -CA ca.crt -CAkey ca.key \
+     -extfile client-cert-ext.cnf \
+     -in client.csr -out client.crt
+   ```
+
+2. **Valid certificate chain**: Certificate must chain to a trusted CA configured in Authorino secrets
+
+3. **Not expired**: Certificate must be within its validity period
+
+4. **Proper encoding**:
+   - XFCC header: [Envoy XFCC text format](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#text-format)
+   - Client-Cert header ([RFC 9440](https://datatracker.ietf.org/doc/rfc9440/)): DER format, base64-encoded
+   - CEL Expression: PEM-encoded, URL-encoded
+
+### Certificate identity object
+
+When X.509 authentication succeeds, the identity object (`auth.identity`) contains the certificate subject fields available for use in authorization rules and response transformations:
+
+| Field | Type | Description | Example |
+|-------|------|-------------|---------|
+| `CommonName` | string | Certificate Common Name (CN) | `"api-client.example.com"` |
+| `Country` | array of strings | Country (C) | `["US"]` |
+| `Organization` | array of strings | Organization (O) | `["ACME Corp"]` |
+| `OrganizationalUnit` | array of strings | Organizational Unit (OU) | `["Engineering", "Platform"]` |
+| `Locality` | array of strings | Locality (L) | `["San Francisco"]` |
+| `Province` | array of strings | Province/State (ST) | `["California"]` |
+| `StreetAddress` | array of strings | Street Address | `["123 Main St"]` |
+| `PostalCode` | array of strings | Postal Code | `["94105"]` |
+| `SerialNumber` | string | Certificate serial number | `"01:23:45:67:89:AB:CD:EF"` |
+
+**Example - Use certificate attributes in authorization:**
+
+```yaml
+authorization:
+  "verify-organization":
+    patternMatching:
+      patterns:
+      - predicate: "auth.identity.Organization[0] == 'ACME Corp'"
+      - predicate: "'Engineering' in auth.identity.OrganizationalUnit"
+```
+
+**Example - Inject certificate attributes into request headers:**
+
+```yaml
+response:
+  success:
+    headers:
+      "x-client-cn":
+        plain:
+          expression: auth.identity.CommonName
+      "x-client-org":
+        plain:
+          expression: auth.identity.Organization[0]
+      "x-client-subject":
+        json:
+          properties:
+            cn:
+              expression: auth.identity.CommonName
+            org:
+              expression: auth.identity.Organization[0]
+            ou:
+              expression: auth.identity.OrganizationalUnit
+```
+
+## Security considerations
+
+### XFCC header security
+
+**Critical requirement:** The XFCC header must originate from a trusted source to prevent spoofing.
+
+#### Tier 1 & 2: XFCC set by gateway after validation ✅
+
+With gateway-level TLS validation, the proxy must be configured to:
+
+1. **Strip incoming XFCC headers**: Any XFCC from incoming requests must be removed to prevent client spoofing
+2. **Set XFCC only after validation**: The proxy sets the XFCC header exclusively after successful TLS validation
+
+Envoy behavior with `forward_client_cert_details: SANITIZE_SET` (recommended):
+- Strips any incoming XFCC headers from untrusted clients
+- Sets the XFCC header only after TLS validation succeeds
+- Provides cryptographic proof that the client possesses the private key
+
+**Verification:** Ensure your Gateway configuration uses the recommended Envoy settings. For Tier 1 (Gateway API v1.5+), this is automatic. For Tier 2, verify your EnvoyFilter or provider-specific resource configuration.
+
+#### Tier 3: XFCC forwarded from client ⚠️
+
+With Tier 3 configuration, the proxy forwards the XFCC or Client-Cert header from the incoming request without validation.
+
+**Risks:**
+- Potential client spoofing of the certificate header
+- No cryptographic proof of private key possession
+- Single validation point (Authorino only)
+
+**Acceptable scenarios:**
+- Certificate header originates from a trusted upstream proxy that performed TLS validation
+- Network topology prevents direct client access to the gateway
+- You understand and accept the L7-only validation trade-offs
+
+**⚠️ Warning:** Do not use Tier 3 configuration unless you trust the source of the certificate header and understand the security implications. When in doubt, use Tier 1 or Tier 2.
+
+### CA certificate management
+
+Proper CA certificate management is critical for maintaining security:
+
+#### Gateway-level CA configuration (Tier 1 & 2)
+
+**Responsibilities:**
+- Securely manage CA certificates for gateway validation
+- **Tier 1**: ConfigMaps referenced in Gateway `spec.tls.frontend.default.validation.caCertificateRefs`
+- **Tier 2**: CA certificates in EnvoyFilter or provider-specific resources
+- Certificate rotation requires ConfigMap updates and potential gateway pod restarts
+- Namespace isolation through ReferenceGrant controls cross-namespace references
+
+#### Authorino-level CA configuration (All tiers)
+
+**Responsibilities:**
+- Manage CA certificates in Kubernetes TLS secrets with appropriate labels
+- Rotation requires updating secrets (Authorino watches for changes)
+- Multi-CA trust via label selectors enables fine-grained revocation control
+- Secrets must be in the Kuadrant namespace
+
+**Key distinction:** Gateway CAs typically represent a single root CA validated at TLS handshake, while Authorino CAs can represent multiple intermediate CAs selected via labels, enabling granular trust management.
+
+### Best practices
+
+1. **Use Tier 1 whenever possible**: Gateway API v1.5+ frontend TLS validation provides standardized, secure configuration
+
+2. **Automate certificate management**: Use [cert-manager](https://cert-manager.io/) for automatic CA certificate provisioning and rotation at both gateway and Authorino levels
+
+3. **Implement certificate rotation strategies**:
+   - Overlap periods where both old and new CAs are trusted
+   - Use label selectors to gradually phase out old CAs
+   - Monitor certificate expiration with alerting
+
+4. **Monitor certificate health**:
+   - Track certificate expiration timelines
+   - Alert on approaching expiration (30, 14, 7 days)
+   - Monitor authentication failure rates
+
+5. **Consider separate CAs for different trust levels**:
+   - Gateway-level: Broad trust (all certificates from organizational CA)
+   - Authorino-level: Granular trust (specific CAs per route/service)
+
+6. **Validate Client Auth EKU**: Ensure all client certificates include the `extendedKeyUsage=clientAuth` extension
+
+7. **Header size considerations**:
+   - Certificate chains in XFCC headers can exceed typical header limits
+   - Consider using shorter certificate chains when possible
+   - Monitor for header size-related failures
+
+8. **Network segmentation**: For Tier 3 configurations, ensure network topology prevents direct client access to the gateway
+
+## Troubleshooting
+
+### Authentication fails with "invalid certificate"
+
+**Possible causes:**
+- Certificate doesn't chain to a trusted CA
+- Certificate is expired
+- Certificate doesn't have Client Authentication EKU
+- CA secret not labeled correctly or not in Kuadrant namespace
+
+**Resolution:**
+```bash
+# Verify certificate has Client Auth EKU
+openssl x509 -in client.crt -noout -text | grep "TLS Web Client Authentication"
+
+# Check certificate validity
+openssl x509 -in client.crt -noout -dates
+
+# Verify CA secret exists and has correct labels
+kubectl get secret -n kuadrant-system -l authorino.kuadrant.io/managed-by=authorino
+
+# Check Authorino logs
+kubectl logs -n kuadrant-system -l authorino-resource-uid=<uid> | grep x509
+```
+
+### XFCC header not populated
+
+**Possible causes:**
+- Gateway not configured for frontend TLS validation (Tier 1)
+- EnvoyFilter not applied correctly (Tier 2)
+- Client didn't present certificate during TLS handshake
+
+**Resolution:**
+```bash
+# For Tier 1: Check Gateway configuration
+kubectl get gateway <gateway-name> -o yaml | grep -A 10 frontend
+
+# Check if XFCC is in request (from Authorino perspective)
+kubectl logs -n kuadrant-system -l authorino-resource-uid=<uid> | grep -i xfcc
+
+# Test TLS handshake
+openssl s_client -connect gateway.example.com:443 \
+  -cert client.crt -key client.key -CAfile ca.crt
+```
+
+### Multi-CA trust not working
+
+**Possible causes:**
+- CA secrets don't have required labels
+- Label selectors don't match any CA secrets
+- Secrets in wrong namespace
+
+**Resolution:**
+```bash
+# List CA secrets with labels
+kubectl get secrets -n kuadrant-system \
+  -l authorino.kuadrant.io/managed-by=authorino \
+  --show-labels
+
+# Verify selector matches secrets
+kubectl get secrets -n kuadrant-system \
+  -l app.kubernetes.io/name=trusted-client
+
+# Check AuthPolicy selector configuration
+kubectl get authpolicy <policy-name> -o yaml | grep -A 5 selector
+```
+
+## See also
+
+- [X.509 Client Certificate Authentication user guide](../user-guides/auth/x509-client-certificate-authentication.md) - Complete working example with certificate generation and testing
+- [Authentication overview](auth.md#choosing-the-right-authentication-method) - Comparison of all authentication methods
+- [AuthPolicy API reference](../reference/authpolicy.md) - Complete AuthPolicy CRD specification
+- [RFC 0015: X.509 Client Certificate Authentication](https://github.com/Kuadrant/architecture/blob/main/rfcs/0015-x509-client-cert-authpolicy.md) - Design document and architectural decisions
+- [Authorino X.509 authentication](https://docs.kuadrant.io/latest/authorino/docs/features/#x509-client-certificate-authentication-authenticationx509) - Detailed Authorino feature documentation
+- [Gateway API v1.5 TLS Frontend Validation](https://gateway-api.sigs.k8s.io/api-types/gateway/#gateway-api-v1-TLSFrontendValidation) - Gateway API specification
+- [Envoy XFCC header specification](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert) - Envoy documentation on XFCC header format and usage
+- [RFC 9440: Client-Cert HTTP Header Field](https://www.rfc-editor.org/rfc/rfc9440.html) - Client-Cert header specification

--- a/doc/overviews/auth.md
+++ b/doc/overviews/auth.md
@@ -260,8 +260,8 @@ Defaults and overrides work at any level of the Gateway API hierarchy:
 The "effective policy" for each request is computed based on hierarchy rules from [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/#resolving-conflicts). Kuadrant implements 4 [merge strategies](https://gateway-api.sigs.k8s.io/geps/gep-713/#designing-a-merge-strategy) allowing atomic or merged composition of policy rules:
 - **Atomic defaults:** The most specific policy fully replaces less specific ones for the topological scope it applies to. No merging of rules occurs. This is the default behavior.
 - **Atomic overrides:** The broadest policy fully replaces more specific ones. No merging of rules occurs.
-- **Merged defaults:** Individual rules from the most specific policy replaces rules with the same name in less specific ones, while rules with different names are both maintained.
-- **Merged overrides:** Individual rules from the broadest policy replaces rules with the same name in more specific ones, while rules with different names are both maintained.
+- **Merged defaults:** Individual rules from the most specific policy replace rules with the same name in less specific ones, while rules with different names are both maintained.
+- **Merged overrides:** Individual rules from the broadest policy replace rules with the same name in more specific ones, while rules with different names are both maintained.
 
 > [!NOTE] Learn more about Defaults & Overrides
 > For detailed behavior and examples of Defaults & Overrides used in the AuthPolicies, see [RFC-0009](https://github.com/Kuadrant/architecture/blob/main/rfcs/0009-defaults-and-overrides.md).

--- a/doc/overviews/auth.md
+++ b/doc/overviews/auth.md
@@ -263,6 +263,9 @@ The "effective policy" for each request is computed based on hierarchy rules fro
 - **Merged defaults:** Individual rules from the most specific policy replaces rules with the same name in less specific ones, while rules with different names are both maintained.
 - **Merged overrides:** Individual rules from the broadest policy replaces rules with the same name in more specific ones, while rules with different names are both maintained.
 
+> [!NOTE] Learn more about Defaults & Overrides
+> For detailed behavior and examples of Defaults & Overrides used in the AuthPolicies, see [RFC-0009](https://github.com/Kuadrant/architecture/blob/main/rfcs/0009-defaults-and-overrides.md).
+
 ### Understand how policies apply to wildcard hostnames
 
 When you define routes with wildcard hostnames (e.g., `*.example.com`) alongside specific hostnames (e.g., `api.example.com`), you may wonder which AuthPolicy takes precedence.

--- a/doc/overviews/auth.md
+++ b/doc/overviews/auth.md
@@ -1,65 +1,108 @@
 # Kuadrant Auth
 
+## Secure API access with authentication and authorization
+
+When protecting APIs in your Kubernetes infrastructure, you need to verify who is making requests (authentication) and what they're allowed to do (authorization). Kuadrant provides flexible authentication and authorization capabilities through the AuthPolicy custom resource, helping you balance security requirements with operational simplicity.
+
+### Common authentication and authorization jobs
+
+Kuadrant AuthPolicy helps you accomplish these common security tasks:
+
+| Job | When you need this | Solution |
+|-----|-------------------|----------|
+| **Secure API access with appropriate authentication** | APIs need protection but different use cases require different authentication methods | Choose from API keys, JWT/OIDC, X.509 certificates, OAuth2 introspection, Kubernetes TokenReview, or allow anonymous access based on your security and compliance requirements |
+| **Verify cryptographic identity with client certificates** | Your organization requires strong identity verification, zero-trust architecture, or compliance with security standards | Use X.509 client certificate authentication with defense-in-depth validation at both TLS and application layers |
+| **Control access with fine-grained authorization** | Authenticated users need different permissions based on roles, attributes, or complex business logic | Enforce authorization rules using pattern matching, OPA policies, Kubernetes RBAC, or SpiceDB |
+| **Apply consistent security policies across API infrastructure** | You manage multiple APIs and routes and need to balance developer flexibility with platform governance | Apply AuthPolicies at Gateway or HTTPRoute level with defaults and overrides to establish security baselines |
+| **Secure outbound API calls with centralized credential management** | Services call external APIs requiring authentication, and you want to avoid distributing secrets to every pod | Use egress gateway credential injection to authenticate internal workloads and inject external API credentials at the gateway |
+
+## Understanding how Kuadrant auth integrates with your infrastructure
+
+When evaluating Kuadrant for API security, you'll want to understand how it fits into your existing Kubernetes and Gateway API infrastructure without requiring changes to your application code.
+
+### How authentication requests are processed
+
+Kuadrant uses the industry-standard [Envoy External Authorization](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter) protocol to enforce authentication and authorization policies:
+
+1. **Request arrives**: Your Gateway (Istio, Envoy Gateway, etc.) receives an API request
+2. **Policy evaluation**: The gateway checks if any AuthPolicy matches the request based on the HTTPRoute or Gateway configuration
+3. **External authorization call**: If a policy matches, the gateway sends an authorization check request to Authorino (the external auth service)
+4. **Authentication and authorization**: Authorino evaluates your authentication rules (API key, JWT, X.509, etc.) and authorization policies
+5. **Decision returned**: Authorino responds with either `ALLOW` (request proceeds) or `DENY` (request rejected with appropriate status code)
+
+This approach provides several benefits:
+- **Zero application changes**: Authentication logic lives in policies, not in your code
+- **Consistent enforcement**: Same auth rules apply regardless of which service handles the request
+- **Defense in depth**: Some authentication methods (like X.509) validate at both the gateway (L4/TLS) and application (L7) layers
+- **Dynamic policy updates**: Change authentication requirements without redeploying services
+
+### What AuthPolicy provides
+
 A Kuadrant AuthPolicy custom resource:
 
-1. Targets Gateway API networking resources [HTTPRoute](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute) and [Gateway](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Gateway), using these to obtain the auth context, i.e., on which traffic workload (HTTP attributes, hostnames, user attributes, etc) to enforce auth.
-2. Supports targeting subsets (sections) of a network resource to apply the auth rules to, i.e. specific listeners of a Gateway or HTTP route rules of an HTTPRoute.
-3. Abstracts the details of the underlying external authorization protocol and configuration resources, that have a much broader remit and surface area.
-4. Enables platform engineers to set defaults that govern behavior at the lower levels of the network, until a more specific policy is applied.
-5. Enables platform engineers to set overrides over policies and/or individual policy rules specified at the lower levels of the network.
+1. **Targets Gateway API resources**: Attaches to [HTTPRoute](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRoute) or [Gateway](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.Gateway) to define which traffic to protect
+2. **Supports fine-grained targeting**: Apply policies to specific Gateway listeners or individual HTTPRoute rules using `sectionName`
+3. **Abstracts complexity**: Simplifies Envoy External Authorization configuration while providing access to powerful authentication methods
+4. **Enables platform governance**: Platform engineers can set `defaults` to establish security baselines that apply until application teams define more specific policies
+5. **Enforces mandatory controls**: Platform engineers can set `overrides` to enforce organization-wide security requirements that cannot be weakened by route-level policies
 
-## How it works
+Check out the [API reference](../reference/authpolicy.md) for the complete AuthPolicy CRD specification.
 
-### Integration
+## Choosing the right authentication method
 
-Kuadrant integrates an [External Authorization](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter) service ("Authorino") that is triggered on matching HTTP contexts.
+When securing API access, different use cases require different authentication approaches. Choose the authentication method that best matches your security requirements, infrastructure, and user experience needs.
 
-The workflow per request goes:
+### Authentication method decision guide
 
-1. On incoming request, the gateway checks the matching rules for enforcing the auth rules, as stated in the AuthPolicy custom resources and targeted Gateway API networking objects
-2. If the request matches, the gateway sends a [CheckRequest](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto#envoy-v3-api-msg-service-auth-v3-checkrequest) to Authorino.
-3. The external auth service responds with a [CheckResponse](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto#service-auth-v3-checkresponse) back to the gateway with either an `OK` or `DENIED` response code.
+| Authentication Method | When to use | Key characteristics | Learn more |
+|-----------------------|-------------|---------------------|------------|
+| **API Key** | Service-to-service communication, developer access, simple token-based auth, small-to-mid scale deployments | Simple to implement; secrets stored in Kubernetes; supports namespace-scoped or cluster-wide keys | [API Key authentication](https://docs.kuadrant.io/latest/authorino/docs/features/#api-key-authenticationapikey) |
+| **JWT / OIDC** | End-user authentication, SSO, federated identity | Industry-standard tokens; integrates with identity providers (Keycloak, Auth0, Okta); supports token validation and claims extraction | [JWT verification](https://docs.kuadrant.io/latest/authorino/docs/features/#jwt-verification-authenticationjwt) |
+| **X.509 Client Certificates** | Zero-trust architecture, cryptographic identity, compliance requirements (mTLS), machine-to-machine with PKI | Strongest authentication; defense-in-depth validation; multi-CA trust with label selectors; requires certificate infrastructure | [X.509 authentication](auth-x509.md) |
+| **OAuth2 Introspection** | Validate tokens issued by external OAuth2/OIDC servers | Delegates validation to token issuer; works with opaque tokens; real-time revocation check | [OAuth2 introspection](https://docs.kuadrant.io/latest/authorino/docs/features/#oauth-20-introspection-authenticationoauth2introspection) |
+| **Kubernetes TokenReview** | In-cluster service-to-service auth, ServiceAccount tokens | Native Kubernetes integration; validates ServiceAccount tokens; leverages existing RBAC | [Kubernetes TokenReview](https://docs.kuadrant.io/latest/authorino/docs/features/#kubernetes-tokenreview-authenticationkubernetestokenreview) |
+| **Plain Identity** | Pre-authenticated requests, custom authentication handled by upstream proxy | Identity extracted from context; authentication performed elsewhere; minimal overhead | [Plain authentication](https://docs.kuadrant.io/latest/authorino/docs/features/#plain-authenticationplain) |
+| **Anonymous Access** | Public endpoints, unauthenticated access to specific routes | No authentication required; useful with conditional policies or selective route protection | [Anonymous access](../user-guides/auth/anonymous-access.md) |
 
-An AuthPolicy and its targeted Gateway API networking resource contain all the statements to configure both the ingress gateway and the external auth service.
+### Choosing an authorization method
 
-### The AuthPolicy custom resource
+After authentication, you may need to enforce authorization rules to control what authenticated users can access:
 
-#### Overview
+| Authorization Method | When to use | Key characteristics | Learn more |
+|---------------------|-------------|---------------------|------------|
+| **Pattern Matching** | Simple attribute-based rules, checking claims or metadata values | CEL expressions; fast evaluation; good for straightforward conditions | [Pattern-matching authorization](https://docs.kuadrant.io/latest/authorino/docs/features/#pattern-matching-authorization-authorizationpatternmatching) |
+| **OPA (Open Policy Agent)** | Complex authorization logic, business rules, policy-as-code | Rego policy language; centralized policy management; supports sophisticated evaluation | [OPA authorization](https://docs.kuadrant.io/latest/authorino/docs/features/#open-policy-agent-opa-rego-policies-authorizationopa) |
+| **Kubernetes SubjectAccessReview** | Leverage Kubernetes RBAC, in-cluster authorization | Native K8s integration; uses existing Roles and RoleBindings; consistent with cluster permissions | [Kubernetes SubjectAccessReview](https://docs.kuadrant.io/latest/authorino/docs/features/#kubernetes-subjectaccessreview-authorizationkubernetessubjectaccessreview) |
+| **SpiceDB** | Fine-grained permissions, relationship-based access control | External Authzed/SpiceDB server; scales to complex permission models; Google Zanzibar-inspired | [SpiceDB authorization](https://docs.kuadrant.io/latest/authorino/docs/features/#spicedb-authorizationspicedb) |
 
-The `AuthPolicy` spec includes the following parts:
+## X.509 client certificate authentication
 
-- A reference to an existing Gateway API resource (`spec.targetRef`)
-- Authentication/authorization scheme (`spec.rules`)
-- Top-level additional conditions (`spec.when`)
-- List of named patterns (`spec.patterns`)
+For cryptographic identity verification using X.509 client certificates with mTLS, see the dedicated [X.509 Client Certificate Authentication overview](auth-x509.md). This authentication method is ideal for zero-trust architectures, compliance requirements, and machine-to-machine communication with PKI.
 
-The auth scheme specify rules for:
+The X.509 overview covers:
+- Configuration tiers (Gateway API v1.5+, provider-specific resources, header-only)
+- Defense-in-depth security model with L4 and L7 validation
+- Multi-CA trust with label selectors
+- Certificate requirements and constraints
+- Security considerations and best practices
+- Troubleshooting guide
 
-- Authentication (`spec.rules.authentication`)
-- External auth metadata fetching (`spec.rules.metadata`)
-- Authorization (`spec.rules.authorization`)
-- Custom response items (`spec.rules.response`)
-- Callbacks (`spec.rules.callbacks`)
 
-Each auth rule can declare specific `when` conditions for the rule to apply.
+## Apply consistent security policies across your API infrastructure
 
-The auth scheme (`rules`), as well as conditions and named patterns can be declared at the top-level level of the spec (with the semantics of _defaults_) or alternatively within explicit `defaults` or `overrides` blocks.
+When managing multiple APIs, routes, and gateways, you need flexible policy targeting that balances developer autonomy with platform governance. AuthPolicy provides multiple targeting options to match your organizational structure and security requirements.
 
-Check out the [API reference](../reference/authpolicy.md) for a full specification of the AuthPolicy CRD.
+### Protect specific routes with HTTPRoute-targeted policies
 
-## Using the AuthPolicy
+**Use HTTPRoute-targeted policies when:** Application teams own their routes and need to define authentication/authorization appropriate for their specific API endpoints.
 
-### Targeting a HTTPRoute networking resource
+An AuthPolicy targeting an HTTPRoute can protect:
+- **All traffic** for the entire route, or
+- **Specific rules** within the route by using `sectionName` to target individual HTTPRouteRules
 
-When targeting a HTTPRoute, an AuthPolicy can be enforced on:
-- all traffic routed by any rule specified in the HTTPRoute; or
-- only traffic routed by a specific set of rules as stated in a selected HTTPRouteRule of the HTTPRoute, by specifying the `sectionName` field in the target reference (`spec.targetRef`) of the policy.
+The policy applies to all hostnames and gateways referenced by the HTTPRoute. Use top-level `when` conditions (`spec.rules.when`) for additional filtering based on request attributes.
 
-Either way, the policy applies across all hostnames (`spec.hostnames`) and Gateways (`spec.parentRefs`) referenced in the HTTPRoute, provided the route is properly attached to the corresponding Gateway listeners.
-
-Additional filters for applying the policy can be set by specifying top-level conditions in the policy (`spec.rules.when`).
-
-**Example 1** - Targeting an entire HTTPRoute
+**Example - Protect an entire HTTPRoute:**
 
 ```yaml
 apiVersion: kuadrant.io/v1
@@ -84,7 +127,8 @@ spec:
 │                     │            │  └────────────┘     │
 │                     │            │        ▲            │
 │                     │            │        │            │
-│                     │            │        │ targetRef  │
+│                     │            │        │ targetRef: │
+│                     │            │        │ - my-route │
 │                     │            │        │            │
 │                     │            │  ┌─────┴──────┐     │
 │                     │            │  │ AuthPolicy │     │
@@ -93,7 +137,7 @@ spec:
 └─────────────────────┘            └─────────────────────┘
 ```
 
-**Example 2** - Targeting a specific set of rules of a HTTPRoute
+**Example - Protect only specific rules within a HTTPRoute:**
 
 ```yaml
 apiVersion: kuadrant.io/v1
@@ -122,7 +166,8 @@ spec:
 │                     │            │  └────────────┘      │
 │                     │            │        ▲             │
 │                     │            │        │             │
-│                     │            │        │ targetRef   │
+│                     │            │        │ targetRef:  │
+│                     │            │        │ - rule-2    │
 │                     │            │        │             │
 │                     │            │  ┌─────┴───────────┐ │
 │                     │            │  │   AuthPolicy    │ │
@@ -131,11 +176,18 @@ spec:
 └─────────────────────┘            └──────────────────────┘
 ```
 
-### Targeting a Gateway networking resource
+### Establish platform-wide security baselines with Gateway-targeted policies
 
-An AuthPolicy that targets a Gateway, without overrides, will be enforced to all HTTP traffic hitting the gateway, unless a more specific AuthPolicy targeting a matching HTTPRoute exists. Any new HTTPRoute referrencing the gateway as parent will be automatically covered by the gateway-targeting AuthPolicy, as well as changes in the existing HTTPRoutes.
+**Use Gateway-targeted policies when:** Platform engineers need to enforce organization-wide security requirements, establish default authentication for all routes, or ensure no route can be deployed without minimum security controls.
 
-Target a Gateway HTTPRoute by setting the `spec.targetRef` field of the AuthPolicy as follows:
+An AuthPolicy targeting a Gateway automatically applies to all routes attached to that gateway, including routes created after the policy. More specific HTTPRoute-targeted policies can override gateway defaults (unless you use `overrides` instead of `defaults`).
+
+Key behaviors:
+- **Automatic coverage**: New HTTPRoutes attached to the gateway are automatically protected
+- **Defaults allow specificity**: HTTPRoute policies override gateway defaults, enabling application teams to customize authentication
+- **Overrides enforce mandates**: Gateway overrides cannot be weakened by route-level policies, ensuring compliance requirements
+
+**Example - Establish default authentication for all routes:**
 
 ```yaml
 apiVersion: kuadrant.io/v1
@@ -157,11 +209,12 @@ spec:
 │                   │             │                      │
 │  ┌─────────┐      │  parentRefs │  ┌───────────┐       │
 │  │ Gateway │◄─────┼─────────────┼──┤ HTTPRoute │       │
-│  | (my-gw) |      │             │  └───────────┘       │
-│  └─────────┘      │             │        ▲             │
-│       ▲           │             │        |             │
+│  | (my-gw) |      │             │  | (my-route)│       │
+│  └─────────┘      │             │  └───────────┘       │
+│       ▲           │             │        ▲             │
 │       │           │             │        │             │
-│       │ targetRef │             │        │ targetRef   │
+│       │ targetRef:│             │        │ targetRef:  │
+│       │ - my-gw   │             │        │ - my-route  │
 │       │           │             │        │             │
 │ ┌─────┴────────┐  │             │  ┌─────┴───────────┐ │
 │ │  AuthPolicy  │  │             │  │   AuthPolicy    │ │
@@ -170,68 +223,155 @@ spec:
 └───────────────────┘             └──────────────────────┘
 ```
 
-### Defaults and Overrides
+### Balance platform governance with application flexibility using Defaults and Overrides
 
-Kuadrant AuthPolicies support Defaults & Overrides essentially as specified in Gateway API [GEP-2649](https://gateway-api.sigs.k8s.io/geps/gep-2649/).
+When managing security across multiple teams and services, you need to balance two goals: establishing organization-wide security baselines while giving application teams the flexibility to customize authentication for their specific needs.
 
-An AuthPolicy can declare a block of _defaults_ (`spec.defaults`) or a block of _overrides_ (`spec.overrides`). By default, policies that do not specify neither `defaults` nor `overrides`, act implicitly as if specifying `defaults`. A default set of policy rules are enforced until a more specific set supersedes them. In contrast, a set of overrides wins over any more specific set of rules.
+AuthPolicy provides two mechanisms based on Gateway API [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/):
 
-Setting _default_ AuthPolicies provide, e.g., platform engineers with the ability to protect the infrastructure against unplanned and malicious network traffic attempt, such as by setting preemptive "deny-all" policies at the level of the gateways that block access on all routes attached to the gateway. Later on, application developers can define more specific auth rules at the level of the HTTPRoutes, opening access to individual routes.
+| Use | When | Example scenario |
+|-----|------|------------------|
+| **Defaults** (`spec.defaults`) | You want to establish security baselines that application teams can customize or override | Platform team sets API key authentication at the Gateway; app teams can override with JWT for specific routes |
+| **Overrides** (`spec.overrides`) | You need to enforce mandatory security requirements that cannot be weakened | Security compliance requires all production traffic to use mTLS; override ensures no route can bypass this requirement |
 
-Inversely, a gateway policy that specify _overrides_ declares a set of rules that is enforced on all routes attached to the gateway, thus atomically replacing any more specific policy occasionally attached to any of those routes.
+**How defaults work:**
+- Policies without explicit `defaults` or `overrides` blocks behave as defaults
+- Default rules apply until a more specific policy supersedes them
+- Application teams can replace defaults with route-specific policies
+- Enables a "secure by default, customize as needed" approach
 
-Although typical examples involve specifying `defaults` and `overrides` at the level of the Gateway object which interact with sets of policy rules defined at the more specific context (HTTPRoute), Defaults & Overrides are actually transversal to object kinds. One can define AuthPolicies with `defaults` or `overrides` at any level of the following hierarchy and including multiple policies at the same level:
-1. Gateway
-2. Gateway listener (by targeting a Gateway with `sectionName`)
+**Example use case for defaults:** Set a "deny-all" policy at the Gateway to protect against unintentional exposure. Application teams then define specific authentication rules for their routes, effectively opening controlled access.
+
+**How overrides work:**
+- Override rules win over any more specific policies
+- Enforces mandatory controls that cannot be weakened by route-level policies
+- Ensures organization-wide compliance requirements are always met
+
+**Example use case for overrides:** Enforce mutual TLS for all production traffic regardless of what application teams configure, ensuring compliance with security standards.
+
+**Policy hierarchy:**
+
+Defaults and overrides work at any level of the Gateway API hierarchy:
+1. Gateway (broadest)
+2. Gateway listener (via `sectionName`)
 3. HTTPRoute
-4. HTTPRouteRule (by targeting a HTTPRoute with `sectionName`)
+4. HTTPRouteRule (via `sectionName`) (most specific)
 
-The final set of policy rules to enforce for a given request, known as "effective policy", is computed based on the basic principles stated in the [Hierarchy](https://gateway-api.sigs.k8s.io/geps/gep-2649/#hierarchy) section of GEP-2649 and [Conflict Resolution](https://gateway-api.sigs.k8s.io/geps/gep-2649/#conflict-resolution) of its predecessor [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/#conflict-resolution), for the hierarchical levels above.
+The "effective policy" for each request is computed based on hierarchy rules from [GEP-713](https://gateway-api.sigs.k8s.io/geps/gep-713/#resolving-conflicts). Kuadrant implements 4 [merge strategies](https://gateway-api.sigs.k8s.io/geps/gep-713/#designing-a-merge-strategy) allowing atomic or merged composition of policy rules:
+- **Atomic defaults:** The most specific policy fully replaces less specific ones for the topological scope it applies to. No merging of rules occurs. This is the default behavior.
+- **Atomic overrides:** The broadest policy fully replaces more specific ones. No merging of rules occurs.
+- **Merged defaults:** Individual rules from the most specific policy replaces rules with the same name in less specific ones, while rules with different names are both maintained.
+- **Merged overrides:** Individual rules from the broadest policy replaces rules with the same name in more specific ones, while rules with different names are both maintained.
 
-Kuadrant AuthPolicies extend Gateway API's Defaults & Overrides with additional merge strategies for allowing users to specify sets of policy rules under `defaults` and/or `overrides` blocks that can be either _atomically_ applied or _merged_ into a composition of policy rules from the multiple AuthPolicies affecting a hierarchy of newtworking objects. The name of the policy rule is used for detecting conflicts.
+### Understand how policies apply to wildcard hostnames
 
-For details of the behavior of Defaults & Overrides for the AuthPolicies covering all supported merge strategies, see [RFC-0009](https://github.com/Kuadrant/architecture/blob/main/rfcs/0009-defaults-and-overrides.md).
+When you define routes with wildcard hostnames (e.g., `*.example.com`) alongside specific hostnames (e.g., `api.example.com`), you may wonder which AuthPolicy takes precedence.
 
-### Hostnames and wildcards
+**Principle: "Most specific wins"**
 
-If an AuthPolicy targets a route defined for a hostname wildcard `*.com` and a second AuthPolicy targets another route for a hostname `api.com`, without any overrides nor merges in place, the policies will be enforced according to the principle of "the more specific wins". E.g., a request coming for `api.com` will be protected according to the rules from the AuthPolicy that targets the route for `api.com`, while a request for `other.com` will be protected with the rules from the AuthPolicy targeting the route for `*.com`. One should not expect both set of policy rules to be enforced on requests to `api.com` simply because both hostname and wildcard match.
+Without overrides in place, the AuthPolicy targeting the most specific matching route applies. Policies don't combine—only one policy's rules are enforced per request.
 
-Example with 3 AuthPolicies and 3 HTTPRoutes, without merges nor overrides in place:
-
+**Example scenario:**
 - AuthPolicy A → HTTPRoute A (`a.toystore.com`)
 - AuthPolicy B → HTTPRoute B (`b.toystore.com`)
 - AuthPolicy W → HTTPRoute W (`*.toystore.com`)
 
-Expected behavior:
+**Request behavior:**
+- Request to `a.toystore.com` → AuthPolicy A applies (specific hostname wins)
+- Request to `b.toystore.com` → AuthPolicy B applies (specific hostname wins)
+- Request to `other.toystore.com` → AuthPolicy W applies (wildcard catches unmatched)
 
-- Request to `a.toystore.com` → AuthPolicy A will be enforced
-- Request to `b.toystore.com` → AuthPolicy B will be enforced
-- Request to `other.toystore.com` → AuthPolicy W will be enforced
+This allows you to set broad defaults with wildcards while overriding authentication for specific subdomains.
 
-### `when` conditions
+### Apply policies conditionally based on request attributes with `when` conditions
 
-`when` conditions can be used to scope an AuthPolicy or auth rule within an AuthPolicy (i.e. to filter the traffic to which a policy or policy rule applies) without any coupling to the underlying network topology.
+**Use `when` conditions when:** You need to activate authentication based on request attributes that can't be expressed in HTTPRoute matching rules, such as source IP ranges, identity-based attributes, resource attributes, custom metadata, or time-based conditions.
 
-Use `when` conditions to conditionally activate policies and policy rules based on attributes that cannot be expressed in the HTTPRoutes' `spec.hostnames` and `spec.rules.matches` fields, or in general in AuthPolicies that target a Gateway.
+Common use cases:
+- Apply different authentication to requests from internal vs. external IP ranges
+- Enable authentication only during specific time windows
+- Apply policies based on JWT claims or other dynamic attributes
 
-`when` conditions in an AuthPolicy are compatible with Authorino [conditions](https://docs.kuadrant.io/latest/authorino/docs/features/#common-feature-conditions-when), thus supporting complex boolean expressions with AND and OR operators, as well as grouping.
+`when` conditions support complex boolean expressions with AND/OR operators and grouping, compatible with Authorino [conditions](https://docs.kuadrant.io/latest/authorino/docs/features/#common-feature-conditions-when).
 
-The selectors within the `when` conditions of an AuthPolicy are a subset of Kuadrant's Well-known Attributes ([RFC 0002](https://github.com/Kuadrant/architecture/blob/main/rfcs/0002-well-known-attributes.md)). Check out the reference for the full list of supported selectors.
+**Example - Apply different authentication based on source IP (internal vs. external traffic):**
 
-Authorino [JSON path string modifiers](https://docs.kuadrant.io/latest/authorino/docs/features/#string-modifiers) can also be applied to the selectors within the `when` conditions of an AuthPolicy.
+```yaml
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: network-based-auth
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: my-api
+  rules:
+    authentication:
+      # Allow anonymous access from internal networks
+      "internal-anonymous":
+        anonymous: {}
+        when:
+        - predicate: "source.address.matches('10\\..*|172\\.(1[6-9]|2[0-9]|3[01])\\..*|192\\.168\\..*')"
 
-## Egress
+      # Require strong authentication from external networks
+      "external-mtls":
+        x509:
+          selector:
+            matchLabels:
+              tier: production
+        when:
+        # Activate when source is NOT in private IP ranges
+        - predicate: "!source.address.matches('10\\..*|172\\.(1[6-9]|2[0-9]|3[01])\\..*|192\\.168\\..*')"
+```
 
-AuthPolicy works on egress gateways with the same attachment model described above. On egress, the primary use case is **credential injection** — i.e., authenticating workloads using a common authentication mechanism at the gateway (e.g. Kubernetes service account tokens) and injecting specific external API credentials (e.g. API key fetched from Vault) into the outbound requests, typically replacing the `Authorization` header.
+This example shows a scenario that cannot be achieved with HTTPRoute matching alone—HTTPRoute has no support for source IP-based routing or matching.
 
-The Gateway resource and policy attachment model are identical between ingress and egress — the Kuadrant operator does not distinguish between them. See the [Egress Gateway Credential Injection](../user-guides/egress/credential-injection.md) guide for a full walkthrough.
+Conditions implement Kuadrant's [Well-known Attributes](https://github.com/Kuadrant/architecture/blob/main/rfcs/0002-well-known-attributes.md). You can use [Common Expression Language (CEL)](https://cel.dev/) predicates or [JSON path selector modifiers](https://docs.kuadrant.io/latest/authorino/docs/features/#string-modifiers) for advanced conditions.
 
-## Examples
+## Secure outbound API calls with credential injection at egress gateways
 
-Check out the following user guides for examples of protecting services with Kuadrant:
+When your services call external APIs that require authentication, you need to centrally manage external credentials at the egress gateway rather than distributing secrets to every pod. This approach maintains security, simplifies credential rotation, and provides centralized audit logging for external API access.
 
-- [Enforcing authentication & authorization with Kuadrant AuthPolicy, for app developers and platform engineers](../user-guides/auth/auth-for-app-devs-and-platform-engineers.md)
-- [Egress Gateway Credential Injection](../user-guides/egress/credential-injection.md)
+### How egress credential injection works
+
+**Use egress credential injection when:**
+- Services need to call external APIs (payment processors, cloud providers, SaaS platforms)
+- External APIs require authentication (API keys, OAuth tokens, custom headers)
+- You want to avoid distributing external API credentials to every pod
+- You need centralized credential management and rotation
+- You want to authenticate internal workloads before allowing external API access
+
+**The credential injection pattern:**
+
+1. **Authenticate internal workload**: Gateway authenticates the workload making the outbound request using internal mechanisms (Kubernetes ServiceAccount tokens, JWT, API keys)
+2. **Fetch external credentials**: Gateway retrieves external API credentials from secure storage (Kubernetes Secrets, Vault, external metadata sources)
+3. **Inject credentials**: Gateway replaces or adds authentication headers in the outbound request with external API credentials
+4. **Forward request**: Request proceeds to the external API with proper authentication
+
+
+**Key characteristics:**
+- **Same attachment model**: AuthPolicy attaches to egress Gateways and HTTPRoutes identically to ingress—Kuadrant doesn't distinguish between ingress and egress
+- **Centralized secret management**: External credentials stored in one location, not distributed to pods
+- **Credential rotation**: Update credentials at the gateway without redeploying workloads
+- **Audit trail**: All external API access logged at the gateway
+- **Defense in depth**: Authenticate internal workloads before allowing external API access
+
+See the [Egress Gateway Credential Injection](../user-guides/egress/credential-injection.md) user guide for a complete walkthrough including HTTPRoute configuration for external services.
+
+## Examples and user guides
+
+Explore these user guides for complete examples of protecting services with Kuadrant AuthPolicy:
+
+### Authentication examples
+- [X.509 Client Certificate Authentication](../user-guides/auth/x509-client-certificate-authentication.md) - Defense-in-depth mTLS with Gateway API v1.5 frontend TLS validation
+- [Anonymous Access](../user-guides/auth/anonymous-access.md) - Selectively allow unauthenticated access to specific routes
+- [Enforcing authentication & authorization with Kuadrant AuthPolicy, for app developers and platform engineers](../user-guides/auth/auth-for-app-devs-and-platform-engineers.md) - API key authentication with platform governance
+
+### Egress gateway examples
+- [Egress Gateway Credential Injection](../user-guides/egress/credential-injection.md) - Centralized credential management for outbound API calls
+
+### Authentication with rate limiting
 - [Authenticated Rate Limiting for Application Developers](../user-guides/ratelimiting/authenticated-rl-for-app-developers.md)
 - [Authenticated Rate Limiting with JWTs and Kubernetes RBAC](../user-guides/ratelimiting/authenticated-rl-with-jwt-and-k8s-authnz.md)
 


### PR DESCRIPTION
## Summary

Implements comprehensive documentation for X.509 client certificate authentication in AuthPolicy using Jobs-to-be-Done (JTBD) documentation strategy.

Closes #1831

## Changes

### New Documentation

**Created [doc/overviews/auth-x509.md](doc/overviews/auth-x509.md)** - Dedicated X.509 authentication overview covering:
- **Configuration tiers**: Gateway API v1.5+ (Tier 1), provider-specific resources (Tier 2), header-only (Tier 3)
- **Defense-in-depth security model**: L4 TLS validation + L7 Authorino validation
- **Multi-CA trust**: Label selector-based CA selection for fine-grained control
- **Certificate requirements**: x509 v3 extension with Client Authentication EKU, encoding formats
- **Security considerations**: XFCC header security, CA certificate management, spoofing prevention (from RFC 0015)
- **Best practices**: cert-manager automation, rotation strategies, monitoring, network segmentation
- **Troubleshooting**: Common issues with resolution steps

### Enhanced Documentation (JTBD-based)

**Updated [doc/overviews/auth.md](doc/overviews/auth.md)** - Transformed from feature-based to job-based structure:
- **Job-oriented introduction**: "Secure API access with authentication and authorization"
- **Common authentication jobs table**: Maps user situations to solutions
- **Authentication method decision guide**: Comprehensive comparison table (API keys, JWT/OIDC, X.509, OAuth2, K8s TokenReview, Plain, Anonymous)
- **Authorization method decision guide**: Pattern Matching, OPA, K8s RBAC, SpiceDB
- **"Understanding how Kuadrant auth integrates"**: Replaces technical "How it works" with user evaluation focus
- **Policy targeting sections**: Reframed with "when to use" guidance (HTTPRoute vs Gateway policies)
- **Defaults & Overrides**: "Balance platform governance with application flexibility" with use cases
- **Conditional policies**: Better `when` conditions example using CEL predicates for source IP matching
- **Concise X.509 summary**: Links to dedicated auth-x509.md

**Updated [doc/reference/authpolicy.md](doc/reference/authpolicy.md)** - Kept focused on API structure:
- Removed detailed X.509 example (belongs in overview/user guides)
- Maintained API reference purpose: document structure, not use cases

### JTBD Benefits Delivered

✅ **Guided path to job completion**: Decision tables → detailed sections → working examples  
✅ **Reduced "How do I...?" questions**: Tables answer "When do I use X.509 vs JWT vs API keys?"  
✅ **Users discover capabilities in context**: X.509 presented alongside all authentication methods  
✅ **Documentation feels "written for me"**: Multiple personas addressed (compliance, zero-trust, PKI users)  
✅ **Stable structure**: Organized by jobs, not features—won't need restructuring when new auth methods added

## Documentation Structure

```
doc/
├── overviews/
│   ├── auth.md              # Main auth overview (JTBD-based, all methods)
│   └── auth-x509.md         # Dedicated X.509 deep-dive (NEW)
├── reference/
│   └── authpolicy.md        # API reference (structure-focused)
└── user-guides/
    └── auth/
        └── x509-client-certificate-authentication.md  # Working example (already exists)
```

## X.509 Documentation Highlights

- **Clear tier guidance**: Tier 1 (recommended) → Tier 2 (alternative) → Tier 3 (exceptional)
- **Security-first approach**: Defense-in-depth explained, spoofing prevention documented
- **RFC 0015 alignment**: All security considerations from architecture RFC integrated
- **Proper context**: X.509 not over-emphasized vs. other authentication methods
- **Complete coverage**: Requirements, constraints, best practices, troubleshooting

## Testing

Documentation follows JTBD principles:
- ✅ Job-oriented structure (organized by what users are trying to accomplish)
- ✅ Decision guidance (tables help users choose the right approach)
- ✅ Context in overview, depth in dedicated doc
- ✅ API reference stays focused on structure
- ✅ Cross-references connect all documentation layers

---

**Note**: This PR uses the Jobs-to-be-Done documentation strategy to transform authentication documentation from feature-focused to user-goal-focused, making it easier for users to find the right solution for their needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive X.509 client‑certificate authentication guide covering gateway vs application validation tiers, multi‑CA trust selection, CA rotation and trust constraints, certificate requirements, response identity injection and troubleshooting.
  * Reworked the authentication overview into a structured guide with decision tables for authN/authZ, clearer policy hierarchy (defaults vs overrides), wildcard precedence, richer conditional activation examples and egress credential‑injection guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->