### PR TITLE
Adopt RFC 0018 release branch naming (release-X.Y)

### DIFF
--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -72,7 +72,7 @@ jobs:
         id: create-release-branch
         shell: bash
         run: |
-          base_branch=release-v$(echo "${{ github.event.inputs.kuadrantOperatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          base_branch=release-$(echo "${{ github.event.inputs.kuadrantOperatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo BASE_BRANCH=$base_branch >> $GITHUB_ENV
           
           if git ls-remote --exit-code --heads origin $base_branch ; then
@@ -125,7 +125,7 @@ jobs:
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: true
           base: ${{ env.BASE_BRANCH }}
-          branch: release-v${{ github.event.inputs.kuadrantOperatorVersion }}
+          branch: release-${{ github.event.inputs.kuadrantOperatorVersion }}
           delete-branch: true
           title: '[Release] Kuadrant Operator v${{ github.event.inputs.kuadrantOperatorVersion }}'
           body: |

--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -72,7 +72,14 @@ jobs:
         id: create-release-branch
         shell: bash
         run: |
-          base_branch=release-$(echo "${{ github.event.inputs.kuadrantOperatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          version="${{ github.event.inputs.kuadrantOperatorVersion }}"
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+            echo "Error: version must be semver format (e.g., 1.4.1, 1.5.0-rc1)"
+            exit 1
+          fi
+          # Extract major.minor from version (e.g., 1.4.1 → 1.4)
+          # Removes: pre-release suffix ([+-].*) and patch version (\.[0-9]*$)
+          base_branch=release-$(echo "$version" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo BASE_BRANCH=$base_branch >> $GITHUB_ENV
           
           if git ls-remote --exit-code --heads origin $base_branch ; then

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -6,6 +6,7 @@ on:
     - closed
     branches:
       - 'release-v[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ name: Test
 on:
   workflow_dispatch:
   push:
-    branches: [ 'main', 'release-v*' ]
+    branches: [ 'main', 'release-*' ]
   pull_request:
     branches: [ '*' ]
   merge_group:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,16 +32,16 @@ Reference [slack Chat](https://kubernetes.slack.com/archives/C05J0D0V525/p174419
 
 ### Local steps
 
-1. Create the `release-vX.Y` branch, if the branch does not already exist. 
-2. Push the `release-vX.Y` to the remote (kuadrant/kuadrant-operator)
-3. Create the `release-vX.Y.Z-rc(n)` branch with `release-vX.Y` as the base.
-4. Cherry-pick commits to the `kudrant-vX.Y.Z-rc(n)` from the relevant sources, i.e. `main`.
+1. Create the `release-X.Y` branch, if the branch does not already exist. 
+2. Push the `release-X.Y` to the remote (kuadrant/kuadrant-operator)
+3. Create the `release-X.Y.Z-rc(n)` branch with `release-X.Y` as the base.
+4. Cherry-pick commits to the `release-X.Y.Z-rc(n)` from the relevant sources, i.e. `main`.
 5. Update the applicable version in the [release.yaml](https://github.com/Kuadrant/kuadrant-operator/blob/main/RELEASE.md#release-file-format).
-6. Run `make prepare-release` on the `release-vX.Y.Z-rc(n)`. If you run into rate limit errors, set the env `GITHUB_TOKEN` with your PAT.
+6. Run `make prepare-release` on the `release-X.Y.Z-rc(n)`. If you run into rate limit errors, set the env `GITHUB_TOKEN` with your PAT.
 
 ### Remote steps
 
-1. Open a PR against the `release-vX.Y` branch with the changes from `release-vX.Y.Z-rc(n)` branch.
+1. Open a PR against the `release-X.Y` branch with the changes from `release-X.Y.Z-rc(n)` branch.
 2. PR verification checks will run.
 3. Get manual review of PR with focus on changes in these areas:
    * `./bundle.Dockerfile`
@@ -50,7 +50,7 @@ Reference [slack Chat](https://kubernetes.slack.com/archives/C05J0D0V525/p174419
    * `./charts/`
 > NOTE: **The PR must receive approval from at least one member of the QE team.**
 4. Merge PR
-5. Run the Release Workflow on the `release-vX.Y`. This does the following:
+5. Run the Release Workflow on the `release-X.Y`. This does the following:
    * Creates the GitHub release
    * Creates tags
 6. Verify that the build [release tag workflow](https://github.com/Kuadrant/kuadrant-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag.
@@ -63,7 +63,7 @@ Resolution of this issue is tracked in [Auto generation of release notes failure
 ## Creating the RC2+
 
 1. Create a local branch based off the, targeted release branch. 
-Example: `git checkout -B release-v1.2.0-rc2 release-v1.2`
+Example: `git checkout -B release-1.2.0-rc2 release-1.2`
 2. Cherry pick the changes required to fix which ever issue justified the creation of a new RC.
 Example: `git cherry-pick <commit sha>`
 3. Update the `release.yaml` with the new version of the kuadrant-operator. 

--- a/doc/overviews/helm-charts-release-process.md
+++ b/doc/overviews/helm-charts-release-process.md
@@ -97,9 +97,9 @@ sequenceDiagram
     Dev->>GHA: Trigger Automated Release Workflow
     GHA->>GHA: Update release.yaml with versions
     GHA->>GHA: Run make prepare-release<br/>• Execute make_chart.sh script<br/>• Build helm templates<br/>• Update Chart.yaml with versions
-    GHA->>GitHub: Create release-v{MAJOR.MINOR} base branch<br/>(if it doesn't exist)
+    GHA->>GitHub: Create release-{MAJOR.MINOR} base branch<br/>(if it doesn't exist)
     GHA->>CreatePR: Invoke create-pull-request
-    CreatePR->>GitHub: Auto-create release-v{FULL_VERSION} branch
+    CreatePR->>GitHub: Auto-create release-{FULL_VERSION} branch
     CreatePR->>GitHub: Commit chart changes to working branch
     CreatePR->>GitHub: Create PR (working → base branch)
 
@@ -161,9 +161,9 @@ sequenceDiagram
         - Updates Chart.yaml with version and dependency versions
 
 3. **Creates Pull Request**:
-    - Creates base branch `release-v{MAJOR.MINOR}` (e.g., `release-v1.0`) if it doesn't exist
+    - Creates base branch `release-{MAJOR.MINOR}` (e.g., `release-v1.0`) if it doesn't exist
     - Uses `peter-evans/create-pull-request` action which automatically:
-      - Creates working branch `release-v{FULL_VERSION}` (e.g., `release-v1.0.0`)
+      - Creates working branch `release-{FULL_VERSION}` (e.g., `release-v1.0.0`)
       - Commits all changes from `make prepare-release`
       - Opens PR from working branch to base branch
 
@@ -171,7 +171,7 @@ sequenceDiagram
 
 **Overview**: Once the release PR is merged the release creation will be triggered.
 
-**Trigger**: Release PR is merged (from `release-v{FULL_VERSION}` to `release-v{MAJOR.MINOR}` branch)
+**Trigger**: Release PR is merged (from `release-{FULL_VERSION}` to `release-{MAJOR.MINOR}` branch)
 
 **Workflow**: [release-operator.yaml](../../.github/workflows/release-operator.yaml)
 

--- a/doc/overviews/helm-charts-release-process.md
+++ b/doc/overviews/helm-charts-release-process.md
@@ -161,9 +161,9 @@ sequenceDiagram
         - Updates Chart.yaml with version and dependency versions
 
 3. **Creates Pull Request**:
-    - Creates base branch `release-{MAJOR.MINOR}` (e.g., `release-v1.0`) if it doesn't exist
+    - Creates base branch `release-{MAJOR.MINOR}` (e.g., `release-1.0`) if it doesn't exist
     - Uses `peter-evans/create-pull-request` action which automatically:
-      - Creates working branch `release-{FULL_VERSION}` (e.g., `release-v1.0.0`)
+      - Creates working branch `release-{FULL_VERSION}` (e.g., `release-1.0.0`)
       - Commits all changes from `make prepare-release`
       - Opens PR from working branch to base branch
 

--- a/utils/release/load_github_envvar.sh
+++ b/utils/release/load_github_envvar.sh
@@ -6,7 +6,7 @@ source $script_dir/shared.sh
 
 log "Loading Environment Variables"
 
-releaseBranch="release-$(echo "$KUADRANT_OPERATOR_TAG" | sed -E 's/^(v[0-9]+\.[0-9]+).*/\1/')"
+releaseBranch="release-$(echo "$KUADRANT_OPERATOR_TAG" | sed -E 's/^v?([0-9]+\.[0-9]+).*/\1/')"
 
 prerelease=false
 if [[ "$KUADRANT_OPERATOR_TAG" =~ [-+] ]]; then


### PR DESCRIPTION
## Summary

Updates workflow triggers, branch construction logic, release scripts, and documentation to support the new `release-X.Y` convention (no `v` prefix, minor-level only) per [RFC 0018](https://github.com/Kuadrant/architecture/blob/main/rfcs/0018-release-branch-naming.md).

## Changes

- `test.yaml` — widen trigger glob from `release-v*` to `release-*`
- `release-operator.yaml` — add `release-[0-9]+.[0-9]+` alongside existing `release-v[0-9]+.[0-9]+` (dual patterns for safe transition)
- `automated-release.yaml` — branch construction produces `release-X.Y` instead of `release-vX.Y`
- `load_github_envvar.sh` — strip `v` prefix when deriving `releaseBranch` from tag
- `RELEASE.md` — update all examples to `release-X.Y`
- `helm-charts-release-process.md` — update all references to `release-{MAJOR.MINOR}`

Part of #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardised release process branch naming conventions from `release-v*` to `release-*` format across GitHub Actions workflows and documentation.
  * Updated automated release workflow configurations and manual release instructions to reflect the new branch naming structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1982)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->