### PR TITLE
Fix issues in the X.509 authentication docs

### DIFF
--- a/doc/overviews/auth-x509.md
+++ b/doc/overviews/auth-x509.md
@@ -242,7 +242,7 @@ kubectl label secret customer-a-ca \
 ```
 
 > [!IMPORTANT] Cross-namespace trust
-> By default, Authorino only trusts CA secrets in the Kuadrant namespace. To allow cross-namespace references, set `allNamespaces: true` in the AuthPolicy, but use this with caution as it expands the trust scope.
+> By default, Authorino only trusts CA secrets in the Kuadrant namespace. To allow cross-namespace references, set `allNamespaces: true` in the x509 spec (`rules.authentication.x509.allNamespaces`), but use this with caution as it expands the trust scope.
 
 ## Certificate requirements and constraints
 
@@ -293,7 +293,7 @@ When X.509 authentication succeeds, the identity object (`auth.identity`) contai
 | `Province` | array of strings | 2.5.4.8 | Province/State (ST) | `["California"]` |
 | `StreetAddress` | array of strings | 2.5.4.9 | Street Address | `["123 Main St"]` |
 | `PostalCode` | array of strings | 2.5.4.17 | Postal Code | `["94105"]` |
-| `SerialNumber` | string | 2.5.4.5 | Subject serial number | `"01:23:45:67:89:AB:CD:EF"` |
+| `SerialNumber` | string | 2.5.4.5 | Subject serial number | `"12345"` |
 
 **Example - Use certificate attributes in authorization:**
 

--- a/doc/user-guides/auth/x509-authentication.md
+++ b/doc/user-guides/auth/x509-authentication.md
@@ -53,7 +53,7 @@ Kuadrant supports three configuration tiers. Choose the one that matches your Ga
 ## Decision tree
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#fff','primaryTextColor':'#000','primaryBorderColor':'#000','lineColor':'#000','secondaryColor':'#fff','tertiaryColor':'#fff','clusterBkg':'#fff','clusterBorder':'#000','edgeLabelBackground':'#fff'}}}%%
+%%{init: {'theme':'neutral'}}%%
 graph TD
     Start[Need X.509 client authentication?]
     Start --> GatewayAPI{Gateway API v1.5+?}
@@ -70,18 +70,6 @@ graph TD
     Tier1 --> Tier1Link[Follow Tier 1 guide]
     Tier2 --> Tier2Link[Follow Tier 2 guide]
     Tier3 --> Tier3Link[Follow Tier 3 guide]
-
-    style Tier1 fill:none,stroke:#000,color:#000
-    style Tier2 fill:none,stroke:#000,color:#000
-    style Tier3 fill:none,stroke:#000,color:#000
-    style Reconsider fill:none,stroke:#000,color:#000
-    style Start fill:none,stroke:#000,color:#000
-    style GatewayAPI fill:none,stroke:#000,color:#000
-    style DefenseDepth fill:none,stroke:#000,color:#000
-    style AcceptL7 fill:none,stroke:#000,color:#000
-    style Tier1Link fill:none,stroke:#000,color:#000
-    style Tier2Link fill:none,stroke:#000,color:#000
-    style Tier3Link fill:none,stroke:#000,color:#000
 ```
 
 ## Understanding the tiers

--- a/doc/user-guides/auth/x509-tier1-gateway-api-validation.md
+++ b/doc/user-guides/auth/x509-tier1-gateway-api-validation.md
@@ -117,6 +117,9 @@ kubectl label secret trusted-client-ca \
 
 Create a Gateway with `spec.tls.frontend.default.validation` to enable client certificate validation at the TLS layer:
 
+> [!NOTE]
+> The example file below also includes a cert-manager Issuer and TLSPolicy for automated server certificate provisioning. The Gateway configuration shown here highlights the key mTLS validation settings.
+
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -130,6 +133,9 @@ spec:
     protocol: HTTPS
     port: 443
     hostname: "*.nip.io"
+    allowedRoutes:
+      namespaces:
+        from: All
     tls:
       mode: Terminate
       certificateRefs:
@@ -192,16 +198,14 @@ spec:
   parentRefs:
   - name: mtls-gateway
     namespace: gateway-system
-  hostnames:
-  - "httpbin.*.nip.io"
   rules:
   - matches:
     - path:
         type: PathPrefix
-        value: "/"
+        value: /
     backendRefs:
     - name: httpbin
-      port: 8080
+      port: 80
 ```
 
 ### Step 6: Configure AuthPolicy for L7 validation
@@ -243,7 +247,7 @@ spec:
     response:
       success:
         headers:
-          "x-client-cn":
+          "x-client-common-name":
             plain:
               expression: auth.identity.CommonName
           "x-client-org":
@@ -438,7 +442,7 @@ spec:
 The following diagram illustrates the component relationships and request flow:
 
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': { 'primaryColor':'#fff','primaryTextColor':'#000','primaryBorderColor':'#000','lineColor':'#000','secondaryColor':'#fff','tertiaryColor':'#fff','clusterBkg':'#fff','clusterBorder':'#000','edgeLabelBackground':'#fff'}}}%%
+%%{init: {'theme':'neutral'}}%%
 graph TB
     Client([Client with<br/>X.509 Certificate])
 
@@ -467,16 +471,6 @@ graph TB
     SVC --> POD
     AP -.->|attached to| HR
     AP -.->|validates cert via<br/>label selector| CASEC
-
-    style GW fill:none,stroke:#000,color:#000
-    style HR fill:none,stroke:#000,color:#000
-    style AP fill:none,stroke:#000,color:#000
-    style CACM fill:none,stroke:#000,color:#000
-    style CASEC fill:none,stroke:#000,color:#000
-    style TLSCERT fill:none,stroke:#000,color:#000
-    style SVC fill:none,stroke:#000,color:#000
-    style POD fill:none,stroke:#000,color:#000
-    style Client fill:none,stroke:#000,color:#000
 ```
 
 ## Troubleshooting

--- a/doc/user-guides/auth/x509-tier3-header-only.md
+++ b/doc/user-guides/auth/x509-tier3-header-only.md
@@ -54,6 +54,7 @@ Tier 3 implements **single-layer validation** at the application level:
 **Required:**
 - **Kuadrant Operator**: Installed with Kuadrant instance deployed
 - **Security awareness**: Understanding of L7-only validation trade-offs
+- **jq**: Command-line JSON processor (for URL-encoding certificates in test commands)
 
 **Recommended:**
 - **Trusted upstream proxy**: Configured for mTLS, certificate header forwarding, and header spoofing prevention
@@ -353,7 +354,7 @@ GATEWAY_IP=$(kubectl get gateway mtls-gateway -n gateway-system -o jsonpath='{.s
 
 # Send request with XFCC header containing the certificate
 curl -ik https://httpbin.$GATEWAY_IP.nip.io/get \
-  -H "X-Forwarded-Client-Cert: Hash=$(openssl x509 -in /tmp/client.crt -outform DER | sha256);Cert=\"$(cat /tmp/client.crt | jq -sRr @uri)\";Subject=\"CN=test-client/O=Kuadrant/C=US\";URI="
+  -H "X-Forwarded-Client-Cert: Hash=$(openssl x509 -in /tmp/client.crt -outform DER | openssl dgst -sha256 | awk '{print $2}');Cert=\"$(cat /tmp/client.crt | jq -sRr @uri)\";Subject=\"CN=test-client/O=Kuadrant/C=US\";URI="
 ```
 
 **Expected**: HTTP 200. Authorino validates the certificate chain against trusted CAs and authorization succeeds.
@@ -376,7 +377,7 @@ openssl req -x509 -newkey rsa:2048 -nodes \
 
 # Try to connect
 curl -ik https://httpbin.$GATEWAY_IP.nip.io/get \
-  -H "X-Forwarded-Client-Cert: Hash=$(openssl x509 -in /tmp/untrusted.crt -outform DER | sha256);Cert=\"$(cat /tmp/untrusted.crt | jq -sRr @uri)\";Subject=\"CN=untrusted-client/O=Untrusted/C=US\";URI="
+  -H "X-Forwarded-Client-Cert: Hash=$(openssl x509 -in /tmp/untrusted.crt -outform DER | openssl dgst -sha256 | awk '{print $2}');Cert=\"$(cat /tmp/untrusted.crt | jq -sRr @uri)\";Subject=\"CN=untrusted-client/O=Untrusted/C=US\";URI="
 ```
 
 **Expected**: HTTP 401. Certificate doesn't chain to trusted CA, Authorino rejects.


### PR DESCRIPTION
See https://github.com/Kuadrant/kuadrant-operator/pull/1931#issuecomment-4334723939

- **Issue 1:** Fixed `sha256` command to use `openssl dgst -sha256 | awk '{print $2}'` (Tier 3 user guide)
- **Issue 2:** Changed SerialNumber example from "01:23:45:67:89:AB:CD:EF" to "12345" (overview)
- **Issue 3:** Aligned inline HTTPRoute example with actual file (removed hostnames, fixed port to 80)
- **Issue 4:** Updated inline AuthPolicy to use "x-client-common-name" instead of "x-client-cn"
- **Issue 5:** Added `jq` to prerequisites in Tier 3 guide
- **Issue 6:** Clarified `allNamespaces` field path as `rules.authentication.x509.allNamespaces`
- **Issue 7:** Updated Mermaid diagrams to use `neutral` theme (2 diagrams)
- **Issue 8:** Added note about Issuer and TLSPolicy resources, added `allowedRoutes.namespaces.from: All` to inline Gateway example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified X.509 cross-namespace CA trust configuration path specifications.
  * Updated X.509 authentication examples with improved Gateway API validation and header configuration guidance.
  * Refined test command documentation for header-only X.509 authentication scenarios with updated tooling references.
  * Enhanced diagram styling consistency across authentication guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->