### PR TITLE
fix: respect CONTAINER_ENGINE in docker-network-ipaddresspool.sh

### DIFF
--- a/make/development-environments.mk
+++ b/make/development-environments.mk
@@ -15,7 +15,7 @@ install-metallb: kustomize yq ## Installs the metallb load balancer allowing use
 	$(KUSTOMIZE) build config/metallb | kubectl apply -f -
 	kubectl -n metallb-system wait --for=condition=Available deployments controller --timeout=300s
 	kubectl -n metallb-system wait --for=condition=ready pod --selector=app=metallb --timeout=60s
-	./utils/docker-network-ipaddresspool.sh kind $(YQ) ${SUBNET_OFFSET} ${CIDR} ${NUM_IPS} | kubectl apply -n metallb-system -f -
+	CONTAINER_ENGINE=$(CONTAINER_ENGINE) ./utils/docker-network-ipaddresspool.sh kind $(YQ) ${SUBNET_OFFSET} ${CIDR} ${NUM_IPS} | kubectl apply -n metallb-system -f -
 
 .PHONY: install-observability-crds
 install-observability-crds: kustomize yq

--- a/utils/docker-network-ipaddresspool.sh
+++ b/utils/docker-network-ipaddresspool.sh
@@ -13,27 +13,18 @@ YQ="${2:-yq}"
 offset=${3:-0}
 cidr=${4:-28}
 numIPs=${5:-16}
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
 
 ## Parse kind network subnet
 ## Take only IPv4 subnets, exclude IPv6
 SUBNET=""
-# Try podman version of cmd first. docker alias may be used for podman, so network
-# command will be different
 set +e
-if command -v podman &>/dev/null; then
+if [[ "$CONTAINER_ENGINE" == "podman" ]]; then
   SUBNET=$(podman network inspect -f '{{range .Subnets}}{{if eq (len .Subnet.IP) 4}}{{.Subnet}}{{end}}{{end}}' $networkName)
-  if [[ -z "$SUBNET" ]]; then
-    echo "Failed to obtain subnet using podman. Trying docker instead..." >&2
-  fi
 else
-  echo "podman not found. Trying docker..." >&2
-fi
-set -e
-
-# Fallback to docker version of cmd
-if [[ -z "$SUBNET" ]]; then
   SUBNET=$(docker network inspect $networkName --format '{{json .IPAM.Config}}' | ${YQ} '.[] | select( .Subnet | test("^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}/\d+$")) | .Subnet')
 fi
+set -e
 # Neither worked, error out
 if [[ -z "$SUBNET" ]]; then
   echo "Error: parsing IPv4 network address for '$networkName' docker network"

--- a/utils/docker-network-ipaddresspool.sh
+++ b/utils/docker-network-ipaddresspool.sh
@@ -17,6 +17,11 @@ CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
 
 ## Parse kind network subnet
 ## Take only IPv4 subnets, exclude IPv6
+if [[ "$CONTAINER_ENGINE" != "podman" && "$CONTAINER_ENGINE" != "docker" ]]; then
+  echo "Error: invalid CONTAINER_ENGINE='$CONTAINER_ENGINE' for network '$networkName'. Must be 'podman' or 'docker'." >&2
+  exit 1
+fi
+
 SUBNET=""
 set +e
 if [[ "$CONTAINER_ENGINE" == "podman" ]]; then


### PR DESCRIPTION
## Summary

The `docker-network-ipaddresspool.sh` script always tried `podman network inspect` first, regardless of the `CONTAINER_ENGINE` variable. This meant that on systems where both podman and docker are installed, the script would query the podman network even when the Kind cluster was created with docker, potentially returning wrong subnet information or failing unnecessarily before falling back.

This change:
- Makes the script use `CONTAINER_ENGINE` (defaulting to `docker`) to decide which runtime to query, consistent with the rest of the project
- Passes `CONTAINER_ENGINE` from the Makefile to the script in `install-metallb`
- Removes the auto-detection/fallback logic in favor of an explicit choice

## Test plan
- [ ] Run `make install-metallb` with default `CONTAINER_ENGINE=docker` and verify the correct subnet is detected
- [ ] Run `make install-metallb CONTAINER_ENGINE=podman` on a podman-based setup and verify it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * MetalLB installation now uses an explicitly configured container engine setting passed to the network setup, with the network script validating the chosen engine and deterministically using either podman or docker. This removes automatic probing and makes behaviour more predictable and fail-fast when an invalid engine is supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->