### PR TITLE
developer portal API update: APIKey use case optional

### DIFF
--- a/bundle/manifests/devportal.kuadrant.io_apikeys.yaml
+++ b/bundle/manifests/devportal.kuadrant.io_apikeys.yaml
@@ -113,7 +113,6 @@ spec:
             - planTier
             - requestedBy
             - secretRef
-            - useCase
             type: object
           status:
             description: APIKeyStatus defines the observed state of APIKey.

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2026-05-08T09:42:37Z"
+    createdAt: "2026-05-19T14:09:29Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -421,7 +421,6 @@ spec:
             - planTier
             - requestedBy
             - secretRef
-            - useCase
             type: object
           status:
             description: APIKeyStatus defines the observed state of APIKey.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Made `useCase` field optional for APIKey resources, allowing creation without specifying this field
  * Updated APIKey status response structure to include `secretRef` field

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->