### PR TITLE
Require maintainer approval to run e2e smoke tests from forks

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -1,7 +1,7 @@
 name: E2E Smoke Test
 
 on:
-  pull_request:
+  pull_request_target: # runs in base repo context, granting access to secrets for fork PRs
     branches: ['main']
   merge_group:
     types: [checks_requested]
@@ -23,8 +23,10 @@ jobs:
 
   smoke-tests:
     name: Smoke Tests
-    if: needs.pre-job.outputs.should_skip != 'true' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    if: needs.pre-job.outputs.should_skip != 'true'
     needs: pre-job
+    # Require maintainer approval for fork PRs to access secrets
+    environment: ${{ github.event.pull_request.head.repo.fork && 'e2e-smoke-test' || '' }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -32,6 +34,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          # pull_request_target checks out base branch by default; override to get PR code
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary
  - Switch smoke test trigger from `pull_request` to `pull_request_target` so fork PRs can access repository
  secrets
  - Add `e2e-smoke-test` environment gate that requires maintainer approval before running on fork PRs
  - Internal PRs (non-fork) continue to run immediately without approval

  ## Prerequisites
  Create an `e2e-smoke-test` environment in **Settings > Environments** with **Required reviewers** enabled.

  ## Security note
  `pull_request_target` runs the workflow YAML from the base branch (`main`), not from the fork. The `ref`
  override checks out the PR's code for testing. Maintainers should review the PR diff before approving the
  workflow run to ensure no malicious changes to build scripts or test targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated testing workflow to support pull requests from external contributors. Added security approval gate for test environment access when PRs originate from forks, ensuring code integrity whilst maintaining security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->