### PR TITLE
docs: clarify supported OTLP protocols for Kuadrant CR tracing endpoint

### DIFF
--- a/doc/observability/tracing.md
+++ b/doc/observability/tracing.md
@@ -83,9 +83,7 @@ spec:
 
 **Tracing Configuration Fields:**
 
-- `defaultEndpoint`: The URL of the tracing collector backend (OTLP endpoint). Supported protocols:
-  - `rpc://` for gRPC OTLP (port 4317)
-  - `http://` for HTTP OTLP (port 4318)
+- `defaultEndpoint`: The URL of the tracing collector backend (OTLP endpoint). Use `rpc://` (gRPC OTLP, port 4317) for full compatibility across all components.
 - `insecure`: Set to `true` to skip TLS certificate verification (useful for development environments).
 
 **Important:** Point to the **collector** service (e.g., `jaeger-collector`), not the query service. The collector receives traces from your applications, while the query service is only for viewing traces in the UI.


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                    
  - Clarify that `defaultEndpoint` in the Kuadrant CR must use `rpc://` (gRPC OTLP, port 4317)     
  - Document that Authorino is the only component supporting `http://` (HTTP OTLP, port 4318), and this must be configured directly in the Authorino CR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified tracing endpoint guidance: recommend using rpc:// for broad compatibility across components.
  * Clarified that http:// OTLP is only supported for Authorino and requires direct Authorino configuration, which overrides the central default endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->