### PR TITLE
feat: add --pprof-bind-address flag for runtime profiling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -201,10 +201,12 @@ func main() {
 		metricsAddr          string
 		enableLeaderElection bool
 		probeAddr            string
+		pprofAddr            string
 		err                  error
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&pprofAddr, "pprof-bind-address", ":8084", "The address the pprof endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -239,6 +241,7 @@ func main() {
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
 		WebhookServer:          webhook.NewServer(webhook.Options{Port: 9443}),
 		HealthProbeBindAddress: probeAddr,
+		PprofBindAddress:       pprofAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "f139389e.kuadrant.io",
 	}

--- a/doc/observability/profiling.md
+++ b/doc/observability/profiling.md
@@ -1,0 +1,109 @@
+# Profiling
+
+All Go-based Kuadrant components support runtime profiling via Go's built-in [pprof](https://pkg.go.dev/net/http/pprof) tooling. This uses controller-runtime's `PprofBindAddress` option, enabled by default on port `8084`.
+
+Profiling is useful for diagnosing performance issues such as slow reconciliation, high CPU usage, or excessive memory allocation at scale.
+
+## Connecting to a component
+
+Port-forward to the component you want to profile:
+
+```bash
+# Kuadrant Operator
+kubectl port-forward -n kuadrant-system deploy/kuadrant-operator-controller-manager 8084:8084
+
+# Authorino (namespace may differ depending on where the Kuadrant CR is installed)
+kubectl port-forward -n kuadrant-system deploy/authorino 8084:8084
+
+# Authorino Operator
+kubectl port-forward -n kuadrant-system deploy/authorino-operator 8084:8084
+
+# Limitador Operator
+kubectl port-forward -n kuadrant-system deploy/limitador-operator-controller-manager 8084:8084
+
+# DNS Operator
+kubectl port-forward -n kuadrant-system deploy/dns-operator-controller-manager 8084:8084
+```
+
+To profile multiple components simultaneously, use different local ports (e.g., 8085, 8086, etc.) to avoid conflicts.
+
+> **Note:** All commands in the sections below assume a single component is being profiled on `localhost:8084`. If profiling multiple components, adjust the port number accordingly.
+
+## Capturing profiles
+
+### CPU profile
+
+Captures a CPU profile for a specified duration (default 30 seconds):
+
+```bash
+go tool pprof http://localhost:8084/debug/pprof/profile?seconds=30
+```
+
+### Heap profile
+
+Captures a snapshot of current memory allocations:
+
+```bash
+go tool pprof http://localhost:8084/debug/pprof/heap
+```
+
+### Goroutine dump
+
+Lists all goroutines and their stack traces, useful for diagnosing stuck reconciliation:
+
+```bash
+curl http://localhost:8084/debug/pprof/goroutine?debug=2
+```
+
+## Analysing profiles
+
+### Interactive web UI
+
+The most useful way to view profiles — opens a browser with flame graphs, call graphs, and source annotation:
+
+```bash
+go tool pprof -http=:8080 http://localhost:8084/debug/pprof/profile?seconds=30
+```
+
+### Save and view later
+
+```bash
+# Save to disk
+curl -o cpu.prof "http://localhost:8084/debug/pprof/profile?seconds=30"
+curl -o heap.prof "http://localhost:8084/debug/pprof/heap"
+
+# View saved profiles
+go tool pprof -http=:8080 cpu.prof
+```
+
+### Compare two profiles
+
+Useful for validating that a change improved performance:
+
+```bash
+go tool pprof -http=:8080 -diff_base=before.prof after.prof
+```
+
+Functions that got faster appear in green, slower in red.
+
+### Terminal-only (no browser)
+
+```bash
+go tool pprof -top cpu.prof              # top functions by flat CPU
+go tool pprof -top -cum cpu.prof         # top functions by cumulative CPU
+go tool pprof -top heap.prof             # top memory allocators
+```
+
+## Configuration
+
+Each component accepts a `--pprof-bind-address` flag:
+
+| Component | Flag | Default |
+|---|---|---|
+| kuadrant-operator | `--pprof-bind-address` | `:8084` |
+| authorino | `--pprof-bind-address` | `:8084` |
+| authorino-operator | `--pprof-bind-address` | `:8084` |
+| limitador-operator | `--pprof-bind-address` | `:8084` |
+| dns-operator | `--pprof-bind-address` | `:8084` |
+
+Set to an empty string to disable: `--pprof-bind-address=""`.


### PR DESCRIPTION
## Summary

Adds runtime profiling support via Go's built-in [pprof](https://pkg.go.dev/net/http/pprof) using controller-runtime's `PprofBindAddress` option. Enabled by default on `:8084`.

Includes a profiling guide at `doc/observability/profiling.md` covering all Kuadrant Go components.

## Motivation

pprof is the standard mechanism for diagnosing performance issues in Go applications. The Kubernetes [kube-apiserver](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) enables profiling via `--profiling` (default: `true`), exposing the same `/debug/pprof/` endpoints. OpenShift provides [built-in tooling](https://docs.openshift.com/container-platform/4.11/scalability_and_performance/node-observability-operator.html) for collecting pprof data from cluster components.

Port 8084 is used consistently across all Kuadrant Go components to avoid conflicts with existing services (e.g., the WASM server on 8082).

## Changes

- Added `--pprof-bind-address` flag (default `:8084`) to `cmd/main.go`
- Added `doc/observability/profiling.md` — covers connecting to all Kuadrant components, capturing CPU/heap/goroutine profiles, and comparing profiles with `go tool pprof`

## Blocked by

The profiling guide documents connecting to all Kuadrant Go components via pprof. It won't be accurate until pprof is enabled in all components:

- [x] https://github.com/Kuadrant/authorino/pull/612
- [x] https://github.com/Kuadrant/authorino-operator/pull/307
- [x] https://github.com/Kuadrant/limitador-operator/pull/249
- [x] https://github.com/Kuadrant/dns-operator/pull/767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable pprof bind address for runtime profiling, controllable via the --pprof-bind-address flag (default: :8084), allowing flexible configuration of profiling endpoints.

* **Documentation**
  * Added a profiling guide covering how to capture and analyse CPU/heap profiles and goroutine dumps, plus port-forwarding and configuration details for profiling endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->