### PR TITLE
Backport patch-safe fixes for v1.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/kuadrant-operator
 
-go 1.25.5
+go 1.25.9
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/utils/release/load_github_envvar.sh
+++ b/utils/release/load_github_envvar.sh
@@ -6,7 +6,8 @@ source $script_dir/shared.sh
 
 log "Loading Environment Variables"
 
-releaseBranch="release-$(echo "$KUADRANT_OPERATOR_TAG" | sed -E 's/^(v[0-9]+\.[0-9]+).*/\1/')"
+# Extract major.minor from tag (e.g., v1.4.4 → 1.4) without v prefix per RFC 0018
+releaseBranch="release-$(echo "$KUADRANT_OPERATOR_TAG" | sed -E 's/^v([0-9]+\.[0-9]+).*/\1/')"
 
 prerelease=false
 if [[ "$KUADRANT_OPERATOR_TAG" =~ [-+] ]]; then


### PR DESCRIPTION
## Summary

Backport fixes for the v1.4.4 patch release. This PR validates the RFC 0018 release branch naming migration (Phase 3 of #1981).

## Changes

- **fix: strip v prefix from release branch name in load_github_envvar.sh** — the sed pattern captured the `v` prefix (`v1.4`) producing `release-v1.4`. Now produces `release-1.4` per RFC 0018. This is the critical fix that makes the release workflow work with the renamed branch.
- **Upgrade Go to 1.25.9** — aligns with all other Kuadrant 1.4.4 components.

## Still needed before merge

Once all component patch releases are tagged, this PR needs additional commits:
- [ ] Update `release.yaml` with new component versions
- [ ] Run `make prepare-release` and commit the generated manifests

### Target component versions for 1.4.4
| Component | 1.4.3 | 1.4.4 |
|-----------|-------|-------|
| authorino-operator | 0.23.1 | 0.23.2 |
| dns-operator | 0.16.0 | 0.16.2 |
| limitador-operator | 0.17.1 | 0.17.2 |
| console-plugin | 0.3.4 | 0.3.7 |
| developer-portal-controller | 0.1.0 | 0.1.1 |
| wasm-shim | 0.12.3 | 0.12.3 (unchanged) |

**Note**: authorino-operator stays on the 0.23 line because v0.24.0 pins authorino v0.25.0 which includes new API surface (XFCC/RFC 9440). The 0.24 line will be used for Kuadrant 1.5.

Part of #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)