### PR TITLE
fix: add missing grpc service bundle manifest

### DIFF
--- a/bundle/manifests/kuadrant-operator-grpc_v1_service.yaml
+++ b/bundle/manifests/kuadrant-operator-grpc_v1_service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+    control-plane: controller-manager
+  name: kuadrant-operator-grpc
+spec:
+  ports:
+  - name: grpc
+    port: 50051
+    protocol: TCP
+    targetPort: grpc
+  selector:
+    app: kuadrant
+    control-plane: controller-manager
+status:
+  loadBalancer: {}


### PR DESCRIPTION
## Summary

- Adds the missing generated `bundle/manifests/kuadrant-operator-grpc_v1_service.yaml` that was missed in #1822 which added `config/manager/grpc_service.yaml`.

## Related PRs

- #1888 and #1882 are adding PR validation for manifests and bundles to prevent this kind of drift in future.