### PR TITLE
Upgrade Go to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/kuadrant-operator
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary
- Bump Go version from 1.25.8 to 1.25.9

### CVEs resolved

| CVE | Package | CVSS | Fixed in |
|-----|---------|------|----------|
| CVE-2026-32280 | `crypto/x509` | 7.5 (High) | 1.25.9 |
| CVE-2026-33810 | `crypto/x509` | Not scored | 1.25.9 |
| CVE-2026-32282 | `internal/syscall/unix` | 7.8 (High) | 1.25.9 |

### Details

- **CVE-2026-32280** (`crypto/x509`): DoS via excessive certificate chain building work when many intermediate certs are passed in `VerifyOptions.Intermediates`. Also affects `crypto/tls` users.
- **CVE-2026-33810** (`crypto/x509`): Certificate validation bypass — excluded DNS constraints not correctly applied to wildcard SANs with different casing.
- **CVE-2026-32282** (`internal/syscall/unix`): `Root.Chmod` can follow symlinks out of the root directory on Linux (TOCTOU race).

Supersedes #1852 (Go 1.25.8 upgrade). Part of #1886.

## Repos checklist
- [x] kuadrant-operator
- [x] authorino
- [x] authorino-operator
- [x] limitador-operator
- [x] dns-operator
- [x] policy-machinery
- [x] developer-portal-controller

## Helm charts
No Helm chart changes needed — Go toolchain bumps affect the compiled binary, not the chart templates/values. Chart `appVersion` is updated at release time when a new tag is cut.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build toolchain version to the latest patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->