### PR TITLE
ratelimit: propagate ParseTopologyPath errors in helpers (#1890)

### DIFF
--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -418,7 +418,14 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 
 		// rate limit
 		if effectivePolicy, ok := effectiveRateLimitPoliciesMap[pathID]; ok {
-			rlAction := buildWasmActionsForRateLimit(effectivePolicy, isRateLimitPolicyAcceptedAndNotDeletedFunc(state))
+			rlAction, rlErr := buildWasmActionsForRateLimit(effectivePolicy, isRateLimitPolicyAcceptedAndNotDeletedFunc(state))
+			if rlErr != nil {
+				logger.Error(rlErr, "failed to build wasm actions for rate limit policy", "pathID", pathID)
+				pathSpan.RecordError(rlErr)
+				pathSpan.SetStatus(codes.Error, "failed to build rate limit actions")
+				pathSpan.End()
+				continue
+			}
 			if hasAuthAccess(rlAction) {
 				actions = append(actions, rlAction...)
 			} else {
@@ -429,7 +436,14 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 		}
 
 		if effectivePolicy, ok := effectiveTokenRateLimitPoliciesMap[pathID]; ok {
-			trlAction := buildWasmActionsForTokenRateLimit(effectivePolicy, isTokenRateLimitPolicyAcceptedAndNotDeletedFunc(state))
+			trlAction, trlErr := buildWasmActionsForTokenRateLimit(effectivePolicy, isTokenRateLimitPolicyAcceptedAndNotDeletedFunc(state))
+			if trlErr != nil {
+				logger.Error(trlErr, "failed to build wasm actions for token rate limit policy", "pathID", pathID)
+				pathSpan.RecordError(trlErr)
+				pathSpan.SetStatus(codes.Error, "failed to build token rate limit actions")
+				pathSpan.End()
+				continue
+			}
 			if hasAuthAccess(trlAction) {
 				actions = append(actions, trlAction...)
 			} else {

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -433,7 +433,14 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 
 		// rate limit
 		if effectivePolicy, ok := effectiveRateLimitPoliciesMap[pathID]; ok {
-			rlAction := buildWasmActionsForRateLimit(effectivePolicy, isRateLimitPolicyAcceptedAndNotDeletedFunc(state))
+			rlAction, rlErr := buildWasmActionsForRateLimit(effectivePolicy, isRateLimitPolicyAcceptedAndNotDeletedFunc(state))
+			if rlErr != nil {
+				logger.Error(rlErr, "failed to build wasm actions for rate limit policy", "pathID", pathID)
+				pathSpan.RecordError(rlErr)
+				pathSpan.SetStatus(codes.Error, "failed to build rate limit actions")
+				pathSpan.End()
+				continue
+			}
 			if hasAuthAccess(rlAction) {
 				actions = append(actions, rlAction...)
 			} else {
@@ -444,7 +451,14 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 		}
 
 		if effectivePolicy, ok := effectiveTokenRateLimitPoliciesMap[pathID]; ok {
-			trlAction := buildWasmActionsForTokenRateLimit(effectivePolicy, isTokenRateLimitPolicyAcceptedAndNotDeletedFunc(state))
+			trlAction, trlErr := buildWasmActionsForTokenRateLimit(effectivePolicy, isTokenRateLimitPolicyAcceptedAndNotDeletedFunc(state))
+			if trlErr != nil {
+				logger.Error(trlErr, "failed to build wasm actions for token rate limit policy", "pathID", pathID)
+				pathSpan.RecordError(trlErr)
+				pathSpan.SetStatus(codes.Error, "failed to build token rate limit actions")
+				pathSpan.End()
+				continue
+			}
 			if hasAuthAccess(trlAction) {
 				actions = append(actions, trlAction...)
 			} else {

--- a/internal/controller/ratelimit_workflow_helpers.go
+++ b/internal/controller/ratelimit_workflow_helpers.go
@@ -303,7 +303,7 @@ func wasmActionsFromTokenLimit(tokenLimit *kuadrantv1alpha1.TokenLimit, limitIde
 	return []wasm.Action{requestAction, responseAction}
 }
 
-func buildWasmActionsForRateLimit(effectivePolicy EffectiveRateLimitPolicy, policyPredicate func(machinery.Policy) bool) []wasm.Action {
+func buildWasmActionsForRateLimit(effectivePolicy EffectiveRateLimitPolicy, policyPredicate func(machinery.Policy) bool) ([]wasm.Action, error) {
 	return buildWasmActionsForAnyRateLimit(
 		effectivePolicy.Path,
 		effectivePolicy.Spec.Rules(),
@@ -319,15 +319,14 @@ func buildWasmActionsForRateLimit(effectivePolicy EffectiveRateLimitPolicy, poli
 	)
 }
 
-func buildWasmActionsForTokenRateLimit(effectivePolicy EffectiveTokenRateLimitPolicy, policyPredicate func(machinery.Policy) bool) []wasm.Action {
+func buildWasmActionsForTokenRateLimit(effectivePolicy EffectiveTokenRateLimitPolicy, policyPredicate func(machinery.Policy) bool) ([]wasm.Action, error) {
 	path := effectivePolicy.Path
 	rules := effectivePolicy.Spec.Rules()
 	policiesInPath := kuadrantv1.PoliciesInPath(path, policyPredicate)
 
 	parsed, err := kuadrantpolicymachinery.ParseTopologyPath(path)
 	if err != nil {
-		// If the path is invalid, return empty actions
-		return []wasm.Action{}
+		return nil, fmt.Errorf("failed to parse topology path for token rate limit policy: %w", err)
 	}
 	limitsNamespace := LimitsNamespaceFromRoute(parsed.GetRoute())
 
@@ -365,7 +364,7 @@ func buildWasmActionsForTokenRateLimit(effectivePolicy EffectiveTokenRateLimitPo
 		allActions = append(allActions, tokenActions...)
 	}
 
-	return allActions
+	return allActions, nil
 }
 
 // buildWasmActionsForAnyRateLimit is the generic implementation used by both rate limit policy types
@@ -376,13 +375,12 @@ func buildWasmActionsForAnyRateLimit(
 	policyPredicate func(machinery.Policy) bool,
 	identifierFunc func(k8stypes.NamespacedName, string) string,
 	actionFunc func(interface{}, string, string, string, kuadrantv1.WhenPredicates) wasm.Action,
-) []wasm.Action {
+) ([]wasm.Action, error) {
 	policiesInPath := kuadrantv1.PoliciesInPath(path, policyPredicate)
 
 	parsed, err := kuadrantpolicymachinery.ParseTopologyPath(path)
 	if err != nil {
-		// If the path is invalid, return empty actions
-		return []wasm.Action{}
+		return nil, fmt.Errorf("failed to parse topology path for rate limit policy: %w", err)
 	}
 	limitsNamespace := LimitsNamespaceFromRoute(parsed.GetRoute())
 
@@ -415,5 +413,5 @@ func buildWasmActionsForAnyRateLimit(
 		sourcePolicyLocator := source.GetLocator()
 
 		return actionFunc(limitSpec, limitIdentifier, scope, sourcePolicyLocator, topLevelWhenPredicates), true
-	})
+	}), nil
 }

--- a/internal/controller/ratelimit_workflow_test.go
+++ b/internal/controller/ratelimit_workflow_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/kuadrant/policy-machinery/machinery"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	kuadrantv1alpha1 "github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 	"github.com/kuadrant/kuadrant-operator/internal/wasm"
 )
 
@@ -242,4 +244,37 @@ func TestWasmActionFromLimit(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildWasmActionsForRateLimitInvalidPath verifies that the rate limit
+// helpers propagate ParseTopologyPath errors instead of silently dropping
+// them (see issue #1890).
+func TestBuildWasmActionsForRateLimitInvalidPath(t *testing.T) {
+	t.Run("buildWasmActionsForRateLimit returns error for invalid path", func(t *testing.T) {
+		policy := EffectiveRateLimitPolicy{
+			Path: []machinery.Targetable{}, // invalid: empty path
+			Spec: kuadrantv1.RateLimitPolicy{},
+		}
+		actions, err := buildWasmActionsForRateLimit(policy, func(machinery.Policy) bool { return true })
+		if err == nil {
+			t.Fatalf("expected error for invalid topology path, got nil; actions=%v", actions)
+		}
+		if actions != nil {
+			t.Errorf("expected nil actions on error, got %v", actions)
+		}
+	})
+
+	t.Run("buildWasmActionsForTokenRateLimit returns error for invalid path", func(t *testing.T) {
+		policy := EffectiveTokenRateLimitPolicy{
+			Path: []machinery.Targetable{}, // invalid: empty path
+			Spec: kuadrantv1alpha1.TokenRateLimitPolicy{},
+		}
+		actions, err := buildWasmActionsForTokenRateLimit(policy, func(machinery.Policy) bool { return true })
+		if err == nil {
+			t.Fatalf("expected error for invalid topology path, got nil; actions=%v", actions)
+		}
+		if actions != nil {
+			t.Errorf("expected nil actions on error, got %v", actions)
+		}
+	})
 }


### PR DESCRIPTION
Fixes #1890. Changes `buildWasmActionsForRateLimit`, `buildWasmActionsForTokenRateLimit`, and `buildWasmActionsForAnyRateLimit` to return `([]wasm.Action, error)` instead of silently dropping `ParseTopologyPath` failures, and updates the istio/envoy-gateway extension reconcilers to log the error, record it on the active span, and skip the path. Adds a unit test covering both helpers with an invalid path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when building WASM actions for rate-limit and token-rate-limit policies: failures are now logged, recorded in tracing spans (marked as errors), and affected paths are skipped to prevent silent failures.
  * Invalid policy topology paths are now detected and surfaced instead of being ignored.

* **Tests**
  * Added unit test coverage for invalid topology path scenarios to ensure errors are returned and actions are not produced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->