### PR TITLE
Cache Kuadrant CR lookup in reconciliation state to fix scaling performance

### DIFF
--- a/internal/controller/auth_policy_status_updater.go
+++ b/internal/controller/auth_policy_status_updater.go
@@ -155,7 +155,7 @@ func (r *AuthPolicyStatusUpdater) UpdateStatus(ctx context.Context, _ []controll
 }
 
 func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolicy, topology *machinery.Topology, state *sync.Map, logger logr.Logger) *metav1.Condition {
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 	if kObj == nil {
 		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrSystemResource("kuadrant"), false)
 	}
@@ -291,7 +291,7 @@ func (r *AuthPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.AuthPolic
 	var componentsToSync []string
 
 	// check the status of Authorino
-	authorino := GetAuthorinoFromTopology(topology)
+	authorino := GetAuthorinoFromTopology(topology, state)
 	if authorino == nil {
 		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrSystemResource("authornio"), false)
 	}

--- a/internal/controller/auth_workflow_helpers.go
+++ b/internal/controller/auth_workflow_helpers.go
@@ -35,8 +35,8 @@ var (
 	ErrMissingStateEffectiveAuthPolicies = fmt.Errorf("missing auth effective policies stored in the reconciliation state")
 )
 
-func GetAuthorinoFromTopology(topology *machinery.Topology) *authorinooperatorv1beta1.Authorino {
-	kuadrant := GetKuadrantFromTopology(topology)
+func GetAuthorinoFromTopology(topology *machinery.Topology, state *sync.Map) *authorinooperatorv1beta1.Authorino {
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		return nil
 	}

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -53,7 +53,7 @@ func (r *AuthConfigsReconciler) Subscription() controller.Subscription {
 func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
 	logger := controller.LoggerFromContext(ctx).WithName("AuthConfigsReconciler").WithValues("context", ctx)
 
-	authorino := GetAuthorinoFromTopology(topology)
+	authorino := GetAuthorinoFromTopology(topology, state)
 	if authorino == nil {
 		logger.V(1).Info("authorino resource not found in the topology")
 		return nil

--- a/internal/controller/authorino_istio_integration_reconciler.go
+++ b/internal/controller/authorino_istio_integration_reconciler.go
@@ -62,7 +62,7 @@ func (a *AuthorinoIstioIntegrationReconciler) Run(baseCtx context.Context, _ []c
 	logger.V(1).Info("reconciling authorino integration in istio", "status", "started")
 	defer logger.V(1).Info("reconciling authorino integration in istio", "status", "completed")
 
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 
 	if kObj == nil {
 		// Nothing to be done. It is expected that the authorino resource managed by kuadrant

--- a/internal/controller/authorino_reconciler.go
+++ b/internal/controller/authorino_reconciler.go
@@ -40,13 +40,13 @@ func (r *AuthorinoReconciler) Subscription() *controller.Subscription {
 	}
 }
 
-func (r *AuthorinoReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
+func (r *AuthorinoReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
 	span := trace.SpanFromContext(ctx)
 	logger := controller.LoggerFromContext(ctx).WithName("AuthorinoReconciler").WithValues("context", ctx)
 	logger.V(1).Info("reconciling authorino resource", "status", "started")
 	defer logger.V(1).Info("reconciling authorino resource", "status", "completed")
 
-	kobj := GetKuadrantFromTopology(topology)
+	kobj := GetKuadrantFromTopology(topology, state)
 	if kobj == nil {
 		span.AddEvent("no kuadrant object found")
 		span.SetStatus(codes.Ok, "")
@@ -59,7 +59,7 @@ func (r *AuthorinoReconciler) Reconcile(ctx context.Context, _ []controller.Reso
 		attribute.String("kuadrant.namespace", kobj.Namespace),
 	)
 
-	clusterAuthorino := GetAuthorinoFromTopology(topology)
+	clusterAuthorino := GetAuthorinoFromTopology(topology, state)
 
 	if clusterAuthorino != nil {
 		span.AddEvent("Authorino resource already exists")

--- a/internal/controller/developerportal_reconciler_test.go
+++ b/internal/controller/developerportal_reconciler_test.go
@@ -86,7 +86,7 @@ func TestDeveloperPortalReconciler(t *testing.T) {
 
 	t.Run("Topology with Kuadrant CR", func(subT *testing.T) {
 		topology := buildTopologyWithKuadrant(subT, true)
-		kuadrantCR := GetKuadrantFromTopology(topology)
+		kuadrantCR := GetKuadrantFromTopology(topology, nil)
 		assert.Assert(subT, kuadrantCR != nil, "GetKuadrantFromTopology should return Kuadrant CR")
 		assert.Equal(subT, kuadrantCR.Name, "kuadrant")
 		assert.Equal(subT, kuadrantCR.IsDeveloperPortalEnabled(), true)

--- a/internal/controller/effective_auth_policies_reconciler.go
+++ b/internal/controller/effective_auth_policies_reconciler.go
@@ -38,7 +38,7 @@ func (r *EffectiveAuthPolicyReconciler) Reconcile(ctx context.Context, _ []contr
 	logger.V(1).Info("generate effective auth policy", "status", "started")
 	defer logger.V(1).Info("generate effective auth policy", "status", "completed")
 
-	kuadrant := GetKuadrantFromTopology(topology)
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		return nil
 	}

--- a/internal/controller/effective_ratelimit_policies_reconciler.go
+++ b/internal/controller/effective_ratelimit_policies_reconciler.go
@@ -38,7 +38,7 @@ func (r *EffectiveRateLimitPolicyReconciler) Reconcile(ctx context.Context, _ []
 	logger.V(1).Info("generating effective rate limit policy", "status", "started")
 	defer logger.V(1).Info("generating effective rate limit policy", "status", "completed")
 
-	kuadrant := GetKuadrantFromTopology(topology)
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		return nil
 	}

--- a/internal/controller/effective_tokenratelimit_policies_reconciler.go
+++ b/internal/controller/effective_tokenratelimit_policies_reconciler.go
@@ -39,7 +39,7 @@ func (r *EffectiveTokenRateLimitPolicyReconciler) Reconcile(ctx context.Context,
 	logger.V(1).Info("generating effective token rate limit policy", "status", "started")
 	defer logger.V(1).Info("generating effective token rate limit policy", "status", "completed")
 
-	kuadrant := GetKuadrantFromTopology(topology)
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		return nil
 	}

--- a/internal/controller/envoy_gateway_auth_cluster_reconciler.go
+++ b/internal/controller/envoy_gateway_auth_cluster_reconciler.go
@@ -53,7 +53,7 @@ func (r *EnvoyGatewayAuthClusterReconciler) Reconcile(ctx context.Context, _ []c
 	logger.V(1).Info("building envoy gateway auth clusters")
 	defer logger.V(1).Info("finished building envoy gateway auth clusters")
 
-	kuadrant := GetKuadrantFromTopology(topology)
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		return nil
 	}

--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -333,7 +333,7 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 
 	serviceBuilder := wasm.NewServiceBuilder(&logger)
 	// Get Kuadrant CR to access observability settings
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 	var observability *wasm.Observability
 	if kObj != nil {
 		observability = wasm.BuildObservabilityConfig(serviceBuilder, &kObj.Spec.Observability)

--- a/internal/controller/envoy_gateway_ratelimit_cluster_reconciler.go
+++ b/internal/controller/envoy_gateway_ratelimit_cluster_reconciler.go
@@ -55,7 +55,7 @@ func (r *EnvoyGatewayRateLimitClusterReconciler) Reconcile(ctx context.Context, 
 	logger.V(1).Info("building envoy gateway rate limit clusters")
 	defer logger.V(1).Info("finished building envoy gateway rate limit clusters")
 
-	kuadrant := GetKuadrantFromTopology(topology)
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		return nil
 	}

--- a/internal/controller/envoy_gateway_tracing_cluster_reconciler.go
+++ b/internal/controller/envoy_gateway_tracing_cluster_reconciler.go
@@ -47,7 +47,7 @@ func (r *EnvoyGatewayTracingClusterReconciler) Reconcile(ctx context.Context, _ 
 	logger.V(1).Info("building envoy gateway tracing clusters")
 	defer logger.V(1).Info("finished building envoy gateway tracing clusters")
 
-	kuadrant := GetKuadrantFromTopology(topology)
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		logger.V(1).Info("kuadrant CR not found")
 		return nil

--- a/internal/controller/istio_auth_cluster_reconciler.go
+++ b/internal/controller/istio_auth_cluster_reconciler.go
@@ -53,7 +53,7 @@ func (r *IstioAuthClusterReconciler) Reconcile(ctx context.Context, _ []controll
 	logger.V(1).Info("building istio auth clusters")
 	defer logger.V(1).Info("finished building istio auth clusters")
 
-	kuadrant := GetKuadrantFromTopology(topology)
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		return nil
 	}

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -339,7 +339,7 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 
 	serviceBuilder := wasm.NewServiceBuilder(&logger)
 	// Get Kuadrant CR to access observability settings
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 	var observability *wasm.Observability
 	if kObj != nil {
 		observability = wasm.BuildObservabilityConfig(serviceBuilder, &kObj.Spec.Observability)

--- a/internal/controller/istio_peerauthentication_reconciler.go
+++ b/internal/controller/istio_peerauthentication_reconciler.go
@@ -63,7 +63,7 @@ func (p *PeerAuthenticationReconciler) Run(baseCtx context.Context, _ []controll
 	logger.V(1).Info("reconciling peerauthentication", "status", "started")
 	defer logger.V(1).Info("reconciling peerauthentication", "status", "completed")
 
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 
 	if kObj == nil {
 		// Nothing to be done. It is expected the limitador and authorino resources

--- a/internal/controller/istio_ratelimit_cluster_reconciler.go
+++ b/internal/controller/istio_ratelimit_cluster_reconciler.go
@@ -55,12 +55,12 @@ func (r *IstioRateLimitClusterReconciler) Reconcile(ctx context.Context, _ []con
 	logger.V(1).Info("building istio rate limit clusters")
 	defer logger.V(1).Info("finished building istio rate limit clusters")
 
-	kuadrant := GetKuadrantFromTopology(topology)
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		return nil
 	}
 
-	limitador := GetLimitadorFromTopology(topology)
+	limitador := GetLimitadorFromTopology(topology, state)
 	if limitador == nil {
 		logger.V(1).Info(ErrMissingLimitador.Error())
 		return nil

--- a/internal/controller/istio_tracing_cluster_reconciler.go
+++ b/internal/controller/istio_tracing_cluster_reconciler.go
@@ -47,7 +47,7 @@ func (r *IstioTracingClusterReconciler) Reconcile(ctx context.Context, _ []contr
 	logger.V(1).Info("building istio tracing clusters")
 	defer logger.V(1).Info("finished building istio tracing clusters")
 
-	kuadrant := GetKuadrantFromTopology(topology)
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		logger.V(1).Info("kuadrant CR not found")
 		return nil

--- a/internal/controller/kuadrant_status_updater.go
+++ b/internal/controller/kuadrant_status_updater.go
@@ -66,7 +66,7 @@ func (r *KuadrantStatusUpdater) Reconcile(ctx context.Context, _ []controller.Re
 	logger.Info("reconciling kuadrant status", "status", "started")
 	defer logger.Info("reconciling kuadrant status", "status", "completed")
 
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 	if kObj == nil {
 		operatormetrics.SetKuadrantExists(false)
 		operatormetrics.ResetKuadrantMetrics()
@@ -83,7 +83,7 @@ func (r *KuadrantStatusUpdater) Reconcile(ctx context.Context, _ []controller.Re
 	operatormetrics.SetKuadrantReady(kObj.Namespace, kObj.Name, isReady)
 
 	// Emit component readiness metrics
-	r.emitComponentMetrics(topology, kObj.Namespace, logger)
+	r.emitComponentMetrics(topology, kObj.Namespace, logger, state)
 
 	equalStatus := kObj.Status.Equals(newStatus, logger)
 	logger.V(1).Info("Status", "status is different", !equalStatus)
@@ -133,7 +133,7 @@ func (r *KuadrantStatusUpdater) calculateStatus(topology *machinery.Topology, lo
 		MtlsLimitador:      mtlsLimitador(kObj, state),
 	}
 
-	availableCond := r.readyCondition(topology, logger)
+	availableCond := r.readyCondition(topology, logger, state)
 
 	meta.SetStatusCondition(&newStatus.Conditions, *availableCond)
 
@@ -158,7 +158,7 @@ func mtlsLimitador(kObj *kuadrantv1beta1.Kuadrant, state *sync.Map) *bool {
 	return ptr.To(kObj.IsMTLSLimitadorEnabled() && len(effectiveRateLimitPoliciesMap) > 0)
 }
 
-func (r *KuadrantStatusUpdater) readyCondition(topology *machinery.Topology, logger logr.Logger) *metav1.Condition {
+func (r *KuadrantStatusUpdater) readyCondition(topology *machinery.Topology, logger logr.Logger, state *sync.Map) *metav1.Condition {
 	cond := &metav1.Condition{
 		Type:    ReadyConditionType,
 		Status:  metav1.ConditionTrue,
@@ -173,14 +173,14 @@ func (r *KuadrantStatusUpdater) readyCondition(topology *machinery.Topology, log
 		return cond
 	}
 
-	if reason := checkLimitadorReady(topology, logger); reason != nil {
+	if reason := checkLimitadorReady(topology, logger, state); reason != nil {
 		cond.Status = metav1.ConditionFalse
 		cond.Reason = "LimitadorNotReady"
 		cond.Message = *reason
 		return cond
 	}
 
-	if reason := checkAuthorinoAvailable(topology, logger); reason != nil {
+	if reason := checkAuthorinoAvailable(topology, logger, state); reason != nil {
 		cond.Status = metav1.ConditionFalse
 		cond.Reason = "AuthorinoNotReady"
 		cond.Message = *reason
@@ -218,8 +218,8 @@ func (r *KuadrantStatusUpdater) isMissingDependency() kuadrant.PolicyError {
 	return nil
 }
 
-func checkLimitadorReady(topology *machinery.Topology, logger logr.Logger) *string {
-	limitadorObj := GetLimitadorFromTopology(topology)
+func checkLimitadorReady(topology *machinery.Topology, logger logr.Logger, state *sync.Map) *string {
+	limitadorObj := GetLimitadorFromTopology(topology, state)
 	if limitadorObj == nil {
 		logger.V(1).Info("failed getting Limitador resource from topology", "status", "error")
 		return ptr.To("limitador resource not in topology")
@@ -236,8 +236,8 @@ func checkLimitadorReady(topology *machinery.Topology, logger logr.Logger) *stri
 	return nil
 }
 
-func checkAuthorinoAvailable(topology *machinery.Topology, logger logr.Logger) *string {
-	authorinoObj := GetAuthorinoFromTopology(topology)
+func checkAuthorinoAvailable(topology *machinery.Topology, logger logr.Logger, state *sync.Map) *string {
+	authorinoObj := GetAuthorinoFromTopology(topology, state)
 	if authorinoObj == nil {
 		logger.V(1).Info("failed getting Authorino resource from topology", "status", "error")
 		return ptr.To("authorino resource not in topology")
@@ -258,12 +258,12 @@ func checkAuthorinoAvailable(topology *machinery.Topology, logger logr.Logger) *
 // emitComponentMetrics emits readiness metrics for Kuadrant-managed components (Authorino and Limitador).
 // This is called during reconciliation when a Kuadrant CR exists to provide real-time visibility into component health.
 // When no CR exists, component metrics are cleared via ResetKuadrantMetrics() instead.
-func (r *KuadrantStatusUpdater) emitComponentMetrics(topology *machinery.Topology, namespace string, logger logr.Logger) {
+func (r *KuadrantStatusUpdater) emitComponentMetrics(topology *machinery.Topology, namespace string, logger logr.Logger, state *sync.Map) {
 	// Check Authorino readiness
-	authorinoReady := checkAuthorinoAvailable(topology, logger) == nil
+	authorinoReady := checkAuthorinoAvailable(topology, logger, state) == nil
 	operatormetrics.SetComponentReady("authorino", namespace, authorinoReady)
 
 	// Check Limitador readiness
-	limitadorReady := checkLimitadorReady(topology, logger) == nil
+	limitadorReady := checkLimitadorReady(topology, logger, state) == nil
 	operatormetrics.SetComponentReady("limitador", namespace, limitadorReady)
 }

--- a/internal/controller/limitador_istio_integration_reconciler.go
+++ b/internal/controller/limitador_istio_integration_reconciler.go
@@ -61,7 +61,7 @@ func (l *LimitadorIstioIntegrationReconciler) Run(baseCtx context.Context, _ []c
 	logger.V(1).Info("reconciling limitador integration in istio", "status", "started")
 	defer logger.V(1).Info("reconciling limitador integration in istio", "status", "completed")
 
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 
 	if kObj == nil {
 		// Nothing to be done. It is expected the limitador resource managed by kuadrant

--- a/internal/controller/limitador_limits_reconciler.go
+++ b/internal/controller/limitador_limits_reconciler.go
@@ -51,7 +51,7 @@ func (r *LimitadorLimitsReconciler) Reconcile(ctx context.Context, _ []controlle
 	logger.Info("Limitador limits reconciler", "status", "started")
 	defer logger.Info("Limitador limits reconciler", "status", "completed")
 
-	limitador := GetLimitadorFromTopology(topology)
+	limitador := GetLimitadorFromTopology(topology, state)
 	if limitador == nil {
 		logger.V(1).Info("not limitador resources found in topology")
 		return nil

--- a/internal/controller/limitador_reconciler.go
+++ b/internal/controller/limitador_reconciler.go
@@ -42,13 +42,13 @@ func (r *LimitadorReconciler) Subscription() *controller.Subscription {
 	}
 }
 
-func (r *LimitadorReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
+func (r *LimitadorReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
 	span := trace.SpanFromContext(ctx)
 	logger := controller.LoggerFromContext(ctx).WithName("LimitadorResourceReconciler").WithValues("context", ctx)
 	logger.Info("reconciling limitador resource", "status", "started")
 	defer logger.Info("reconciling limitador resource", "status", "completed")
 
-	kobj := GetKuadrantFromTopology(topology)
+	kobj := GetKuadrantFromTopology(topology, state)
 	if kobj == nil {
 		span.AddEvent("no kuadrant object found")
 		span.SetStatus(codes.Ok, "no kuadrant resource")

--- a/internal/controller/observability_reconciler.go
+++ b/internal/controller/observability_reconciler.go
@@ -374,7 +374,7 @@ func (r *ObservabilityReconciler) Subscription() *controller.Subscription {
 	}
 }
 
-func (r *ObservabilityReconciler) Reconcile(baseCtx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
+func (r *ObservabilityReconciler) Reconcile(baseCtx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
 	logger := controller.LoggerFromContext(baseCtx).WithName("ObservabilityReconciler")
 	ctx := logr.NewContext(baseCtx, logger)
 	logger.V(1).Info("reconciling observability", "status", "started")
@@ -390,7 +390,7 @@ func (r *ObservabilityReconciler) Reconcile(baseCtx context.Context, _ []control
 
 	// Check that a kuadrant resource exists, and observability enabled,
 	// otherwise delete all monitors
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 	if kObj == nil || !kObj.Spec.Observability.Enable {
 		logger.V(1).Info("deleting any existing monitors", "kuadrant", kObj != nil)
 		r.deleteAllMonitors(ctx, monitorObjs, logger)

--- a/internal/controller/ratelimit_policy_status_updater.go
+++ b/internal/controller/ratelimit_policy_status_updater.go
@@ -153,7 +153,7 @@ func (r *RateLimitPolicyStatusUpdater) UpdateStatus(ctx context.Context, _ []con
 }
 
 func (r *RateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.RateLimitPolicy, topology *machinery.Topology, state *sync.Map, logger logr.Logger) *metav1.Condition {
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 	if kObj == nil {
 		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrSystemResource("kuadrant"), false)
 	}
@@ -265,7 +265,7 @@ func (r *RateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1.Rate
 	if limitadorLimitsModified, stateLimitadorLimitsModifiedPresent := state.Load(StateLimitadorLimitsModified); stateLimitadorLimitsModifiedPresent && limitadorLimitsModified.(bool) {
 		componentsToSync = append(componentsToSync, kuadrantv1beta1.LimitadorGroupKind.Kind)
 	} else {
-		limitador := GetLimitadorFromTopology(topology)
+		limitador := GetLimitadorFromTopology(topology, state)
 		if limitador == nil {
 			return kuadrant.EnforcedCondition(policy, kuadrant.NewErrSystemResource("limitador"), false)
 		}

--- a/internal/controller/ratelimit_workflow_helpers.go
+++ b/internal/controller/ratelimit_workflow_helpers.go
@@ -44,8 +44,8 @@ var (
 	ErrMissingStateEffectiveTokenRateLimitPolicies = fmt.Errorf("missing token rate limit effective policies stored in the reconciliation state")
 )
 
-func GetLimitadorFromTopology(topology *machinery.Topology) *limitadorv1alpha1.Limitador {
-	kuadrant := GetKuadrantFromTopology(topology)
+func GetLimitadorFromTopology(topology *machinery.Topology, state *sync.Map) *limitadorv1alpha1.Limitador {
+	kuadrant := GetKuadrantFromTopology(topology, state)
 	if kuadrant == nil {
 		return nil
 	}

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -833,7 +833,18 @@ func (b *BootOptionsBuilder) finalStepsWorkflow() *controller.Workflow {
 	return workflow
 }
 
-func GetKuadrantFromTopology(topology *machinery.Topology) *kuadrantv1beta1.Kuadrant {
+func GetKuadrantFromTopology(topology *machinery.Topology, state *sync.Map) *kuadrantv1beta1.Kuadrant {
+	const stateKuadrantKey = "kuadrant"
+
+	//PERF: The lo.FilterMap function is extremely slow.
+	//In large topologies it is faster to get the kuadrant CR from the state object
+	if state != nil {
+		stateKuadrant, ok := state.Load(stateKuadrantKey)
+		if ok {
+			kuadrant, _ := stateKuadrant.(*kuadrantv1beta1.Kuadrant)
+			return kuadrant
+		}
+	}
 	kuadrants := lo.FilterMap(topology.Objects().Roots(), func(root machinery.Object, _ int) (controller.Object, bool) {
 		o, isSortable := root.(controller.Object)
 		return o, isSortable && root.GroupVersionKind().GroupKind() == kuadrantv1beta1.KuadrantGroupKind && o.GetDeletionTimestamp() == nil
@@ -843,6 +854,9 @@ func GetKuadrantFromTopology(topology *machinery.Topology) *kuadrantv1beta1.Kuad
 	}
 	sort.Sort(controller.ObjectsByCreationTimestamp(kuadrants))
 	kuadrant, _ := kuadrants[0].(*kuadrantv1beta1.Kuadrant)
+	if state != nil {
+		state.Store(stateKuadrantKey, kuadrant)
+	}
 	return kuadrant
 }
 

--- a/internal/controller/state_of_the_world_test.go
+++ b/internal/controller/state_of_the_world_test.go
@@ -102,7 +102,7 @@ func TestGetKuadrant(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetKuadrantFromTopology(tt.args.topology)
+			got := GetKuadrantFromTopology(tt.args.topology, nil)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetKuadrantFromTopology() got = %v, want %v", got, tt.want)
 			}

--- a/internal/controller/tokenratelimitpolicy_status_updater.go
+++ b/internal/controller/tokenratelimitpolicy_status_updater.go
@@ -143,7 +143,7 @@ func (r *TokenRateLimitPolicyStatusUpdater) UpdateStatus(ctx context.Context, _ 
 }
 
 func (r *TokenRateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1alpha1.TokenRateLimitPolicy, topology *machinery.Topology, state *sync.Map) *metav1.Condition {
-	kObj := GetKuadrantFromTopology(topology)
+	kObj := GetKuadrantFromTopology(topology, state)
 	if kObj == nil {
 		return kuadrant.EnforcedCondition(policy, kuadrant.NewErrSystemResource("kuadrant"), false)
 	}
@@ -252,7 +252,7 @@ func (r *TokenRateLimitPolicyStatusUpdater) enforcedCondition(policy *kuadrantv1
 	if limitadorLimitsModified, stateLimitadorLimitsModifiedPresent := state.Load(StateLimitadorLimitsModified); stateLimitadorLimitsModifiedPresent && limitadorLimitsModified.(bool) {
 		componentsToSync = append(componentsToSync, kuadrantv1beta1.LimitadorGroupKind.Kind)
 	} else {
-		limitador := GetLimitadorFromTopology(topology)
+		limitador := GetLimitadorFromTopology(topology, state)
 		if limitador == nil {
 			return kuadrant.EnforcedCondition(policy, kuadrant.NewErrSystemResource("limitador"), false)
 		}


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/1919

# Summary

`GetKuadrantFromTopology` is called by nearly every reconciler in the operator. Each call performs a `lo.FilterMap` over all topology roots, type-asserts, filters by GroupKind and deletion timestamp, then sorts by creation timestamp. In large topologies (hundreds of HTTPRoutes with policies), this becomes a significant bottleneck because the function is invoked many times per reconciliation cycle.

This change introduces a simple cache-on-first-access pattern: `GetKuadrantFromTopology` now accepts the shared `*sync.Map` reconciliation state and stores the result under a `"kuadrant"` key after the first lookup. Subsequent calls within the same reconciliation cycle return the cached value directly, avoiding repeated topology traversal.

All callers of `GetKuadrantFromTopology`, `GetAuthorinoFromTopology`, and `GetLimitadorFromTopology` across 28 files are updated to pass the `state` parameter through. The Authorino and Limitador helper functions benefit transitively since they delegate to `GetKuadrantFromTopology` internally.

# Dependency

This change depends on https://github.com/Kuadrant/kuadrant-operator/pull/1923, which fixes WasmPlugin comparison to use order-insensitive equality checks. Without that fix, non-deterministic map iteration causes phantom spec changes that trigger unnecessary reconciliation cycles, amplifying the very performance problem this PR addresses.

# Acceptance criteria

The issue does not define explicit acceptance criteria, but describes the scaling problem with `enforcedCondition` and related status update functions where topology traversal time grows with resource count. This PR directly addresses the root cause by ensuring the expensive `lo.FilterMap` + sort over topology roots in `GetKuadrantFromTopology` executes at most once per reconciliation cycle, reducing the per-call cost from O(n) to O(1) for all subsequent invocations.

# Findings

Using the test set up in [perftest:boomatang-perf-0](https://github.com/Kuadrant/perftest/tree/boomatang-perf-0) the following table of results were created based on the attached log files. In the naming the "patch" refers to the #1923 code rebase on current main. The "fix" is this change set on the same patched main version. CPU usage is eye balled in k9s, and is a very around that value. The deploy of kuadrant-operator was modified to allow 10 vCPU and  2 GB of RAM. RAM usage was not monitored. 

The test run used 600 resource for the test. That is 600 HTTProutes, each with an AuthPolicy and RateLimitPolicy attached. In total 600 HTTPRoutes, 600 AuthPolicy and 600 RateLimitPolicy.

|run|start log line|start time|end log line |end time | CPU | Total time | 
| --- | --- | --- | ---| --- | --- | --- |
| patch only | 107 | 10:22:48 | 1895 | 11:01:30 | ~3.5 | 00:38:42 |
|patch + fix | 118 | 11:39:51 | 3904 | 11:43:19 | ~2.0 | 00:03:28 |



[kuadrant-operator+patch.log](https://github.com/user-attachments/files/27710057/kuadrant-operator%2Bpatch.log)
[kuadrant-operator+patch+fix.log](https://github.com/user-attachments/files/27710059/kuadrant-operator%2Bpatch%2Bfix.log)

## Note on log lines
The `patch + fix` logs have a far higher number of logs, with a lot being errors similar to `the object has been modified; please apply your changes to the latest version and try again`. This is down to the speed in which the reconcile loop can now run. We are not getting the events fast enough from the API server. 

There is possible later improvements to be made here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Topology lookups now use a shared reconciliation state cache for faster component discovery and fewer redundant operations.

* **Reliability / Behaviour**
  * Reconciliation flows and integrations (auth, rate-limit, tracing, observability) now derive component presence from the shared state, improving consistency of apply/remove decisions.

* **Monitoring**
  * Component readiness and status metrics are computed using the reconciliation state for more accurate status reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1957)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->