### PR TITLE
feat: Extension SDK action pipeline improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,20 @@ make deploy
 
 # Deploy dependencies only
 make deploy-dependencies
+
+# Local setup with a custom wasm-shim and extra extensions (e.g. threat-policy)
+# 1. Build wasm-shim from local repo
+docker build -t quay.io/kuadrant/wasm-shim:dev /path/to/wasm-shim
+# 2. Build operator with extra extensions, load images, and deploy
+make docker-build IMG=quay.io/kuadrant/kuadrant-operator:dev EXTRA_EXTENSIONS=threat-policy
+make local-setup IMG=quay.io/kuadrant/kuadrant-operator:dev
+# 3. Push wasm-shim to Kind's local registry (Istio fetches wasm via OCI, not container runtime)
+docker tag quay.io/kuadrant/wasm-shim:dev localhost:5001/kuadrant/wasm-shim:dev
+docker push localhost:5001/kuadrant/wasm-shim:dev
+# 4. Point operator at the local registry (use the registry's Kind-network IP)
+REGISTRY_IP=$(docker inspect kind-registry --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+kubectl set env deployment/kuadrant-operator-controller-manager -n kuadrant-system \
+  RELATED_IMAGE_WASMSHIM=oci://${REGISTRY_IP}:5000/kuadrant/wasm-shim:dev
 ```
 
 ### Code Generation

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,12 @@ RUN if [ "$WITH_EXTENSIONS" = "true" ]; then \
     fi
 
 # Build additional extensions specified via EXTRA_EXTENSIONS (space-separated list of directory names under cmd/extensions/)
-RUN for ext in $EXTRA_EXTENSIONS; do \
-    echo "Building extra extension: $ext" && \
-    mkdir -p extensions/$ext && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o extensions/$ext/$ext cmd/extensions/$ext/main.go; \
+RUN set -e; \
+    for ext in $EXTRA_EXTENSIONS; do \
+      echo "Building extra extension: $ext"; \
+      mkdir -p "extensions/$ext"; \
+      CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} \
+        go build -a -o "extensions/$ext/$ext" "cmd/extensions/$ext/main.go"; \
     done
 
 # Use distroless as minimal base image to package the manager binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ARG GIT_SHA
 ARG DIRTY
 ARG VERSION
 ARG WITH_EXTENSIONS=true
+ARG EXTRA_EXTENSIONS=""
 
 ENV GIT_SHA=${GIT_SHA:-unknown}
 ENV DIRTY=${DIRTY:-unknown}
@@ -49,6 +50,13 @@ RUN if [ "$WITH_EXTENSIONS" = "true" ]; then \
     else \
     echo "Skipping extensions build"; \
     fi
+
+# Build additional extensions specified via EXTRA_EXTENSIONS (space-separated list of directory names under cmd/extensions/)
+RUN for ext in $EXTRA_EXTENSIONS; do \
+    echo "Building extra extension: $ext" && \
+    mkdir -p extensions/$ext && \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o extensions/$ext/$ext cmd/extensions/$ext/main.go; \
+    done
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,7 @@ KUADRANT_SA_NAME ?= kuadrant-operator-controller-manager
 
 #Kuadrant Extensions
 WITH_EXTENSIONS ?= true
+EXTRA_EXTENSIONS ?=
 EXTENSIONS_DIRECTORIES ?= $(shell ls -d $(PROJECT_PATH)/cmd/extensions/*/)
 
 # Kuadrant component versions
@@ -428,6 +429,7 @@ docker-build: ## Build docker image with the manager.
 		--build-arg VERSION=v$(VERSION) \
 		--build-arg WITH_EXTENSIONS=$(WITH_EXTENSIONS) \
 		--build-arg WASM_SHIM_IMAGE=$(RELATED_IMAGE_WASMSHIM) \
+		--build-arg EXTRA_EXTENSIONS="$(EXTRA_EXTENSIONS)" \
 		$(CONTAINER_ENGINE_EXTRA_FLAGS) \
 		-t $(IMG) .
 

--- a/cmd/extensions/threat-policy/internal/controller/threatpolicy_reconciler.go
+++ b/cmd/extensions/threat-policy/internal/controller/threatpolicy_reconciler.go
@@ -88,7 +88,10 @@ func (r *ThreatPolicyReconciler) validateTarget(ctx context.Context, pol *v1alph
 	}
 
 	if err := r.Client.Get(ctx, nn, obj); err != nil {
-		return kuadrant.NewErrTargetNotFound("ThreatPolicy", ref.LocalPolicyTargetReference, err)
+		if errors.IsNotFound(err) {
+			return kuadrant.NewErrTargetNotFound("ThreatPolicy", ref.LocalPolicyTargetReference, err)
+		}
+		return err
 	}
 	return nil
 }

--- a/cmd/extensions/threat-policy/internal/controller/threatpolicy_reconciler.go
+++ b/cmd/extensions/threat-policy/internal/controller/threatpolicy_reconciler.go
@@ -7,10 +7,14 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kuadrant/kuadrant-operator/cmd/extensions/threat-policy/api/v1alpha1"
+	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
 	extcontroller "github.com/kuadrant/kuadrant-operator/pkg/extension/controller"
 	"github.com/kuadrant/kuadrant-operator/pkg/extension/types"
 )
@@ -69,7 +73,31 @@ func (r *ThreatPolicyReconciler) Reconcile(ctx context.Context, request reconcil
 	return reconcile.Result{}, nil
 }
 
+func (r *ThreatPolicyReconciler) validateTarget(ctx context.Context, pol *v1alpha1.ThreatPolicy) error {
+	ref := pol.Spec.TargetRef
+	nn := k8stypes.NamespacedName{Name: string(ref.Name), Namespace: pol.Namespace}
+
+	var obj client.Object
+	switch ref.Kind {
+	case "Gateway":
+		obj = &gwapiv1.Gateway{}
+	case "HTTPRoute":
+		obj = &gwapiv1.HTTPRoute{}
+	default:
+		return fmt.Errorf("unsupported targetRef kind: %s", ref.Kind)
+	}
+
+	if err := r.Client.Get(ctx, nn, obj); err != nil {
+		return kuadrant.NewErrTargetNotFound("ThreatPolicy", ref.LocalPolicyTargetReference, err)
+	}
+	return nil
+}
+
 func (r *ThreatPolicyReconciler) reconcileSpec(ctx context.Context, pol *v1alpha1.ThreatPolicy, kuadrantCtx types.KuadrantCtx) (*v1alpha1.ThreatPolicyStatus, error) {
+	if err := r.validateTarget(ctx, pol); err != nil {
+		return calculateErrorStatus(pol, err), err
+	}
+
 	r.Logger.Info("registering action method", "url", threatServiceURL)
 
 	if err := kuadrantCtx.RegisterActionMethod(ctx, pol, types.ActionMethodConfig{

--- a/cmd/extensions/threat-policy/internal/controller/threatpolicy_reconciler.go
+++ b/cmd/extensions/threat-policy/internal/controller/threatpolicy_reconciler.go
@@ -85,30 +85,36 @@ func (r *ThreatPolicyReconciler) reconcileSpec(ctx context.Context, pol *v1alpha
 
 	r.Logger.Info("action method registered successfully", "url", threatServiceURL)
 
-	err := kuadrantCtx.NewPipeline(pol).
-		OnRequest(types.AllowAction{
-			Intention: `request.url_path != "/blocked"`,
-		}).
-		OnRequest(types.GRPCMethodAction{
-			Predicate: `"x-assess-threat" in request.headers`,
-			Method:    "assess-threat",
-			Var:       "threatResponse",
-			Intention: fmt.Sprintf("threatResponse.threat_level < %d", pol.Spec.Threshold),
-		}).
-		OnResponse(
-			types.AddHeadersAction{
-				Predicate:    `"x-assess-threat" in request.headers`,
-				HeadersToAdd: `[["x-threat-assessed", "true"]]`,
-			},
-			types.AddHeadersAction{
-				Predicate:    `!("x-assess-threat" in request.headers)`,
-				HeadersToAdd: `[["x-threat-assessed", "false"]]`,
-			},
-			types.AddHeadersAction{
-				HeadersToAdd: fmt.Sprintf(`[["x-threat-threshold", "%d"]]`, pol.Spec.Threshold),
-			},
-		).
-		Commit(ctx)
+	pipeline := kuadrantCtx.NewPipeline(pol)
+
+	if err := pipeline.OnHTTPRequest(
+		types.GRPCMethodAction{
+			Method: "assess-threat",
+			Var:    "threatResponse",
+		},
+		types.FailAction{
+			Predicate:  `threatResponse.threat_level < 0`,
+			LogMessage: "threat assessment returned invalid threat_level",
+		},
+		types.DenyAction{
+			Predicate:   fmt.Sprintf("threatResponse.threat_level >= %d", pol.Spec.Threshold),
+			WithStatus:  403,
+			WithHeaders: `[["x-threat-blocked", "true"], ["x-threat-level", string(threatResponse.threat_level)]]`,
+			WithBody:    "Request blocked: threat level exceeds threshold",
+		},
+	); err != nil {
+		return calculateErrorStatus(pol, err), err
+	}
+
+	if err := pipeline.OnHTTPResponse(
+		types.AddHeadersAction{
+			HeadersToAdd: fmt.Sprintf(`[["x-threat-threshold", "%d"], ["x-threat-score", string(threatResponse.threat_level)]]`, pol.Spec.Threshold),
+		},
+	); err != nil {
+		return calculateErrorStatus(pol, err), err
+	}
+
+	err := pipeline.Commit(ctx)
 
 	if err != nil {
 		r.Logger.Error(err, "failed to commit pipeline")

--- a/internal/extension/cel_utils.go
+++ b/internal/extension/cel_utils.go
@@ -1,0 +1,76 @@
+package extension
+
+import (
+	"fmt"
+
+	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/parser"
+)
+
+func extractVarFieldAccesses(expr string, knownVars map[string]string) (map[string][][]string, error) {
+	prsr, err := parser.NewParser()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL parser: %w", err)
+	}
+	parsed, iss := prsr.Parse(common.NewTextSource(expr))
+	if len(iss.GetErrors()) > 0 {
+		return nil, fmt.Errorf("failed to parse CEL expression: %s", iss.ToDisplayString())
+	}
+
+	result := make(map[string][][]string)
+	collectFieldAccesses(parsed.Expr(), knownVars, result)
+	return result, nil
+}
+
+func collectFieldAccesses(expr ast.Expr, knownVars map[string]string, result map[string][][]string) {
+	if expr == nil {
+		return
+	}
+
+	if expr.Kind() == ast.SelectKind {
+		varName, fields := resolveSelectChain(expr)
+		if varName != "" {
+			if _, ok := knownVars[varName]; ok {
+				result[varName] = append(result[varName], fields)
+				return
+			}
+		}
+	}
+
+	switch expr.Kind() {
+	case ast.SelectKind:
+		collectFieldAccesses(expr.AsSelect().Operand(), knownVars, result)
+	case ast.CallKind:
+		call := expr.AsCall()
+		if t := call.Target(); t != nil {
+			collectFieldAccesses(t, knownVars, result)
+		}
+		for _, arg := range call.Args() {
+			collectFieldAccesses(arg, knownVars, result)
+		}
+	case ast.ListKind:
+		for _, elem := range expr.AsList().Elements() {
+			collectFieldAccesses(elem, knownVars, result)
+		}
+	case ast.MapKind:
+		for _, entry := range expr.AsMap().Entries() {
+			mapEntry := entry.AsMapEntry()
+			collectFieldAccesses(mapEntry.Key(), knownVars, result)
+			collectFieldAccesses(mapEntry.Value(), knownVars, result)
+		}
+	}
+}
+
+func resolveSelectChain(expr ast.Expr) (string, []string) {
+	var fields []string
+	current := expr
+	for current.Kind() == ast.SelectKind {
+		fields = append([]string{current.AsSelect().FieldName()}, fields...)
+		current = current.AsSelect().Operand()
+	}
+	if current.Kind() == ast.IdentKind {
+		return current.AsIdent(), fields
+	}
+	return "", nil
+}

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -827,17 +827,17 @@ func (s *extensionService) validateActions(policyID ResourceID, actions []*extpb
 			}
 
 		case extpb.ActionType_ACTION_TYPE_DENY:
-			if err := validateHTTPStatusCode(action.DenyWith, fmt.Sprintf("actions[%d].deny_with", i)); err != nil {
-				return nil, err
+			if action.WithStatus != 0 {
+				if err := validateHTTPStatusCode(fmt.Sprintf("%d", action.WithStatus), fmt.Sprintf("actions[%d].with_status", i)); err != nil {
+					return nil, err
+				}
 			}
-			entry.DenyWith = action.DenyWith
+			entry.WithStatus = int(action.WithStatus)
+			entry.WithHeaders = action.WithHeaders
+			entry.WithBody = action.WithBody
 
-		case extpb.ActionType_ACTION_TYPE_FAILURE:
-			if err := validateHTTPStatusCode(action.FailureCode, fmt.Sprintf("actions[%d].failure_code", i)); err != nil {
-				return nil, err
-			}
-			entry.FailureCode = action.FailureCode
-			entry.FailureMessage = action.FailureMessage
+		case extpb.ActionType_ACTION_TYPE_FAIL:
+			entry.LogMessage = action.LogMessage
 
 		case extpb.ActionType_ACTION_TYPE_ADD_HEADERS:
 			if action.HeadersToAdd == "" {

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -32,10 +32,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common"
-	"github.com/google/cel-go/common/ast"
 	celtypes "github.com/google/cel-go/common/types"
-	"github.com/google/cel-go/parser"
 	authorinov1beta3 "github.com/kuadrant/authorino/api/v1beta3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -783,9 +780,77 @@ func (s *extensionService) PipelineCommit(_ context.Context, request *extpb.Pipe
 	return &emptypb.Empty{}, nil
 }
 
+type actionValidationCtx struct {
+	store       *RegisteredDataStore
+	policyID    ResourceID
+	varToMethod map[string]string
+}
+
+type actionEntryValidator func(action *extpb.ActionEntry, index int, entry *PipelineActionEntry, vctx *actionValidationCtx) error
+
+var actionEntryValidators = map[extpb.ActionType]actionEntryValidator{
+	extpb.ActionType_ACTION_TYPE_GRPC_METHOD: validateGRPCMethodEntry,
+	extpb.ActionType_ACTION_TYPE_DENY:        validateDenyEntry,
+	extpb.ActionType_ACTION_TYPE_FAIL:        validateFailEntry,
+	extpb.ActionType_ACTION_TYPE_ADD_HEADERS: validateAddHeadersEntry,
+}
+
+func validateGRPCMethodEntry(action *extpb.ActionEntry, index int, entry *PipelineActionEntry, vctx *actionValidationCtx) error {
+	if action.Method == "" {
+		return fmt.Errorf("actions[%d]: method must be specified for grpc_method actions", index)
+	}
+	if !vctx.store.HasUpstreamName(vctx.policyID, action.Method) {
+		return fmt.Errorf("actions[%d]: method %q is not a registered action method for this policy", index, action.Method)
+	}
+	if action.Var != "" && !varNameRegexp.MatchString(action.Var) {
+		return fmt.Errorf("actions[%d]: var %q must match [a-zA-Z_][a-zA-Z0-9_]*", index, action.Var)
+	}
+	entry.Method = action.Method
+	entry.Var = action.Var
+	if action.Var != "" {
+		vctx.varToMethod[action.Var] = action.Method
+	}
+	return nil
+}
+
+func validateDenyEntry(action *extpb.ActionEntry, index int, entry *PipelineActionEntry, _ *actionValidationCtx) error {
+	if action.WithStatus != 0 {
+		if err := validateHTTPStatusCode(fmt.Sprintf("%d", action.WithStatus), fmt.Sprintf("actions[%d].with_status", index)); err != nil {
+			return err
+		}
+	}
+	entry.WithStatus = int(action.WithStatus)
+	entry.WithHeaders = action.WithHeaders
+	entry.WithBody = action.WithBody
+	return nil
+}
+
+func validateFailEntry(action *extpb.ActionEntry, index int, entry *PipelineActionEntry, _ *actionValidationCtx) error {
+	if strings.TrimSpace(action.LogMessage) == "" {
+		return fmt.Errorf("actions[%d]: log_message must be specified for fail actions", index)
+	}
+	entry.LogMessage = action.LogMessage
+	return nil
+}
+
+func validateAddHeadersEntry(action *extpb.ActionEntry, index int, entry *PipelineActionEntry, _ *actionValidationCtx) error {
+	if action.HeadersToAdd == "" {
+		return fmt.Errorf("actions[%d]: headers_to_add must be specified for add_headers actions", index)
+	}
+	if err := validateCELExpression(action.HeadersToAdd); err != nil {
+		return fmt.Errorf("actions[%d].headers_to_add: %w", index, err)
+	}
+	entry.HeadersToAdd = action.HeadersToAdd
+	return nil
+}
+
 func (s *extensionService) validateActions(policyID ResourceID, actions []*extpb.ActionEntry) ([]PipelineActionEntry, error) {
 	entries := make([]PipelineActionEntry, 0, len(actions))
-	varToMethod := make(map[string]string)
+	vctx := actionValidationCtx{
+		store:       s.registeredData,
+		policyID:    policyID,
+		varToMethod: make(map[string]string),
+	}
 
 	for i, action := range actions {
 		if action == nil {
@@ -809,57 +874,19 @@ func (s *extensionService) validateActions(policyID ResourceID, actions []*extpb
 			Phase:      action.Phase,
 		}
 
-		switch action.ActionType {
-		case extpb.ActionType_ACTION_TYPE_GRPC_METHOD:
-			if action.Method == "" {
-				return nil, fmt.Errorf("actions[%d]: method must be specified for grpc_method actions", i)
-			}
-			if !s.registeredData.HasUpstreamName(policyID, action.Method) {
-				return nil, fmt.Errorf("actions[%d]: method %q is not a registered action method for this policy", i, action.Method)
-			}
-			if action.Var != "" && !varNameRegexp.MatchString(action.Var) {
-				return nil, fmt.Errorf("actions[%d]: var %q must match [a-zA-Z_][a-zA-Z0-9_]*", i, action.Var)
-			}
-			entry.Method = action.Method
-			entry.Var = action.Var
-			if action.Var != "" {
-				varToMethod[action.Var] = action.Method
-			}
-
-		case extpb.ActionType_ACTION_TYPE_DENY:
-			if action.WithStatus != 0 {
-				if err := validateHTTPStatusCode(fmt.Sprintf("%d", action.WithStatus), fmt.Sprintf("actions[%d].with_status", i)); err != nil {
-					return nil, err
-				}
-			}
-			entry.WithStatus = int(action.WithStatus)
-			entry.WithHeaders = action.WithHeaders
-			entry.WithBody = action.WithBody
-
-		case extpb.ActionType_ACTION_TYPE_FAIL:
-			if strings.TrimSpace(action.LogMessage) == "" {
-				return nil, fmt.Errorf("actions[%d]: log_message must be specified for fail actions", i)
-			}
-			entry.LogMessage = action.LogMessage
-
-		case extpb.ActionType_ACTION_TYPE_ADD_HEADERS:
-			if action.HeadersToAdd == "" {
-				return nil, fmt.Errorf("actions[%d]: headers_to_add must be specified for add_headers actions", i)
-			}
-			if err := validateCELExpression(action.HeadersToAdd); err != nil {
-				return nil, fmt.Errorf("actions[%d].headers_to_add: %w", i, err)
-			}
-			entry.HeadersToAdd = action.HeadersToAdd
-
-		default:
+		validator, ok := actionEntryValidators[action.ActionType]
+		if !ok {
 			return nil, fmt.Errorf("actions[%d]: unknown action_type %s", i, action.ActionType)
+		}
+		if err := validator(action, i, &entry, &vctx); err != nil {
+			return nil, err
 		}
 
 		entries = append(entries, entry)
 	}
 
-	if len(varToMethod) > 0 {
-		if err := s.validateCrossActionVars(policyID, actions, varToMethod); err != nil {
+	if len(vctx.varToMethod) > 0 {
+		if err := s.validateCrossActionVars(policyID, actions, vctx.varToMethod); err != nil {
 			return nil, err
 		}
 	}
@@ -898,10 +925,12 @@ func (s *extensionService) validateCrossActionVars(policyID ResourceID, actions 
 				cacheKey := ProtoCacheKey{ClusterName: upstreamEntry.ClusterName, Service: upstreamEntry.Service}
 				fds, ok := s.registeredData.GetProtoDescriptor(cacheKey)
 				if !ok {
+					s.logger.V(1).Info("proto descriptor not cached, skipping field validation", "var", varName, "method", methodName)
 					continue
 				}
 				responseType := findResponseMessageType(fds, upstreamEntry.Service, upstreamEntry.Method)
 				if responseType == "" {
+					s.logger.V(1).Info("response message type not found, skipping field validation", "var", varName, "method", methodName, "service", upstreamEntry.Service)
 					continue
 				}
 				for _, chain := range chains {
@@ -924,147 +953,6 @@ func collectCELExpressions(action *extpb.ActionEntry) []string {
 		exprs = append(exprs, action.HeadersToAdd)
 	}
 	return exprs
-}
-
-func extractVarFieldAccesses(expr string, knownVars map[string]string) (map[string][][]string, error) {
-	prsr, err := parser.NewParser()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create CEL parser: %w", err)
-	}
-	parsed, iss := prsr.Parse(common.NewTextSource(expr))
-	if len(iss.GetErrors()) > 0 {
-		return nil, fmt.Errorf("failed to parse CEL expression: %s", iss.ToDisplayString())
-	}
-
-	result := make(map[string][][]string)
-	collectFieldAccesses(parsed.Expr(), knownVars, result)
-	return result, nil
-}
-
-func collectFieldAccesses(expr ast.Expr, knownVars map[string]string, result map[string][][]string) {
-	if expr == nil {
-		return
-	}
-
-	if expr.Kind() == ast.SelectKind {
-		varName, fields := resolveSelectChain(expr)
-		if varName != "" {
-			if _, ok := knownVars[varName]; ok {
-				result[varName] = append(result[varName], fields)
-				return
-			}
-		}
-	}
-
-	switch expr.Kind() {
-	case ast.SelectKind:
-		collectFieldAccesses(expr.AsSelect().Operand(), knownVars, result)
-	case ast.CallKind:
-		call := expr.AsCall()
-		if t := call.Target(); t != nil {
-			collectFieldAccesses(t, knownVars, result)
-		}
-		for _, arg := range call.Args() {
-			collectFieldAccesses(arg, knownVars, result)
-		}
-	case ast.ListKind:
-		for _, elem := range expr.AsList().Elements() {
-			collectFieldAccesses(elem, knownVars, result)
-		}
-	case ast.MapKind:
-		for _, entry := range expr.AsMap().Entries() {
-			mapEntry := entry.AsMapEntry()
-			collectFieldAccesses(mapEntry.Key(), knownVars, result)
-			collectFieldAccesses(mapEntry.Value(), knownVars, result)
-		}
-	}
-}
-
-func resolveSelectChain(expr ast.Expr) (string, []string) {
-	var fields []string
-	current := expr
-	for current.Kind() == ast.SelectKind {
-		fields = append([]string{current.AsSelect().FieldName()}, fields...)
-		current = current.AsSelect().Operand()
-	}
-	if current.Kind() == ast.IdentKind {
-		return current.AsIdent(), fields
-	}
-	return "", nil
-}
-
-func findResponseMessageType(fds *descriptorpb.FileDescriptorSet, serviceName, methodName string) string {
-	for _, file := range fds.File {
-		for _, svc := range file.Service {
-			fullServiceName := svc.GetName()
-			if file.Package != nil && *file.Package != "" {
-				fullServiceName = *file.Package + "." + svc.GetName()
-			}
-			if fullServiceName != serviceName {
-				continue
-			}
-			for _, method := range svc.Method {
-				if method.GetName() == methodName {
-					return method.GetOutputType()
-				}
-			}
-		}
-	}
-	return ""
-}
-
-func findMessageDescriptor(fds *descriptorpb.FileDescriptorSet, messageType string) *descriptorpb.DescriptorProto {
-	normalizedType := strings.TrimPrefix(messageType, ".")
-	for _, file := range fds.File {
-		pkg := file.GetPackage()
-		for _, msg := range file.MessageType {
-			fqn := msg.GetName()
-			if pkg != "" {
-				fqn = pkg + "." + msg.GetName()
-			}
-			if fqn == normalizedType {
-				return msg
-			}
-		}
-	}
-	return nil
-}
-
-func validateFieldAccess(fds *descriptorpb.FileDescriptorSet, messageType string, fieldPath []string) error {
-	if len(fieldPath) == 0 {
-		return nil
-	}
-
-	msg := findMessageDescriptor(fds, messageType)
-	if msg == nil {
-		return fmt.Errorf("message type %q not found in proto descriptors", messageType)
-	}
-
-	currentMsg := msg
-	for i, fieldName := range fieldPath {
-		var found *descriptorpb.FieldDescriptorProto
-		for _, f := range currentMsg.Field {
-			if f.GetName() == fieldName {
-				found = f
-				break
-			}
-		}
-		if found == nil {
-			return fmt.Errorf("field %q not found on message %q", fieldName, currentMsg.GetName())
-		}
-
-		if i < len(fieldPath)-1 {
-			if found.GetType() != descriptorpb.FieldDescriptorProto_TYPE_MESSAGE {
-				return fmt.Errorf("field %q on message %q is not a message type, cannot access sub-fields", fieldName, currentMsg.GetName())
-			}
-			nextMsg := findMessageDescriptor(fds, found.GetTypeName())
-			if nextMsg == nil {
-				return fmt.Errorf("message type %q for field %q not found", found.GetTypeName(), fieldName)
-			}
-			currentMsg = nextMsg
-		}
-	}
-	return nil
 }
 
 // Creates a locator matching the definition in policy-machinery

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -747,7 +747,7 @@ func validateCELExpression(expr string) error {
 	return nil
 }
 
-var varNameRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
+var varNameRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
 func (s *extensionService) PipelineCommit(_ context.Context, request *extpb.PipelineCommitRequest) (*emptypb.Empty, error) {
 	if request == nil {
@@ -818,7 +818,7 @@ func (s *extensionService) validateActions(policyID ResourceID, actions []*extpb
 				return nil, fmt.Errorf("actions[%d]: method %q is not a registered action method for this policy", i, action.Method)
 			}
 			if action.Var != "" && !varNameRegexp.MatchString(action.Var) {
-				return nil, fmt.Errorf("actions[%d]: var %q must match [a-zA-Z_][a-zA-Z0-9_-]*", i, action.Var)
+				return nil, fmt.Errorf("actions[%d]: var %q must match [a-zA-Z_][a-zA-Z0-9_]*", i, action.Var)
 			}
 			entry.Method = action.Method
 			entry.Var = action.Var
@@ -837,6 +837,9 @@ func (s *extensionService) validateActions(policyID ResourceID, actions []*extpb
 			entry.WithBody = action.WithBody
 
 		case extpb.ActionType_ACTION_TYPE_FAIL:
+			if strings.TrimSpace(action.LogMessage) == "" {
+				return nil, fmt.Errorf("actions[%d]: log_message must be specified for fail actions", i)
+			}
 			entry.LogMessage = action.LogMessage
 
 		case extpb.ActionType_ACTION_TYPE_ADD_HEADERS:

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -744,18 +744,7 @@ func validateCELExpression(expr string) error {
 	return nil
 }
 
-// validRequestActionTypes lists action types allowed in the request phase.
-var validRequestActionTypes = map[extpb.ActionType]bool{
-	extpb.ActionType_ACTION_TYPE_GRPC_METHOD: true,
-	extpb.ActionType_ACTION_TYPE_ALLOW:       true,
-}
-
-// validResponseActionTypes lists action types allowed in the response phase.
-var validResponseActionTypes = map[extpb.ActionType]bool{
-	extpb.ActionType_ACTION_TYPE_ADD_HEADERS:        true,
-	extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE: true,
-}
-
+// TODO(#1964): Rewrite PipelineCommit handler with full validation for unified action entries
 func (s *extensionService) PipelineCommit(_ context.Context, request *extpb.PipelineCommitRequest) (*emptypb.Empty, error) {
 	if request == nil {
 		return nil, errors.New("request cannot be nil")
@@ -766,131 +755,38 @@ func (s *extensionService) PipelineCommit(_ context.Context, request *extpb.Pipe
 		return nil, err
 	}
 
-	requestEntries, err := s.validateRequestActions(policyID, request.RequestActions)
-	if err != nil {
-		return nil, err
+	entries := make([]PipelineActionEntry, 0, len(request.Actions))
+	for _, action := range request.Actions {
+		entries = append(entries, PipelineActionEntry{
+			ActionType: action.ActionType,
+			Predicate:  action.Predicate,
+			Phase:      action.Phase,
+			Method:     action.Method,
+			Var:        action.Var,
+			DenyWith:   action.DenyWith,
+			HeadersToAdd:   action.HeadersToAdd,
+			FailureMessage: action.FailureMessage,
+			FailureCode:    action.FailureCode,
+		})
 	}
 
-	responseEntries, err := s.validateResponseActions(request.ResponseActions)
-	if err != nil {
+	if err := s.registeredData.ReplacePipelineActions(policyID, entries); err != nil {
 		return nil, err
 	}
-
-	s.registeredData.ReplacePipelineActions(policyID, requestEntries, responseEntries)
 
 	s.logger.Info("pipeline committed",
 		"policy", fmt.Sprintf("%s/%s", policyID.Namespace, policyID.Name),
-		"requestActions", len(requestEntries),
-		"responseActions", len(responseEntries))
+		"actions", len(entries))
 
 	if s.changeNotifier != nil {
-		reason := fmt.Sprintf("pipeline committed for policy %s/%s (%d request, %d response actions)",
-			policyID.Namespace, policyID.Name, len(requestEntries), len(responseEntries))
+		reason := fmt.Sprintf("pipeline committed for policy %s/%s (%d actions)",
+			policyID.Namespace, policyID.Name, len(entries))
 		if err := s.changeNotifier(reason); err != nil {
 			s.logger.Error(err, "failed to trigger change notification", "reason", reason)
 		}
 	}
 
 	return &emptypb.Empty{}, nil
-}
-
-func (s *extensionService) validateRequestActions(policyID ResourceID, actions []*extpb.RequestActionEntry) ([]PipelineActionEntry, error) {
-	entries := make([]PipelineActionEntry, 0, len(actions))
-	for i, action := range actions {
-		if action == nil {
-			return nil, fmt.Errorf("request_actions[%d]: entry cannot be nil", i)
-		}
-		if action.ActionType == extpb.ActionType_ACTION_TYPE_UNSPECIFIED {
-			return nil, fmt.Errorf("request_actions[%d]: action_type must be specified", i)
-		}
-		if !validRequestActionTypes[action.ActionType] {
-			return nil, fmt.Errorf("request_actions[%d]: action_type %s is not valid in the request phase", i, action.ActionType)
-		}
-
-		if action.Predicate != "" {
-			if err := validateCELExpression(action.Predicate); err != nil {
-				return nil, fmt.Errorf("request_actions[%d].predicate: %w", i, err)
-			}
-		}
-
-		entry := PipelineActionEntry{
-			ActionType: action.ActionType,
-			Predicate:  action.Predicate,
-		}
-
-		switch action.ActionType {
-		case extpb.ActionType_ACTION_TYPE_GRPC_METHOD:
-			if action.Method == "" {
-				return nil, fmt.Errorf("request_actions[%d]: method must be specified for grpc_method actions", i)
-			}
-			if !s.registeredData.HasUpstreamName(policyID, action.Method) {
-				return nil, fmt.Errorf("request_actions[%d]: method %q is not a registered action method for this policy", i, action.Method)
-			}
-			if action.Intention != "" {
-				if err := validateCELExpression(action.Intention); err != nil {
-					return nil, fmt.Errorf("request_actions[%d].intention: %w", i, err)
-				}
-			}
-			entry.Intention = action.Intention
-			entry.Method = action.Method
-			entry.Var = action.Var
-		case extpb.ActionType_ACTION_TYPE_ALLOW:
-			if action.Intention != "" {
-				if err := validateCELExpression(action.Intention); err != nil {
-					return nil, fmt.Errorf("request_actions[%d].intention: %w", i, err)
-				}
-			}
-			entry.Intention = action.Intention
-		}
-
-		entries = append(entries, entry)
-	}
-	return entries, nil
-}
-
-func (s *extensionService) validateResponseActions(actions []*extpb.ResponseActionEntry) ([]PipelineActionEntry, error) {
-	entries := make([]PipelineActionEntry, 0, len(actions))
-	for i, action := range actions {
-		if action == nil {
-			return nil, fmt.Errorf("response_actions[%d]: entry cannot be nil", i)
-		}
-		if action.ActionType == extpb.ActionType_ACTION_TYPE_UNSPECIFIED {
-			return nil, fmt.Errorf("response_actions[%d]: action_type must be specified", i)
-		}
-		if !validResponseActionTypes[action.ActionType] {
-			return nil, fmt.Errorf("response_actions[%d]: action_type %s is not valid in the response phase", i, action.ActionType)
-		}
-
-		if action.Predicate != "" {
-			if err := validateCELExpression(action.Predicate); err != nil {
-				return nil, fmt.Errorf("response_actions[%d].predicate: %w", i, err)
-			}
-		}
-
-		entry := PipelineActionEntry{
-			ActionType: action.ActionType,
-			Predicate:  action.Predicate,
-		}
-
-		switch action.ActionType {
-		case extpb.ActionType_ACTION_TYPE_ADD_HEADERS:
-			if action.HeadersToAdd == "" {
-				return nil, fmt.Errorf("response_actions[%d]: headers_to_add must be specified for add_headers actions", i)
-			}
-			if err := validateCELExpression(action.HeadersToAdd); err != nil {
-				return nil, fmt.Errorf("response_actions[%d].headers_to_add: %w", i, err)
-			}
-			entry.HeadersToAdd = action.HeadersToAdd
-		case extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE:
-			if action.NewResponseCode < 100 || action.NewResponseCode > 599 {
-				return nil, fmt.Errorf("response_actions[%d]: new_response_code must be between 100 and 599, got %d", i, action.NewResponseCode)
-			}
-			entry.NewResponseCode = action.NewResponseCode
-		}
-
-		entries = append(entries, entry)
-	}
-	return entries, nil
 }
 
 // Creates a locator matching the definition in policy-machinery

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -32,7 +32,10 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/ast"
 	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/parser"
 	authorinov1beta3 "github.com/kuadrant/authorino/api/v1beta3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -744,7 +747,8 @@ func validateCELExpression(expr string) error {
 	return nil
 }
 
-// TODO(#1964): Rewrite PipelineCommit handler with full validation for unified action entries
+var varNameRegexp = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
+
 func (s *extensionService) PipelineCommit(_ context.Context, request *extpb.PipelineCommitRequest) (*emptypb.Empty, error) {
 	if request == nil {
 		return nil, errors.New("request cannot be nil")
@@ -755,19 +759,9 @@ func (s *extensionService) PipelineCommit(_ context.Context, request *extpb.Pipe
 		return nil, err
 	}
 
-	entries := make([]PipelineActionEntry, 0, len(request.Actions))
-	for _, action := range request.Actions {
-		entries = append(entries, PipelineActionEntry{
-			ActionType: action.ActionType,
-			Predicate:  action.Predicate,
-			Phase:      action.Phase,
-			Method:     action.Method,
-			Var:        action.Var,
-			DenyWith:   action.DenyWith,
-			HeadersToAdd:   action.HeadersToAdd,
-			FailureMessage: action.FailureMessage,
-			FailureCode:    action.FailureCode,
-		})
+	entries, err := s.validateActions(policyID, request.Actions)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := s.registeredData.ReplacePipelineActions(policyID, entries); err != nil {
@@ -787,6 +781,287 @@ func (s *extensionService) PipelineCommit(_ context.Context, request *extpb.Pipe
 	}
 
 	return &emptypb.Empty{}, nil
+}
+
+func (s *extensionService) validateActions(policyID ResourceID, actions []*extpb.ActionEntry) ([]PipelineActionEntry, error) {
+	entries := make([]PipelineActionEntry, 0, len(actions))
+	varToMethod := make(map[string]string)
+
+	for i, action := range actions {
+		if action == nil {
+			return nil, fmt.Errorf("actions[%d]: entry cannot be nil", i)
+		}
+		if action.ActionType == extpb.ActionType_ACTION_TYPE_UNSPECIFIED {
+			return nil, fmt.Errorf("actions[%d]: action_type must be specified", i)
+		}
+		if action.Phase != string(PipelinePhaseRequest) && action.Phase != string(PipelinePhaseResponse) {
+			return nil, fmt.Errorf("actions[%d]: phase must be %q or %q, got %q", i, PipelinePhaseRequest, PipelinePhaseResponse, action.Phase)
+		}
+		if action.Predicate != "" {
+			if err := validateCELExpression(action.Predicate); err != nil {
+				return nil, fmt.Errorf("actions[%d].predicate: %w", i, err)
+			}
+		}
+
+		entry := PipelineActionEntry{
+			ActionType: action.ActionType,
+			Predicate:  action.Predicate,
+			Phase:      action.Phase,
+		}
+
+		switch action.ActionType {
+		case extpb.ActionType_ACTION_TYPE_GRPC_METHOD:
+			if action.Method == "" {
+				return nil, fmt.Errorf("actions[%d]: method must be specified for grpc_method actions", i)
+			}
+			if !s.registeredData.HasUpstreamName(policyID, action.Method) {
+				return nil, fmt.Errorf("actions[%d]: method %q is not a registered action method for this policy", i, action.Method)
+			}
+			if action.Var != "" && !varNameRegexp.MatchString(action.Var) {
+				return nil, fmt.Errorf("actions[%d]: var %q must match [a-zA-Z_][a-zA-Z0-9_-]*", i, action.Var)
+			}
+			entry.Method = action.Method
+			entry.Var = action.Var
+			if action.Var != "" {
+				varToMethod[action.Var] = action.Method
+			}
+
+		case extpb.ActionType_ACTION_TYPE_DENY:
+			if err := validateHTTPStatusCode(action.DenyWith, fmt.Sprintf("actions[%d].deny_with", i)); err != nil {
+				return nil, err
+			}
+			entry.DenyWith = action.DenyWith
+
+		case extpb.ActionType_ACTION_TYPE_FAILURE:
+			if err := validateHTTPStatusCode(action.FailureCode, fmt.Sprintf("actions[%d].failure_code", i)); err != nil {
+				return nil, err
+			}
+			entry.FailureCode = action.FailureCode
+			entry.FailureMessage = action.FailureMessage
+
+		case extpb.ActionType_ACTION_TYPE_ADD_HEADERS:
+			if action.HeadersToAdd == "" {
+				return nil, fmt.Errorf("actions[%d]: headers_to_add must be specified for add_headers actions", i)
+			}
+			if err := validateCELExpression(action.HeadersToAdd); err != nil {
+				return nil, fmt.Errorf("actions[%d].headers_to_add: %w", i, err)
+			}
+			entry.HeadersToAdd = action.HeadersToAdd
+
+		default:
+			return nil, fmt.Errorf("actions[%d]: unknown action_type %s", i, action.ActionType)
+		}
+
+		entries = append(entries, entry)
+	}
+
+	if len(varToMethod) > 0 {
+		if err := s.validateCrossActionVars(policyID, actions, varToMethod); err != nil {
+			return nil, err
+		}
+	}
+
+	return entries, nil
+}
+
+func validateHTTPStatusCode(code, field string) error {
+	if code == "" {
+		return fmt.Errorf("%s: must be specified", field)
+	}
+	n, err := strconv.Atoi(code)
+	if err != nil {
+		return fmt.Errorf("%s: %q is not a valid integer", field, code)
+	}
+	if n < 100 || n > 599 {
+		return fmt.Errorf("%s: must be between 100 and 599, got %d", field, n)
+	}
+	return nil
+}
+
+func (s *extensionService) validateCrossActionVars(policyID ResourceID, actions []*extpb.ActionEntry, varToMethod map[string]string) error {
+	for i, action := range actions {
+		exprs := collectCELExpressions(action)
+		for _, expr := range exprs {
+			fieldAccesses, err := extractVarFieldAccesses(expr, varToMethod)
+			if err != nil {
+				return fmt.Errorf("actions[%d]: %w", i, err)
+			}
+			for varName, chains := range fieldAccesses {
+				methodName := varToMethod[varName]
+				_, upstreamEntry, found := s.registeredData.GetUpstreamByName(policyID, methodName)
+				if !found {
+					continue
+				}
+				cacheKey := ProtoCacheKey{ClusterName: upstreamEntry.ClusterName, Service: upstreamEntry.Service}
+				fds, ok := s.registeredData.GetProtoDescriptor(cacheKey)
+				if !ok {
+					continue
+				}
+				responseType := findResponseMessageType(fds, upstreamEntry.Service, upstreamEntry.Method)
+				if responseType == "" {
+					continue
+				}
+				for _, chain := range chains {
+					if err := validateFieldAccess(fds, responseType, chain); err != nil {
+						return fmt.Errorf("actions[%d]: variable %q: %w", i, varName, err)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func collectCELExpressions(action *extpb.ActionEntry) []string {
+	var exprs []string
+	if action.Predicate != "" {
+		exprs = append(exprs, action.Predicate)
+	}
+	if action.HeadersToAdd != "" {
+		exprs = append(exprs, action.HeadersToAdd)
+	}
+	return exprs
+}
+
+func extractVarFieldAccesses(expr string, knownVars map[string]string) (map[string][][]string, error) {
+	prsr, err := parser.NewParser()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL parser: %w", err)
+	}
+	parsed, iss := prsr.Parse(common.NewTextSource(expr))
+	if len(iss.GetErrors()) > 0 {
+		return nil, fmt.Errorf("failed to parse CEL expression: %s", iss.ToDisplayString())
+	}
+
+	result := make(map[string][][]string)
+	collectFieldAccesses(parsed.Expr(), knownVars, result)
+	return result, nil
+}
+
+func collectFieldAccesses(expr ast.Expr, knownVars map[string]string, result map[string][][]string) {
+	if expr == nil {
+		return
+	}
+
+	if expr.Kind() == ast.SelectKind {
+		varName, fields := resolveSelectChain(expr)
+		if varName != "" {
+			if _, ok := knownVars[varName]; ok {
+				result[varName] = append(result[varName], fields)
+				return
+			}
+		}
+	}
+
+	switch expr.Kind() {
+	case ast.SelectKind:
+		collectFieldAccesses(expr.AsSelect().Operand(), knownVars, result)
+	case ast.CallKind:
+		call := expr.AsCall()
+		if t := call.Target(); t != nil {
+			collectFieldAccesses(t, knownVars, result)
+		}
+		for _, arg := range call.Args() {
+			collectFieldAccesses(arg, knownVars, result)
+		}
+	case ast.ListKind:
+		for _, elem := range expr.AsList().Elements() {
+			collectFieldAccesses(elem, knownVars, result)
+		}
+	case ast.MapKind:
+		for _, entry := range expr.AsMap().Entries() {
+			mapEntry := entry.AsMapEntry()
+			collectFieldAccesses(mapEntry.Key(), knownVars, result)
+			collectFieldAccesses(mapEntry.Value(), knownVars, result)
+		}
+	}
+}
+
+func resolveSelectChain(expr ast.Expr) (string, []string) {
+	var fields []string
+	current := expr
+	for current.Kind() == ast.SelectKind {
+		fields = append([]string{current.AsSelect().FieldName()}, fields...)
+		current = current.AsSelect().Operand()
+	}
+	if current.Kind() == ast.IdentKind {
+		return current.AsIdent(), fields
+	}
+	return "", nil
+}
+
+func findResponseMessageType(fds *descriptorpb.FileDescriptorSet, serviceName, methodName string) string {
+	for _, file := range fds.File {
+		for _, svc := range file.Service {
+			fullServiceName := svc.GetName()
+			if file.Package != nil && *file.Package != "" {
+				fullServiceName = *file.Package + "." + svc.GetName()
+			}
+			if fullServiceName != serviceName {
+				continue
+			}
+			for _, method := range svc.Method {
+				if method.GetName() == methodName {
+					return method.GetOutputType()
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func findMessageDescriptor(fds *descriptorpb.FileDescriptorSet, messageType string) *descriptorpb.DescriptorProto {
+	normalizedType := strings.TrimPrefix(messageType, ".")
+	for _, file := range fds.File {
+		pkg := file.GetPackage()
+		for _, msg := range file.MessageType {
+			fqn := msg.GetName()
+			if pkg != "" {
+				fqn = pkg + "." + msg.GetName()
+			}
+			if fqn == normalizedType {
+				return msg
+			}
+		}
+	}
+	return nil
+}
+
+func validateFieldAccess(fds *descriptorpb.FileDescriptorSet, messageType string, fieldPath []string) error {
+	if len(fieldPath) == 0 {
+		return nil
+	}
+
+	msg := findMessageDescriptor(fds, messageType)
+	if msg == nil {
+		return fmt.Errorf("message type %q not found in proto descriptors", messageType)
+	}
+
+	currentMsg := msg
+	for i, fieldName := range fieldPath {
+		var found *descriptorpb.FieldDescriptorProto
+		for _, f := range currentMsg.Field {
+			if f.GetName() == fieldName {
+				found = f
+				break
+			}
+		}
+		if found == nil {
+			return fmt.Errorf("field %q not found on message %q", fieldName, currentMsg.GetName())
+		}
+
+		if i < len(fieldPath)-1 {
+			if found.GetType() != descriptorpb.FieldDescriptorProto_TYPE_MESSAGE {
+				return fmt.Errorf("field %q on message %q is not a message type, cannot access sub-fields", fieldName, currentMsg.GetName())
+			}
+			nextMsg := findMessageDescriptor(fds, found.GetTypeName())
+			if nextMsg == nil {
+				return fmt.Errorf("message type %q for field %q not found", found.GetTypeName(), fieldName)
+			}
+			currentMsg = nextMsg
+		}
+	}
+	return nil
 }
 
 // Creates a locator matching the definition in policy-machinery

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -1003,7 +1003,272 @@ func TestPipelineCommit_InvalidPhase_RejectsAll(t *testing.T) {
 	}
 }
 
-// TODO(#1964): Add validation tests for CEL predicates, action type / phase constraints, nil entries
+func TestPipelineCommit_NilActionEntry(t *testing.T) {
+	svc := newTestExtensionService()
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			nil,
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for nil action entry")
+	}
+	if !strings.Contains(err.Error(), "cannot be nil") {
+		t.Errorf("Expected nil entry error, got: %v", err)
+	}
+}
+
+func TestPipelineCommit_InvalidActionType(t *testing.T) {
+	svc := newTestExtensionService()
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_UNSPECIFIED, Phase: "request"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for unspecified action type")
+	}
+	if !strings.Contains(err.Error(), "action_type must be specified") {
+		t.Errorf("Expected action_type error, got: %v", err)
+	}
+}
+
+func TestPipelineCommit_InvalidPredicate(t *testing.T) {
+	svc := newTestExtensionService()
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403", Predicate: "!!!invalid cel"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for invalid CEL predicate")
+	}
+	if !strings.Contains(err.Error(), "predicate") {
+		t.Errorf("Expected predicate error, got: %v", err)
+	}
+}
+
+func TestPipelineCommit_GRPCMethod_UnregisteredMethod(t *testing.T) {
+	svc := newTestExtensionService()
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "nonexistent"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for unregistered method")
+	}
+	if !strings.Contains(err.Error(), "not a registered action method") {
+		t.Errorf("Expected registered method error, got: %v", err)
+	}
+}
+
+func TestPipelineCommit_GRPCMethod_MissingMethod(t *testing.T) {
+	svc := newTestExtensionService()
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for missing method")
+	}
+	if !strings.Contains(err.Error(), "method must be specified") {
+		t.Errorf("Expected method error, got: %v", err)
+	}
+}
+
+func TestPipelineCommit_GRPCMethod_InvalidVarName(t *testing.T) {
+	svc := newTestExtensionService()
+	registerTestActionMethod(t, svc, "demo", "assess-threat")
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "assess-threat", Var: "invalid var!"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for invalid var name")
+	}
+	if !strings.Contains(err.Error(), "var") {
+		t.Errorf("Expected var name error, got: %v", err)
+	}
+}
+
+func TestPipelineCommit_Deny_InvalidStatusCode(t *testing.T) {
+	svc := newTestExtensionService()
+	tests := []struct {
+		name     string
+		denyWith string
+	}{
+		{"empty", ""},
+		{"not a number", "abc"},
+		{"too low", "99"},
+		{"too high", "600"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+				Policy: testPipelinePolicy(),
+				Actions: []*extpb.ActionEntry{
+					{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: tt.denyWith},
+				},
+			})
+			if err == nil {
+				t.Fatalf("Expected error for DenyWith=%q", tt.denyWith)
+			}
+		})
+	}
+}
+
+func TestPipelineCommit_Failure_InvalidStatusCode(t *testing.T) {
+	svc := newTestExtensionService()
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, Phase: "request", FailureCode: "999", FailureMessage: "error"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for invalid failure code")
+	}
+	if !strings.Contains(err.Error(), "failure_code") {
+		t.Errorf("Expected failure_code error, got: %v", err)
+	}
+}
+
+func TestPipelineCommit_AddHeaders_MissingHeadersToAdd(t *testing.T) {
+	svc := newTestExtensionService()
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, Phase: "response"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for missing headers_to_add")
+	}
+	if !strings.Contains(err.Error(), "headers_to_add must be specified") {
+		t.Errorf("Expected headers_to_add error, got: %v", err)
+	}
+}
+
+func TestPipelineCommit_AddHeaders_InvalidCEL(t *testing.T) {
+	svc := newTestExtensionService()
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, Phase: "response", HeadersToAdd: "!!!invalid cel"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for invalid CEL in headers_to_add")
+	}
+	if !strings.Contains(err.Error(), "headers_to_add") {
+		t.Errorf("Expected headers_to_add error, got: %v", err)
+	}
+}
+
+func testFDSWithMessages() *descriptorpb.FileDescriptorSet {
+	return &descriptorpb.FileDescriptorSet{
+		File: []*descriptorpb.FileDescriptorProto{
+			{
+				Name:    proto.String("test.proto"),
+				Package: proto.String("example.v1"),
+				Service: []*descriptorpb.ServiceDescriptorProto{
+					{
+						Name: proto.String("ExampleService"),
+						Method: []*descriptorpb.MethodDescriptorProto{
+							{
+								Name:       proto.String("ExampleMethod"),
+								InputType:  proto.String(".example.v1.ExampleRequest"),
+								OutputType: proto.String(".example.v1.ExampleResponse"),
+							},
+						},
+					},
+				},
+				MessageType: []*descriptorpb.DescriptorProto{
+					{
+						Name: proto.String("ExampleRequest"),
+						Field: []*descriptorpb.FieldDescriptorProto{
+							{Name: proto.String("query"), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum()},
+						},
+					},
+					{
+						Name: proto.String("ExampleResponse"),
+						Field: []*descriptorpb.FieldDescriptorProto{
+							{Name: proto.String("threat_level"), Type: descriptorpb.FieldDescriptorProto_TYPE_INT32.Enum()},
+							{Name: proto.String("category"), Type: descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum()},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func registerTestActionMethodWithFDS(t *testing.T, svc *extensionService, policyName, methodName string) {
+	t.Helper()
+	fds := testFDSWithMessages()
+	svc.reflectionFetcher = func(_ context.Context, _, serviceName, method string) (*descriptorpb.FileDescriptorSet, error) {
+		if !validateMethodExists(fds, serviceName, method) {
+			return nil, fmt.Errorf("method %q not found in service %q", method, serviceName)
+		}
+		return fds, nil
+	}
+	req := &extpb.RegisterActionMethodRequest{
+		Policy: testPolicy("DemoPolicy", "default", policyName,
+			testTargetRef("gateway.networking.k8s.io", "HTTPRoute", "my-route", "default")),
+		Name:    methodName,
+		Url:     "grpc://svc:8081",
+		Service: "example.v1.ExampleService",
+		Method:  "ExampleMethod",
+	}
+	_, err := svc.RegisterActionMethod(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Failed to register action method %q: %v", methodName, err)
+	}
+}
+
+func TestPipelineCommit_CrossAction_ValidVarFieldAccess(t *testing.T) {
+	svc := newTestExtensionService()
+	registerTestActionMethodWithFDS(t, svc, "demo", "assess-threat")
+
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "assess-threat", Var: "threatResponse"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "response", DenyWith: "403", Predicate: "threatResponse.threat_level >= 5"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Expected no error for valid field access, got: %v", err)
+	}
+}
+
+func TestPipelineCommit_CrossAction_InvalidVarFieldAccess(t *testing.T) {
+	svc := newTestExtensionService()
+	registerTestActionMethodWithFDS(t, svc, "demo", "assess-threat")
+
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "assess-threat", Var: "threatResponse"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "response", DenyWith: "403", Predicate: "threatResponse.nonexistent_field >= 5"},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error for invalid field access on proto response")
+	}
+	if !strings.Contains(err.Error(), "nonexistent_field") {
+		t.Errorf("Expected field name in error, got: %v", err)
+	}
+}
 
 func TestPipelineCommit_AtomicReplacement(t *testing.T) {
 	svc := newTestExtensionService()

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -936,13 +936,11 @@ func TestPipelineCommit_BothPhases(t *testing.T) {
 
 	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Predicate: "true", Intention: "response.score > 5", Var: "threatResponse"},
-			{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW},
-		},
-		ResponseActions: []*extpb.ResponseActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: `{"x-checked": "true"}`, Predicate: "true"},
-			{ActionType: extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE, NewResponseCode: 403},
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "assess-threat", Predicate: "true", Var: "threatResponse"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, Phase: "response", HeadersToAdd: `{"x-checked": "true"}`, Predicate: "true"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, Phase: "response", FailureCode: "500", FailureMessage: "internal error"},
 		},
 	})
 	if err != nil {
@@ -963,11 +961,11 @@ func TestPipelineCommit_BothPhases(t *testing.T) {
 	if reqActions[0].Var != "threatResponse" {
 		t.Errorf("Expected var 'threatResponse', got %q", reqActions[0].Var)
 	}
-	if reqActions[0].Intention != "response.score > 5" {
-		t.Errorf("Expected intention, got %q", reqActions[0].Intention)
+	if reqActions[1].ActionType != extpb.ActionType_ACTION_TYPE_DENY {
+		t.Errorf("Expected second request action DENY, got %s", reqActions[1].ActionType)
 	}
-	if reqActions[1].ActionType != extpb.ActionType_ACTION_TYPE_ALLOW {
-		t.Errorf("Expected second request action ALLOW, got %s", reqActions[1].ActionType)
+	if reqActions[1].DenyWith != "403" {
+		t.Errorf("Expected DenyWith '403', got %q", reqActions[1].DenyWith)
 	}
 
 	respActions := svc.registeredData.GetPipelineActions(policyID, PipelinePhaseResponse)
@@ -977,44 +975,22 @@ func TestPipelineCommit_BothPhases(t *testing.T) {
 	if respActions[0].HeadersToAdd != `{"x-checked": "true"}` {
 		t.Errorf("Expected headers_to_add, got %q", respActions[0].HeadersToAdd)
 	}
-	if respActions[1].NewResponseCode != 403 {
-		t.Errorf("Expected response code 403, got %d", respActions[1].NewResponseCode)
+	if respActions[1].FailureCode != "500" {
+		t.Errorf("Expected failure code '500', got %q", respActions[1].FailureCode)
+	}
+	if respActions[1].FailureMessage != "internal error" {
+		t.Errorf("Expected failure message 'internal error', got %q", respActions[1].FailureMessage)
 	}
 }
 
-func TestPipelineCommit_InvalidRequestAction_RejectsAll(t *testing.T) {
-	svc := newTestExtensionService()
-	registerTestActionMethod(t, svc, "demo", "assess-threat")
-
-	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
-		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "nonexistent"},
-		},
-		ResponseActions: []*extpb.ResponseActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE, NewResponseCode: 200},
-		},
-	})
-	if err == nil {
-		t.Fatal("Expected error for invalid request action")
-	}
-
-	policyID := ResourceID{Kind: "DemoPolicy", Namespace: "default", Name: "demo"}
-	if actions := svc.registeredData.GetPipelineActions(policyID, PipelinePhaseResponse); len(actions) != 0 {
-		t.Errorf("Expected no response actions stored after request validation failure, got %d", len(actions))
-	}
-}
-
-func TestPipelineCommit_InvalidResponseAction_RejectsAll(t *testing.T) {
+func TestPipelineCommit_InvalidPhase_RejectsAll(t *testing.T) {
 	svc := newTestExtensionService()
 
 	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW},
-		},
-		ResponseActions: []*extpb.ResponseActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE, NewResponseCode: 0},
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "invalid", DenyWith: "403"},
 		},
 	})
 	if err == nil {
@@ -1027,105 +1003,7 @@ func TestPipelineCommit_InvalidResponseAction_RejectsAll(t *testing.T) {
 	}
 }
 
-func TestPipelineCommit_InvalidPredicate(t *testing.T) {
-	svc := newTestExtensionService()
-	registerTestActionMethod(t, svc, "demo", "assess-threat")
-
-	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
-		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Predicate: "!!!invalid cel"},
-		},
-	})
-	if err == nil {
-		t.Fatal("Expected error for invalid CEL predicate")
-	}
-	if !strings.Contains(err.Error(), "predicate") {
-		t.Errorf("Expected predicate in error, got: %v", err)
-	}
-}
-
-func TestPipelineCommit_InvalidIntention(t *testing.T) {
-	svc := newTestExtensionService()
-	registerTestActionMethod(t, svc, "demo", "assess-threat")
-
-	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
-		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Intention: "!!!bad cel"},
-		},
-	})
-	if err == nil {
-		t.Fatal("Expected error for invalid CEL intention")
-	}
-	if !strings.Contains(err.Error(), "intention") {
-		t.Errorf("Expected intention error, got: %v", err)
-	}
-}
-
-func TestPipelineCommit_RequestPhaseActionInResponsePhase(t *testing.T) {
-	svc := newTestExtensionService()
-	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
-		Policy: testPipelinePolicy(),
-		ResponseActions: []*extpb.ResponseActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD},
-		},
-	})
-	if err == nil {
-		t.Fatal("Expected error for request-phase action in response phase")
-	}
-	if !strings.Contains(err.Error(), "not valid in the response phase") {
-		t.Errorf("Expected phase error, got: %v", err)
-	}
-}
-
-func TestPipelineCommit_ResponsePhaseActionInRequestPhase(t *testing.T) {
-	svc := newTestExtensionService()
-	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
-		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS},
-		},
-	})
-	if err == nil {
-		t.Fatal("Expected error for response-phase action in request phase")
-	}
-	if !strings.Contains(err.Error(), "not valid in the request phase") {
-		t.Errorf("Expected phase error, got: %v", err)
-	}
-}
-
-func TestPipelineCommit_NilRequestActionEntry(t *testing.T) {
-	svc := newTestExtensionService()
-	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
-		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			nil,
-		},
-	})
-	if err == nil {
-		t.Fatal("Expected error for nil request action entry")
-	}
-	if !strings.Contains(err.Error(), "entry cannot be nil") {
-		t.Errorf("Expected nil entry error, got: %v", err)
-	}
-}
-
-func TestPipelineCommit_NilResponseActionEntry(t *testing.T) {
-	svc := newTestExtensionService()
-	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
-		Policy: testPipelinePolicy(),
-		ResponseActions: []*extpb.ResponseActionEntry{
-			nil,
-		},
-	})
-	if err == nil {
-		t.Fatal("Expected error for nil response action entry")
-	}
-	if !strings.Contains(err.Error(), "entry cannot be nil") {
-		t.Errorf("Expected nil entry error, got: %v", err)
-	}
-}
+// TODO(#1964): Add validation tests for CEL predicates, action type / phase constraints, nil entries
 
 func TestPipelineCommit_AtomicReplacement(t *testing.T) {
 	svc := newTestExtensionService()
@@ -1134,8 +1012,8 @@ func TestPipelineCommit_AtomicReplacement(t *testing.T) {
 	// First commit
 	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: "first"},
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403"},
 		},
 	})
 	if err != nil {
@@ -1145,8 +1023,8 @@ func TestPipelineCommit_AtomicReplacement(t *testing.T) {
 	// Second commit replaces, not appends
 	_, err = svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: "second"},
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "401"},
 		},
 	})
 	if err != nil {
@@ -1158,8 +1036,8 @@ func TestPipelineCommit_AtomicReplacement(t *testing.T) {
 	if len(actions) != 1 {
 		t.Fatalf("Expected 1 action after replacement, got %d", len(actions))
 	}
-	if actions[0].Intention != "second" {
-		t.Errorf("Expected replaced action with intention 'second', got %q", actions[0].Intention)
+	if actions[0].DenyWith != "401" {
+		t.Errorf("Expected replaced action with DenyWith '401', got %q", actions[0].DenyWith)
 	}
 }
 
@@ -1174,8 +1052,8 @@ func TestPipelineCommit_ChangeNotifier(t *testing.T) {
 
 	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
-		RequestActions: []*extpb.RequestActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW},
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403"},
 		},
 	})
 	if err != nil {

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -938,9 +938,9 @@ func TestPipelineCommit_BothPhases(t *testing.T) {
 		Policy: testPipelinePolicy(),
 		Actions: []*extpb.ActionEntry{
 			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "assess-threat", Predicate: "true", Var: "threatResponse"},
-			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", WithStatus: 403},
 			{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, Phase: "response", HeadersToAdd: `{"x-checked": "true"}`, Predicate: "true"},
-			{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, Phase: "response", FailureCode: "500", FailureMessage: "internal error"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_FAIL, Phase: "response", LogMessage: "internal error"},
 		},
 	})
 	if err != nil {
@@ -964,8 +964,8 @@ func TestPipelineCommit_BothPhases(t *testing.T) {
 	if reqActions[1].ActionType != extpb.ActionType_ACTION_TYPE_DENY {
 		t.Errorf("Expected second request action DENY, got %s", reqActions[1].ActionType)
 	}
-	if reqActions[1].DenyWith != "403" {
-		t.Errorf("Expected DenyWith '403', got %q", reqActions[1].DenyWith)
+	if reqActions[1].WithStatus != 403 {
+		t.Errorf("Expected WithStatus 403, got %d", reqActions[1].WithStatus)
 	}
 
 	respActions := svc.registeredData.GetPipelineActions(policyID, PipelinePhaseResponse)
@@ -975,11 +975,8 @@ func TestPipelineCommit_BothPhases(t *testing.T) {
 	if respActions[0].HeadersToAdd != `{"x-checked": "true"}` {
 		t.Errorf("Expected headers_to_add, got %q", respActions[0].HeadersToAdd)
 	}
-	if respActions[1].FailureCode != "500" {
-		t.Errorf("Expected failure code '500', got %q", respActions[1].FailureCode)
-	}
-	if respActions[1].FailureMessage != "internal error" {
-		t.Errorf("Expected failure message 'internal error', got %q", respActions[1].FailureMessage)
+	if respActions[1].LogMessage != "internal error" {
+		t.Errorf("Expected log message 'internal error', got %q", respActions[1].LogMessage)
 	}
 }
 
@@ -989,8 +986,8 @@ func TestPipelineCommit_InvalidPhase_RejectsAll(t *testing.T) {
 	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
 		Actions: []*extpb.ActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403"},
-			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "invalid", DenyWith: "403"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", WithStatus: 403},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "invalid", WithStatus: 403},
 		},
 	})
 	if err == nil {
@@ -1040,7 +1037,7 @@ func TestPipelineCommit_InvalidPredicate(t *testing.T) {
 	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
 		Actions: []*extpb.ActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403", Predicate: "!!!invalid cel"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", WithStatus: 403, Predicate: "!!!invalid cel"},
 		},
 	})
 	if err == nil {
@@ -1103,42 +1100,24 @@ func TestPipelineCommit_GRPCMethod_InvalidVarName(t *testing.T) {
 func TestPipelineCommit_Deny_InvalidStatusCode(t *testing.T) {
 	svc := newTestExtensionService()
 	tests := []struct {
-		name     string
-		denyWith string
+		name       string
+		withStatus int32
 	}{
-		{"empty", ""},
-		{"not a number", "abc"},
-		{"too low", "99"},
-		{"too high", "600"},
+		{"too low", 99},
+		{"too high", 600},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 				Policy: testPipelinePolicy(),
 				Actions: []*extpb.ActionEntry{
-					{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: tt.denyWith},
+					{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", WithStatus: tt.withStatus},
 				},
 			})
 			if err == nil {
-				t.Fatalf("Expected error for DenyWith=%q", tt.denyWith)
+				t.Fatalf("Expected error for WithStatus=%d", tt.withStatus)
 			}
 		})
-	}
-}
-
-func TestPipelineCommit_Failure_InvalidStatusCode(t *testing.T) {
-	svc := newTestExtensionService()
-	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
-		Policy: testPipelinePolicy(),
-		Actions: []*extpb.ActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, Phase: "request", FailureCode: "999", FailureMessage: "error"},
-		},
-	})
-	if err == nil {
-		t.Fatal("Expected error for invalid failure code")
-	}
-	if !strings.Contains(err.Error(), "failure_code") {
-		t.Errorf("Expected failure_code error, got: %v", err)
 	}
 }
 
@@ -1243,7 +1222,7 @@ func TestPipelineCommit_CrossAction_ValidVarFieldAccess(t *testing.T) {
 		Policy: testPipelinePolicy(),
 		Actions: []*extpb.ActionEntry{
 			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "assess-threat", Var: "threatResponse"},
-			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "response", DenyWith: "403", Predicate: "threatResponse.threat_level >= 5"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "response", WithStatus: 403, Predicate: "threatResponse.threat_level >= 5"},
 		},
 	})
 	if err != nil {
@@ -1259,7 +1238,7 @@ func TestPipelineCommit_CrossAction_InvalidVarFieldAccess(t *testing.T) {
 		Policy: testPipelinePolicy(),
 		Actions: []*extpb.ActionEntry{
 			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "assess-threat", Var: "threatResponse"},
-			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "response", DenyWith: "403", Predicate: "threatResponse.nonexistent_field >= 5"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "response", WithStatus: 403, Predicate: "threatResponse.nonexistent_field >= 5"},
 		},
 	})
 	if err == nil {
@@ -1278,7 +1257,7 @@ func TestPipelineCommit_AtomicReplacement(t *testing.T) {
 	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
 		Actions: []*extpb.ActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", WithStatus: 403},
 		},
 	})
 	if err != nil {
@@ -1289,7 +1268,7 @@ func TestPipelineCommit_AtomicReplacement(t *testing.T) {
 	_, err = svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
 		Actions: []*extpb.ActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "401"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", WithStatus: 401},
 		},
 	})
 	if err != nil {
@@ -1301,8 +1280,8 @@ func TestPipelineCommit_AtomicReplacement(t *testing.T) {
 	if len(actions) != 1 {
 		t.Fatalf("Expected 1 action after replacement, got %d", len(actions))
 	}
-	if actions[0].DenyWith != "401" {
-		t.Errorf("Expected replaced action with DenyWith '401', got %q", actions[0].DenyWith)
+	if actions[0].WithStatus != 401 {
+		t.Errorf("Expected replaced action with WithStatus 401, got %d", actions[0].WithStatus)
 	}
 }
 
@@ -1318,7 +1297,7 @@ func TestPipelineCommit_ChangeNotifier(t *testing.T) {
 	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
 		Policy: testPipelinePolicy(),
 		Actions: []*extpb.ActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403"},
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", WithStatus: 403},
 		},
 	})
 	if err != nil {

--- a/internal/extension/proto_utils.go
+++ b/internal/extension/proto_utils.go
@@ -36,9 +36,21 @@ func findMessageDescriptor(fds *descriptorpb.FileDescriptorSet, messageType stri
 			if pkg != "" {
 				fqn = pkg + "." + msg.GetName()
 			}
-			if fqn == normalizedType {
-				return msg
+			if found := searchMessage(msg, fqn, normalizedType); found != nil {
+				return found
 			}
+		}
+	}
+	return nil
+}
+
+func searchMessage(msg *descriptorpb.DescriptorProto, fqn, target string) *descriptorpb.DescriptorProto {
+	if fqn == target {
+		return msg
+	}
+	for _, nested := range msg.NestedType {
+		if found := searchMessage(nested, fqn+"."+nested.GetName(), target); found != nil {
+			return found
 		}
 	}
 	return nil

--- a/internal/extension/proto_utils.go
+++ b/internal/extension/proto_utils.go
@@ -1,0 +1,82 @@
+package extension
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+func findResponseMessageType(fds *descriptorpb.FileDescriptorSet, serviceName, methodName string) string {
+	for _, file := range fds.File {
+		for _, svc := range file.Service {
+			fullServiceName := svc.GetName()
+			if file.Package != nil && *file.Package != "" {
+				fullServiceName = *file.Package + "." + svc.GetName()
+			}
+			if fullServiceName != serviceName {
+				continue
+			}
+			for _, method := range svc.Method {
+				if method.GetName() == methodName {
+					return method.GetOutputType()
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func findMessageDescriptor(fds *descriptorpb.FileDescriptorSet, messageType string) *descriptorpb.DescriptorProto {
+	normalizedType := strings.TrimPrefix(messageType, ".")
+	for _, file := range fds.File {
+		pkg := file.GetPackage()
+		for _, msg := range file.MessageType {
+			fqn := msg.GetName()
+			if pkg != "" {
+				fqn = pkg + "." + msg.GetName()
+			}
+			if fqn == normalizedType {
+				return msg
+			}
+		}
+	}
+	return nil
+}
+
+func validateFieldAccess(fds *descriptorpb.FileDescriptorSet, messageType string, fieldPath []string) error {
+	if len(fieldPath) == 0 {
+		return nil
+	}
+
+	msg := findMessageDescriptor(fds, messageType)
+	if msg == nil {
+		return fmt.Errorf("message type %q not found in proto descriptors", messageType)
+	}
+
+	currentMsg := msg
+	for i, fieldName := range fieldPath {
+		var found *descriptorpb.FieldDescriptorProto
+		for _, f := range currentMsg.Field {
+			if f.GetName() == fieldName {
+				found = f
+				break
+			}
+		}
+		if found == nil {
+			return fmt.Errorf("field %q not found on message %q", fieldName, currentMsg.GetName())
+		}
+
+		if i < len(fieldPath)-1 {
+			if found.GetType() != descriptorpb.FieldDescriptorProto_TYPE_MESSAGE {
+				return fmt.Errorf("field %q on message %q is not a message type, cannot access sub-fields", fieldName, currentMsg.GetName())
+			}
+			nextMsg := findMessageDescriptor(fds, found.GetTypeName())
+			if nextMsg == nil {
+				return fmt.Errorf("message type %q for field %q not found", found.GetTypeName(), fieldName)
+			}
+			currentMsg = nextMsg
+		}
+	}
+	return nil
+}

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -1080,6 +1080,11 @@ func translatePipelineToTypedActions(
 		}
 	}
 
+	varPatterns := make(map[string]*regexp.Regexp, len(varToMethod))
+	for varName := range varToMethod {
+		varPatterns[varName] = regexp.MustCompile(`\b` + regexp.QuoteMeta(varName) + `\b`)
+	}
+
 	grpcOnReply := make(map[string][]wasm.TypedAction)
 
 	classifyAndConvert := func(entries []PipelineActionEntry, phase string) {
@@ -1089,15 +1094,15 @@ func translatePipelineToTypedActions(
 			}
 			ta := entryToTypedAction(e, sources, phase)
 			for varName, methodName := range varToMethod {
-				if actionReferencesVar(e, varName) {
+				if entryMatchesVar(e, varPatterns[varName]) {
 					grpcOnReply[methodName] = append(grpcOnReply[methodName], ta)
 					break
 				}
 			}
 		}
 	}
-	classifyAndConvert(requestEntries, "request")
-	classifyAndConvert(responseEntries, "response")
+	classifyAndConvert(requestEntries, string(PipelinePhaseRequest))
+	classifyAndConvert(responseEntries, string(PipelinePhaseResponse))
 
 	var result []wasm.TypedAction
 	emittedGRPC := make(map[string]bool)
@@ -1116,7 +1121,7 @@ func translatePipelineToTypedActions(
 			}
 			isVarDependent := false
 			for varName := range varToMethod {
-				if actionReferencesVar(e, varName) {
+				if entryMatchesVar(e, varPatterns[varName]) {
 					isVarDependent = true
 					break
 				}
@@ -1126,14 +1131,13 @@ func translatePipelineToTypedActions(
 			}
 		}
 	}
-	emit(requestEntries, "request")
-	emit(responseEntries, "response")
+	emit(requestEntries, string(PipelinePhaseRequest))
+	emit(responseEntries, string(PipelinePhaseResponse))
 
 	return result
 }
 
-func actionReferencesVar(entry PipelineActionEntry, varName string) bool {
-	pattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(varName) + `\b`)
+func entryMatchesVar(entry PipelineActionEntry, pattern *regexp.Regexp) bool {
 	if entry.Predicate != "" && pattern.MatchString(entry.Predicate) {
 		return true
 	}
@@ -1162,7 +1166,7 @@ func entryToTypedAction(entry PipelineActionEntry, sources []string, phase strin
 	case extpb.ActionType_ACTION_TYPE_ADD_HEADERS:
 		ta.Type = "headers"
 		ta.Headers = entry.HeadersToAdd
-		if phase == "response" {
+		if phase == string(PipelinePhaseResponse) {
 			ta.Target = "response"
 		}
 	case extpb.ActionType_ACTION_TYPE_FAIL:

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -1044,7 +1044,8 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 
 		routeLocator := policyRouteLocator[policyID]
 		for i := range wasmConfig.ActionSets {
-			if routeLocator != "" && wasmConfig.ActionSets[i].SourceRoute != routeLocator {
+			asRoute := wasmConfig.ActionSets[i].SourceRoute
+			if routeLocator != "" && asRoute != "" && asRoute != routeLocator {
 				continue
 			}
 			wasmConfig.ActionSets[i].TypedActions = append(wasmConfig.ActionSets[i].TypedActions, typedActions...)

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -971,6 +971,10 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 	// Inject registered upstream services matching the current target refs
 	relevantUpstreamKeys := m.store.GetRelevantUpstreamKeys(targetRefs)
 
+	if wasmConfig.Services == nil {
+		wasmConfig.Services = make(map[string]wasm.Service)
+	}
+
 	// Build method name → wasm service key lookup and inject services
 	methodServiceKeys := make(map[ResourceID]map[string]string) // policy → method name → service key
 	for key, entry := range relevantUpstreamKeys {
@@ -984,9 +988,6 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 			GrpcMethod:  &entry.Method,
 		}
 		wasmServiceKey := "ext-" + HashUpstreamServiceConfig(svc)
-		if wasmConfig.Services == nil {
-			wasmConfig.Services = make(map[string]wasm.Service)
-		}
 		wasmConfig.Services[wasmServiceKey] = svc
 
 		if methodServiceKeys[key.Policy] == nil {

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -22,6 +22,7 @@ import (
 	"maps"
 	"regexp"
 	"sort"
+	"strings"
 
 	"sync"
 
@@ -326,16 +327,17 @@ const (
 
 // PipelineActionEntry represents a single stored pipeline action.
 type PipelineActionEntry struct {
-	Index          int
-	ActionType     extpb.ActionType
-	Predicate      string
-	Phase          string // "request" or "response"
-	Method         string // registered action method name (grpc_method)
-	Var            string // variable name for gRPC response (grpc_method)
-	DenyWith       string // HTTP status code to send (deny)
-	HeadersToAdd   string // CEL expression for headers (add_headers)
-	FailureMessage string // response body (failure)
-	FailureCode    string // HTTP status code (failure)
+	Index        int
+	ActionType   extpb.ActionType
+	Predicate    string
+	Phase        string // "request" or "response"
+	Method       string // registered action method name (grpc_method)
+	Var          string // variable name for gRPC response (grpc_method)
+	WithStatus   int    // HTTP status code (deny); 0 means unset
+	WithHeaders  string // CEL expression — array of [name, value] pairs (deny)
+	WithBody     string // response body string (deny)
+	HeadersToAdd string // CEL expression for headers (add_headers)
+	LogMessage   string // error message to log (fail)
 }
 
 // pipelineKey identifies a set of actions for a specific policy and phase.
@@ -1137,7 +1139,10 @@ func actionReferencesVar(entry PipelineActionEntry, varName string) bool {
 	if entry.HeadersToAdd != "" && pattern.MatchString(entry.HeadersToAdd) {
 		return true
 	}
-	if entry.FailureMessage != "" && pattern.MatchString(entry.FailureMessage) {
+	if entry.WithHeaders != "" && pattern.MatchString(entry.WithHeaders) {
+		return true
+	}
+	if entry.LogMessage != "" && pattern.MatchString(entry.LogMessage) {
 		return true
 	}
 	return false
@@ -1152,20 +1157,36 @@ func entryToTypedAction(entry PipelineActionEntry, sources []string, phase strin
 	case extpb.ActionType_ACTION_TYPE_DENY:
 		ta.Type = "deny"
 		ta.Terminal = true
-		ta.DenyWith = entry.DenyWith
+		ta.DenyWith = buildDenyResponseExpr(entry.WithStatus, entry.WithHeaders, entry.WithBody)
 	case extpb.ActionType_ACTION_TYPE_ADD_HEADERS:
 		ta.Type = "headers"
 		ta.Headers = entry.HeadersToAdd
 		if phase == "response" {
 			ta.Target = "response"
 		}
-	case extpb.ActionType_ACTION_TYPE_FAILURE:
-		ta.Type = "failure"
+	case extpb.ActionType_ACTION_TYPE_FAIL:
+		ta.Type = "fail"
 		ta.Terminal = true
-		ta.FailureMessage = entry.FailureMessage
-		ta.FailureCode = entry.FailureCode
+		ta.LogMessage = entry.LogMessage
 	}
 	return ta
+}
+
+func buildDenyResponseExpr(status int, headers, body string) string {
+	var parts []string
+	if status != 0 {
+		parts = append(parts, fmt.Sprintf("status: %du", status))
+	}
+	if headers != "" {
+		parts = append(parts, fmt.Sprintf("headers: %s", headers))
+	}
+	if body != "" {
+		parts = append(parts, fmt.Sprintf("body: '%s'", body))
+	}
+	if len(parts) == 0 {
+		return "DenyResponse{}"
+	}
+	return fmt.Sprintf("DenyResponse{%s}", strings.Join(parts, ", "))
 }
 
 func grpcToTypedAction(entry PipelineActionEntry, methods map[string]string, upstreamByMethod map[string]RegisteredUpstreamEntry, sources []string) wasm.TypedAction {

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -656,6 +656,17 @@ func (r *RegisteredDataStore) HasUpstreamName(policy ResourceID, name string) bo
 	return false
 }
 
+func (r *RegisteredDataStore) GetUpstreamByName(policy ResourceID, name string) (RegisteredUpstreamKey, RegisteredUpstreamEntry, bool) {
+	r.upstreamsMutex.RLock()
+	defer r.upstreamsMutex.RUnlock()
+	for k, v := range r.registeredUpstreams {
+		if k.Policy == policy && k.Name == name {
+			return k, v, true
+		}
+	}
+	return RegisteredUpstreamKey{}, RegisteredUpstreamEntry{}, false
+}
+
 func (r *RegisteredDataStore) GetUpstreamsForPolicy(policy ResourceID) []RegisteredUpstreamEntry {
 	r.upstreamsMutex.RLock()
 	defer r.upstreamsMutex.RUnlock()

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"maps"
+	"regexp"
 	"sort"
 
 	"sync"
@@ -998,7 +999,7 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 	}
 
 	// Translate pipeline actions into TypedAction entries (deterministic order across policies)
-	policyIDs := lo.Keys(methodServiceKeys)
+	policyIDs := lo.Uniq(append(lo.Keys(methodServiceKeys), m.store.GetPoliciesWithPipelineActions()...))
 	sort.Slice(policyIDs, func(i, j int) bool {
 		if policyIDs[i].Kind != policyIDs[j].Kind {
 			return policyIDs[i].Kind < policyIDs[j].Kind
@@ -1031,13 +1032,21 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 		requestEntries := m.store.GetPipelineActions(policyID, PipelinePhaseRequest)
 		responseEntries := m.store.GetPipelineActions(policyID, PipelinePhaseResponse)
 
-		// TODO(#1967): Rewrite pipeline action → TypedAction translation for unified action model
-		_ = requestEntries
-		_ = responseEntries
-		_ = methods
-		_ = sources
-		_ = upstreamByMethod
-		_ = policyRouteLocator
+		typedActions := translatePipelineToTypedActions(
+			requestEntries, responseEntries,
+			methods, upstreamByMethod[policyID], sources,
+		)
+		if len(typedActions) == 0 {
+			continue
+		}
+
+		routeLocator := policyRouteLocator[policyID]
+		for i := range wasmConfig.ActionSets {
+			if routeLocator != "" && wasmConfig.ActionSets[i].SourceRoute != routeLocator {
+				continue
+			}
+			wasmConfig.ActionSets[i].TypedActions = append(wasmConfig.ActionSets[i].TypedActions, typedActions...)
+		}
 	}
 
 	return nil
@@ -1048,6 +1057,129 @@ func predicateOrTrue(predicate string) string {
 		return "true"
 	}
 	return predicate
+}
+
+func translatePipelineToTypedActions(
+	requestEntries, responseEntries []PipelineActionEntry,
+	methods map[string]string,
+	upstreamByMethod map[string]RegisteredUpstreamEntry,
+	sources []string,
+) []wasm.TypedAction {
+	varToMethod := make(map[string]string)
+	for _, e := range requestEntries {
+		if e.ActionType == extpb.ActionType_ACTION_TYPE_GRPC_METHOD && e.Var != "" {
+			varToMethod[e.Var] = e.Method
+		}
+	}
+	for _, e := range responseEntries {
+		if e.ActionType == extpb.ActionType_ACTION_TYPE_GRPC_METHOD && e.Var != "" {
+			varToMethod[e.Var] = e.Method
+		}
+	}
+
+	grpcOnReply := make(map[string][]wasm.TypedAction)
+
+	classifyAndConvert := func(entries []PipelineActionEntry, phase string) {
+		for _, e := range entries {
+			if e.ActionType == extpb.ActionType_ACTION_TYPE_GRPC_METHOD {
+				continue
+			}
+			ta := entryToTypedAction(e, sources, phase)
+			for varName, methodName := range varToMethod {
+				if actionReferencesVar(e, varName) {
+					grpcOnReply[methodName] = append(grpcOnReply[methodName], ta)
+					break
+				}
+			}
+		}
+	}
+	classifyAndConvert(requestEntries, "request")
+	classifyAndConvert(responseEntries, "response")
+
+	var result []wasm.TypedAction
+	emittedGRPC := make(map[string]bool)
+
+	emit := func(entries []PipelineActionEntry, phase string) {
+		for _, e := range entries {
+			if e.ActionType == extpb.ActionType_ACTION_TYPE_GRPC_METHOD {
+				if emittedGRPC[e.Method] {
+					continue
+				}
+				emittedGRPC[e.Method] = true
+				ta := grpcToTypedAction(e, methods, upstreamByMethod, sources)
+				ta.OnReply = grpcOnReply[e.Method]
+				result = append(result, ta)
+				continue
+			}
+			isVarDependent := false
+			for varName := range varToMethod {
+				if actionReferencesVar(e, varName) {
+					isVarDependent = true
+					break
+				}
+			}
+			if !isVarDependent {
+				result = append(result, entryToTypedAction(e, sources, phase))
+			}
+		}
+	}
+	emit(requestEntries, "request")
+	emit(responseEntries, "response")
+
+	return result
+}
+
+func actionReferencesVar(entry PipelineActionEntry, varName string) bool {
+	pattern := regexp.MustCompile(`\b` + regexp.QuoteMeta(varName) + `\b`)
+	if entry.Predicate != "" && pattern.MatchString(entry.Predicate) {
+		return true
+	}
+	if entry.HeadersToAdd != "" && pattern.MatchString(entry.HeadersToAdd) {
+		return true
+	}
+	if entry.FailureMessage != "" && pattern.MatchString(entry.FailureMessage) {
+		return true
+	}
+	return false
+}
+
+func entryToTypedAction(entry PipelineActionEntry, sources []string, phase string) wasm.TypedAction {
+	ta := wasm.TypedAction{
+		Predicate:            predicateOrTrue(entry.Predicate),
+		SourcePolicyLocators: sources,
+	}
+	switch entry.ActionType {
+	case extpb.ActionType_ACTION_TYPE_DENY:
+		ta.Type = "deny"
+		ta.Terminal = true
+		ta.DenyWith = entry.DenyWith
+	case extpb.ActionType_ACTION_TYPE_ADD_HEADERS:
+		ta.Type = "headers"
+		ta.Headers = entry.HeadersToAdd
+		if phase == "response" {
+			ta.Target = "response"
+		}
+	case extpb.ActionType_ACTION_TYPE_FAILURE:
+		ta.Type = "failure"
+		ta.Terminal = true
+		ta.FailureMessage = entry.FailureMessage
+		ta.FailureCode = entry.FailureCode
+	}
+	return ta
+}
+
+func grpcToTypedAction(entry PipelineActionEntry, methods map[string]string, upstreamByMethod map[string]RegisteredUpstreamEntry, sources []string) wasm.TypedAction {
+	ta := wasm.TypedAction{
+		Type:                 "grpc",
+		Predicate:            predicateOrTrue(entry.Predicate),
+		Var:                  entry.Var,
+		Service:              methods[entry.Method],
+		SourcePolicyLocators: sources,
+	}
+	if upstream, ok := upstreamByMethod[entry.Method]; ok {
+		ta.MessageBuilder = upstream.MessageTemplate
+	}
+	return ta
 }
 
 // HashUpstreamServiceConfig produces a deterministic short hash from a wasm.Service

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -325,14 +325,16 @@ const (
 
 // PipelineActionEntry represents a single stored pipeline action.
 type PipelineActionEntry struct {
-	Index           int
-	ActionType      extpb.ActionType
-	Predicate       string
-	Intention       string // CEL expression (grpc_method, allow)
-	Method          string // registered action method name (grpc_method)
-	Var             string // variable name for gRPC response (grpc_method)
-	HeadersToAdd    string // CEL expression for headers (add_headers)
-	NewResponseCode int32  // HTTP status code (with_response_code)
+	Index          int
+	ActionType     extpb.ActionType
+	Predicate      string
+	Phase          string // "request" or "response"
+	Method         string // registered action method name (grpc_method)
+	Var            string // variable name for gRPC response (grpc_method)
+	DenyWith       string // HTTP status code to send (deny)
+	HeadersToAdd   string // CEL expression for headers (add_headers)
+	FailureMessage string // response body (failure)
+	FailureCode    string // HTTP status code (failure)
 }
 
 // pipelineKey identifies a set of actions for a specific policy and phase.
@@ -717,8 +719,15 @@ func (r *RegisteredDataStore) ClearPipelinePhase(policy ResourceID, phase Pipeli
 }
 
 // ReplacePipelineActions atomically clears all pipeline actions for a policy
-// and replaces them with the provided request and response entries.
-func (r *RegisteredDataStore) ReplacePipelineActions(policy ResourceID, requestEntries, responseEntries []PipelineActionEntry) {
+// and replaces them with the provided entries, grouped by their Phase field.
+// Returns an error if any entry has an invalid phase.
+func (r *RegisteredDataStore) ReplacePipelineActions(policy ResourceID, entries []PipelineActionEntry) error {
+	for i, entry := range entries {
+		if entry.Phase != string(PipelinePhaseRequest) && entry.Phase != string(PipelinePhaseResponse) {
+			return fmt.Errorf("entries[%d]: invalid phase %q, must be %q or %q", i, entry.Phase, PipelinePhaseRequest, PipelinePhaseResponse)
+		}
+	}
+
 	r.pipelineMutex.Lock()
 	defer r.pipelineMutex.Unlock()
 
@@ -728,23 +737,22 @@ func (r *RegisteredDataStore) ReplacePipelineActions(policy ResourceID, requestE
 		delete(r.pipelineCounters, key)
 	}
 
-	if len(requestEntries) > 0 {
-		key := pipelineKey{Policy: policy, Phase: PipelinePhaseRequest}
-		for i := range requestEntries {
-			requestEntries[i].Index = i
-		}
-		r.pipelineActions[key] = requestEntries
-		r.pipelineCounters[key] = len(requestEntries)
+	grouped := map[PipelinePhase][]PipelineActionEntry{}
+	for _, entry := range entries {
+		phase := PipelinePhase(entry.Phase)
+		grouped[phase] = append(grouped[phase], entry)
 	}
 
-	if len(responseEntries) > 0 {
-		key := pipelineKey{Policy: policy, Phase: PipelinePhaseResponse}
-		for i := range responseEntries {
-			responseEntries[i].Index = i
+	for phase, phaseEntries := range grouped {
+		key := pipelineKey{Policy: policy, Phase: phase}
+		for i := range phaseEntries {
+			phaseEntries[i].Index = i
 		}
-		r.pipelineActions[key] = responseEntries
-		r.pipelineCounters[key] = len(responseEntries)
+		r.pipelineActions[key] = phaseEntries
+		r.pipelineCounters[key] = len(phaseEntries)
 	}
+
+	return nil
 }
 
 // ClearPipelineActions removes all pipeline actions for a policy across both phases
@@ -1012,125 +1020,13 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 		requestEntries := m.store.GetPipelineActions(policyID, PipelinePhaseRequest)
 		responseEntries := m.store.GetPipelineActions(policyID, PipelinePhaseResponse)
 
-		// Build response-phase TypedActions (these nest inside gRPC action's onReply)
-		var onReplyActions []wasm.TypedAction
-		for _, entry := range responseEntries {
-			switch entry.ActionType {
-			case extpb.ActionType_ACTION_TYPE_ADD_HEADERS:
-				onReplyActions = append(onReplyActions, wasm.TypedAction{
-					Type:                 "headers",
-					Predicate:            predicateOrTrue(entry.Predicate),
-					Terminal:             false,
-					Target:               "response",
-					Headers:              entry.HeadersToAdd,
-					SourcePolicyLocators: sources,
-				})
-			case extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE:
-				onReplyActions = append(onReplyActions, wasm.TypedAction{
-					Type:                 "deny",
-					Predicate:            predicateOrTrue(entry.Predicate),
-					Terminal:             true,
-					DenyWith:             fmt.Sprintf("DenyResponse{status: %du}", entry.NewResponseCode),
-					SourcePolicyLocators: sources,
-				})
-			}
-		}
-
-		// Collect AllowAction deny entries first — the wasm-shim only supports
-		// gRPC typed actions at the top level, so AllowAction denies must be
-		// injected into a gRPC action's onReply.
-		var allowDenyActions []wasm.TypedAction
-		for _, entry := range requestEntries {
-			if entry.ActionType == extpb.ActionType_ACTION_TYPE_ALLOW && entry.Intention != "" {
-				denyPredicate := fmt.Sprintf("!(%s)", entry.Intention)
-				if entry.Predicate != "" {
-					denyPredicate = fmt.Sprintf("%s && !(%s)", entry.Predicate, entry.Intention)
-				}
-				allowDenyActions = append(allowDenyActions, wasm.TypedAction{
-					Type:                 "deny",
-					Predicate:            denyPredicate,
-					Terminal:             true,
-					DenyWith:             "DenyResponse{status: 403u}",
-					SourcePolicyLocators: sources,
-				})
-			}
-		}
-
-		// Build request-phase TypedActions
-		var typedActions []wasm.TypedAction
-		allowsPrepended := false
-		for _, entry := range requestEntries {
-			if entry.ActionType != extpb.ActionType_ACTION_TYPE_GRPC_METHOD {
-				continue
-			}
-			grpcPredicate := predicateOrTrue(entry.Predicate)
-
-			ta := wasm.TypedAction{
-				Type:                 "grpc",
-				Terminal:             false,
-				Var:                  entry.Var,
-				Service:              methods[entry.Method],
-				SourcePolicyLocators: sources,
-			}
-			if upstream, ok := upstreamByMethod[policyID][entry.Method]; ok && upstream.MessageTemplate != "" {
-				ta.MessageBuilder = upstream.MessageTemplate
-			}
-
-			if len(allowDenyActions) > 0 && !allowsPrepended {
-				// AllowActions must fire regardless of the gRPC predicate, so
-				// we remove the predicate from this gRPC action (it fires
-				// unconditionally) and move the original predicate into the
-				// intention deny predicate.
-				ta.Predicate = "true"
-				ta.OnReply = append(ta.OnReply, allowDenyActions...)
-				allowsPrepended = true
-
-				if entry.Intention != "" {
-					intentionPredicate := fmt.Sprintf("!(%s)", entry.Intention)
-					if grpcPredicate != "true" {
-						intentionPredicate = fmt.Sprintf("%s && !(%s)", grpcPredicate, entry.Intention)
-					}
-					ta.OnReply = append(ta.OnReply, wasm.TypedAction{
-						Type:                 "deny",
-						Predicate:            intentionPredicate,
-						Terminal:             true,
-						DenyWith:             "DenyResponse{status: 403u}",
-						SourcePolicyLocators: sources,
-					})
-				}
-			} else {
-				ta.Predicate = grpcPredicate
-				if entry.Intention != "" {
-					ta.OnReply = append(ta.OnReply, wasm.TypedAction{
-						Type:                 "deny",
-						Predicate:            fmt.Sprintf("!(%s)", entry.Intention),
-						Terminal:             true,
-						DenyWith:             "DenyResponse{status: 403u}",
-						SourcePolicyLocators: sources,
-					})
-				}
-			}
-
-			ta.OnReply = append(ta.OnReply, onReplyActions...)
-			typedActions = append(typedActions, ta)
-		}
-
-		// If there are only response actions and no request actions, attach them directly
-		if len(requestEntries) == 0 && len(onReplyActions) > 0 {
-			typedActions = append(typedActions, onReplyActions...)
-		}
-
-		// Append typed actions to matching action sets. If the policy targets a
-		// specific route, only action sets created from that route receive the
-		// actions. If the policy targets a gateway (or no route locator is
-		// known), all action sets receive the actions.
-		routeLocator := policyRouteLocator[policyID]
-		for i := range wasmConfig.ActionSets {
-			if routeLocator != "" && wasmConfig.ActionSets[i].SourceRoute != "" && wasmConfig.ActionSets[i].SourceRoute != routeLocator {
-				continue
-			}
-			wasmConfig.ActionSets[i].TypedActions = append(wasmConfig.ActionSets[i].TypedActions, typedActions...)
-		}
+		// TODO(#1967): Rewrite pipeline action → TypedAction translation for unified action model
+		_ = requestEntries
+		_ = responseEntries
+		_ = methods
+		_ = sources
+		_ = upstreamByMethod
+		_ = policyRouteLocator
 	}
 
 	return nil

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -1181,7 +1181,8 @@ func buildDenyResponseExpr(status int, headers, body string) string {
 		parts = append(parts, fmt.Sprintf("headers: %s", headers))
 	}
 	if body != "" {
-		parts = append(parts, fmt.Sprintf("body: '%s'", body))
+		escaped := strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(body)
+		parts = append(parts, fmt.Sprintf("body: '%s'", escaped))
 	}
 	if len(parts) == 0 {
 		return "DenyResponse{}"

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -1182,7 +1182,7 @@ func buildDenyResponseExpr(status int, headers, body string) string {
 		parts = append(parts, fmt.Sprintf("headers: %s", headers))
 	}
 	if body != "" {
-		escaped := strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(body)
+		escaped := strings.NewReplacer(`\`, `\\`, `'`, `\'`, "\n", `\n`, "\r", `\r`).Replace(body)
 		parts = append(parts, fmt.Sprintf("body: '%s'", escaped))
 	}
 	if len(parts) == 0 {

--- a/internal/extension/registry_test.go
+++ b/internal/extension/registry_test.go
@@ -1468,7 +1468,7 @@ func TestPipelineActionStore_AppendAndGet(t *testing.T) {
 
 	actions := []PipelineActionEntry{
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "checkThreat", Var: "threatResponse"},
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, WithStatus: 403},
 	}
 
 	startIdx := store.AppendPipelineActions(policy, PipelinePhaseRequest, actions)
@@ -1508,7 +1508,7 @@ func TestPipelineActionStore_SequentialAppends(t *testing.T) {
 
 	// Second append continues index sequence
 	startIdx = store.AppendPipelineActions(policy, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, WithStatus: 403},
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check2"},
 	})
 	if startIdx != 1 {
@@ -1535,7 +1535,7 @@ func TestPipelineActionStore_SeparatePhases(t *testing.T) {
 	})
 	store.AppendPipelineActions(policy, PipelinePhaseResponse, []PipelineActionEntry{
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: "{'x-checked': 'true'}"},
-		{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, FailureMessage: "blocked", FailureCode: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_FAIL, LogMessage: "blocked"},
 	})
 
 	reqActions := store.GetPipelineActions(policy, PipelinePhaseRequest)
@@ -1562,7 +1562,7 @@ func TestPipelineActionStore_SeparatePolicies(t *testing.T) {
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check1"},
 	})
 	store.AppendPipelineActions(policy2, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, WithStatus: 403},
 	})
 
 	p1Actions := store.GetPipelineActions(policy1, PipelinePhaseRequest)
@@ -1591,7 +1591,7 @@ func TestPipelineActionStore_ClearPipelineActions(t *testing.T) {
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: "{'x': '1'}"},
 	})
 	store.AppendPipelineActions(otherPolicy, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, WithStatus: 403},
 	})
 
 	cleared := store.ClearPipelineActions(policy)
@@ -1634,7 +1634,7 @@ func TestPipelineActionStore_CounterResetsAfterClear(t *testing.T) {
 
 	store.AppendPipelineActions(policy, PipelinePhaseRequest, []PipelineActionEntry{
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD},
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, WithStatus: 403},
 	})
 
 	store.ClearPipelineActions(policy)
@@ -2051,14 +2051,14 @@ func TestMutateWasmConfig_TranslatesPipelineActions(t *testing.T) {
 
 	// Request phase: deny (root), grpc with var, deny referencing var (onReply)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/blocked"`, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/blocked"`, WithStatus: 403},
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse", Predicate: `"x-assess-threat" in request.headers`},
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "threatResponse.threat_level > 5", DenyWith: "429"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "threatResponse.threat_level > 5", WithStatus: 429},
 	})
-	// Response phase: add_headers (root), failure referencing var (onReply)
+	// Response phase: add_headers (root), fail referencing var (onReply)
 	store.AppendPipelineActions(policyID, PipelinePhaseResponse, []PipelineActionEntry{
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: `{"x-checked": "true"}`},
-		{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, Predicate: "threatResponse.blocked", FailureMessage: "blocked by threat policy", FailureCode: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_FAIL, Predicate: "threatResponse.blocked", LogMessage: "blocked by threat policy"},
 	})
 
 	mutator := NewRegisteredDataMutator[*wasm.Config](store)
@@ -2093,8 +2093,8 @@ func TestMutateWasmConfig_TranslatesPipelineActions(t *testing.T) {
 	if typed[0].Predicate != `request.url_path == "/blocked"` {
 		t.Errorf("typed[0]: expected predicate, got %q", typed[0].Predicate)
 	}
-	if typed[0].DenyWith != "403" {
-		t.Errorf("typed[0]: expected denyWith '403', got %q", typed[0].DenyWith)
+	if typed[0].DenyWith != "DenyResponse{status: 403u}" {
+		t.Errorf("typed[0]: expected denyWith 'DenyResponse{status: 403u}', got %q", typed[0].DenyWith)
 	}
 	if !typed[0].Terminal {
 		t.Error("typed[0]: expected terminal")
@@ -2134,23 +2134,20 @@ func TestMutateWasmConfig_TranslatesPipelineActions(t *testing.T) {
 	if grpc.OnReply[0].Predicate != "threatResponse.threat_level > 5" {
 		t.Errorf("onReply[0]: expected predicate, got %q", grpc.OnReply[0].Predicate)
 	}
-	if grpc.OnReply[0].DenyWith != "429" {
-		t.Errorf("onReply[0]: expected denyWith '429', got %q", grpc.OnReply[0].DenyWith)
+	if grpc.OnReply[0].DenyWith != "DenyResponse{status: 429u}" {
+		t.Errorf("onReply[0]: expected denyWith 'DenyResponse{status: 429u}', got %q", grpc.OnReply[0].DenyWith)
 	}
 	if !grpc.OnReply[0].Terminal {
 		t.Error("onReply[0]: expected terminal")
 	}
-	if grpc.OnReply[1].Type != "failure" {
-		t.Errorf("onReply[1]: expected type 'failure', got %q", grpc.OnReply[1].Type)
+	if grpc.OnReply[1].Type != "fail" {
+		t.Errorf("onReply[1]: expected type 'fail', got %q", grpc.OnReply[1].Type)
 	}
 	if grpc.OnReply[1].Predicate != "threatResponse.blocked" {
 		t.Errorf("onReply[1]: expected predicate, got %q", grpc.OnReply[1].Predicate)
 	}
-	if grpc.OnReply[1].FailureMessage != "blocked by threat policy" {
-		t.Errorf("onReply[1]: expected failureMessage, got %q", grpc.OnReply[1].FailureMessage)
-	}
-	if grpc.OnReply[1].FailureCode != "403" {
-		t.Errorf("onReply[1]: expected failureCode '403', got %q", grpc.OnReply[1].FailureCode)
+	if grpc.OnReply[1].LogMessage != "blocked by threat policy" {
+		t.Errorf("onReply[1]: expected logMessage, got %q", grpc.OnReply[1].LogMessage)
 	}
 
 	// typed[2]: response headers (root-level, no var reference)
@@ -2211,7 +2208,7 @@ func TestMutateWasmConfig_PipelineActionsAppendToMultipleActionSets(t *testing.T
 	)
 
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "request.method == 'GET'", DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "request.method == 'GET'", WithStatus: 403},
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check"},
 	})
 
@@ -2296,9 +2293,9 @@ func TestApplyWasmConfigMutators_CreatesActionSetsFromTopology(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/blocked"`, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/blocked"`, WithStatus: 403},
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse"},
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "threatResponse.threat_level > 5", DenyWith: "429"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "threatResponse.threat_level > 5", WithStatus: 429},
 	})
 
 	savedRegistry := *GlobalMutatorRegistry
@@ -2360,8 +2357,8 @@ func TestApplyWasmConfigMutators_CreatesActionSetsFromTopology(t *testing.T) {
 	if as.TypedActions[1].OnReply[0].Type != "deny" {
 		t.Errorf("Expected onReply[0] deny, got %s", as.TypedActions[1].OnReply[0].Type)
 	}
-	if as.TypedActions[1].OnReply[0].DenyWith != "429" {
-		t.Errorf("Expected onReply[0] denyWith '429', got %q", as.TypedActions[1].OnReply[0].DenyWith)
+	if as.TypedActions[1].OnReply[0].DenyWith != "DenyResponse{status: 429u}" {
+		t.Errorf("Expected onReply[0] denyWith 'DenyResponse{status: 429u}', got %q", as.TypedActions[1].OnReply[0].DenyWith)
 	}
 }
 
@@ -2415,7 +2412,7 @@ func TestApplyWasmConfigMutators_ExistingActionSetsPreserved(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "request.method == 'GET'", DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "request.method == 'GET'", WithStatus: 403},
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat"},
 	})
 
@@ -2487,15 +2484,15 @@ func TestReplacePipelineActions(t *testing.T) {
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: `{"x-old": "true"}`},
 	})
 	store.AppendPipelineActions(otherPolicy, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, WithStatus: 403},
 	})
 
 	// Replace both phases atomically
 	err := store.ReplacePipelineActions(policy, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403", Predicate: `request.url_path == "/blocked"`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", WithStatus: 403, Predicate: `request.url_path == "/blocked"`},
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "new-check", Var: "threatResponse"},
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, Phase: "response", HeadersToAdd: `{"x-new": "true"}`},
-		{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, Phase: "response", FailureMessage: "blocked", FailureCode: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_FAIL, Phase: "response", LogMessage: "blocked"},
 	})
 	if err != nil {
 		t.Fatalf("ReplacePipelineActions returned error: %v", err)
@@ -2524,8 +2521,8 @@ func TestReplacePipelineActions(t *testing.T) {
 	if respActions[0].HeadersToAdd != `{"x-new": "true"}` {
 		t.Errorf("First response action headers = %q, unexpected", respActions[0].HeadersToAdd)
 	}
-	if respActions[1].FailureCode != "403" {
-		t.Errorf("Second response action failure code = %q, want %q", respActions[1].FailureCode, "403")
+	if respActions[1].LogMessage != "blocked" {
+		t.Errorf("Second response action log message = %q, want %q", respActions[1].LogMessage, "blocked")
 	}
 
 	// Other policy unaffected
@@ -2543,7 +2540,7 @@ func TestReplacePipelineActions_InvalidPhase(t *testing.T) {
 	policy := testResourceID("ThreatPolicy", "default", "my-policy")
 
 	err := store.ReplacePipelineActions(policy, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "invalid", DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "invalid", WithStatus: 403},
 	})
 	if err == nil {
 		t.Fatal("Expected error for invalid phase, got nil")
@@ -2584,7 +2581,7 @@ func TestApplyWasmConfigMutators_RouteTargetedPipelineActions(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/blocked"`, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/blocked"`, WithStatus: 403},
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat"},
 	})
 
@@ -2665,7 +2662,7 @@ func TestMutateWasmConfig_DenyOnlyPipelineProducesRootAction(t *testing.T) {
 	policyID := testResourceID("DenyPolicy", "default", "deny-only")
 
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/admin"`, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/admin"`, WithStatus: 403},
 	})
 
 	wasmConfig := wasm.Config{
@@ -2693,8 +2690,8 @@ func TestMutateWasmConfig_DenyOnlyPipelineProducesRootAction(t *testing.T) {
 	if ta.Predicate != `request.url_path == "/admin"` {
 		t.Errorf("Expected predicate, got %q", ta.Predicate)
 	}
-	if ta.DenyWith != "403" {
-		t.Errorf("Expected denyWith '403', got %q", ta.DenyWith)
+	if ta.DenyWith != "DenyResponse{status: 403u}" {
+		t.Errorf("Expected denyWith 'DenyResponse{status: 403u}', got %q", ta.DenyWith)
 	}
 	if !ta.Terminal {
 		t.Error("Expected deny action to be terminal")

--- a/internal/extension/registry_test.go
+++ b/internal/extension/registry_test.go
@@ -2038,26 +2038,27 @@ func TestCollectRouteUpstreams(t *testing.T) {
 }
 
 func TestMutateWasmConfig_TranslatesPipelineActions(t *testing.T) {
-	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
 	store := NewRegisteredDataStore()
 	mockTargetRef := createMockGatewayTargetRef()
 	targetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "Gateway", Name: mockTargetRef.GetName(), Namespace: mockTargetRef.GetNamespace()}
 	policyID := testResourceID("ThreatPolicy", "default", "my-threat")
 
-	// Register an upstream (required for grpc_method actions)
 	store.SetUpstream(
 		RegisteredUpstreamKey{Policy: policyID, Name: "assess-threat", URL: "grpc://svc:8081", Service: "threat.Service", Method: "Check"},
 		RegisteredUpstreamEntry{ClusterName: "ext-svc-8081", Host: "svc", Port: 8081, TargetRef: targetRef, FailureMode: "deny", Timeout: "100ms", Service: "threat.Service", Method: "Check", MessageTemplate: "threat.v1.Request{path: request.path}"},
 		testFileDescriptorSet(),
 	)
 
-	// Register pipeline actions
+	// Request phase: deny (root), grpc with var, deny referencing var (onReply)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: `request.url_path != "/blocked"`},
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse", DenyWith: "threatResponse.threat_level < 5", Predicate: `"x-assess-threat" in request.headers`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/blocked"`, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse", Predicate: `"x-assess-threat" in request.headers`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "threatResponse.threat_level > 5", DenyWith: "429"},
 	})
+	// Response phase: add_headers (root), failure referencing var (onReply)
 	store.AppendPipelineActions(policyID, PipelinePhaseResponse, []PipelineActionEntry{
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: `{"x-checked": "true"}`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, Predicate: "threatResponse.blocked", FailureMessage: "blocked by threat policy", FailureCode: "403"},
 	})
 
 	mutator := NewRegisteredDataMutator[*wasm.Config](store)
@@ -2073,74 +2074,94 @@ func TestMutateWasmConfig_TranslatesPipelineActions(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Legacy actions unchanged
 	if len(wasmConfig.ActionSets[0].Actions) != 0 {
 		t.Errorf("Expected 0 legacy actions, got %d", len(wasmConfig.ActionSets[0].Actions))
 	}
 
 	typed := wasmConfig.ActionSets[0].TypedActions
-	// AllowAction causes gRPC predicate to be removed; allow deny is prepended to onReply
-	if len(typed) != 1 {
-		t.Fatalf("Expected 1 TypedAction (grpc), got %d", len(typed))
+	// Root-level: deny, grpc (with onReply), headers
+	if len(typed) != 3 {
+		t.Fatalf("Expected 3 root-level TypedActions, got %d", len(typed))
 	}
 
 	expectedLocator := "ThreatPolicy/default/my-threat"
 
-	// gRPC action fires unconditionally (predicate moved to onReply)
-	grpc := typed[0]
-	if grpc.Type != "grpc" {
-		t.Errorf("Expected typed[0] type 'grpc', got %q", grpc.Type)
+	// typed[0]: root deny
+	if typed[0].Type != "deny" {
+		t.Errorf("typed[0]: expected type 'deny', got %q", typed[0].Type)
 	}
-	if grpc.Predicate != "true" {
-		t.Errorf("Expected typed[0] predicate 'true' (AllowAction removes gRPC predicate), got %q", grpc.Predicate)
+	if typed[0].Predicate != `request.url_path == "/blocked"` {
+		t.Errorf("typed[0]: expected predicate, got %q", typed[0].Predicate)
 	}
-	if grpc.Var != "threatResponse" {
-		t.Errorf("Expected typed[0] var 'threatResponse', got %q", grpc.Var)
+	if typed[0].DenyWith != "403" {
+		t.Errorf("typed[0]: expected denyWith '403', got %q", typed[0].DenyWith)
 	}
-	if grpc.Service == "" {
-		t.Error("Expected typed[0] service to be set")
-	}
-	if grpc.MessageBuilder != "threat.v1.Request{path: request.path}" {
-		t.Errorf("Expected typed[0] messageBuilder, got %q", grpc.MessageBuilder)
-	}
-	if grpc.Terminal {
-		t.Error("Expected typed[0] to NOT be terminal")
-	}
-	if len(grpc.SourcePolicyLocators) != 1 || grpc.SourcePolicyLocators[0] != expectedLocator {
-		t.Errorf("typed[0]: expected source locator %q, got %v", expectedLocator, grpc.SourcePolicyLocators)
+	if !typed[0].Terminal {
+		t.Error("typed[0]: expected terminal")
 	}
 
-	// onReply: allow deny + intention deny (combined with gRPC predicate) + add_headers
-	if len(grpc.OnReply) != 3 {
-		t.Fatalf("Expected 3 onReply actions, got %d", len(grpc.OnReply))
+	// typed[1]: grpc with onReply
+	grpc := typed[1]
+	if grpc.Type != "grpc" {
+		t.Errorf("typed[1]: expected type 'grpc', got %q", grpc.Type)
 	}
-	// onReply[0]: AllowAction deny
+	if grpc.Predicate != `"x-assess-threat" in request.headers` {
+		t.Errorf("typed[1]: expected predicate, got %q", grpc.Predicate)
+	}
+	if grpc.Var != "threatResponse" {
+		t.Errorf("typed[1]: expected var 'threatResponse', got %q", grpc.Var)
+	}
+	if grpc.Service == "" {
+		t.Error("typed[1]: expected service to be set")
+	}
+	if grpc.MessageBuilder != "threat.v1.Request{path: request.path}" {
+		t.Errorf("typed[1]: expected messageBuilder, got %q", grpc.MessageBuilder)
+	}
+	if grpc.Terminal {
+		t.Error("typed[1]: expected NOT terminal")
+	}
+	if len(grpc.SourcePolicyLocators) != 1 || grpc.SourcePolicyLocators[0] != expectedLocator {
+		t.Errorf("typed[1]: expected source %q, got %v", expectedLocator, grpc.SourcePolicyLocators)
+	}
+
+	// onReply: deny (var-dependent) + failure (var-dependent)
+	if len(grpc.OnReply) != 2 {
+		t.Fatalf("Expected 2 onReply actions, got %d", len(grpc.OnReply))
+	}
 	if grpc.OnReply[0].Type != "deny" {
-		t.Errorf("Expected onReply[0] type 'deny', got %q", grpc.OnReply[0].Type)
+		t.Errorf("onReply[0]: expected type 'deny', got %q", grpc.OnReply[0].Type)
 	}
-	if grpc.OnReply[0].Predicate != `!(request.url_path != "/blocked")` {
-		t.Errorf("Expected onReply[0] allow deny predicate, got %q", grpc.OnReply[0].Predicate)
+	if grpc.OnReply[0].Predicate != "threatResponse.threat_level > 5" {
+		t.Errorf("onReply[0]: expected predicate, got %q", grpc.OnReply[0].Predicate)
+	}
+	if grpc.OnReply[0].DenyWith != "429" {
+		t.Errorf("onReply[0]: expected denyWith '429', got %q", grpc.OnReply[0].DenyWith)
 	}
 	if !grpc.OnReply[0].Terminal {
-		t.Error("Expected onReply[0] to be terminal")
+		t.Error("onReply[0]: expected terminal")
 	}
-	// onReply[1]: intention deny (combined with original gRPC predicate)
-	if grpc.OnReply[1].Type != "deny" {
-		t.Errorf("Expected onReply[1] type 'deny', got %q", grpc.OnReply[1].Type)
+	if grpc.OnReply[1].Type != "failure" {
+		t.Errorf("onReply[1]: expected type 'failure', got %q", grpc.OnReply[1].Type)
 	}
-	expectedIntentionPredicate := `"x-assess-threat" in request.headers && !(threatResponse.threat_level < 5)`
-	if grpc.OnReply[1].Predicate != expectedIntentionPredicate {
-		t.Errorf("Expected onReply[1] combined predicate %q, got %q", expectedIntentionPredicate, grpc.OnReply[1].Predicate)
+	if grpc.OnReply[1].Predicate != "threatResponse.blocked" {
+		t.Errorf("onReply[1]: expected predicate, got %q", grpc.OnReply[1].Predicate)
 	}
-	// onReply[2]: add_headers
-	if grpc.OnReply[2].Type != "headers" {
-		t.Errorf("Expected onReply[2] type 'headers', got %q", grpc.OnReply[2].Type)
+	if grpc.OnReply[1].FailureMessage != "blocked by threat policy" {
+		t.Errorf("onReply[1]: expected failureMessage, got %q", grpc.OnReply[1].FailureMessage)
 	}
-	if grpc.OnReply[2].Headers != `{"x-checked": "true"}` {
-		t.Errorf("Expected onReply[2] headers, got %q", grpc.OnReply[2].Headers)
+	if grpc.OnReply[1].FailureCode != "403" {
+		t.Errorf("onReply[1]: expected failureCode '403', got %q", grpc.OnReply[1].FailureCode)
 	}
-	if grpc.OnReply[2].Target != "response" {
-		t.Errorf("Expected onReply[2] target 'response', got %q", grpc.OnReply[2].Target)
+
+	// typed[2]: response headers (root-level, no var reference)
+	if typed[2].Type != "headers" {
+		t.Errorf("typed[2]: expected type 'headers', got %q", typed[2].Type)
+	}
+	if typed[2].Headers != `{"x-checked": "true"}` {
+		t.Errorf("typed[2]: expected headers, got %q", typed[2].Headers)
+	}
+	if typed[2].Target != "response" {
+		t.Errorf("typed[2]: expected target 'response', got %q", typed[2].Target)
 	}
 }
 
@@ -2178,7 +2199,6 @@ func TestMutateWasmConfig_NoPipelineActionsNoChange(t *testing.T) {
 }
 
 func TestMutateWasmConfig_PipelineActionsAppendToMultipleActionSets(t *testing.T) {
-	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
 	store := NewRegisteredDataStore()
 	mockTargetRef := createMockGatewayTargetRef()
 	targetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "Gateway", Name: mockTargetRef.GetName(), Namespace: mockTargetRef.GetNamespace()}
@@ -2191,8 +2211,8 @@ func TestMutateWasmConfig_PipelineActionsAppendToMultipleActionSets(t *testing.T
 	)
 
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "request.method == 'GET'"},
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check", DenyWith: "response.ok"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "request.method == 'GET'", DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check"},
 	})
 
 	mutator := NewRegisteredDataMutator[*wasm.Config](store)
@@ -2209,23 +2229,16 @@ func TestMutateWasmConfig_PipelineActionsAppendToMultipleActionSets(t *testing.T
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// TypedActions should be appended to BOTH action sets (single grpc with allow deny in onReply)
 	for i, as := range wasmConfig.ActionSets {
-		if len(as.TypedActions) != 1 {
-			t.Errorf("ActionSet[%d]: expected 1 typed action (grpc), got %d", i, len(as.TypedActions))
+		if len(as.TypedActions) != 2 {
+			t.Errorf("ActionSet[%d]: expected 2 typed actions, got %d", i, len(as.TypedActions))
+			continue
 		}
-		if as.TypedActions[0].Type != "grpc" {
-			t.Errorf("ActionSet[%d]: expected grpc typed action, got %s", i, as.TypedActions[0].Type)
+		if as.TypedActions[0].Type != "deny" {
+			t.Errorf("ActionSet[%d]: expected typed[0] deny, got %s", i, as.TypedActions[0].Type)
 		}
-		if as.TypedActions[0].Predicate != "true" {
-			t.Errorf("ActionSet[%d]: expected predicate 'true', got %s", i, as.TypedActions[0].Predicate)
-		}
-		// onReply should have allow deny + intention deny
-		if len(as.TypedActions[0].OnReply) < 2 {
-			t.Errorf("ActionSet[%d]: expected at least 2 onReply actions, got %d", i, len(as.TypedActions[0].OnReply))
-		}
-		if as.TypedActions[0].OnReply[0].Type != "deny" {
-			t.Errorf("ActionSet[%d]: expected onReply[0] deny (allow), got %s", i, as.TypedActions[0].OnReply[0].Type)
+		if as.TypedActions[1].Type != "grpc" {
+			t.Errorf("ActionSet[%d]: expected typed[1] grpc, got %s", i, as.TypedActions[1].Type)
 		}
 	}
 }
@@ -2273,8 +2286,6 @@ func findGatewayInTopology(t *testing.T, topology *machinery.Topology, name stri
 }
 
 func TestApplyWasmConfigMutators_CreatesActionSetsFromTopology(t *testing.T) {
-	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
-	// Set up: extension policy has pipeline actions and upstreams, but no auth/ratelimit policies exist
 	store := NewRegisteredDataStore()
 	gatewayTargetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "Gateway", Name: "test-gateway", Namespace: "test-namespace"}
 	policyID := testResourceID("ThreatPolicy", "default", "my-threat")
@@ -2285,17 +2296,16 @@ func TestApplyWasmConfigMutators_CreatesActionSetsFromTopology(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: `request.url_path != "/blocked"`},
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse", DenyWith: "threatResponse.threat_level < 5"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/blocked"`, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "threatResponse.threat_level > 5", DenyWith: "429"},
 	})
 
-	// Register the mutator globally (save and restore to avoid test pollution)
 	savedRegistry := *GlobalMutatorRegistry
 	defer func() { *GlobalMutatorRegistry = savedRegistry }()
 	*GlobalMutatorRegistry = MutatorRegistry{}
 	GlobalMutatorRegistry.RegisterWasmConfigMutator(NewRegisteredDataMutator[*wasm.Config](store))
 
-	// Build a topology with one gateway, one listener, one HTTPRoute
 	gw := BuildGateway(func(g *gwapiv1.Gateway) {
 		g.Name = "test-gateway"
 		g.Namespace = "test-namespace"
@@ -2325,36 +2335,33 @@ func TestApplyWasmConfigMutators_CreatesActionSetsFromTopology(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// ActionSets should have been created from the topology
 	if len(wasmConfig.ActionSets) == 0 {
 		t.Fatal("Expected actionsets to be created from topology, got 0")
 	}
 
-	// Verify the actionset has the correct hostname
 	as := wasmConfig.ActionSets[0]
 	if len(as.RouteRuleConditions.Hostnames) != 1 || as.RouteRuleConditions.Hostnames[0] != "api.example.com" {
 		t.Errorf("Expected hostname 'api.example.com', got %v", as.RouteRuleConditions.Hostnames)
 	}
 
-	// AllowAction causes gRPC to fire unconditionally; allow deny is in onReply
-	if len(as.TypedActions) != 1 {
-		t.Fatalf("Expected 1 typed action (grpc), got %d", len(as.TypedActions))
+	// Root-level: deny + grpc (with var-dependent deny in onReply)
+	if len(as.TypedActions) != 2 {
+		t.Fatalf("Expected 2 root-level typed actions, got %d", len(as.TypedActions))
 	}
-	if as.TypedActions[0].Type != "grpc" {
-		t.Errorf("Expected grpc typed action, got %s", as.TypedActions[0].Type)
+	if as.TypedActions[0].Type != "deny" {
+		t.Errorf("Expected typed[0] deny, got %s", as.TypedActions[0].Type)
 	}
-	if as.TypedActions[0].Predicate != "true" {
-		t.Errorf("Expected predicate 'true', got %q", as.TypedActions[0].Predicate)
+	if as.TypedActions[1].Type != "grpc" {
+		t.Errorf("Expected typed[1] grpc, got %s", as.TypedActions[1].Type)
 	}
-	// onReply[0]: allow deny, onReply[1]: intention deny
-	if len(as.TypedActions[0].OnReply) < 2 {
-		t.Fatalf("Expected at least 2 onReply actions, got %d", len(as.TypedActions[0].OnReply))
+	if len(as.TypedActions[1].OnReply) != 1 {
+		t.Fatalf("Expected 1 onReply action, got %d", len(as.TypedActions[1].OnReply))
 	}
-	if as.TypedActions[0].OnReply[0].Type != "deny" {
-		t.Errorf("Expected onReply[0] deny (allow), got %s", as.TypedActions[0].OnReply[0].Type)
+	if as.TypedActions[1].OnReply[0].Type != "deny" {
+		t.Errorf("Expected onReply[0] deny, got %s", as.TypedActions[1].OnReply[0].Type)
 	}
-	if as.TypedActions[0].OnReply[0].Predicate != `!(request.url_path != "/blocked")` {
-		t.Errorf("Expected allow deny predicate, got %q", as.TypedActions[0].OnReply[0].Predicate)
+	if as.TypedActions[1].OnReply[0].DenyWith != "429" {
+		t.Errorf("Expected onReply[0] denyWith '429', got %q", as.TypedActions[1].OnReply[0].DenyWith)
 	}
 }
 
@@ -2398,7 +2405,6 @@ func TestApplyWasmConfigMutators_NoRoutesNoActionSets(t *testing.T) {
 }
 
 func TestApplyWasmConfigMutators_ExistingActionSetsPreserved(t *testing.T) {
-	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
 	store := NewRegisteredDataStore()
 	gatewayTargetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "Gateway", Name: "test-gateway", Namespace: "test-namespace"}
 	policyID := testResourceID("ThreatPolicy", "default", "my-threat")
@@ -2409,8 +2415,8 @@ func TestApplyWasmConfigMutators_ExistingActionSetsPreserved(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "request.method == 'GET'"},
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", DenyWith: "response.ok"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "request.method == 'GET'", DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat"},
 	})
 
 	savedRegistry := *GlobalMutatorRegistry
@@ -2430,7 +2436,6 @@ func TestApplyWasmConfigMutators_ExistingActionSetsPreserved(t *testing.T) {
 	topology := testTopology(t, []*gwapiv1.Gateway{gw}, []*gwapiv1.HTTPRoute{route}, nil)
 	gateway := findGatewayInTopology(t, topology, "test-gateway")
 
-	// Pre-existing actionsets from AuthPolicy
 	wasmConfig := wasm.Config{
 		ActionSets: []wasm.ActionSet{
 			{Name: "auth-actionset", Actions: []wasm.Action{{ServiceName: "auth-service"}}},
@@ -2442,7 +2447,6 @@ func TestApplyWasmConfigMutators_ExistingActionSetsPreserved(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Should still have exactly 1 actionset (the existing one, not duplicated)
 	if len(wasmConfig.ActionSets) != 1 {
 		t.Fatalf("Expected 1 actionset (existing), got %d", len(wasmConfig.ActionSets))
 	}
@@ -2450,7 +2454,6 @@ func TestApplyWasmConfigMutators_ExistingActionSetsPreserved(t *testing.T) {
 		t.Errorf("Expected existing actionset preserved, got name %q", wasmConfig.ActionSets[0].Name)
 	}
 
-	// Legacy actions preserved, pipeline TypedActions appended
 	actions := wasmConfig.ActionSets[0].Actions
 	if len(actions) != 1 {
 		t.Fatalf("Expected 1 legacy action, got %d", len(actions))
@@ -2459,22 +2462,15 @@ func TestApplyWasmConfigMutators_ExistingActionSetsPreserved(t *testing.T) {
 		t.Errorf("Expected legacy action to be auth-service, got %s", actions[0].ServiceName)
 	}
 
-	// AllowAction causes single gRPC action with allow deny in onReply
 	typed := wasmConfig.ActionSets[0].TypedActions
-	if len(typed) != 1 {
-		t.Fatalf("Expected 1 typed action (grpc), got %d", len(typed))
+	if len(typed) != 2 {
+		t.Fatalf("Expected 2 typed actions (deny + grpc), got %d", len(typed))
 	}
-	if typed[0].Type != "grpc" {
-		t.Errorf("Expected grpc typed action, got %s", typed[0].Type)
+	if typed[0].Type != "deny" {
+		t.Errorf("Expected typed[0] deny, got %s", typed[0].Type)
 	}
-	if typed[0].Predicate != "true" {
-		t.Errorf("Expected predicate 'true', got %q", typed[0].Predicate)
-	}
-	if len(typed[0].OnReply) < 2 {
-		t.Fatalf("Expected at least 2 onReply actions (allow deny + intention deny), got %d", len(typed[0].OnReply))
-	}
-	if typed[0].OnReply[0].Type != "deny" {
-		t.Errorf("Expected onReply[0] deny (allow), got %s", typed[0].OnReply[0].Type)
+	if typed[1].Type != "grpc" {
+		t.Errorf("Expected typed[1] grpc, got %s", typed[1].Type)
 	}
 }
 
@@ -2578,9 +2574,6 @@ func TestReplacePipelineActions_EmptyReplacement(t *testing.T) {
 }
 
 func TestApplyWasmConfigMutators_RouteTargetedPipelineActions(t *testing.T) {
-	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
-	// Extension policy targets an HTTPRoute (not a Gateway).
-	// The upstreams and pipeline actions reference the route's targetRef.
 	store := NewRegisteredDataStore()
 	routeTargetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "HTTPRoute", Name: "test-route", Namespace: "test-namespace"}
 	policyID := testResourceID("ThreatPolicy", "test-namespace", "route-threat")
@@ -2591,10 +2584,8 @@ func TestApplyWasmConfigMutators_RouteTargetedPipelineActions(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: `request.url_path != "/blocked"`},
-	})
-	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, DenyWith: "threatResponse.threat_level < 5", Method: "assess-threat"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/blocked"`, DenyWith: "403"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat"},
 	})
 
 	savedRegistry := *GlobalMutatorRegistry
@@ -2606,7 +2597,7 @@ func TestApplyWasmConfigMutators_RouteTargetedPipelineActions(t *testing.T) {
 		g.Name = "test-gateway"
 		g.Namespace = "test-namespace"
 	})
-	route := BuildHTTPRoute(func(r *gwapiv1.HTTPRoute) {
+	matchingRoute := BuildHTTPRoute(func(r *gwapiv1.HTTPRoute) {
 		r.Name = "test-route"
 		r.Namespace = "test-namespace"
 		r.Spec.ParentRefs = []gwapiv1.ParentReference{{Name: "test-gateway"}}
@@ -2621,8 +2612,23 @@ func TestApplyWasmConfigMutators_RouteTargetedPipelineActions(t *testing.T) {
 			}},
 		}}
 	})
+	otherRoute := BuildHTTPRoute(func(r *gwapiv1.HTTPRoute) {
+		r.Name = "other-route"
+		r.Namespace = "test-namespace"
+		r.Spec.ParentRefs = []gwapiv1.ParentReference{{Name: "test-gateway"}}
+		r.Spec.Hostnames = []gwapiv1.Hostname{"other.example.com"}
+		r.Spec.Rules = []gwapiv1.HTTPRouteRule{{
+			Matches: []gwapiv1.HTTPRouteMatch{{
+				Path: &gwapiv1.HTTPPathMatch{
+					Type:  ptr.To(gwapiv1.PathMatchExact),
+					Value: ptr.To("/other"),
+				},
+				Method: ptr.To(gwapiv1.HTTPMethodGet),
+			}},
+		}}
+	})
 
-	topology := testTopology(t, []*gwapiv1.Gateway{gw}, []*gwapiv1.HTTPRoute{route}, nil)
+	topology := testTopology(t, []*gwapiv1.Gateway{gw}, []*gwapiv1.HTTPRoute{matchingRoute, otherRoute}, nil)
 	gateway := findGatewayInTopology(t, topology, "test-gateway")
 
 	wasmConfig := wasm.Config{}
@@ -2631,60 +2637,40 @@ func TestApplyWasmConfigMutators_RouteTargetedPipelineActions(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// ActionSets should be created from topology for route-targeted policies
-	if len(wasmConfig.ActionSets) == 0 {
-		t.Fatal("Expected actionsets to be created from topology for route-targeted policy, got 0")
+	// Only the matching route's action set survives; empty skeletons are filtered out.
+	if len(wasmConfig.ActionSets) != 1 {
+		t.Fatalf("Expected 1 actionset (matching route only), got %d", len(wasmConfig.ActionSets))
 	}
 
 	as := wasmConfig.ActionSets[0]
 	if len(as.RouteRuleConditions.Hostnames) != 1 || as.RouteRuleConditions.Hostnames[0] != "api.example.com" {
 		t.Errorf("Expected hostname 'api.example.com', got %v", as.RouteRuleConditions.Hostnames)
 	}
-
-	// AllowAction causes single gRPC action with allow deny in onReply
-	typed := as.TypedActions
-	if len(typed) != 1 {
-		t.Fatalf("Expected 1 typed action (grpc), got %d", len(typed))
+	if len(as.TypedActions) != 2 {
+		t.Fatalf("Expected 2 typed actions on matching route, got %d", len(as.TypedActions))
 	}
-	if typed[0].Type != "grpc" {
-		t.Errorf("Expected grpc typed action, got %s", typed[0].Type)
+	if as.TypedActions[0].Type != "deny" {
+		t.Errorf("Expected typed[0] deny, got %s", as.TypedActions[0].Type)
 	}
-	if typed[0].Predicate != "true" {
-		t.Errorf("Expected predicate 'true', got %q", typed[0].Predicate)
+	if as.TypedActions[1].Type != "grpc" {
+		t.Errorf("Expected typed[1] grpc, got %s", as.TypedActions[1].Type)
 	}
-	if typed[0].Service == "" {
+	if as.TypedActions[1].Service == "" {
 		t.Error("Expected grpc typed action to have service set")
-	}
-	// onReply: allow deny + intention deny
-	if len(typed[0].OnReply) < 2 {
-		t.Fatalf("Expected at least 2 onReply actions, got %d", len(typed[0].OnReply))
-	}
-	if typed[0].OnReply[0].Type != "deny" {
-		t.Errorf("Expected onReply[0] deny (allow), got %s", typed[0].OnReply[0].Type)
-	}
-	if typed[0].OnReply[0].Predicate != `!(request.url_path != "/blocked")` {
-		t.Errorf("Expected allow deny predicate, got %q", typed[0].OnReply[0].Predicate)
-	}
-	if typed[0].OnReply[1].Type != "deny" {
-		t.Errorf("Expected onReply[1] deny (intention), got %s", typed[0].OnReply[1].Type)
 	}
 }
 
-// TestMutateWasmConfig_AllowOnlyPipelineProducesNoActions documents the known
-// limitation that a policy with only AllowAction (no grpc_method) produces no
-// typed actions, because the wasm-shim requires gRPC typed actions at the top
-// level and allow denies are currently injected into a gRPC action's onReply.
-func TestMutateWasmConfig_AllowOnlyPipelineProducesNoActions(t *testing.T) {
+func TestMutateWasmConfig_DenyOnlyPipelineProducesRootAction(t *testing.T) {
 	store := NewRegisteredDataStore()
-	policyID := testResourceID("AllowPolicy", "default", "allow-only")
+	policyID := testResourceID("DenyPolicy", "default", "deny-only")
 
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: `request.url_path != "/admin"`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/admin"`, DenyWith: "403"},
 	})
 
 	wasmConfig := wasm.Config{
 		ActionSets: []wasm.ActionSet{{
-			Name: "allow-test",
+			Name: "deny-test",
 			RouteRuleConditions: wasm.RouteRuleConditions{
 				Hostnames: []string{"example.com"},
 			},
@@ -2697,10 +2683,20 @@ func TestMutateWasmConfig_AllowOnlyPipelineProducesNoActions(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	// Known limitation: allow-only policies without a grpc_method produce
-	// zero typed actions because allow denies can only be injected into a
-	// gRPC action's onReply in the current wasm-shim model.
-	if len(wasmConfig.ActionSets[0].TypedActions) != 0 {
-		t.Errorf("Expected 0 typed actions (known limitation), got %d", len(wasmConfig.ActionSets[0].TypedActions))
+	if len(wasmConfig.ActionSets[0].TypedActions) != 1 {
+		t.Fatalf("Expected 1 typed action, got %d", len(wasmConfig.ActionSets[0].TypedActions))
+	}
+	ta := wasmConfig.ActionSets[0].TypedActions[0]
+	if ta.Type != "deny" {
+		t.Errorf("Expected type 'deny', got %q", ta.Type)
+	}
+	if ta.Predicate != `request.url_path == "/admin"` {
+		t.Errorf("Expected predicate, got %q", ta.Predicate)
+	}
+	if ta.DenyWith != "403" {
+		t.Errorf("Expected denyWith '403', got %q", ta.DenyWith)
+	}
+	if !ta.Terminal {
+		t.Error("Expected deny action to be terminal")
 	}
 }

--- a/internal/extension/registry_test.go
+++ b/internal/extension/registry_test.go
@@ -2657,6 +2657,103 @@ func TestApplyWasmConfigMutators_RouteTargetedPipelineActions(t *testing.T) {
 	}
 }
 
+func TestApplyWasmConfigMutators_RouteTargetedExtensionWithBuiltinActionSets(t *testing.T) {
+	// This test reproduces the bug where extension pipeline actions targeting an
+	// HTTPRoute are lost when built-in policies (AuthPolicy/RateLimitPolicy) have
+	// already created ActionSets for the same route. Built-in ActionSets don't set
+	// SourceRoute, so the extension's route-matching logic in mutateWasmConfig skips
+	// them all — resulting in extension TypedActions never being appended.
+	store := NewRegisteredDataStore()
+	routeTargetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "HTTPRoute", Name: "test-route", Namespace: "test-namespace"}
+	policyID := testResourceID("ThreatPolicy", "test-namespace", "route-threat")
+
+	store.SetUpstream(
+		RegisteredUpstreamKey{Policy: policyID, Name: "assess-threat", URL: "grpc://svc:8081", Service: "threat.Service", Method: "Check"},
+		RegisteredUpstreamEntry{ClusterName: "ext-svc-8081", Host: "svc", Port: 8081, TargetRef: routeTargetRef, FailureMode: "deny", Timeout: "100ms", Service: "threat.Service", Method: "Check"},
+		testFileDescriptorSet(),
+	)
+	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "threatResponse.threat_level > 5", WithStatus: 403},
+	})
+
+	savedRegistry := *GlobalMutatorRegistry
+	defer func() { *GlobalMutatorRegistry = savedRegistry }()
+	*GlobalMutatorRegistry = MutatorRegistry{}
+	GlobalMutatorRegistry.RegisterWasmConfigMutator(NewRegisteredDataMutator[*wasm.Config](store))
+
+	gw := BuildGateway(func(g *gwapiv1.Gateway) {
+		g.Name = "test-gateway"
+		g.Namespace = "test-namespace"
+	})
+	route := BuildHTTPRoute(func(r *gwapiv1.HTTPRoute) {
+		r.Name = "test-route"
+		r.Namespace = "test-namespace"
+		r.Spec.ParentRefs = []gwapiv1.ParentReference{{Name: "test-gateway"}}
+		r.Spec.Hostnames = []gwapiv1.Hostname{"api.example.com"}
+		r.Spec.Rules = []gwapiv1.HTTPRouteRule{{
+			Matches: []gwapiv1.HTTPRouteMatch{{
+				Path: &gwapiv1.HTTPPathMatch{
+					Type:  ptr.To(gwapiv1.PathMatchExact),
+					Value: ptr.To("/toy"),
+				},
+				Method: ptr.To(gwapiv1.HTTPMethodGet),
+			}},
+		}}
+	})
+
+	topology := testTopology(t, []*gwapiv1.Gateway{gw}, []*gwapiv1.HTTPRoute{route}, nil)
+	gateway := findGatewayInTopology(t, topology, "test-gateway")
+
+	// Simulate built-in policies (AuthPolicy/RateLimitPolicy) having already
+	// created ActionSets. Crucially, these do NOT have SourceRoute set — exactly
+	// as BuildActionSetsForPath produces them.
+	wasmConfig := wasm.Config{
+		ActionSets: []wasm.ActionSet{
+			{
+				Name: "builtin-actionset",
+				RouteRuleConditions: wasm.RouteRuleConditions{
+					Hostnames: []string{"api.example.com"},
+				},
+				Actions: []wasm.Action{{ServiceName: "authorino-auth"}},
+			},
+		},
+	}
+
+	err := ApplyWasmConfigMutators(&wasmConfig, gateway, topology)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Built-in action set must survive
+	if len(wasmConfig.ActionSets) != 1 {
+		t.Fatalf("Expected 1 actionset, got %d", len(wasmConfig.ActionSets))
+	}
+
+	as := wasmConfig.ActionSets[0]
+
+	// Built-in actions preserved
+	if len(as.Actions) != 1 || as.Actions[0].ServiceName != "authorino-auth" {
+		t.Errorf("Expected built-in action preserved, got %v", as.Actions)
+	}
+
+	// Extension TypedActions must be merged alongside the built-in actions.
+	// The deny depends on the var "threatResponse" from the gRPC action, so it
+	// gets nested in the gRPC action's OnReply rather than being a separate root action.
+	if len(as.TypedActions) != 1 {
+		t.Fatalf("Expected 1 typed action (grpc with deny in onReply) merged into built-in actionset, got %d", len(as.TypedActions))
+	}
+	if as.TypedActions[0].Type != "grpc" {
+		t.Errorf("Expected typed[0] grpc, got %s", as.TypedActions[0].Type)
+	}
+	if len(as.TypedActions[0].OnReply) != 1 {
+		t.Fatalf("Expected 1 onReply action (deny), got %d", len(as.TypedActions[0].OnReply))
+	}
+	if as.TypedActions[0].OnReply[0].Type != "deny" {
+		t.Errorf("Expected onReply[0] deny, got %s", as.TypedActions[0].OnReply[0].Type)
+	}
+}
+
 func TestMutateWasmConfig_DenyOnlyPipelineProducesRootAction(t *testing.T) {
 	store := NewRegisteredDataStore()
 	policyID := testResourceID("DenyPolicy", "default", "deny-only")

--- a/internal/extension/registry_test.go
+++ b/internal/extension/registry_test.go
@@ -1467,8 +1467,8 @@ func TestPipelineActionStore_AppendAndGet(t *testing.T) {
 	policy := testResourceID("ThreatPolicy", "default", "my-policy")
 
 	actions := []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "checkThreat", Intention: "resp.HeatLevel == 5"},
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: "request.auth.identity.admin == true"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "checkThreat", Var: "threatResponse"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
 	}
 
 	startIdx := store.AppendPipelineActions(policy, PipelinePhaseRequest, actions)
@@ -1489,8 +1489,8 @@ func TestPipelineActionStore_AppendAndGet(t *testing.T) {
 	if retrieved[0].Method != "checkThreat" {
 		t.Errorf("First action method = %q, want %q", retrieved[0].Method, "checkThreat")
 	}
-	if retrieved[1].ActionType != extpb.ActionType_ACTION_TYPE_ALLOW {
-		t.Errorf("Second action type = %v, want ALLOW", retrieved[1].ActionType)
+	if retrieved[1].ActionType != extpb.ActionType_ACTION_TYPE_DENY {
+		t.Errorf("Second action type = %v, want DENY", retrieved[1].ActionType)
 	}
 }
 
@@ -1508,7 +1508,7 @@ func TestPipelineActionStore_SequentialAppends(t *testing.T) {
 
 	// Second append continues index sequence
 	startIdx = store.AppendPipelineActions(policy, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: "true"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check2"},
 	})
 	if startIdx != 1 {
@@ -1535,7 +1535,7 @@ func TestPipelineActionStore_SeparatePhases(t *testing.T) {
 	})
 	store.AppendPipelineActions(policy, PipelinePhaseResponse, []PipelineActionEntry{
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: "{'x-checked': 'true'}"},
-		{ActionType: extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE, NewResponseCode: 403},
+		{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, FailureMessage: "blocked", FailureCode: "403"},
 	})
 
 	reqActions := store.GetPipelineActions(policy, PipelinePhaseRequest)
@@ -1562,7 +1562,7 @@ func TestPipelineActionStore_SeparatePolicies(t *testing.T) {
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check1"},
 	})
 	store.AppendPipelineActions(policy2, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: "true"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
 	})
 
 	p1Actions := store.GetPipelineActions(policy1, PipelinePhaseRequest)
@@ -1574,8 +1574,8 @@ func TestPipelineActionStore_SeparatePolicies(t *testing.T) {
 	if p1Actions[0].Method != "check1" {
 		t.Errorf("Policy1 action method = %q, want %q", p1Actions[0].Method, "check1")
 	}
-	if p2Actions[0].ActionType != extpb.ActionType_ACTION_TYPE_ALLOW {
-		t.Errorf("Policy2 action type = %v, want ALLOW", p2Actions[0].ActionType)
+	if p2Actions[0].ActionType != extpb.ActionType_ACTION_TYPE_DENY {
+		t.Errorf("Policy2 action type = %v, want DENY", p2Actions[0].ActionType)
 	}
 }
 
@@ -1591,7 +1591,7 @@ func TestPipelineActionStore_ClearPipelineActions(t *testing.T) {
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: "{'x': '1'}"},
 	})
 	store.AppendPipelineActions(otherPolicy, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
 	})
 
 	cleared := store.ClearPipelineActions(policy)
@@ -1634,7 +1634,7 @@ func TestPipelineActionStore_CounterResetsAfterClear(t *testing.T) {
 
 	store.AppendPipelineActions(policy, PipelinePhaseRequest, []PipelineActionEntry{
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD},
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
 	})
 
 	store.ClearPipelineActions(policy)
@@ -1706,7 +1706,7 @@ func TestPipelineActionStore_PredicatePreserved(t *testing.T) {
 			ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD,
 			Predicate:  "request.headers['check'] == '1' && request.method == 'GET'",
 			Method:     "checkThreat",
-			Intention:  "resp.ok",
+			Var:        "threatResponse",
 		},
 	})
 
@@ -2038,6 +2038,7 @@ func TestCollectRouteUpstreams(t *testing.T) {
 }
 
 func TestMutateWasmConfig_TranslatesPipelineActions(t *testing.T) {
+	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
 	store := NewRegisteredDataStore()
 	mockTargetRef := createMockGatewayTargetRef()
 	targetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "Gateway", Name: mockTargetRef.GetName(), Namespace: mockTargetRef.GetNamespace()}
@@ -2052,8 +2053,8 @@ func TestMutateWasmConfig_TranslatesPipelineActions(t *testing.T) {
 
 	// Register pipeline actions
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: `request.url_path != "/blocked"`},
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse", Intention: "threatResponse.threat_level < 5", Predicate: `"x-assess-threat" in request.headers`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: `request.url_path != "/blocked"`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse", DenyWith: "threatResponse.threat_level < 5", Predicate: `"x-assess-threat" in request.headers`},
 	})
 	store.AppendPipelineActions(policyID, PipelinePhaseResponse, []PipelineActionEntry{
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: `{"x-checked": "true"}`},
@@ -2177,6 +2178,7 @@ func TestMutateWasmConfig_NoPipelineActionsNoChange(t *testing.T) {
 }
 
 func TestMutateWasmConfig_PipelineActionsAppendToMultipleActionSets(t *testing.T) {
+	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
 	store := NewRegisteredDataStore()
 	mockTargetRef := createMockGatewayTargetRef()
 	targetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "Gateway", Name: mockTargetRef.GetName(), Namespace: mockTargetRef.GetNamespace()}
@@ -2189,8 +2191,8 @@ func TestMutateWasmConfig_PipelineActionsAppendToMultipleActionSets(t *testing.T
 	)
 
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: "request.method == 'GET'"},
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check", Intention: "response.ok"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "request.method == 'GET'"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check", DenyWith: "response.ok"},
 	})
 
 	mutator := NewRegisteredDataMutator[*wasm.Config](store)
@@ -2271,6 +2273,7 @@ func findGatewayInTopology(t *testing.T, topology *machinery.Topology, name stri
 }
 
 func TestApplyWasmConfigMutators_CreatesActionSetsFromTopology(t *testing.T) {
+	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
 	// Set up: extension policy has pipeline actions and upstreams, but no auth/ratelimit policies exist
 	store := NewRegisteredDataStore()
 	gatewayTargetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "Gateway", Name: "test-gateway", Namespace: "test-namespace"}
@@ -2282,8 +2285,8 @@ func TestApplyWasmConfigMutators_CreatesActionSetsFromTopology(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: `request.url_path != "/blocked"`},
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse", Intention: "threatResponse.threat_level < 5"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: `request.url_path != "/blocked"`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Var: "threatResponse", DenyWith: "threatResponse.threat_level < 5"},
 	})
 
 	// Register the mutator globally (save and restore to avoid test pollution)
@@ -2366,7 +2369,7 @@ func TestApplyWasmConfigMutators_NoRoutesNoActionSets(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY},
 	})
 
 	savedRegistry := *GlobalMutatorRegistry
@@ -2395,6 +2398,7 @@ func TestApplyWasmConfigMutators_NoRoutesNoActionSets(t *testing.T) {
 }
 
 func TestApplyWasmConfigMutators_ExistingActionSetsPreserved(t *testing.T) {
+	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
 	store := NewRegisteredDataStore()
 	gatewayTargetRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "Gateway", Name: "test-gateway", Namespace: "test-namespace"}
 	policyID := testResourceID("ThreatPolicy", "default", "my-threat")
@@ -2405,8 +2409,8 @@ func TestApplyWasmConfigMutators_ExistingActionSetsPreserved(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: "request.method == 'GET'"},
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", Intention: "response.ok"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "request.method == 'GET'"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess-threat", DenyWith: "response.ok"},
 	})
 
 	savedRegistry := *GlobalMutatorRegistry
@@ -2487,28 +2491,27 @@ func TestReplacePipelineActions(t *testing.T) {
 		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: `{"x-old": "true"}`},
 	})
 	store.AppendPipelineActions(otherPolicy, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: "true"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: "403"},
 	})
 
 	// Replace both phases atomically
-	store.ReplacePipelineActions(policy,
-		[]PipelineActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: `request.url_path != "/blocked"`},
-			{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "new-check", Intention: "resp.ok"},
-		},
-		[]PipelineActionEntry{
-			{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, HeadersToAdd: `{"x-new": "true"}`},
-			{ActionType: extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE, NewResponseCode: 403},
-		},
-	)
+	err := store.ReplacePipelineActions(policy, []PipelineActionEntry{
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", DenyWith: "403", Predicate: `request.url_path == "/blocked"`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Phase: "request", Method: "new-check", Var: "threatResponse"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_ADD_HEADERS, Phase: "response", HeadersToAdd: `{"x-new": "true"}`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_FAILURE, Phase: "response", FailureMessage: "blocked", FailureCode: "403"},
+	})
+	if err != nil {
+		t.Fatalf("ReplacePipelineActions returned error: %v", err)
+	}
 
 	// Verify request actions replaced
 	reqActions := store.GetPipelineActions(policy, PipelinePhaseRequest)
 	if len(reqActions) != 2 {
 		t.Fatalf("Expected 2 request actions, got %d", len(reqActions))
 	}
-	if reqActions[0].ActionType != extpb.ActionType_ACTION_TYPE_ALLOW {
-		t.Errorf("First request action type = %v, want ALLOW", reqActions[0].ActionType)
+	if reqActions[0].ActionType != extpb.ActionType_ACTION_TYPE_DENY {
+		t.Errorf("First request action type = %v, want DENY", reqActions[0].ActionType)
 	}
 	if reqActions[1].Method != "new-check" {
 		t.Errorf("Second request action method = %q, want %q", reqActions[1].Method, "new-check")
@@ -2525,8 +2528,8 @@ func TestReplacePipelineActions(t *testing.T) {
 	if respActions[0].HeadersToAdd != `{"x-new": "true"}` {
 		t.Errorf("First response action headers = %q, unexpected", respActions[0].HeadersToAdd)
 	}
-	if respActions[1].NewResponseCode != 403 {
-		t.Errorf("Second response action code = %d, want 403", respActions[1].NewResponseCode)
+	if respActions[1].FailureCode != "403" {
+		t.Errorf("Second response action failure code = %q, want %q", respActions[1].FailureCode, "403")
 	}
 
 	// Other policy unaffected
@@ -2534,8 +2537,20 @@ func TestReplacePipelineActions(t *testing.T) {
 	if len(otherActions) != 1 {
 		t.Fatalf("Expected other policy to still have 1 action, got %d", len(otherActions))
 	}
-	if otherActions[0].ActionType != extpb.ActionType_ACTION_TYPE_ALLOW {
-		t.Errorf("Other policy action type = %v, want ALLOW", otherActions[0].ActionType)
+	if otherActions[0].ActionType != extpb.ActionType_ACTION_TYPE_DENY {
+		t.Errorf("Other policy action type = %v, want DENY", otherActions[0].ActionType)
+	}
+}
+
+func TestReplacePipelineActions_InvalidPhase(t *testing.T) {
+	store := NewRegisteredDataStore()
+	policy := testResourceID("ThreatPolicy", "default", "my-policy")
+
+	err := store.ReplacePipelineActions(policy, []PipelineActionEntry{
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "invalid", DenyWith: "403"},
+	})
+	if err == nil {
+		t.Fatal("Expected error for invalid phase, got nil")
 	}
 }
 
@@ -2547,8 +2562,10 @@ func TestReplacePipelineActions_EmptyReplacement(t *testing.T) {
 		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "check"},
 	})
 
-	// Replace with empty slices clears everything
-	store.ReplacePipelineActions(policy, nil, nil)
+	// Replace with nil clears everything
+	if err := store.ReplacePipelineActions(policy, nil); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 
 	reqActions := store.GetPipelineActions(policy, PipelinePhaseRequest)
 	if reqActions != nil {
@@ -2561,6 +2578,7 @@ func TestReplacePipelineActions_EmptyReplacement(t *testing.T) {
 }
 
 func TestApplyWasmConfigMutators_RouteTargetedPipelineActions(t *testing.T) {
+	t.Skip("TODO(#1967): rewrite after pipeline action → TypedAction translation is implemented")
 	// Extension policy targets an HTTPRoute (not a Gateway).
 	// The upstreams and pipeline actions reference the route's targetRef.
 	store := NewRegisteredDataStore()
@@ -2573,10 +2591,10 @@ func TestApplyWasmConfigMutators_RouteTargetedPipelineActions(t *testing.T) {
 		testFileDescriptorSet(),
 	)
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: `request.url_path != "/blocked"`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: `request.url_path != "/blocked"`},
 	})
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Intention: "threatResponse.threat_level < 5", Method: "assess-threat"},
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, DenyWith: "threatResponse.threat_level < 5", Method: "assess-threat"},
 	})
 
 	savedRegistry := *GlobalMutatorRegistry
@@ -2661,7 +2679,7 @@ func TestMutateWasmConfig_AllowOnlyPipelineProducesNoActions(t *testing.T) {
 	policyID := testResourceID("AllowPolicy", "default", "allow-only")
 
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
-		{ActionType: extpb.ActionType_ACTION_TYPE_ALLOW, Intention: `request.url_path != "/admin"`},
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, DenyWith: `request.url_path != "/admin"`},
 	})
 
 	wasmConfig := wasm.Config{

--- a/internal/wasm/types.go
+++ b/internal/wasm/types.go
@@ -484,6 +484,8 @@ type TypedAction struct {
 	DenyWith       string        `json:"denyWith,omitempty"`
 	Target         string        `json:"target,omitempty"`
 	Headers        string        `json:"headers,omitempty"`
+	FailureMessage string        `json:"failureMessage,omitempty"`
+	FailureCode    string        `json:"failureCode,omitempty"`
 	// SourcePolicyLocators tracks all policies that contributed to this action.
 	// Format: "kind/namespace/name"
 	SourcePolicyLocators []string `json:"sources,omitempty"`
@@ -499,6 +501,8 @@ func (t TypedAction) EqualTo(other TypedAction) bool {
 		t.DenyWith != other.DenyWith ||
 		t.Target != other.Target ||
 		t.Headers != other.Headers ||
+		t.FailureMessage != other.FailureMessage ||
+		t.FailureCode != other.FailureCode ||
 		!slices.Equal(t.SourcePolicyLocators, other.SourcePolicyLocators) ||
 		len(t.OnReply) != len(other.OnReply) {
 		return false

--- a/internal/wasm/types.go
+++ b/internal/wasm/types.go
@@ -484,8 +484,7 @@ type TypedAction struct {
 	DenyWith       string        `json:"denyWith,omitempty"`
 	Target         string        `json:"target,omitempty"`
 	Headers        string        `json:"headers,omitempty"`
-	FailureMessage string        `json:"failureMessage,omitempty"`
-	FailureCode    string        `json:"failureCode,omitempty"`
+	LogMessage     string        `json:"logMessage,omitempty"`
 	// SourcePolicyLocators tracks all policies that contributed to this action.
 	// Format: "kind/namespace/name"
 	SourcePolicyLocators []string `json:"sources,omitempty"`
@@ -501,8 +500,7 @@ func (t TypedAction) EqualTo(other TypedAction) bool {
 		t.DenyWith != other.DenyWith ||
 		t.Target != other.Target ||
 		t.Headers != other.Headers ||
-		t.FailureMessage != other.FailureMessage ||
-		t.FailureCode != other.FailureCode ||
+		t.LogMessage != other.LogMessage ||
 		!slices.Equal(t.SourcePolicyLocators, other.SourcePolicyLocators) ||
 		len(t.OnReply) != len(other.OnReply) {
 		return false

--- a/internal/wasm/types_test.go
+++ b/internal/wasm/types_test.go
@@ -473,6 +473,64 @@ func TestTypedAction_EqualTo(t *testing.T) {
 	}
 }
 
+func TestTypedAction_FailureType_JSON(t *testing.T) {
+	ta := TypedAction{
+		Type:           "failure",
+		Predicate:      `request.headers["x-debug"] == "true"`,
+		Terminal:       true,
+		FailureMessage: "Request blocked by threat policy",
+		FailureCode:    "500",
+	}
+
+	data, err := json.Marshal(ta)
+	if err != nil {
+		t.Fatalf("failed to marshal TypedAction: %v", err)
+	}
+
+	var roundTripped TypedAction
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("failed to unmarshal TypedAction: %v", err)
+	}
+
+	if !ta.EqualTo(roundTripped) {
+		t.Fatalf("round-tripped TypedAction not equal:\n  got:  %+v\n  want: %+v", roundTripped, ta)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+	if raw["type"] != "failure" {
+		t.Errorf("Expected type 'failure', got %v", raw["type"])
+	}
+	if raw["failureMessage"] != "Request blocked by threat policy" {
+		t.Errorf("Expected failureMessage, got %v", raw["failureMessage"])
+	}
+	if raw["failureCode"] != "500" {
+		t.Errorf("Expected failureCode '500', got %v", raw["failureCode"])
+	}
+}
+
+func TestTypedAction_EqualTo_FailureFields(t *testing.T) {
+	a := TypedAction{Type: "failure", Predicate: "true", Terminal: true, FailureMessage: "error", FailureCode: "500"}
+	b := TypedAction{Type: "failure", Predicate: "true", Terminal: true, FailureMessage: "error", FailureCode: "500"}
+	if !a.EqualTo(b) {
+		t.Fatal("identical failure TypedActions should be equal")
+	}
+
+	diffMsg := b
+	diffMsg.FailureMessage = "other"
+	if a.EqualTo(diffMsg) {
+		t.Fatal("TypedActions with different FailureMessage should not be equal")
+	}
+
+	diffCode := b
+	diffCode.FailureCode = "403"
+	if a.EqualTo(diffCode) {
+		t.Fatal("TypedActions with different FailureCode should not be equal")
+	}
+}
+
 func TestActionSet_MixedActions_JSON(t *testing.T) {
 	as := ActionSet{
 		Name: "test-set",

--- a/internal/wasm/types_test.go
+++ b/internal/wasm/types_test.go
@@ -473,13 +473,12 @@ func TestTypedAction_EqualTo(t *testing.T) {
 	}
 }
 
-func TestTypedAction_FailureType_JSON(t *testing.T) {
+func TestTypedAction_FailType_JSON(t *testing.T) {
 	ta := TypedAction{
-		Type:           "failure",
-		Predicate:      `request.headers["x-debug"] == "true"`,
-		Terminal:       true,
-		FailureMessage: "Request blocked by threat policy",
-		FailureCode:    "500",
+		Type:       "fail",
+		Predicate:  `threatResponse.error_code != 0`,
+		Terminal:   true,
+		LogMessage: "Threat service returned unexpected error",
 	}
 
 	data, err := json.Marshal(ta)
@@ -500,34 +499,25 @@ func TestTypedAction_FailureType_JSON(t *testing.T) {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
-	if raw["type"] != "failure" {
-		t.Errorf("Expected type 'failure', got %v", raw["type"])
+	if raw["type"] != "fail" {
+		t.Errorf("Expected type 'fail', got %v", raw["type"])
 	}
-	if raw["failureMessage"] != "Request blocked by threat policy" {
-		t.Errorf("Expected failureMessage, got %v", raw["failureMessage"])
-	}
-	if raw["failureCode"] != "500" {
-		t.Errorf("Expected failureCode '500', got %v", raw["failureCode"])
+	if raw["logMessage"] != "Threat service returned unexpected error" {
+		t.Errorf("Expected logMessage, got %v", raw["logMessage"])
 	}
 }
 
-func TestTypedAction_EqualTo_FailureFields(t *testing.T) {
-	a := TypedAction{Type: "failure", Predicate: "true", Terminal: true, FailureMessage: "error", FailureCode: "500"}
-	b := TypedAction{Type: "failure", Predicate: "true", Terminal: true, FailureMessage: "error", FailureCode: "500"}
+func TestTypedAction_EqualTo_FailFields(t *testing.T) {
+	a := TypedAction{Type: "fail", Predicate: "true", Terminal: true, LogMessage: "error"}
+	b := TypedAction{Type: "fail", Predicate: "true", Terminal: true, LogMessage: "error"}
 	if !a.EqualTo(b) {
-		t.Fatal("identical failure TypedActions should be equal")
+		t.Fatal("identical fail TypedActions should be equal")
 	}
 
 	diffMsg := b
-	diffMsg.FailureMessage = "other"
+	diffMsg.LogMessage = "other"
 	if a.EqualTo(diffMsg) {
-		t.Fatal("TypedActions with different FailureMessage should not be equal")
-	}
-
-	diffCode := b
-	diffCode.FailureCode = "403"
-	if a.EqualTo(diffCode) {
-		t.Fatal("TypedActions with different FailureCode should not be equal")
+		t.Fatal("TypedActions with different LogMessage should not be equal")
 	}
 }
 

--- a/internal/wasm/utils.go
+++ b/internal/wasm/utils.go
@@ -292,8 +292,9 @@ func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery
 				}
 
 				actionSet := ActionSet{
-					Name:    ActionSetNameForPath(pathID, j, string(hostname)),
-					Actions: actions,
+					Name:        ActionSetNameForPath(pathID, j, string(hostname)),
+					Actions:     actions,
+					SourceRoute: fmt.Sprintf("HTTPRoute/%s/%s", parsed.HTTPRoute.GetNamespace(), parsed.HTTPRoute.GetName()),
 				}
 				routeRuleConditions := RouteRuleConditions{
 					Hostnames: []string{string(hostname)},
@@ -360,8 +361,9 @@ func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery
 				}
 
 				actionSet := ActionSet{
-					Name:    ActionSetNameForPath(pathID, j, string(hostname)),
-					Actions: actions,
+					Name:        ActionSetNameForPath(pathID, j, string(hostname)),
+					Actions:     actions,
+					SourceRoute: fmt.Sprintf("GRPCRoute/%s/%s", parsed.GRPCRoute.GetNamespace(), parsed.GRPCRoute.GetName()),
 				}
 				routeRuleConditions := RouteRuleConditions{
 					Hostnames: []string{string(hostname)},

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -344,9 +344,16 @@ func (ec *ExtensionController) NewPipeline(policy exttypes.Policy) exttypes.Pipe
 	}
 }
 
+type pipelinePhase = string
+
+const (
+	phaseRequest  pipelinePhase = "request"
+	phaseResponse pipelinePhase = "response"
+)
+
 type pipelineEntry struct {
 	action exttypes.Action
-	phase  string // "request" or "response"
+	phase  pipelinePhase
 }
 
 // PipelineImpl implements Pipeline by accumulating actions locally with
@@ -360,15 +367,15 @@ type PipelineImpl struct {
 
 func (p *PipelineImpl) OnHTTPRequest(actions ...exttypes.Action) error {
 	for _, entry := range p.actions {
-		if entry.phase == "response" {
+		if entry.phase == phaseResponse {
 			return fmt.Errorf("cannot add request actions after response actions have been added")
 		}
 	}
-	return p.validateAndAppend("request", actions)
+	return p.validateAndAppend(phaseRequest, actions)
 }
 
 func (p *PipelineImpl) OnHTTPResponse(actions ...exttypes.Action) error {
-	return p.validateAndAppend("response", actions)
+	return p.validateAndAppend(phaseResponse, actions)
 }
 
 func (p *PipelineImpl) validateAndAppend(phase string, actions []exttypes.Action) error {
@@ -379,16 +386,21 @@ func (p *PipelineImpl) validateAndAppend(phase string, actions []exttypes.Action
 		}
 	}
 
+	varPatterns := make(map[string]*regexp.Regexp, len(batchVars))
+	for varName := range batchVars {
+		varPatterns[varName] = regexp.MustCompile(`\b` + regexp.QuoteMeta(varName) + `\b`)
+	}
+
 	localPopulated := make(map[string]bool, len(p.populatedVars))
 	for k := range p.populatedVars {
 		localPopulated[k] = true
 	}
 
 	for _, action := range actions {
-		exprs := celExpressionsFrom(action)
+		exprs := action.CelExpressions()
 		for _, expr := range exprs {
-			for varName := range batchVars {
-				if !localPopulated[varName] && celReferencesVar(expr, varName) {
+			for varName, pattern := range varPatterns {
+				if !localPopulated[varName] && pattern.MatchString(expr) {
 					return fmt.Errorf("action references variable %q before it is populated", varName)
 				}
 			}
@@ -411,39 +423,6 @@ func (p *PipelineImpl) validateAndAppend(phase string, actions []exttypes.Action
 	return nil
 }
 
-func celExpressionsFrom(action exttypes.Action) []string {
-	var exprs []string
-	switch a := action.(type) {
-	case exttypes.GRPCMethodAction:
-		if a.Predicate != "" {
-			exprs = append(exprs, a.Predicate)
-		}
-	case exttypes.DenyAction:
-		if a.Predicate != "" {
-			exprs = append(exprs, a.Predicate)
-		}
-		if a.WithHeaders != "" {
-			exprs = append(exprs, a.WithHeaders)
-		}
-	case exttypes.FailAction:
-		if a.Predicate != "" {
-			exprs = append(exprs, a.Predicate)
-		}
-	case exttypes.AddHeadersAction:
-		if a.Predicate != "" {
-			exprs = append(exprs, a.Predicate)
-		}
-		if a.HeadersToAdd != "" {
-			exprs = append(exprs, a.HeadersToAdd)
-		}
-	}
-	return exprs
-}
-
-func celReferencesVar(expr, varName string) bool {
-	return regexp.MustCompile(`\b` + regexp.QuoteMeta(varName) + `\b`).MatchString(expr)
-}
-
 func (p *PipelineImpl) Commit(ctx context.Context) error {
 	entries := make([]*extpb.ActionEntry, 0, len(p.actions))
 	for _, pe := range p.actions {
@@ -458,29 +437,7 @@ func (p *PipelineImpl) Commit(ctx context.Context) error {
 
 func convertAction(pe pipelineEntry) *extpb.ActionEntry {
 	entry := &extpb.ActionEntry{Phase: pe.phase}
-	switch a := pe.action.(type) {
-	case exttypes.GRPCMethodAction:
-		entry.ActionType = extpb.ActionType_ACTION_TYPE_GRPC_METHOD
-		entry.Predicate = a.Predicate
-		entry.Method = a.Method
-		entry.Var = a.Var
-	case exttypes.DenyAction:
-		entry.ActionType = extpb.ActionType_ACTION_TYPE_DENY
-		entry.Predicate = a.Predicate
-		entry.WithStatus = int32(a.WithStatus) //nolint:gosec // HTTP status codes are validated and always fit in int32
-		entry.WithHeaders = a.WithHeaders
-		entry.WithBody = a.WithBody
-	case exttypes.FailAction:
-		entry.ActionType = extpb.ActionType_ACTION_TYPE_FAIL
-		entry.Predicate = a.Predicate
-		entry.LogMessage = a.LogMessage
-	case exttypes.AddHeadersAction:
-		entry.ActionType = extpb.ActionType_ACTION_TYPE_ADD_HEADERS
-		entry.Predicate = a.Predicate
-		entry.HeadersToAdd = a.HeadersToAdd
-	default:
-		panic(fmt.Sprintf("unknown action type: %T", pe.action))
-	}
+	pe.action.PopulateProtobuf(entry)
 	return entry
 }
 

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -464,7 +464,7 @@ func convertAction(pe pipelineEntry) *extpb.ActionEntry {
 	case exttypes.DenyAction:
 		entry.ActionType = extpb.ActionType_ACTION_TYPE_DENY
 		entry.Predicate = a.Predicate
-		entry.WithStatus = int32(a.WithStatus)
+		entry.WithStatus = int32(a.WithStatus) //nolint:gosec // HTTP status codes are validated and always fit in int32
 		entry.WithHeaders = a.WithHeaders
 		entry.WithBody = a.WithBody
 	case exttypes.FailAction:

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -335,87 +336,114 @@ func (ec *ExtensionController) RegisterActionMethod(ctx context.Context, policy 
 
 // NewPipeline creates a Pipeline bound to the given policy. No I/O is performed;
 // the returned Pipeline captures the policy and gRPC client for later use.
-// Call OnRequest/OnResponse to accumulate actions, then Commit to send them.
 func (ec *ExtensionController) NewPipeline(policy exttypes.Policy) exttypes.Pipeline {
 	return &PipelineImpl{
-		policy: policy,
-		client: ec.extensionClient.client,
+		policy:        policy,
+		client:        ec.extensionClient.client,
+		populatedVars: make(map[string]bool),
 	}
 }
 
-// PipelineImpl implements Pipeline by accumulating actions locally and sending
-// them to the operator in a single PipelineCommit gRPC call.
+type pipelineEntry struct {
+	action exttypes.Action
+	phase  string // "request" or "response"
+}
+
+// PipelineImpl implements Pipeline by accumulating actions locally with
+// ordering validation. Commit sends all actions to the operator atomically.
 type PipelineImpl struct {
-	policy          exttypes.Policy
-	client          extpb.ExtensionServiceClient
-	requestActions  []*extpb.RequestActionEntry
-	responseActions []*extpb.ResponseActionEntry
+	policy        exttypes.Policy
+	client        extpb.ExtensionServiceClient
+	actions       []pipelineEntry
+	populatedVars map[string]bool
 }
 
-func (p *PipelineImpl) OnRequest(actions ...exttypes.RequestAction) exttypes.Pipeline {
-	for _, action := range actions {
-		p.requestActions = append(p.requestActions, convertRequestAction(action))
+func (p *PipelineImpl) OnHTTPRequest(actions ...exttypes.Action) error {
+	for _, entry := range p.actions {
+		if entry.phase == "response" {
+			return fmt.Errorf("cannot add request actions after response actions have been added")
+		}
 	}
-	return p
+	return p.validateAndAppend("request", actions)
 }
 
-func (p *PipelineImpl) OnResponse(actions ...exttypes.ResponseAction) exttypes.Pipeline {
+func (p *PipelineImpl) OnHTTPResponse(actions ...exttypes.Action) error {
+	return p.validateAndAppend("response", actions)
+}
+
+func (p *PipelineImpl) validateAndAppend(phase string, actions []exttypes.Action) error {
+	batchVars := make(map[string]bool)
 	for _, action := range actions {
-		p.responseActions = append(p.responseActions, convertResponseAction(action))
+		if grpc, ok := action.(exttypes.GRPCMethodAction); ok && grpc.Var != "" {
+			batchVars[grpc.Var] = true
+		}
 	}
-	return p
+
+	localPopulated := make(map[string]bool, len(p.populatedVars))
+	for k := range p.populatedVars {
+		localPopulated[k] = true
+	}
+
+	for _, action := range actions {
+		exprs := celExpressionsFrom(action)
+		for _, expr := range exprs {
+			for varName := range batchVars {
+				if !localPopulated[varName] && celReferencesVar(expr, varName) {
+					return fmt.Errorf("action references variable %q before it is populated", varName)
+				}
+			}
+		}
+
+		if grpc, ok := action.(exttypes.GRPCMethodAction); ok && grpc.Var != "" {
+			if localPopulated[grpc.Var] {
+				return fmt.Errorf("duplicate variable name %q", grpc.Var)
+			}
+			localPopulated[grpc.Var] = true
+		}
+	}
+
+	for k := range localPopulated {
+		p.populatedVars[k] = true
+	}
+	for _, action := range actions {
+		p.actions = append(p.actions, pipelineEntry{action: action, phase: phase})
+	}
+	return nil
+}
+
+func celExpressionsFrom(action exttypes.Action) []string {
+	var exprs []string
+	switch a := action.(type) {
+	case exttypes.GRPCMethodAction:
+		if a.Predicate != "" {
+			exprs = append(exprs, a.Predicate)
+		}
+	case exttypes.DenyAction:
+		if a.Predicate != "" {
+			exprs = append(exprs, a.Predicate)
+		}
+	case exttypes.FailureAction:
+		if a.Predicate != "" {
+			exprs = append(exprs, a.Predicate)
+		}
+	case exttypes.AddHeadersAction:
+		if a.Predicate != "" {
+			exprs = append(exprs, a.Predicate)
+		}
+		if a.HeadersToAdd != "" {
+			exprs = append(exprs, a.HeadersToAdd)
+		}
+	}
+	return exprs
+}
+
+func celReferencesVar(expr, varName string) bool {
+	return regexp.MustCompile(`\b` + regexp.QuoteMeta(varName) + `\b`).MatchString(expr)
 }
 
 func (p *PipelineImpl) Commit(ctx context.Context) error {
-	_, err := p.client.PipelineCommit(ctx, &extpb.PipelineCommitRequest{
-		Policy:          convertPolicyToProtobuf(p.policy),
-		RequestActions:  p.requestActions,
-		ResponseActions: p.responseActions,
-	})
-	return err
-}
-
-func convertRequestAction(action exttypes.RequestAction) *extpb.RequestActionEntry {
-	switch a := action.(type) {
-	case exttypes.GRPCMethodAction:
-		return &extpb.RequestActionEntry{
-			ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD,
-			Predicate:  a.Predicate,
-			Intention:  a.Intention,
-			Method:     a.Method,
-			Var:        a.Var,
-		}
-	case exttypes.AllowAction:
-		return &extpb.RequestActionEntry{
-			ActionType: extpb.ActionType_ACTION_TYPE_ALLOW,
-			Predicate:  a.Predicate,
-			Intention:  a.Intention,
-		}
-	default:
-		panic(fmt.Sprintf("unknown request action type: %T", action))
-	}
-}
-
-func convertResponseAction(action exttypes.ResponseAction) *extpb.ResponseActionEntry {
-	switch a := action.(type) {
-	case exttypes.AddHeadersAction:
-		return &extpb.ResponseActionEntry{
-			ActionType:   extpb.ActionType_ACTION_TYPE_ADD_HEADERS,
-			Predicate:    a.Predicate,
-			HeadersToAdd: a.HeadersToAdd,
-		}
-	case exttypes.WithResponseCodeAction:
-		if a.NewResponseCode < 100 || a.NewResponseCode > 599 {
-			panic(fmt.Sprintf("NewResponseCode must be 100-599, got %d", a.NewResponseCode))
-		}
-		return &extpb.ResponseActionEntry{
-			ActionType:      extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE,
-			Predicate:       a.Predicate,
-			NewResponseCode: int32(a.NewResponseCode), // #nosec G115
-		}
-	default:
-		panic(fmt.Sprintf("unknown response action type: %T", action))
-	}
+	// TODO: proto conversion will be updated in #1973
+	panic("pipeline proto conversion not yet implemented")
 }
 
 // Manager returns the underlying controller-runtime Manager.

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -422,7 +422,7 @@ func celExpressionsFrom(action exttypes.Action) []string {
 		if a.Predicate != "" {
 			exprs = append(exprs, a.Predicate)
 		}
-	case exttypes.FailureAction:
+	case exttypes.FailAction:
 		if a.Predicate != "" {
 			exprs = append(exprs, a.Predicate)
 		}
@@ -464,12 +464,13 @@ func convertAction(pe pipelineEntry) *extpb.ActionEntry {
 	case exttypes.DenyAction:
 		entry.ActionType = extpb.ActionType_ACTION_TYPE_DENY
 		entry.Predicate = a.Predicate
-		entry.DenyWith = a.DenyWith
-	case exttypes.FailureAction:
-		entry.ActionType = extpb.ActionType_ACTION_TYPE_FAILURE
+		entry.WithStatus = int32(a.WithStatus)
+		entry.WithHeaders = a.WithHeaders
+		entry.WithBody = a.WithBody
+	case exttypes.FailAction:
+		entry.ActionType = extpb.ActionType_ACTION_TYPE_FAIL
 		entry.Predicate = a.Predicate
-		entry.FailureMessage = a.FailureMessage
-		entry.FailureCode = a.FailureCode
+		entry.LogMessage = a.LogMessage
 	case exttypes.AddHeadersAction:
 		entry.ActionType = extpb.ActionType_ACTION_TYPE_ADD_HEADERS
 		entry.Predicate = a.Predicate

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -422,6 +422,9 @@ func celExpressionsFrom(action exttypes.Action) []string {
 		if a.Predicate != "" {
 			exprs = append(exprs, a.Predicate)
 		}
+		if a.WithHeaders != "" {
+			exprs = append(exprs, a.WithHeaders)
+		}
 	case exttypes.FailAction:
 		if a.Predicate != "" {
 			exprs = append(exprs, a.Predicate)

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -442,8 +442,42 @@ func celReferencesVar(expr, varName string) bool {
 }
 
 func (p *PipelineImpl) Commit(ctx context.Context) error {
-	// TODO: proto conversion will be updated in #1973
-	panic("pipeline proto conversion not yet implemented")
+	entries := make([]*extpb.ActionEntry, 0, len(p.actions))
+	for _, pe := range p.actions {
+		entries = append(entries, convertAction(pe))
+	}
+	_, err := p.client.PipelineCommit(ctx, &extpb.PipelineCommitRequest{
+		Policy:  convertPolicyToProtobuf(p.policy),
+		Actions: entries,
+	})
+	return err
+}
+
+func convertAction(pe pipelineEntry) *extpb.ActionEntry {
+	entry := &extpb.ActionEntry{Phase: pe.phase}
+	switch a := pe.action.(type) {
+	case exttypes.GRPCMethodAction:
+		entry.ActionType = extpb.ActionType_ACTION_TYPE_GRPC_METHOD
+		entry.Predicate = a.Predicate
+		entry.Method = a.Method
+		entry.Var = a.Var
+	case exttypes.DenyAction:
+		entry.ActionType = extpb.ActionType_ACTION_TYPE_DENY
+		entry.Predicate = a.Predicate
+		entry.DenyWith = a.DenyWith
+	case exttypes.FailureAction:
+		entry.ActionType = extpb.ActionType_ACTION_TYPE_FAILURE
+		entry.Predicate = a.Predicate
+		entry.FailureMessage = a.FailureMessage
+		entry.FailureCode = a.FailureCode
+	case exttypes.AddHeadersAction:
+		entry.ActionType = extpb.ActionType_ACTION_TYPE_ADD_HEADERS
+		entry.Predicate = a.Predicate
+		entry.HeadersToAdd = a.HeadersToAdd
+	default:
+		panic(fmt.Sprintf("unknown action type: %T", pe.action))
+	}
+	return entry
 }
 
 // Manager returns the underlying controller-runtime Manager.

--- a/pkg/extension/controller/controller_test.go
+++ b/pkg/extension/controller/controller_test.go
@@ -415,118 +415,188 @@ func TestNewPipeline_ReturnsNonNil(t *testing.T) {
 	assert.Assert(t, pipeline != nil)
 }
 
-func TestPipelineCommit_SendsBothPhases(t *testing.T) {
-	var capturedReq *extpb.PipelineCommitRequest
-	mock := &mockExtensionServiceClient{
-		pipelineCommitFn: func(_ context.Context, in *extpb.PipelineCommitRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-			capturedReq = in
-			return &emptypb.Empty{}, nil
-		},
-	}
+func TestPipeline_AccumulatesBothPhases(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
 
-	ec := newTestExtensionController(mock)
-	policy := &mockPolicy{name: "my-policy", namespace: "default"}
-	pipeline := ec.NewPipeline(policy)
-
-	pipeline.OnRequest(
+	err := p.OnHTTPRequest(
 		exttypes.GRPCMethodAction{
 			Predicate: "true",
-			Intention: "response.score > 5",
 			Method:    "assess-threat",
 			Var:       "threatResponse",
 		},
-		exttypes.AllowAction{
-			Predicate: "request.path != '/health'",
-			Intention: "request.auth.claims.role == 'admin'",
+		exttypes.DenyAction{
+			Predicate: `request.url_path == "/blocked"`,
+			DenyWith:  "403",
 		},
 	)
-	pipeline.OnResponse(
+	assert.NilError(t, err)
+
+	err = p.OnHTTPResponse(
+		exttypes.DenyAction{
+			Predicate: "threatResponse.threat_level >= 5",
+			DenyWith:  "403",
+		},
 		exttypes.AddHeadersAction{
-			Predicate:    "true",
 			HeadersToAdd: `{"x-threat-checked": "true"}`,
 		},
-		exttypes.WithResponseCodeAction{
-			Predicate:       "response.score > 5",
-			NewResponseCode: 403,
+	)
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(p.actions), 4)
+	assert.Equal(t, p.actions[0].phase, "request")
+	assert.Equal(t, p.actions[1].phase, "request")
+	assert.Equal(t, p.actions[2].phase, "response")
+	assert.Equal(t, p.actions[3].phase, "response")
+}
+
+func TestPipeline_PhaseOrdering_RequestAfterResponse(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPResponse(exttypes.AddHeadersAction{
+		HeadersToAdd: `{"x-checked": "true"}`,
+	})
+	assert.NilError(t, err)
+
+	err = p.OnHTTPRequest(exttypes.DenyAction{
+		Predicate: "true",
+		DenyWith:  "403",
+	})
+	assert.Assert(t, err != nil)
+	assert.Assert(t, cmp.Contains(err.Error(), "cannot add request actions after response actions"))
+}
+
+func TestPipeline_VarAvailability_ForwardReference(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPRequest(
+		exttypes.DenyAction{
+			Predicate: "threatResponse.threat_level >= 5",
+			DenyWith:  "403",
+		},
+		exttypes.GRPCMethodAction{
+			Method: "assess-threat",
+			Var:    "threatResponse",
 		},
 	)
-
-	err := pipeline.Commit(context.Background())
-	assert.NilError(t, err)
-	assert.Assert(t, capturedReq != nil)
-	assert.Equal(t, capturedReq.Policy.Metadata.Name, "my-policy")
-	assert.Equal(t, capturedReq.Policy.Metadata.Namespace, "default")
-
-	// Request actions
-	assert.Assert(t, cmp.Len(capturedReq.RequestActions, 2))
-	assert.Equal(t, capturedReq.RequestActions[0].ActionType, extpb.ActionType_ACTION_TYPE_GRPC_METHOD)
-	assert.Equal(t, capturedReq.RequestActions[0].Method, "assess-threat")
-	assert.Equal(t, capturedReq.RequestActions[0].Var, "threatResponse")
-	assert.Equal(t, capturedReq.RequestActions[0].Intention, "response.score > 5")
-	assert.Equal(t, capturedReq.RequestActions[1].ActionType, extpb.ActionType_ACTION_TYPE_ALLOW)
-	assert.Equal(t, capturedReq.RequestActions[1].Intention, "request.auth.claims.role == 'admin'")
-
-	// Response actions
-	assert.Assert(t, cmp.Len(capturedReq.ResponseActions, 2))
-	assert.Equal(t, capturedReq.ResponseActions[0].ActionType, extpb.ActionType_ACTION_TYPE_ADD_HEADERS)
-	assert.Equal(t, capturedReq.ResponseActions[0].HeadersToAdd, `{"x-threat-checked": "true"}`)
-	assert.Equal(t, capturedReq.ResponseActions[1].ActionType, extpb.ActionType_ACTION_TYPE_WITH_RESPONSE_CODE)
-	assert.Equal(t, capturedReq.ResponseActions[1].NewResponseCode, int32(403))
-}
-
-func TestPipelineCommit_EmptyPipeline(t *testing.T) {
-	var capturedReq *extpb.PipelineCommitRequest
-	mock := &mockExtensionServiceClient{
-		pipelineCommitFn: func(_ context.Context, in *extpb.PipelineCommitRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-			capturedReq = in
-			return &emptypb.Empty{}, nil
-		},
-	}
-
-	ec := newTestExtensionController(mock)
-	pipeline := ec.NewPipeline(&mockPolicy{name: "p", namespace: "ns"})
-
-	err := pipeline.Commit(context.Background())
-	assert.NilError(t, err)
-	assert.Assert(t, capturedReq != nil)
-	assert.Assert(t, cmp.Len(capturedReq.RequestActions, 0))
-	assert.Assert(t, cmp.Len(capturedReq.ResponseActions, 0))
-}
-
-func TestPipelineCommit_PropagatesError(t *testing.T) {
-	mock := &mockExtensionServiceClient{
-		pipelineCommitFn: func(_ context.Context, _ *extpb.PipelineCommitRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-			return nil, status.Error(codes.InvalidArgument, "bad action")
-		},
-	}
-
-	ec := newTestExtensionController(mock)
-	pipeline := ec.NewPipeline(&mockPolicy{name: "p", namespace: "ns"})
-	pipeline.OnRequest(exttypes.AllowAction{})
-
-	err := pipeline.Commit(context.Background())
 	assert.Assert(t, err != nil)
-	assert.Assert(t, cmp.Contains(err.Error(), "bad action"))
+	assert.Assert(t, cmp.Contains(err.Error(), "references variable \"threatResponse\" before it is populated"))
 }
 
-func TestPipelineCommit_MultipleOnRequestCalls(t *testing.T) {
-	var capturedReq *extpb.PipelineCommitRequest
-	mock := &mockExtensionServiceClient{
-		pipelineCommitFn: func(_ context.Context, in *extpb.PipelineCommitRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
-			capturedReq = in
-			return &emptypb.Empty{}, nil
+func TestPipeline_VarAvailability_WithinCallValid(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPRequest(
+		exttypes.GRPCMethodAction{
+			Method: "assess-threat",
+			Var:    "threatResponse",
 		},
-	}
-
-	ec := newTestExtensionController(mock)
-	pipeline := ec.NewPipeline(&mockPolicy{name: "p", namespace: "ns"})
-
-	pipeline.OnRequest(exttypes.AllowAction{Intention: "first"})
-	pipeline.OnRequest(exttypes.AllowAction{Intention: "second"})
-
-	err := pipeline.Commit(context.Background())
+		exttypes.DenyAction{
+			Predicate: "threatResponse.threat_level >= 5",
+			DenyWith:  "403",
+		},
+	)
 	assert.NilError(t, err)
-	assert.Assert(t, cmp.Len(capturedReq.RequestActions, 2))
-	assert.Equal(t, capturedReq.RequestActions[0].Intention, "first")
-	assert.Equal(t, capturedReq.RequestActions[1].Intention, "second")
+}
+
+func TestPipeline_VarAvailability_CrossCallValid(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPRequest(exttypes.GRPCMethodAction{
+		Method: "assess-threat",
+		Var:    "threatResponse",
+	})
+	assert.NilError(t, err)
+
+	err = p.OnHTTPResponse(exttypes.DenyAction{
+		Predicate: "threatResponse.threat_level >= 5",
+		DenyWith:  "403",
+	})
+	assert.NilError(t, err)
+}
+
+func TestPipeline_DuplicateVarName(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPRequest(
+		exttypes.GRPCMethodAction{Method: "method-a", Var: "myVar"},
+		exttypes.GRPCMethodAction{Method: "method-b", Var: "myVar"},
+	)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, cmp.Contains(err.Error(), "duplicate variable name \"myVar\""))
+}
+
+func TestPipeline_DuplicateVarName_AcrossCalls(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPRequest(exttypes.GRPCMethodAction{Method: "method-a", Var: "myVar"})
+	assert.NilError(t, err)
+
+	err = p.OnHTTPRequest(exttypes.GRPCMethodAction{Method: "method-b", Var: "myVar"})
+	assert.Assert(t, err != nil)
+	assert.Assert(t, cmp.Contains(err.Error(), "duplicate variable name \"myVar\""))
+}
+
+func TestPipeline_NoVarReference_NoError(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPRequest(
+		exttypes.DenyAction{
+			Predicate: `request.url_path == "/blocked"`,
+			DenyWith:  "403",
+		},
+		exttypes.FailureAction{
+			Predicate:      `request.headers["x-debug"] == "true"`,
+			FailureMessage: "debug failure",
+			FailureCode:    "500",
+		},
+	)
+	assert.NilError(t, err)
+
+	err = p.OnHTTPResponse(exttypes.AddHeadersAction{
+		HeadersToAdd: `{"x-checked": "true"}`,
+	})
+	assert.NilError(t, err)
+}
+
+func TestPipeline_MultipleOnHTTPRequestCalls(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPRequest(exttypes.DenyAction{Predicate: "true", DenyWith: "403"})
+	assert.NilError(t, err)
+
+	err = p.OnHTTPRequest(exttypes.DenyAction{Predicate: "false", DenyWith: "404"})
+	assert.NilError(t, err)
+
+	assert.Equal(t, len(p.actions), 2)
+}
+
+func TestPipeline_VarInHeadersToAdd(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPRequest(exttypes.GRPCMethodAction{
+		Method: "assess-threat",
+		Var:    "threatResponse",
+	})
+	assert.NilError(t, err)
+
+	err = p.OnHTTPResponse(exttypes.AddHeadersAction{
+		HeadersToAdd: `{"x-threat-level": string(threatResponse.threat_level)}`,
+	})
+	assert.NilError(t, err)
+}
+
+func TestPipeline_VarInHeadersToAdd_ForwardReference(t *testing.T) {
+	p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+	err := p.OnHTTPRequest(
+		exttypes.AddHeadersAction{
+			HeadersToAdd: `{"x-threat-level": string(threatResponse.threat_level)}`,
+		},
+		exttypes.GRPCMethodAction{
+			Method: "assess-threat",
+			Var:    "threatResponse",
+		},
+	)
+	assert.Assert(t, err != nil)
+	assert.Assert(t, cmp.Contains(err.Error(), "references variable \"threatResponse\" before it is populated"))
 }

--- a/pkg/extension/controller/controller_test.go
+++ b/pkg/extension/controller/controller_test.go
@@ -425,16 +425,16 @@ func TestPipeline_AccumulatesBothPhases(t *testing.T) {
 			Var:       "threatResponse",
 		},
 		exttypes.DenyAction{
-			Predicate: `request.url_path == "/blocked"`,
-			DenyWith:  "403",
+			Predicate:  `request.url_path == "/blocked"`,
+			WithStatus: 403,
 		},
 	)
 	assert.NilError(t, err)
 
 	err = p.OnHTTPResponse(
 		exttypes.DenyAction{
-			Predicate: "threatResponse.threat_level >= 5",
-			DenyWith:  "403",
+			Predicate:  "threatResponse.threat_level >= 5",
+			WithStatus: 403,
 		},
 		exttypes.AddHeadersAction{
 			HeadersToAdd: `{"x-threat-checked": "true"}`,
@@ -458,8 +458,8 @@ func TestPipeline_PhaseOrdering_RequestAfterResponse(t *testing.T) {
 	assert.NilError(t, err)
 
 	err = p.OnHTTPRequest(exttypes.DenyAction{
-		Predicate: "true",
-		DenyWith:  "403",
+		Predicate:  "true",
+		WithStatus: 403,
 	})
 	assert.Assert(t, err != nil)
 	assert.Assert(t, cmp.Contains(err.Error(), "cannot add request actions after response actions"))
@@ -470,8 +470,8 @@ func TestPipeline_VarAvailability_ForwardReference(t *testing.T) {
 
 	err := p.OnHTTPRequest(
 		exttypes.DenyAction{
-			Predicate: "threatResponse.threat_level >= 5",
-			DenyWith:  "403",
+			Predicate:  "threatResponse.threat_level >= 5",
+			WithStatus: 403,
 		},
 		exttypes.GRPCMethodAction{
 			Method: "assess-threat",
@@ -491,8 +491,8 @@ func TestPipeline_VarAvailability_WithinCallValid(t *testing.T) {
 			Var:    "threatResponse",
 		},
 		exttypes.DenyAction{
-			Predicate: "threatResponse.threat_level >= 5",
-			DenyWith:  "403",
+			Predicate:  "threatResponse.threat_level >= 5",
+			WithStatus: 403,
 		},
 	)
 	assert.NilError(t, err)
@@ -508,8 +508,8 @@ func TestPipeline_VarAvailability_CrossCallValid(t *testing.T) {
 	assert.NilError(t, err)
 
 	err = p.OnHTTPResponse(exttypes.DenyAction{
-		Predicate: "threatResponse.threat_level >= 5",
-		DenyWith:  "403",
+		Predicate:  "threatResponse.threat_level >= 5",
+		WithStatus: 403,
 	})
 	assert.NilError(t, err)
 }
@@ -541,13 +541,12 @@ func TestPipeline_NoVarReference_NoError(t *testing.T) {
 
 	err := p.OnHTTPRequest(
 		exttypes.DenyAction{
-			Predicate: `request.url_path == "/blocked"`,
-			DenyWith:  "403",
+			Predicate:  `request.url_path == "/blocked"`,
+			WithStatus: 403,
 		},
-		exttypes.FailureAction{
-			Predicate:      `request.headers["x-debug"] == "true"`,
-			FailureMessage: "debug failure",
-			FailureCode:    "500",
+		exttypes.FailAction{
+			Predicate:  `request.headers["x-debug"] == "true"`,
+			LogMessage: "debug failure",
 		},
 	)
 	assert.NilError(t, err)
@@ -561,10 +560,10 @@ func TestPipeline_NoVarReference_NoError(t *testing.T) {
 func TestPipeline_MultipleOnHTTPRequestCalls(t *testing.T) {
 	p := &PipelineImpl{populatedVars: make(map[string]bool)}
 
-	err := p.OnHTTPRequest(exttypes.DenyAction{Predicate: "true", DenyWith: "403"})
+	err := p.OnHTTPRequest(exttypes.DenyAction{Predicate: "true", WithStatus: 403})
 	assert.NilError(t, err)
 
-	err = p.OnHTTPRequest(exttypes.DenyAction{Predicate: "false", DenyWith: "404"})
+	err = p.OnHTTPRequest(exttypes.DenyAction{Predicate: "false", WithStatus: 404})
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(p.actions), 2)
@@ -615,26 +614,25 @@ func TestPipelineCommit_SendsAllActions(t *testing.T) {
 
 	err := pipeline.OnHTTPRequest(
 		exttypes.DenyAction{
-			Predicate: `request.url_path == "/blocked"`,
-			DenyWith:  "403",
+			Predicate:  `request.url_path == "/blocked"`,
+			WithStatus: 403,
 		},
 		exttypes.GRPCMethodAction{
 			Predicate: "true",
 			Method:    "assess-threat",
 			Var:       "threatResponse",
 		},
-		exttypes.FailureAction{
-			Predicate:      `request.headers["x-debug"] == "true"`,
-			FailureMessage: "Request blocked",
-			FailureCode:    "500",
+		exttypes.FailAction{
+			Predicate:  `request.headers["x-debug"] == "true"`,
+			LogMessage: "Request blocked",
 		},
 	)
 	assert.NilError(t, err)
 
 	err = pipeline.OnHTTPResponse(
 		exttypes.DenyAction{
-			Predicate: "threatResponse.threat_level >= 5",
-			DenyWith:  "403",
+			Predicate:  "threatResponse.threat_level >= 5",
+			WithStatus: 403,
 		},
 		exttypes.AddHeadersAction{
 			HeadersToAdd: `{"x-threat-checked": "true"}`,
@@ -652,17 +650,16 @@ func TestPipelineCommit_SendsAllActions(t *testing.T) {
 
 	assert.Equal(t, capturedReq.Actions[0].ActionType, extpb.ActionType_ACTION_TYPE_DENY)
 	assert.Equal(t, capturedReq.Actions[0].Phase, "request")
-	assert.Equal(t, capturedReq.Actions[0].DenyWith, "403")
+	assert.Equal(t, capturedReq.Actions[0].WithStatus, int32(403))
 
 	assert.Equal(t, capturedReq.Actions[1].ActionType, extpb.ActionType_ACTION_TYPE_GRPC_METHOD)
 	assert.Equal(t, capturedReq.Actions[1].Phase, "request")
 	assert.Equal(t, capturedReq.Actions[1].Method, "assess-threat")
 	assert.Equal(t, capturedReq.Actions[1].Var, "threatResponse")
 
-	assert.Equal(t, capturedReq.Actions[2].ActionType, extpb.ActionType_ACTION_TYPE_FAILURE)
+	assert.Equal(t, capturedReq.Actions[2].ActionType, extpb.ActionType_ACTION_TYPE_FAIL)
 	assert.Equal(t, capturedReq.Actions[2].Phase, "request")
-	assert.Equal(t, capturedReq.Actions[2].FailureMessage, "Request blocked")
-	assert.Equal(t, capturedReq.Actions[2].FailureCode, "500")
+	assert.Equal(t, capturedReq.Actions[2].LogMessage, "Request blocked")
 
 	assert.Equal(t, capturedReq.Actions[3].ActionType, extpb.ActionType_ACTION_TYPE_DENY)
 	assert.Equal(t, capturedReq.Actions[3].Phase, "response")
@@ -699,7 +696,7 @@ func TestPipelineCommit_PropagatesError(t *testing.T) {
 
 	ec := newTestExtensionController(mock)
 	pipeline := ec.NewPipeline(&mockPolicy{name: "p", namespace: "ns"})
-	_ = pipeline.OnHTTPRequest(exttypes.DenyAction{Predicate: "true", DenyWith: "403"})
+	_ = pipeline.OnHTTPRequest(exttypes.DenyAction{Predicate: "true", WithStatus: 403})
 
 	err := pipeline.Commit(context.Background())
 	assert.Assert(t, err != nil)

--- a/pkg/extension/controller/controller_test.go
+++ b/pkg/extension/controller/controller_test.go
@@ -600,3 +600,108 @@ func TestPipeline_VarInHeadersToAdd_ForwardReference(t *testing.T) {
 	assert.Assert(t, err != nil)
 	assert.Assert(t, cmp.Contains(err.Error(), "references variable \"threatResponse\" before it is populated"))
 }
+
+func TestPipelineCommit_SendsAllActions(t *testing.T) {
+	var capturedReq *extpb.PipelineCommitRequest
+	mock := &mockExtensionServiceClient{
+		pipelineCommitFn: func(_ context.Context, in *extpb.PipelineCommitRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			capturedReq = in
+			return &emptypb.Empty{}, nil
+		},
+	}
+
+	ec := newTestExtensionController(mock)
+	pipeline := ec.NewPipeline(&mockPolicy{name: "my-policy", namespace: "default"})
+
+	err := pipeline.OnHTTPRequest(
+		exttypes.DenyAction{
+			Predicate: `request.url_path == "/blocked"`,
+			DenyWith:  "403",
+		},
+		exttypes.GRPCMethodAction{
+			Predicate: "true",
+			Method:    "assess-threat",
+			Var:       "threatResponse",
+		},
+		exttypes.FailureAction{
+			Predicate:      `request.headers["x-debug"] == "true"`,
+			FailureMessage: "Request blocked",
+			FailureCode:    "500",
+		},
+	)
+	assert.NilError(t, err)
+
+	err = pipeline.OnHTTPResponse(
+		exttypes.DenyAction{
+			Predicate: "threatResponse.threat_level >= 5",
+			DenyWith:  "403",
+		},
+		exttypes.AddHeadersAction{
+			HeadersToAdd: `{"x-threat-checked": "true"}`,
+		},
+	)
+	assert.NilError(t, err)
+
+	err = pipeline.Commit(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, capturedReq != nil)
+	assert.Equal(t, capturedReq.Policy.Metadata.Name, "my-policy")
+	assert.Equal(t, capturedReq.Policy.Metadata.Namespace, "default")
+
+	assert.Assert(t, cmp.Len(capturedReq.Actions, 5))
+
+	assert.Equal(t, capturedReq.Actions[0].ActionType, extpb.ActionType_ACTION_TYPE_DENY)
+	assert.Equal(t, capturedReq.Actions[0].Phase, "request")
+	assert.Equal(t, capturedReq.Actions[0].DenyWith, "403")
+
+	assert.Equal(t, capturedReq.Actions[1].ActionType, extpb.ActionType_ACTION_TYPE_GRPC_METHOD)
+	assert.Equal(t, capturedReq.Actions[1].Phase, "request")
+	assert.Equal(t, capturedReq.Actions[1].Method, "assess-threat")
+	assert.Equal(t, capturedReq.Actions[1].Var, "threatResponse")
+
+	assert.Equal(t, capturedReq.Actions[2].ActionType, extpb.ActionType_ACTION_TYPE_FAILURE)
+	assert.Equal(t, capturedReq.Actions[2].Phase, "request")
+	assert.Equal(t, capturedReq.Actions[2].FailureMessage, "Request blocked")
+	assert.Equal(t, capturedReq.Actions[2].FailureCode, "500")
+
+	assert.Equal(t, capturedReq.Actions[3].ActionType, extpb.ActionType_ACTION_TYPE_DENY)
+	assert.Equal(t, capturedReq.Actions[3].Phase, "response")
+
+	assert.Equal(t, capturedReq.Actions[4].ActionType, extpb.ActionType_ACTION_TYPE_ADD_HEADERS)
+	assert.Equal(t, capturedReq.Actions[4].Phase, "response")
+	assert.Equal(t, capturedReq.Actions[4].HeadersToAdd, `{"x-threat-checked": "true"}`)
+}
+
+func TestPipelineCommit_EmptyPipeline(t *testing.T) {
+	var capturedReq *extpb.PipelineCommitRequest
+	mock := &mockExtensionServiceClient{
+		pipelineCommitFn: func(_ context.Context, in *extpb.PipelineCommitRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			capturedReq = in
+			return &emptypb.Empty{}, nil
+		},
+	}
+
+	ec := newTestExtensionController(mock)
+	pipeline := ec.NewPipeline(&mockPolicy{name: "p", namespace: "ns"})
+
+	err := pipeline.Commit(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, capturedReq != nil)
+	assert.Assert(t, cmp.Len(capturedReq.Actions, 0))
+}
+
+func TestPipelineCommit_PropagatesError(t *testing.T) {
+	mock := &mockExtensionServiceClient{
+		pipelineCommitFn: func(_ context.Context, _ *extpb.PipelineCommitRequest, _ ...grpc.CallOption) (*emptypb.Empty, error) {
+			return nil, status.Error(codes.InvalidArgument, "bad action")
+		},
+	}
+
+	ec := newTestExtensionController(mock)
+	pipeline := ec.NewPipeline(&mockPolicy{name: "p", namespace: "ns"})
+	_ = pipeline.OnHTTPRequest(exttypes.DenyAction{Predicate: "true", DenyWith: "403"})
+
+	err := pipeline.Commit(context.Background())
+	assert.Assert(t, err != nil)
+	assert.Assert(t, cmp.Contains(err.Error(), "bad action"))
+}

--- a/pkg/extension/grpc/v1/kuadrant.pb.go
+++ b/pkg/extension/grpc/v1/kuadrant.pb.go
@@ -78,11 +78,11 @@ func (Domain) EnumDescriptor() ([]byte, []int) {
 type ActionType int32
 
 const (
-	ActionType_ACTION_TYPE_UNSPECIFIED        ActionType = 0
-	ActionType_ACTION_TYPE_GRPC_METHOD        ActionType = 1
-	ActionType_ACTION_TYPE_ALLOW              ActionType = 2
-	ActionType_ACTION_TYPE_ADD_HEADERS        ActionType = 3
-	ActionType_ACTION_TYPE_WITH_RESPONSE_CODE ActionType = 4
+	ActionType_ACTION_TYPE_UNSPECIFIED ActionType = 0
+	ActionType_ACTION_TYPE_GRPC_METHOD ActionType = 1
+	ActionType_ACTION_TYPE_DENY        ActionType = 2
+	ActionType_ACTION_TYPE_ADD_HEADERS ActionType = 3
+	ActionType_ACTION_TYPE_FAILURE     ActionType = 4
 )
 
 // Enum value maps for ActionType.
@@ -90,16 +90,16 @@ var (
 	ActionType_name = map[int32]string{
 		0: "ACTION_TYPE_UNSPECIFIED",
 		1: "ACTION_TYPE_GRPC_METHOD",
-		2: "ACTION_TYPE_ALLOW",
+		2: "ACTION_TYPE_DENY",
 		3: "ACTION_TYPE_ADD_HEADERS",
-		4: "ACTION_TYPE_WITH_RESPONSE_CODE",
+		4: "ACTION_TYPE_FAILURE",
 	}
 	ActionType_value = map[string]int32{
-		"ACTION_TYPE_UNSPECIFIED":        0,
-		"ACTION_TYPE_GRPC_METHOD":        1,
-		"ACTION_TYPE_ALLOW":              2,
-		"ACTION_TYPE_ADD_HEADERS":        3,
-		"ACTION_TYPE_WITH_RESPONSE_CODE": 4,
+		"ACTION_TYPE_UNSPECIFIED": 0,
+		"ACTION_TYPE_GRPC_METHOD": 1,
+		"ACTION_TYPE_DENY":        2,
+		"ACTION_TYPE_ADD_HEADERS": 3,
+		"ACTION_TYPE_FAILURE":     4,
 	}
 )
 
@@ -714,32 +714,36 @@ func (x *RegisterActionMethodRequest) GetMessageTemplate() string {
 	return ""
 }
 
-// RequestActionEntry represents a single action in the request phase.
-type RequestActionEntry struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	ActionType    ActionType             `protobuf:"varint,1,opt,name=action_type,json=actionType,proto3,enum=kuadrant.v1.ActionType" json:"action_type,omitempty"`
-	Predicate     string                 `protobuf:"bytes,2,opt,name=predicate,proto3" json:"predicate,omitempty"` // CEL predicate — if false, skip this action
-	Intention     string                 `protobuf:"bytes,3,opt,name=intention,proto3" json:"intention,omitempty"` // CEL expression evaluated against the gRPC response or request
-	Method        string                 `protobuf:"bytes,4,opt,name=method,proto3" json:"method,omitempty"`       // Name of a registered ActionMethod (for grpc_method type)
-	Var           string                 `protobuf:"bytes,5,opt,name=var,proto3" json:"var,omitempty"`             // Variable name for the gRPC response (used by onReply predicates)
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+// ActionEntry represents a single action in either the request or response phase.
+type ActionEntry struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	ActionType     ActionType             `protobuf:"varint,1,opt,name=action_type,json=actionType,proto3,enum=kuadrant.v1.ActionType" json:"action_type,omitempty"`
+	Predicate      string                 `protobuf:"bytes,2,opt,name=predicate,proto3" json:"predicate,omitempty"`                                 // CEL predicate — if false, skip this action
+	Phase          string                 `protobuf:"bytes,3,opt,name=phase,proto3" json:"phase,omitempty"`                                         // "request" or "response"
+	Method         string                 `protobuf:"bytes,4,opt,name=method,proto3" json:"method,omitempty"`                                       // Name of a registered ActionMethod (for grpc_method type)
+	Var            string                 `protobuf:"bytes,5,opt,name=var,proto3" json:"var,omitempty"`                                             // Variable name to store gRPC response (for grpc_method type)
+	DenyWith       string                 `protobuf:"bytes,6,opt,name=deny_with,json=denyWith,proto3" json:"deny_with,omitempty"`                   // HTTP status code to send (for deny type)
+	HeadersToAdd   string                 `protobuf:"bytes,7,opt,name=headers_to_add,json=headersToAdd,proto3" json:"headers_to_add,omitempty"`     // CEL expression evaluating to a map of headers (for add_headers type)
+	FailureMessage string                 `protobuf:"bytes,8,opt,name=failure_message,json=failureMessage,proto3" json:"failure_message,omitempty"` // Response body sent to client (for failure type)
+	FailureCode    string                 `protobuf:"bytes,9,opt,name=failure_code,json=failureCode,proto3" json:"failure_code,omitempty"`          // HTTP status code (for failure type)
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
-func (x *RequestActionEntry) Reset() {
-	*x = RequestActionEntry{}
+func (x *ActionEntry) Reset() {
+	*x = ActionEntry{}
 	mi := &file_v1_kuadrant_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *RequestActionEntry) String() string {
+func (x *ActionEntry) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*RequestActionEntry) ProtoMessage() {}
+func (*ActionEntry) ProtoMessage() {}
 
-func (x *RequestActionEntry) ProtoReflect() protoreflect.Message {
+func (x *ActionEntry) ProtoReflect() protoreflect.Message {
 	mi := &file_v1_kuadrant_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -751,128 +755,86 @@ func (x *RequestActionEntry) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use RequestActionEntry.ProtoReflect.Descriptor instead.
-func (*RequestActionEntry) Descriptor() ([]byte, []int) {
+// Deprecated: Use ActionEntry.ProtoReflect.Descriptor instead.
+func (*ActionEntry) Descriptor() ([]byte, []int) {
 	return file_v1_kuadrant_proto_rawDescGZIP(), []int{11}
 }
 
-func (x *RequestActionEntry) GetActionType() ActionType {
+func (x *ActionEntry) GetActionType() ActionType {
 	if x != nil {
 		return x.ActionType
 	}
 	return ActionType_ACTION_TYPE_UNSPECIFIED
 }
 
-func (x *RequestActionEntry) GetPredicate() string {
+func (x *ActionEntry) GetPredicate() string {
 	if x != nil {
 		return x.Predicate
 	}
 	return ""
 }
 
-func (x *RequestActionEntry) GetIntention() string {
+func (x *ActionEntry) GetPhase() string {
 	if x != nil {
-		return x.Intention
+		return x.Phase
 	}
 	return ""
 }
 
-func (x *RequestActionEntry) GetMethod() string {
+func (x *ActionEntry) GetMethod() string {
 	if x != nil {
 		return x.Method
 	}
 	return ""
 }
 
-func (x *RequestActionEntry) GetVar() string {
+func (x *ActionEntry) GetVar() string {
 	if x != nil {
 		return x.Var
 	}
 	return ""
 }
 
-// ResponseActionEntry represents a single action in the response phase.
-type ResponseActionEntry struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	ActionType      ActionType             `protobuf:"varint,1,opt,name=action_type,json=actionType,proto3,enum=kuadrant.v1.ActionType" json:"action_type,omitempty"`
-	Predicate       string                 `protobuf:"bytes,2,opt,name=predicate,proto3" json:"predicate,omitempty"`                                       // CEL predicate — if false, skip this action
-	HeadersToAdd    string                 `protobuf:"bytes,3,opt,name=headers_to_add,json=headersToAdd,proto3" json:"headers_to_add,omitempty"`           // CEL expression evaluating to a map of headers (for add_headers type)
-	NewResponseCode int32                  `protobuf:"varint,4,opt,name=new_response_code,json=newResponseCode,proto3" json:"new_response_code,omitempty"` // HTTP status code (for with_response_code type)
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
-}
-
-func (x *ResponseActionEntry) Reset() {
-	*x = ResponseActionEntry{}
-	mi := &file_v1_kuadrant_proto_msgTypes[12]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ResponseActionEntry) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ResponseActionEntry) ProtoMessage() {}
-
-func (x *ResponseActionEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_kuadrant_proto_msgTypes[12]
+func (x *ActionEntry) GetDenyWith() string {
 	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use ResponseActionEntry.ProtoReflect.Descriptor instead.
-func (*ResponseActionEntry) Descriptor() ([]byte, []int) {
-	return file_v1_kuadrant_proto_rawDescGZIP(), []int{12}
-}
-
-func (x *ResponseActionEntry) GetActionType() ActionType {
-	if x != nil {
-		return x.ActionType
-	}
-	return ActionType_ACTION_TYPE_UNSPECIFIED
-}
-
-func (x *ResponseActionEntry) GetPredicate() string {
-	if x != nil {
-		return x.Predicate
+		return x.DenyWith
 	}
 	return ""
 }
 
-func (x *ResponseActionEntry) GetHeadersToAdd() string {
+func (x *ActionEntry) GetHeadersToAdd() string {
 	if x != nil {
 		return x.HeadersToAdd
 	}
 	return ""
 }
 
-func (x *ResponseActionEntry) GetNewResponseCode() int32 {
+func (x *ActionEntry) GetFailureMessage() string {
 	if x != nil {
-		return x.NewResponseCode
+		return x.FailureMessage
 	}
-	return 0
+	return ""
+}
+
+func (x *ActionEntry) GetFailureCode() string {
+	if x != nil {
+		return x.FailureCode
+	}
+	return ""
 }
 
 // PipelineCommitRequest atomically replaces all pipeline actions for a policy.
 type PipelineCommitRequest struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	Policy          *Policy                `protobuf:"bytes,1,opt,name=policy,proto3" json:"policy,omitempty"`
-	RequestActions  []*RequestActionEntry  `protobuf:"bytes,2,rep,name=request_actions,json=requestActions,proto3" json:"request_actions,omitempty"`
-	ResponseActions []*ResponseActionEntry `protobuf:"bytes,3,rep,name=response_actions,json=responseActions,proto3" json:"response_actions,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Policy        *Policy                `protobuf:"bytes,1,opt,name=policy,proto3" json:"policy,omitempty"`
+	Actions       []*ActionEntry         `protobuf:"bytes,2,rep,name=actions,proto3" json:"actions,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PipelineCommitRequest) Reset() {
 	*x = PipelineCommitRequest{}
-	mi := &file_v1_kuadrant_proto_msgTypes[13]
+	mi := &file_v1_kuadrant_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -884,7 +846,7 @@ func (x *PipelineCommitRequest) String() string {
 func (*PipelineCommitRequest) ProtoMessage() {}
 
 func (x *PipelineCommitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_kuadrant_proto_msgTypes[13]
+	mi := &file_v1_kuadrant_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -897,7 +859,7 @@ func (x *PipelineCommitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PipelineCommitRequest.ProtoReflect.Descriptor instead.
 func (*PipelineCommitRequest) Descriptor() ([]byte, []int) {
-	return file_v1_kuadrant_proto_rawDescGZIP(), []int{13}
+	return file_v1_kuadrant_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *PipelineCommitRequest) GetPolicy() *Policy {
@@ -907,16 +869,9 @@ func (x *PipelineCommitRequest) GetPolicy() *Policy {
 	return nil
 }
 
-func (x *PipelineCommitRequest) GetRequestActions() []*RequestActionEntry {
+func (x *PipelineCommitRequest) GetActions() []*ActionEntry {
 	if x != nil {
-		return x.RequestActions
-	}
-	return nil
-}
-
-func (x *PipelineCommitRequest) GetResponseActions() []*ResponseActionEntry {
-	if x != nil {
-		return x.ResponseActions
+		return x.Actions
 	}
 	return nil
 }
@@ -965,35 +920,32 @@ const file_v1_kuadrant_proto_rawDesc = "" +
 	"\aservice\x18\x03 \x01(\tR\aservice\x12\x16\n" +
 	"\x06method\x18\x04 \x01(\tR\x06method\x12\x12\n" +
 	"\x04name\x18\x05 \x01(\tR\x04name\x12)\n" +
-	"\x10message_template\x18\x06 \x01(\tR\x0fmessageTemplate\"\xb4\x01\n" +
-	"\x12RequestActionEntry\x128\n" +
+	"\x10message_template\x18\x06 \x01(\tR\x0fmessageTemplate\"\xb4\x02\n" +
+	"\vActionEntry\x128\n" +
 	"\vaction_type\x18\x01 \x01(\x0e2\x17.kuadrant.v1.ActionTypeR\n" +
 	"actionType\x12\x1c\n" +
-	"\tpredicate\x18\x02 \x01(\tR\tpredicate\x12\x1c\n" +
-	"\tintention\x18\x03 \x01(\tR\tintention\x12\x16\n" +
+	"\tpredicate\x18\x02 \x01(\tR\tpredicate\x12\x14\n" +
+	"\x05phase\x18\x03 \x01(\tR\x05phase\x12\x16\n" +
 	"\x06method\x18\x04 \x01(\tR\x06method\x12\x10\n" +
-	"\x03var\x18\x05 \x01(\tR\x03var\"\xbf\x01\n" +
-	"\x13ResponseActionEntry\x128\n" +
-	"\vaction_type\x18\x01 \x01(\x0e2\x17.kuadrant.v1.ActionTypeR\n" +
-	"actionType\x12\x1c\n" +
-	"\tpredicate\x18\x02 \x01(\tR\tpredicate\x12$\n" +
-	"\x0eheaders_to_add\x18\x03 \x01(\tR\fheadersToAdd\x12*\n" +
-	"\x11new_response_code\x18\x04 \x01(\x05R\x0fnewResponseCode\"\xdb\x01\n" +
+	"\x03var\x18\x05 \x01(\tR\x03var\x12\x1b\n" +
+	"\tdeny_with\x18\x06 \x01(\tR\bdenyWith\x12$\n" +
+	"\x0eheaders_to_add\x18\a \x01(\tR\fheadersToAdd\x12'\n" +
+	"\x0ffailure_message\x18\b \x01(\tR\x0efailureMessage\x12!\n" +
+	"\ffailure_code\x18\t \x01(\tR\vfailureCode\"x\n" +
 	"\x15PipelineCommitRequest\x12+\n" +
-	"\x06policy\x18\x01 \x01(\v2\x13.kuadrant.v1.PolicyR\x06policy\x12H\n" +
-	"\x0frequest_actions\x18\x02 \x03(\v2\x1f.kuadrant.v1.RequestActionEntryR\x0erequestActions\x12K\n" +
-	"\x10response_actions\x18\x03 \x03(\v2 .kuadrant.v1.ResponseActionEntryR\x0fresponseActions*E\n" +
+	"\x06policy\x18\x01 \x01(\v2\x13.kuadrant.v1.PolicyR\x06policy\x122\n" +
+	"\aactions\x18\x02 \x03(\v2\x18.kuadrant.v1.ActionEntryR\aactions*E\n" +
 	"\x06Domain\x12\x16\n" +
 	"\x12DOMAIN_UNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vDOMAIN_AUTH\x10\x01\x12\x12\n" +
-	"\x0eDOMAIN_REQUEST\x10\x02*\x9e\x01\n" +
+	"\x0eDOMAIN_REQUEST\x10\x02*\x92\x01\n" +
 	"\n" +
 	"ActionType\x12\x1b\n" +
 	"\x17ACTION_TYPE_UNSPECIFIED\x10\x00\x12\x1b\n" +
-	"\x17ACTION_TYPE_GRPC_METHOD\x10\x01\x12\x15\n" +
-	"\x11ACTION_TYPE_ALLOW\x10\x02\x12\x1b\n" +
-	"\x17ACTION_TYPE_ADD_HEADERS\x10\x03\x12\"\n" +
-	"\x1eACTION_TYPE_WITH_RESPONSE_CODE\x10\x042\xbb\x04\n" +
+	"\x17ACTION_TYPE_GRPC_METHOD\x10\x01\x12\x14\n" +
+	"\x10ACTION_TYPE_DENY\x10\x02\x12\x1b\n" +
+	"\x17ACTION_TYPE_ADD_HEADERS\x10\x03\x12\x17\n" +
+	"\x13ACTION_TYPE_FAILURE\x10\x042\xbb\x04\n" +
 	"\x10ExtensionService\x12=\n" +
 	"\x04Ping\x12\x18.kuadrant.v1.PingRequest\x1a\x19.kuadrant.v1.PongResponse\"\x00\x12N\n" +
 	"\tSubscribe\x12\x1d.kuadrant.v1.SubscribeRequest\x1a\x1e.kuadrant.v1.SubscribeResponse\"\x000\x01\x12F\n" +
@@ -1016,7 +968,7 @@ func file_v1_kuadrant_proto_rawDescGZIP() []byte {
 }
 
 var file_v1_kuadrant_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_v1_kuadrant_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_v1_kuadrant_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_v1_kuadrant_proto_goTypes = []any{
 	(Domain)(0),                         // 0: kuadrant.v1.Domain
 	(ActionType)(0),                     // 1: kuadrant.v1.ActionType
@@ -1031,52 +983,49 @@ var file_v1_kuadrant_proto_goTypes = []any{
 	(*ClearPolicyRequest)(nil),          // 10: kuadrant.v1.ClearPolicyRequest
 	(*ClearPolicyResponse)(nil),         // 11: kuadrant.v1.ClearPolicyResponse
 	(*RegisterActionMethodRequest)(nil), // 12: kuadrant.v1.RegisterActionMethodRequest
-	(*RequestActionEntry)(nil),          // 13: kuadrant.v1.RequestActionEntry
-	(*ResponseActionEntry)(nil),         // 14: kuadrant.v1.ResponseActionEntry
-	(*PipelineCommitRequest)(nil),       // 15: kuadrant.v1.PipelineCommitRequest
-	(*timestamp.Timestamp)(nil),         // 16: google.protobuf.Timestamp
-	(*Policy)(nil),                      // 17: kuadrant.v1.Policy
-	(*v1alpha1.Value)(nil),              // 18: google.api.expr.v1alpha1.Value
-	(*status.Status)(nil),               // 19: google.rpc.Status
-	(*Metadata)(nil),                    // 20: kuadrant.v1.Metadata
-	(*empty.Empty)(nil),                 // 21: google.protobuf.Empty
+	(*ActionEntry)(nil),                 // 13: kuadrant.v1.ActionEntry
+	(*PipelineCommitRequest)(nil),       // 14: kuadrant.v1.PipelineCommitRequest
+	(*timestamp.Timestamp)(nil),         // 15: google.protobuf.Timestamp
+	(*Policy)(nil),                      // 16: kuadrant.v1.Policy
+	(*v1alpha1.Value)(nil),              // 17: google.api.expr.v1alpha1.Value
+	(*status.Status)(nil),               // 18: google.rpc.Status
+	(*Metadata)(nil),                    // 19: kuadrant.v1.Metadata
+	(*empty.Empty)(nil),                 // 20: google.protobuf.Empty
 }
 var file_v1_kuadrant_proto_depIdxs = []int32{
-	16, // 0: kuadrant.v1.PingRequest.out:type_name -> google.protobuf.Timestamp
-	16, // 1: kuadrant.v1.PongResponse.in:type_name -> google.protobuf.Timestamp
-	17, // 2: kuadrant.v1.ResolveRequest.policy:type_name -> kuadrant.v1.Policy
-	18, // 3: kuadrant.v1.ResolveResponse.cel_result:type_name -> google.api.expr.v1alpha1.Value
+	15, // 0: kuadrant.v1.PingRequest.out:type_name -> google.protobuf.Timestamp
+	15, // 1: kuadrant.v1.PongResponse.in:type_name -> google.protobuf.Timestamp
+	16, // 2: kuadrant.v1.ResolveRequest.policy:type_name -> kuadrant.v1.Policy
+	17, // 3: kuadrant.v1.ResolveResponse.cel_result:type_name -> google.api.expr.v1alpha1.Value
 	8,  // 4: kuadrant.v1.SubscribeResponse.event:type_name -> kuadrant.v1.Event
-	19, // 5: kuadrant.v1.SubscribeResponse.error:type_name -> google.rpc.Status
-	20, // 6: kuadrant.v1.Event.metadata:type_name -> kuadrant.v1.Metadata
-	17, // 7: kuadrant.v1.RegisterMutatorRequest.policy:type_name -> kuadrant.v1.Policy
+	18, // 5: kuadrant.v1.SubscribeResponse.error:type_name -> google.rpc.Status
+	19, // 6: kuadrant.v1.Event.metadata:type_name -> kuadrant.v1.Metadata
+	16, // 7: kuadrant.v1.RegisterMutatorRequest.policy:type_name -> kuadrant.v1.Policy
 	0,  // 8: kuadrant.v1.RegisterMutatorRequest.domain:type_name -> kuadrant.v1.Domain
-	17, // 9: kuadrant.v1.ClearPolicyRequest.policy:type_name -> kuadrant.v1.Policy
-	17, // 10: kuadrant.v1.RegisterActionMethodRequest.policy:type_name -> kuadrant.v1.Policy
-	1,  // 11: kuadrant.v1.RequestActionEntry.action_type:type_name -> kuadrant.v1.ActionType
-	1,  // 12: kuadrant.v1.ResponseActionEntry.action_type:type_name -> kuadrant.v1.ActionType
-	17, // 13: kuadrant.v1.PipelineCommitRequest.policy:type_name -> kuadrant.v1.Policy
-	13, // 14: kuadrant.v1.PipelineCommitRequest.request_actions:type_name -> kuadrant.v1.RequestActionEntry
-	14, // 15: kuadrant.v1.PipelineCommitRequest.response_actions:type_name -> kuadrant.v1.ResponseActionEntry
-	2,  // 16: kuadrant.v1.ExtensionService.Ping:input_type -> kuadrant.v1.PingRequest
-	7,  // 17: kuadrant.v1.ExtensionService.Subscribe:input_type -> kuadrant.v1.SubscribeRequest
-	4,  // 18: kuadrant.v1.ExtensionService.Resolve:input_type -> kuadrant.v1.ResolveRequest
-	9,  // 19: kuadrant.v1.ExtensionService.RegisterMutator:input_type -> kuadrant.v1.RegisterMutatorRequest
-	10, // 20: kuadrant.v1.ExtensionService.ClearPolicy:input_type -> kuadrant.v1.ClearPolicyRequest
-	12, // 21: kuadrant.v1.ExtensionService.RegisterActionMethod:input_type -> kuadrant.v1.RegisterActionMethodRequest
-	15, // 22: kuadrant.v1.ExtensionService.PipelineCommit:input_type -> kuadrant.v1.PipelineCommitRequest
-	3,  // 23: kuadrant.v1.ExtensionService.Ping:output_type -> kuadrant.v1.PongResponse
-	6,  // 24: kuadrant.v1.ExtensionService.Subscribe:output_type -> kuadrant.v1.SubscribeResponse
-	5,  // 25: kuadrant.v1.ExtensionService.Resolve:output_type -> kuadrant.v1.ResolveResponse
-	21, // 26: kuadrant.v1.ExtensionService.RegisterMutator:output_type -> google.protobuf.Empty
-	11, // 27: kuadrant.v1.ExtensionService.ClearPolicy:output_type -> kuadrant.v1.ClearPolicyResponse
-	21, // 28: kuadrant.v1.ExtensionService.RegisterActionMethod:output_type -> google.protobuf.Empty
-	21, // 29: kuadrant.v1.ExtensionService.PipelineCommit:output_type -> google.protobuf.Empty
-	23, // [23:30] is the sub-list for method output_type
-	16, // [16:23] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	16, // 9: kuadrant.v1.ClearPolicyRequest.policy:type_name -> kuadrant.v1.Policy
+	16, // 10: kuadrant.v1.RegisterActionMethodRequest.policy:type_name -> kuadrant.v1.Policy
+	1,  // 11: kuadrant.v1.ActionEntry.action_type:type_name -> kuadrant.v1.ActionType
+	16, // 12: kuadrant.v1.PipelineCommitRequest.policy:type_name -> kuadrant.v1.Policy
+	13, // 13: kuadrant.v1.PipelineCommitRequest.actions:type_name -> kuadrant.v1.ActionEntry
+	2,  // 14: kuadrant.v1.ExtensionService.Ping:input_type -> kuadrant.v1.PingRequest
+	7,  // 15: kuadrant.v1.ExtensionService.Subscribe:input_type -> kuadrant.v1.SubscribeRequest
+	4,  // 16: kuadrant.v1.ExtensionService.Resolve:input_type -> kuadrant.v1.ResolveRequest
+	9,  // 17: kuadrant.v1.ExtensionService.RegisterMutator:input_type -> kuadrant.v1.RegisterMutatorRequest
+	10, // 18: kuadrant.v1.ExtensionService.ClearPolicy:input_type -> kuadrant.v1.ClearPolicyRequest
+	12, // 19: kuadrant.v1.ExtensionService.RegisterActionMethod:input_type -> kuadrant.v1.RegisterActionMethodRequest
+	14, // 20: kuadrant.v1.ExtensionService.PipelineCommit:input_type -> kuadrant.v1.PipelineCommitRequest
+	3,  // 21: kuadrant.v1.ExtensionService.Ping:output_type -> kuadrant.v1.PongResponse
+	6,  // 22: kuadrant.v1.ExtensionService.Subscribe:output_type -> kuadrant.v1.SubscribeResponse
+	5,  // 23: kuadrant.v1.ExtensionService.Resolve:output_type -> kuadrant.v1.ResolveResponse
+	20, // 24: kuadrant.v1.ExtensionService.RegisterMutator:output_type -> google.protobuf.Empty
+	11, // 25: kuadrant.v1.ExtensionService.ClearPolicy:output_type -> kuadrant.v1.ClearPolicyResponse
+	20, // 26: kuadrant.v1.ExtensionService.RegisterActionMethod:output_type -> google.protobuf.Empty
+	20, // 27: kuadrant.v1.ExtensionService.PipelineCommit:output_type -> google.protobuf.Empty
+	21, // [21:28] is the sub-list for method output_type
+	14, // [14:21] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_v1_kuadrant_proto_init() }
@@ -1092,7 +1041,7 @@ func file_v1_kuadrant_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_kuadrant_proto_rawDesc), len(file_v1_kuadrant_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   14,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/extension/grpc/v1/kuadrant.pb.go
+++ b/pkg/extension/grpc/v1/kuadrant.pb.go
@@ -82,7 +82,7 @@ const (
 	ActionType_ACTION_TYPE_GRPC_METHOD ActionType = 1
 	ActionType_ACTION_TYPE_DENY        ActionType = 2
 	ActionType_ACTION_TYPE_ADD_HEADERS ActionType = 3
-	ActionType_ACTION_TYPE_FAILURE     ActionType = 4
+	ActionType_ACTION_TYPE_FAIL        ActionType = 4
 )
 
 // Enum value maps for ActionType.
@@ -92,14 +92,14 @@ var (
 		1: "ACTION_TYPE_GRPC_METHOD",
 		2: "ACTION_TYPE_DENY",
 		3: "ACTION_TYPE_ADD_HEADERS",
-		4: "ACTION_TYPE_FAILURE",
+		4: "ACTION_TYPE_FAIL",
 	}
 	ActionType_value = map[string]int32{
 		"ACTION_TYPE_UNSPECIFIED": 0,
 		"ACTION_TYPE_GRPC_METHOD": 1,
 		"ACTION_TYPE_DENY":        2,
 		"ACTION_TYPE_ADD_HEADERS": 3,
-		"ACTION_TYPE_FAILURE":     4,
+		"ACTION_TYPE_FAIL":        4,
 	}
 )
 
@@ -716,18 +716,19 @@ func (x *RegisterActionMethodRequest) GetMessageTemplate() string {
 
 // ActionEntry represents a single action in either the request or response phase.
 type ActionEntry struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	ActionType     ActionType             `protobuf:"varint,1,opt,name=action_type,json=actionType,proto3,enum=kuadrant.v1.ActionType" json:"action_type,omitempty"`
-	Predicate      string                 `protobuf:"bytes,2,opt,name=predicate,proto3" json:"predicate,omitempty"`                                 // CEL predicate — if false, skip this action
-	Phase          string                 `protobuf:"bytes,3,opt,name=phase,proto3" json:"phase,omitempty"`                                         // "request" or "response"
-	Method         string                 `protobuf:"bytes,4,opt,name=method,proto3" json:"method,omitempty"`                                       // Name of a registered ActionMethod (for grpc_method type)
-	Var            string                 `protobuf:"bytes,5,opt,name=var,proto3" json:"var,omitempty"`                                             // Variable name to store gRPC response (for grpc_method type)
-	DenyWith       string                 `protobuf:"bytes,6,opt,name=deny_with,json=denyWith,proto3" json:"deny_with,omitempty"`                   // HTTP status code to send (for deny type)
-	HeadersToAdd   string                 `protobuf:"bytes,7,opt,name=headers_to_add,json=headersToAdd,proto3" json:"headers_to_add,omitempty"`     // CEL expression evaluating to a map of headers (for add_headers type)
-	FailureMessage string                 `protobuf:"bytes,8,opt,name=failure_message,json=failureMessage,proto3" json:"failure_message,omitempty"` // Response body sent to client (for failure type)
-	FailureCode    string                 `protobuf:"bytes,9,opt,name=failure_code,json=failureCode,proto3" json:"failure_code,omitempty"`          // HTTP status code (for failure type)
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ActionType    ActionType             `protobuf:"varint,1,opt,name=action_type,json=actionType,proto3,enum=kuadrant.v1.ActionType" json:"action_type,omitempty"`
+	Predicate     string                 `protobuf:"bytes,2,opt,name=predicate,proto3" json:"predicate,omitempty"`                             // CEL predicate — if false, skip this action
+	Phase         string                 `protobuf:"bytes,3,opt,name=phase,proto3" json:"phase,omitempty"`                                     // "request" or "response"
+	Method        string                 `protobuf:"bytes,4,opt,name=method,proto3" json:"method,omitempty"`                                   // Name of a registered ActionMethod (for grpc_method type)
+	Var           string                 `protobuf:"bytes,5,opt,name=var,proto3" json:"var,omitempty"`                                         // Variable name to store gRPC response (for grpc_method type)
+	WithStatus    int32                  `protobuf:"varint,6,opt,name=with_status,json=withStatus,proto3" json:"with_status,omitempty"`        // HTTP status code (for deny type); 0 means unset
+	WithHeaders   string                 `protobuf:"bytes,9,opt,name=with_headers,json=withHeaders,proto3" json:"with_headers,omitempty"`      // CEL expression — array of [name, value] pairs (for deny type)
+	WithBody      string                 `protobuf:"bytes,10,opt,name=with_body,json=withBody,proto3" json:"with_body,omitempty"`              // Response body string (for deny type)
+	HeadersToAdd  string                 `protobuf:"bytes,7,opt,name=headers_to_add,json=headersToAdd,proto3" json:"headers_to_add,omitempty"` // CEL expression evaluating to a map of headers (for add_headers type)
+	LogMessage    string                 `protobuf:"bytes,8,opt,name=log_message,json=logMessage,proto3" json:"log_message,omitempty"`         // Error message to log (for fail type)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ActionEntry) Reset() {
@@ -795,9 +796,23 @@ func (x *ActionEntry) GetVar() string {
 	return ""
 }
 
-func (x *ActionEntry) GetDenyWith() string {
+func (x *ActionEntry) GetWithStatus() int32 {
 	if x != nil {
-		return x.DenyWith
+		return x.WithStatus
+	}
+	return 0
+}
+
+func (x *ActionEntry) GetWithHeaders() string {
+	if x != nil {
+		return x.WithHeaders
+	}
+	return ""
+}
+
+func (x *ActionEntry) GetWithBody() string {
+	if x != nil {
+		return x.WithBody
 	}
 	return ""
 }
@@ -809,16 +824,9 @@ func (x *ActionEntry) GetHeadersToAdd() string {
 	return ""
 }
 
-func (x *ActionEntry) GetFailureMessage() string {
+func (x *ActionEntry) GetLogMessage() string {
 	if x != nil {
-		return x.FailureMessage
-	}
-	return ""
-}
-
-func (x *ActionEntry) GetFailureCode() string {
-	if x != nil {
-		return x.FailureCode
+		return x.LogMessage
 	}
 	return ""
 }
@@ -920,32 +928,36 @@ const file_v1_kuadrant_proto_rawDesc = "" +
 	"\aservice\x18\x03 \x01(\tR\aservice\x12\x16\n" +
 	"\x06method\x18\x04 \x01(\tR\x06method\x12\x12\n" +
 	"\x04name\x18\x05 \x01(\tR\x04name\x12)\n" +
-	"\x10message_template\x18\x06 \x01(\tR\x0fmessageTemplate\"\xb4\x02\n" +
+	"\x10message_template\x18\x06 \x01(\tR\x0fmessageTemplate\"\xcd\x02\n" +
 	"\vActionEntry\x128\n" +
 	"\vaction_type\x18\x01 \x01(\x0e2\x17.kuadrant.v1.ActionTypeR\n" +
 	"actionType\x12\x1c\n" +
 	"\tpredicate\x18\x02 \x01(\tR\tpredicate\x12\x14\n" +
 	"\x05phase\x18\x03 \x01(\tR\x05phase\x12\x16\n" +
 	"\x06method\x18\x04 \x01(\tR\x06method\x12\x10\n" +
-	"\x03var\x18\x05 \x01(\tR\x03var\x12\x1b\n" +
-	"\tdeny_with\x18\x06 \x01(\tR\bdenyWith\x12$\n" +
-	"\x0eheaders_to_add\x18\a \x01(\tR\fheadersToAdd\x12'\n" +
-	"\x0ffailure_message\x18\b \x01(\tR\x0efailureMessage\x12!\n" +
-	"\ffailure_code\x18\t \x01(\tR\vfailureCode\"x\n" +
+	"\x03var\x18\x05 \x01(\tR\x03var\x12\x1f\n" +
+	"\vwith_status\x18\x06 \x01(\x05R\n" +
+	"withStatus\x12!\n" +
+	"\fwith_headers\x18\t \x01(\tR\vwithHeaders\x12\x1b\n" +
+	"\twith_body\x18\n" +
+	" \x01(\tR\bwithBody\x12$\n" +
+	"\x0eheaders_to_add\x18\a \x01(\tR\fheadersToAdd\x12\x1f\n" +
+	"\vlog_message\x18\b \x01(\tR\n" +
+	"logMessage\"x\n" +
 	"\x15PipelineCommitRequest\x12+\n" +
 	"\x06policy\x18\x01 \x01(\v2\x13.kuadrant.v1.PolicyR\x06policy\x122\n" +
 	"\aactions\x18\x02 \x03(\v2\x18.kuadrant.v1.ActionEntryR\aactions*E\n" +
 	"\x06Domain\x12\x16\n" +
 	"\x12DOMAIN_UNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vDOMAIN_AUTH\x10\x01\x12\x12\n" +
-	"\x0eDOMAIN_REQUEST\x10\x02*\x92\x01\n" +
+	"\x0eDOMAIN_REQUEST\x10\x02*\x8f\x01\n" +
 	"\n" +
 	"ActionType\x12\x1b\n" +
 	"\x17ACTION_TYPE_UNSPECIFIED\x10\x00\x12\x1b\n" +
 	"\x17ACTION_TYPE_GRPC_METHOD\x10\x01\x12\x14\n" +
 	"\x10ACTION_TYPE_DENY\x10\x02\x12\x1b\n" +
-	"\x17ACTION_TYPE_ADD_HEADERS\x10\x03\x12\x17\n" +
-	"\x13ACTION_TYPE_FAILURE\x10\x042\xbb\x04\n" +
+	"\x17ACTION_TYPE_ADD_HEADERS\x10\x03\x12\x14\n" +
+	"\x10ACTION_TYPE_FAIL\x10\x042\xbb\x04\n" +
 	"\x10ExtensionService\x12=\n" +
 	"\x04Ping\x12\x18.kuadrant.v1.PingRequest\x1a\x19.kuadrant.v1.PongResponse\"\x00\x12N\n" +
 	"\tSubscribe\x12\x1d.kuadrant.v1.SubscribeRequest\x1a\x1e.kuadrant.v1.SubscribeResponse\"\x000\x01\x12F\n" +

--- a/pkg/extension/grpc/v1/kuadrant.proto
+++ b/pkg/extension/grpc/v1/kuadrant.proto
@@ -102,7 +102,7 @@ enum ActionType {
   ACTION_TYPE_GRPC_METHOD = 1;
   ACTION_TYPE_DENY = 2;
   ACTION_TYPE_ADD_HEADERS = 3;
-  ACTION_TYPE_FAILURE = 4;
+  ACTION_TYPE_FAIL = 4;
 }
 
 // ActionEntry represents a single action in either the request or response phase.
@@ -112,10 +112,11 @@ message ActionEntry {
   string phase = 3;            // "request" or "response"
   string method = 4;           // Name of a registered ActionMethod (for grpc_method type)
   string var = 5;              // Variable name to store gRPC response (for grpc_method type)
-  string deny_with = 6;        // HTTP status code to send (for deny type)
+  int32 with_status = 6;        // HTTP status code (for deny type); 0 means unset
+  string with_headers = 9;     // CEL expression — array of [name, value] pairs (for deny type)
+  string with_body = 10;       // Response body string (for deny type)
   string headers_to_add = 7;   // CEL expression evaluating to a map of headers (for add_headers type)
-  string failure_message = 8;  // Response body sent to client (for failure type)
-  string failure_code = 9;     // HTTP status code (for failure type)
+  string log_message = 8;      // Error message to log (for fail type)
 }
 
 // PipelineCommitRequest atomically replaces all pipeline actions for a policy.

--- a/pkg/extension/grpc/v1/kuadrant.proto
+++ b/pkg/extension/grpc/v1/kuadrant.proto
@@ -100,31 +100,26 @@ message RegisterActionMethodRequest {
 enum ActionType {
   ACTION_TYPE_UNSPECIFIED = 0;
   ACTION_TYPE_GRPC_METHOD = 1;
-  ACTION_TYPE_ALLOW = 2;
+  ACTION_TYPE_DENY = 2;
   ACTION_TYPE_ADD_HEADERS = 3;
-  ACTION_TYPE_WITH_RESPONSE_CODE = 4;
+  ACTION_TYPE_FAILURE = 4;
 }
 
-// RequestActionEntry represents a single action in the request phase.
-message RequestActionEntry {
+// ActionEntry represents a single action in either the request or response phase.
+message ActionEntry {
   ActionType action_type = 1;
-  string predicate = 2;   // CEL predicate — if false, skip this action
-  string intention = 3;   // CEL expression evaluated against the gRPC response or request
-  string method = 4;      // Name of a registered ActionMethod (for grpc_method type)
-  string var = 5;         // Variable name for the gRPC response (used by onReply predicates)
-}
-
-// ResponseActionEntry represents a single action in the response phase.
-message ResponseActionEntry {
-  ActionType action_type = 1;
-  string predicate = 2;       // CEL predicate — if false, skip this action
-  string headers_to_add = 3;  // CEL expression evaluating to a map of headers (for add_headers type)
-  int32 new_response_code = 4;  // HTTP status code (for with_response_code type)
+  string predicate = 2;        // CEL predicate — if false, skip this action
+  string phase = 3;            // "request" or "response"
+  string method = 4;           // Name of a registered ActionMethod (for grpc_method type)
+  string var = 5;              // Variable name to store gRPC response (for grpc_method type)
+  string deny_with = 6;        // HTTP status code to send (for deny type)
+  string headers_to_add = 7;   // CEL expression evaluating to a map of headers (for add_headers type)
+  string failure_message = 8;  // Response body sent to client (for failure type)
+  string failure_code = 9;     // HTTP status code (for failure type)
 }
 
 // PipelineCommitRequest atomically replaces all pipeline actions for a policy.
 message PipelineCommitRequest {
   kuadrant.v1.Policy policy = 1;
-  repeated RequestActionEntry request_actions = 2;
-  repeated ResponseActionEntry response_actions = 3;
+  repeated ActionEntry actions = 2;
 }

--- a/pkg/extension/grpc/v1/pipeline_proto_test.go
+++ b/pkg/extension/grpc/v1/pipeline_proto_test.go
@@ -32,7 +32,7 @@ func TestActionType_EnumValues(t *testing.T) {
 		{"grpc_method", ActionType_ACTION_TYPE_GRPC_METHOD, "ACTION_TYPE_GRPC_METHOD"},
 		{"deny", ActionType_ACTION_TYPE_DENY, "ACTION_TYPE_DENY"},
 		{"add_headers", ActionType_ACTION_TYPE_ADD_HEADERS, "ACTION_TYPE_ADD_HEADERS"},
-		{"failure", ActionType_ACTION_TYPE_FAILURE, "ACTION_TYPE_FAILURE"},
+		{"fail", ActionType_ACTION_TYPE_FAIL, "ACTION_TYPE_FAIL"},
 	}
 
 	for _, tt := range tests {
@@ -70,13 +70,21 @@ func TestActionEntry_FieldAccessors(t *testing.T) {
 	}
 
 	denyEntry := &ActionEntry{
-		ActionType: ActionType_ACTION_TYPE_DENY,
-		Predicate:  "threatResponse.threat_level >= 5",
-		Phase:      "response",
-		DenyWith:   "403",
+		ActionType:  ActionType_ACTION_TYPE_DENY,
+		Predicate:   "threatResponse.threat_level >= 5",
+		Phase:       "response",
+		WithStatus:  403,
+		WithHeaders: `[["x-threat-assessed", "true"]]`,
+		WithBody:    "Blocked by threat policy",
 	}
-	if denyEntry.GetDenyWith() != "403" {
-		t.Errorf("GetDenyWith() = %q, want %q", denyEntry.GetDenyWith(), "403")
+	if denyEntry.GetWithStatus() != 403 {
+		t.Errorf("GetWithStatus() = %d, want %d", denyEntry.GetWithStatus(), 403)
+	}
+	if denyEntry.GetWithHeaders() != `[["x-threat-assessed", "true"]]` {
+		t.Errorf("GetWithHeaders() = %q, unexpected", denyEntry.GetWithHeaders())
+	}
+	if denyEntry.GetWithBody() != "Blocked by threat policy" {
+		t.Errorf("GetWithBody() = %q, unexpected", denyEntry.GetWithBody())
 	}
 	if denyEntry.GetPhase() != "response" {
 		t.Errorf("GetPhase() = %q, want %q", denyEntry.GetPhase(), "response")
@@ -91,18 +99,14 @@ func TestActionEntry_FieldAccessors(t *testing.T) {
 		t.Errorf("GetHeadersToAdd() = %q, unexpected", headersEntry.GetHeadersToAdd())
 	}
 
-	failureEntry := &ActionEntry{
-		ActionType:     ActionType_ACTION_TYPE_FAILURE,
-		Predicate:      `request.headers["x-debug"] == "true"`,
-		Phase:          "request",
-		FailureMessage: "Request blocked by threat policy",
-		FailureCode:    "500",
+	failEntry := &ActionEntry{
+		ActionType: ActionType_ACTION_TYPE_FAIL,
+		Predicate:  `threatResponse.error_code != 0`,
+		Phase:      "response",
+		LogMessage: "Threat service returned unexpected error",
 	}
-	if failureEntry.GetFailureMessage() != "Request blocked by threat policy" {
-		t.Errorf("GetFailureMessage() = %q, unexpected", failureEntry.GetFailureMessage())
-	}
-	if failureEntry.GetFailureCode() != "500" {
-		t.Errorf("GetFailureCode() = %q, want %q", failureEntry.GetFailureCode(), "500")
+	if failEntry.GetLogMessage() != "Threat service returned unexpected error" {
+		t.Errorf("GetLogMessage() = %q, unexpected", failEntry.GetLogMessage())
 	}
 }
 
@@ -124,17 +128,20 @@ func TestActionEntry_NilSafeGetters(t *testing.T) {
 	if entry.GetVar() != "" {
 		t.Errorf("GetVar() on nil should return empty string")
 	}
-	if entry.GetDenyWith() != "" {
-		t.Errorf("GetDenyWith() on nil should return empty string")
+	if entry.GetWithStatus() != 0 {
+		t.Errorf("GetWithStatus() on nil should return 0")
+	}
+	if entry.GetWithHeaders() != "" {
+		t.Errorf("GetWithHeaders() on nil should return empty string")
+	}
+	if entry.GetWithBody() != "" {
+		t.Errorf("GetWithBody() on nil should return empty string")
 	}
 	if entry.GetHeadersToAdd() != "" {
 		t.Errorf("GetHeadersToAdd() on nil should return empty string")
 	}
-	if entry.GetFailureMessage() != "" {
-		t.Errorf("GetFailureMessage() on nil should return empty string")
-	}
-	if entry.GetFailureCode() != "" {
-		t.Errorf("GetFailureCode() on nil should return empty string")
+	if entry.GetLogMessage() != "" {
+		t.Errorf("GetLogMessage() on nil should return empty string")
 	}
 }
 
@@ -151,7 +158,7 @@ func TestPipelineCommitRequest_FieldAccessors(t *testing.T) {
 			ActionType: ActionType_ACTION_TYPE_DENY,
 			Predicate:  `request.url_path == "/blocked"`,
 			Phase:      "request",
-			DenyWith:   "403",
+			WithStatus: 403,
 		},
 		{
 			ActionType: ActionType_ACTION_TYPE_GRPC_METHOD,
@@ -163,7 +170,7 @@ func TestPipelineCommitRequest_FieldAccessors(t *testing.T) {
 			ActionType: ActionType_ACTION_TYPE_DENY,
 			Predicate:  "threatResponse.threat_level >= 5",
 			Phase:      "response",
-			DenyWith:   "403",
+			WithStatus: 403,
 		},
 		{
 			ActionType:   ActionType_ACTION_TYPE_ADD_HEADERS,
@@ -183,8 +190,8 @@ func TestPipelineCommitRequest_FieldAccessors(t *testing.T) {
 	if len(req.GetActions()) != 4 {
 		t.Fatalf("GetActions() length = %d, want 4", len(req.GetActions()))
 	}
-	if req.GetActions()[0].GetDenyWith() != "403" {
-		t.Errorf("first action DenyWith = %q, want %q", req.GetActions()[0].GetDenyWith(), "403")
+	if req.GetActions()[0].GetWithStatus() != 403 {
+		t.Errorf("first action WithStatus = %d, want %d", req.GetActions()[0].GetWithStatus(), 403)
 	}
 	if req.GetActions()[1].GetMethod() != "checkThreatLevel" {
 		t.Errorf("second action Method = %q, want %q", req.GetActions()[1].GetMethod(), "checkThreatLevel")

--- a/pkg/extension/grpc/v1/pipeline_proto_test.go
+++ b/pkg/extension/grpc/v1/pipeline_proto_test.go
@@ -30,9 +30,9 @@ func TestActionType_EnumValues(t *testing.T) {
 	}{
 		{"unspecified", ActionType_ACTION_TYPE_UNSPECIFIED, "ACTION_TYPE_UNSPECIFIED"},
 		{"grpc_method", ActionType_ACTION_TYPE_GRPC_METHOD, "ACTION_TYPE_GRPC_METHOD"},
-		{"allow", ActionType_ACTION_TYPE_ALLOW, "ACTION_TYPE_ALLOW"},
+		{"deny", ActionType_ACTION_TYPE_DENY, "ACTION_TYPE_DENY"},
 		{"add_headers", ActionType_ACTION_TYPE_ADD_HEADERS, "ACTION_TYPE_ADD_HEADERS"},
-		{"with_response_code", ActionType_ACTION_TYPE_WITH_RESPONSE_CODE, "ACTION_TYPE_WITH_RESPONSE_CODE"},
+		{"failure", ActionType_ACTION_TYPE_FAILURE, "ACTION_TYPE_FAILURE"},
 	}
 
 	for _, tt := range tests {
@@ -44,12 +44,13 @@ func TestActionType_EnumValues(t *testing.T) {
 	}
 }
 
-func TestRequestActionEntry_FieldAccessors(t *testing.T) {
-	entry := &RequestActionEntry{
+func TestActionEntry_FieldAccessors(t *testing.T) {
+	entry := &ActionEntry{
 		ActionType: ActionType_ACTION_TYPE_GRPC_METHOD,
 		Predicate:  "request.headers['check'] == '1'",
-		Intention:  "checkThreatResponse.HeatLevel == 5",
+		Phase:      "request",
 		Method:     "checkThreatLevel",
+		Var:        "threatResponse",
 	}
 
 	if entry.GetActionType() != ActionType_ACTION_TYPE_GRPC_METHOD {
@@ -58,16 +59,55 @@ func TestRequestActionEntry_FieldAccessors(t *testing.T) {
 	if entry.GetPredicate() != "request.headers['check'] == '1'" {
 		t.Errorf("GetPredicate() = %q, unexpected", entry.GetPredicate())
 	}
-	if entry.GetIntention() != "checkThreatResponse.HeatLevel == 5" {
-		t.Errorf("GetIntention() = %q, unexpected", entry.GetIntention())
+	if entry.GetPhase() != "request" {
+		t.Errorf("GetPhase() = %q, want %q", entry.GetPhase(), "request")
 	}
 	if entry.GetMethod() != "checkThreatLevel" {
 		t.Errorf("GetMethod() = %q, unexpected", entry.GetMethod())
 	}
+	if entry.GetVar() != "threatResponse" {
+		t.Errorf("GetVar() = %q, unexpected", entry.GetVar())
+	}
+
+	denyEntry := &ActionEntry{
+		ActionType: ActionType_ACTION_TYPE_DENY,
+		Predicate:  "threatResponse.threat_level >= 5",
+		Phase:      "response",
+		DenyWith:   "403",
+	}
+	if denyEntry.GetDenyWith() != "403" {
+		t.Errorf("GetDenyWith() = %q, want %q", denyEntry.GetDenyWith(), "403")
+	}
+	if denyEntry.GetPhase() != "response" {
+		t.Errorf("GetPhase() = %q, want %q", denyEntry.GetPhase(), "response")
+	}
+
+	headersEntry := &ActionEntry{
+		ActionType:   ActionType_ACTION_TYPE_ADD_HEADERS,
+		HeadersToAdd: `{"x-threat-checked": "true"}`,
+		Phase:        "response",
+	}
+	if headersEntry.GetHeadersToAdd() != `{"x-threat-checked": "true"}` {
+		t.Errorf("GetHeadersToAdd() = %q, unexpected", headersEntry.GetHeadersToAdd())
+	}
+
+	failureEntry := &ActionEntry{
+		ActionType:     ActionType_ACTION_TYPE_FAILURE,
+		Predicate:      `request.headers["x-debug"] == "true"`,
+		Phase:          "request",
+		FailureMessage: "Request blocked by threat policy",
+		FailureCode:    "500",
+	}
+	if failureEntry.GetFailureMessage() != "Request blocked by threat policy" {
+		t.Errorf("GetFailureMessage() = %q, unexpected", failureEntry.GetFailureMessage())
+	}
+	if failureEntry.GetFailureCode() != "500" {
+		t.Errorf("GetFailureCode() = %q, want %q", failureEntry.GetFailureCode(), "500")
+	}
 }
 
-func TestRequestActionEntry_NilSafeGetters(t *testing.T) {
-	var entry *RequestActionEntry
+func TestActionEntry_NilSafeGetters(t *testing.T) {
+	var entry *ActionEntry
 
 	if entry.GetActionType() != ActionType_ACTION_TYPE_UNSPECIFIED {
 		t.Errorf("GetActionType() on nil should return UNSPECIFIED")
@@ -75,59 +115,26 @@ func TestRequestActionEntry_NilSafeGetters(t *testing.T) {
 	if entry.GetPredicate() != "" {
 		t.Errorf("GetPredicate() on nil should return empty string")
 	}
-	if entry.GetIntention() != "" {
-		t.Errorf("GetIntention() on nil should return empty string")
+	if entry.GetPhase() != "" {
+		t.Errorf("GetPhase() on nil should return empty string")
 	}
 	if entry.GetMethod() != "" {
 		t.Errorf("GetMethod() on nil should return empty string")
 	}
-}
-
-func TestResponseActionEntry_FieldAccessors(t *testing.T) {
-	entry := &ResponseActionEntry{
-		ActionType:      ActionType_ACTION_TYPE_ADD_HEADERS,
-		Predicate:       "response.code == 200",
-		HeadersToAdd:    "{'x-threat-checked': 'true'}",
-		NewResponseCode: 0,
+	if entry.GetVar() != "" {
+		t.Errorf("GetVar() on nil should return empty string")
 	}
-
-	if entry.GetActionType() != ActionType_ACTION_TYPE_ADD_HEADERS {
-		t.Errorf("GetActionType() = %v, want %v", entry.GetActionType(), ActionType_ACTION_TYPE_ADD_HEADERS)
-	}
-	if entry.GetPredicate() != "response.code == 200" {
-		t.Errorf("GetPredicate() = %q, unexpected", entry.GetPredicate())
-	}
-	if entry.GetHeadersToAdd() != "{'x-threat-checked': 'true'}" {
-		t.Errorf("GetHeadersToAdd() = %q, unexpected", entry.GetHeadersToAdd())
-	}
-	if entry.GetNewResponseCode() != 0 {
-		t.Errorf("GetNewResponseCode() = %d, want 0", entry.GetNewResponseCode())
-	}
-
-	// Test with_response_code type
-	codeEntry := &ResponseActionEntry{
-		ActionType:      ActionType_ACTION_TYPE_WITH_RESPONSE_CODE,
-		NewResponseCode: 403,
-	}
-	if codeEntry.GetNewResponseCode() != 403 {
-		t.Errorf("GetNewResponseCode() = %d, want 403", codeEntry.GetNewResponseCode())
-	}
-}
-
-func TestResponseActionEntry_NilSafeGetters(t *testing.T) {
-	var entry *ResponseActionEntry
-
-	if entry.GetActionType() != ActionType_ACTION_TYPE_UNSPECIFIED {
-		t.Errorf("GetActionType() on nil should return UNSPECIFIED")
-	}
-	if entry.GetPredicate() != "" {
-		t.Errorf("GetPredicate() on nil should return empty string")
+	if entry.GetDenyWith() != "" {
+		t.Errorf("GetDenyWith() on nil should return empty string")
 	}
 	if entry.GetHeadersToAdd() != "" {
 		t.Errorf("GetHeadersToAdd() on nil should return empty string")
 	}
-	if entry.GetNewResponseCode() != 0 {
-		t.Errorf("GetNewResponseCode() on nil should return 0")
+	if entry.GetFailureMessage() != "" {
+		t.Errorf("GetFailureMessage() on nil should return empty string")
+	}
+	if entry.GetFailureCode() != "" {
+		t.Errorf("GetFailureCode() on nil should return empty string")
 	}
 }
 
@@ -139,54 +146,54 @@ func TestPipelineCommitRequest_FieldAccessors(t *testing.T) {
 			Name:      "my-policy",
 		},
 	}
-	requestActions := []*RequestActionEntry{
+	actions := []*ActionEntry{
+		{
+			ActionType: ActionType_ACTION_TYPE_DENY,
+			Predicate:  `request.url_path == "/blocked"`,
+			Phase:      "request",
+			DenyWith:   "403",
+		},
 		{
 			ActionType: ActionType_ACTION_TYPE_GRPC_METHOD,
+			Phase:      "request",
 			Method:     "checkThreatLevel",
-			Intention:  "checkThreatLevelResponse.HeatLevel == 5",
+			Var:        "threatResponse",
 		},
 		{
-			ActionType: ActionType_ACTION_TYPE_ALLOW,
-			Intention:  "request.auth.identity.admin == true",
+			ActionType: ActionType_ACTION_TYPE_DENY,
+			Predicate:  "threatResponse.threat_level >= 5",
+			Phase:      "response",
+			DenyWith:   "403",
 		},
-	}
-	responseActions := []*ResponseActionEntry{
 		{
 			ActionType:   ActionType_ACTION_TYPE_ADD_HEADERS,
-			HeadersToAdd: "{'x-threat-checked': 'true'}",
-		},
-		{
-			ActionType:      ActionType_ACTION_TYPE_WITH_RESPONSE_CODE,
-			NewResponseCode: 429,
+			Phase:        "response",
+			HeadersToAdd: `{"x-threat-checked": "true"}`,
 		},
 	}
 
 	req := &PipelineCommitRequest{
-		Policy:          policy,
-		RequestActions:  requestActions,
-		ResponseActions: responseActions,
+		Policy:  policy,
+		Actions: actions,
 	}
 
 	if req.GetPolicy() != policy {
 		t.Errorf("GetPolicy() returned unexpected value")
 	}
-	if len(req.GetRequestActions()) != 2 {
-		t.Fatalf("GetRequestActions() length = %d, want 2", len(req.GetRequestActions()))
+	if len(req.GetActions()) != 4 {
+		t.Fatalf("GetActions() length = %d, want 4", len(req.GetActions()))
 	}
-	if req.GetRequestActions()[0].GetMethod() != "checkThreatLevel" {
-		t.Errorf("first request action Method = %q, want %q", req.GetRequestActions()[0].GetMethod(), "checkThreatLevel")
+	if req.GetActions()[0].GetDenyWith() != "403" {
+		t.Errorf("first action DenyWith = %q, want %q", req.GetActions()[0].GetDenyWith(), "403")
 	}
-	if req.GetRequestActions()[1].GetActionType() != ActionType_ACTION_TYPE_ALLOW {
-		t.Errorf("second request action type = %v, want ALLOW", req.GetRequestActions()[1].GetActionType())
+	if req.GetActions()[1].GetMethod() != "checkThreatLevel" {
+		t.Errorf("second action Method = %q, want %q", req.GetActions()[1].GetMethod(), "checkThreatLevel")
 	}
-	if len(req.GetResponseActions()) != 2 {
-		t.Fatalf("GetResponseActions() length = %d, want 2", len(req.GetResponseActions()))
+	if req.GetActions()[2].GetPhase() != "response" {
+		t.Errorf("third action Phase = %q, want %q", req.GetActions()[2].GetPhase(), "response")
 	}
-	if req.GetResponseActions()[0].GetHeadersToAdd() != "{'x-threat-checked': 'true'}" {
-		t.Errorf("first response action HeadersToAdd = %q, unexpected", req.GetResponseActions()[0].GetHeadersToAdd())
-	}
-	if req.GetResponseActions()[1].GetNewResponseCode() != 429 {
-		t.Errorf("second response action NewResponseCode = %d, want 429", req.GetResponseActions()[1].GetNewResponseCode())
+	if req.GetActions()[3].GetHeadersToAdd() != `{"x-threat-checked": "true"}` {
+		t.Errorf("fourth action HeadersToAdd = %q, unexpected", req.GetActions()[3].GetHeadersToAdd())
 	}
 }
 
@@ -196,11 +203,8 @@ func TestPipelineCommitRequest_NilSafeGetters(t *testing.T) {
 	if req.GetPolicy() != nil {
 		t.Errorf("GetPolicy() on nil should return nil")
 	}
-	if req.GetRequestActions() != nil {
-		t.Errorf("GetRequestActions() on nil should return nil")
-	}
-	if req.GetResponseActions() != nil {
-		t.Errorf("GetResponseActions() on nil should return nil")
+	if req.GetActions() != nil {
+		t.Errorf("GetActions() on nil should return nil")
 	}
 }
 

--- a/pkg/extension/types/actions.go
+++ b/pkg/extension/types/actions.go
@@ -8,7 +8,7 @@ type ActionType string
 const (
 	ActionTypeGRPCMethod ActionType = "grpc_method"
 	ActionTypeDeny       ActionType = "deny"
-	ActionTypeFailure    ActionType = "failure"
+	ActionTypeFail       ActionType = "fail"
 	ActionTypeAddHeaders ActionType = "add_headers"
 )
 
@@ -29,29 +29,30 @@ type GRPCMethodAction struct {
 func (a GRPCMethodAction) actionType() ActionType { return ActionTypeGRPCMethod }
 
 // DenyAction denies the request or response when the predicate evaluates
-// to true.
+// to true. All response fields are optional.
 //
 // Phase semantics:
-//   - Request phase: deny sends the status code to the origin
+//   - Request phase: deny sends the response to the origin
 //     (request never reaches backend)
-//   - Response phase: deny sends the status code to the destination
+//   - Response phase: deny sends the response to the destination
 //     (backend response replaced before reaching client)
 type DenyAction struct {
-	Predicate string // CEL — if true, deny with DenyWith code
-	DenyWith  string // HTTP status code to send (e.g. "403")
+	Predicate   string // CEL — if true, deny
+	WithStatus  int    // HTTP status code (e.g. 403); optional
+	WithHeaders string // CEL expression — array of [name, value] pairs; optional
+	WithBody    string // Response body string; optional
 }
 
 func (a DenyAction) actionType() ActionType { return ActionTypeDeny }
 
-// FailureAction terminates the request with both a status code and a
-// human-readable message body when the predicate evaluates to true.
-type FailureAction struct {
-	Predicate      string // CEL — if true, send failure response
-	FailureMessage string // Response body sent to the client
-	FailureCode    string // HTTP status code (e.g. "500")
+// FailAction logs an error message and terminates the action chain when
+// the predicate evaluates to true. Maps to the wasm-shim's "fail" type.
+type FailAction struct {
+	Predicate  string // CEL — if true, fail with log message
+	LogMessage string // Error message to log
 }
 
-func (a FailureAction) actionType() ActionType { return ActionTypeFailure }
+func (a FailAction) actionType() ActionType { return ActionTypeFail }
 
 // AddHeadersAction adds headers to the request or response depending on
 // the phase in which it is used, when the predicate evaluates to true.

--- a/pkg/extension/types/actions.go
+++ b/pkg/extension/types/actions.go
@@ -6,65 +6,71 @@ import "context"
 type ActionType string
 
 const (
-	ActionTypeGRPCMethod       ActionType = "grpc_method"
-	ActionTypeAllow            ActionType = "allow"
-	ActionTypeAddHeaders       ActionType = "add_headers"
-	ActionTypeWithResponseCode ActionType = "with_response_code"
+	ActionTypeGRPCMethod ActionType = "grpc_method"
+	ActionTypeDeny       ActionType = "deny"
+	ActionTypeFailure    ActionType = "failure"
+	ActionTypeAddHeaders ActionType = "add_headers"
 )
 
-// RequestAction is the interface implemented by actions that can be used
-// in the request phase of a pipeline.
-type RequestAction interface {
-	requestActionType() ActionType
+// Action is the interface implemented by all pipeline action types.
+// Actions can be used in either the request or response phase.
+type Action interface {
+	actionType() ActionType
 }
 
-// ResponseAction is the interface implemented by actions that can be used
-// in the response phase of a pipeline.
-type ResponseAction interface {
-	responseActionType() ActionType
-}
-
-// GRPCMethodAction invokes a registered gRPC action method and evaluates
-// the response. Implements RequestAction.
+// GRPCMethodAction invokes a registered gRPC action method and optionally
+// stores the response in a named variable for use by subsequent actions.
 type GRPCMethodAction struct {
-	Predicate string // CEL predicate — if false, skip this action
-	Intention string // CEL expression evaluated against the gRPC response
+	Predicate string // CEL — if true, call the gRPC method
 	Method    string // Name of a registered ActionMethod
-	Var       string // Variable name for the gRPC response (used by onReply predicates)
+	Var       string // Variable name to store gRPC response (optional)
 }
 
-func (a GRPCMethodAction) requestActionType() ActionType { return ActionTypeGRPCMethod }
+func (a GRPCMethodAction) actionType() ActionType { return ActionTypeGRPCMethod }
 
-// AllowAction permits or denies the request based on request attributes only.
-// No gRPC call is made. Implements RequestAction.
-type AllowAction struct {
-	Predicate string // CEL predicate — if false, skip this action
-	Intention string // CEL expression — if false, deny the request
+// DenyAction denies the request or response when the predicate evaluates
+// to true.
+//
+// Phase semantics:
+//   - Request phase: deny sends the status code to the origin
+//     (request never reaches backend)
+//   - Response phase: deny sends the status code to the destination
+//     (backend response replaced before reaching client)
+type DenyAction struct {
+	Predicate string // CEL — if true, deny with DenyWith code
+	DenyWith  string // HTTP status code to send (e.g. "403")
 }
 
-func (a AllowAction) requestActionType() ActionType { return ActionTypeAllow }
+func (a DenyAction) actionType() ActionType { return ActionTypeDeny }
 
-// AddHeadersAction adds headers to the response. Implements ResponseAction.
+// FailureAction terminates the request with both a status code and a
+// human-readable message body when the predicate evaluates to true.
+type FailureAction struct {
+	Predicate      string // CEL — if true, send failure response
+	FailureMessage string // Response body sent to the client
+	FailureCode    string // HTTP status code (e.g. "500")
+}
+
+func (a FailureAction) actionType() ActionType { return ActionTypeFailure }
+
+// AddHeadersAction adds headers to the request or response depending on
+// the phase in which it is used, when the predicate evaluates to true.
+//
+// Phase semantics:
+//   - Request phase: headers added to the request before it reaches the backend
+//   - Response phase: headers added to the response before it reaches the client
 type AddHeadersAction struct {
-	Predicate    string // CEL predicate — if false, skip this action
-	HeadersToAdd string // CEL expression evaluating to a map of headers to add
+	Predicate    string // CEL — if true, add the headers
+	HeadersToAdd string // CEL expression evaluating to a map of headers
 }
 
-func (a AddHeadersAction) responseActionType() ActionType { return ActionTypeAddHeaders }
+func (a AddHeadersAction) actionType() ActionType { return ActionTypeAddHeaders }
 
-// WithResponseCodeAction modifies the HTTP response code. Implements ResponseAction.
-type WithResponseCodeAction struct {
-	Predicate       string // CEL predicate — if false, skip this action
-	NewResponseCode int    // HTTP status code to set on the response
-}
-
-func (a WithResponseCodeAction) responseActionType() ActionType { return ActionTypeWithResponseCode }
-
-// Pipeline provides a builder for composing ordered actions on request
-// and response phases. OnRequest/OnResponse accumulate actions locally;
-// Commit sends the full pipeline to the operator in a single atomic gRPC call.
+// Pipeline provides a builder for composing ordered actions on HTTP request
+// and response phases. Actions accumulate locally with immediate ordering
+// validation. Commit sends all actions atomically to the operator.
 type Pipeline interface {
-	OnRequest(actions ...RequestAction) Pipeline
-	OnResponse(actions ...ResponseAction) Pipeline
+	OnHTTPRequest(actions ...Action) error
+	OnHTTPResponse(actions ...Action) error
 	Commit(ctx context.Context) error
 }

--- a/pkg/extension/types/actions.go
+++ b/pkg/extension/types/actions.go
@@ -1,6 +1,10 @@
 package types
 
-import "context"
+import (
+	"context"
+
+	extpb "github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v1"
+)
 
 // ActionType discriminates how the wasm-shim dispatches an action.
 type ActionType string
@@ -16,6 +20,8 @@ const (
 // Actions can be used in either the request or response phase.
 type Action interface {
 	actionType() ActionType
+	CelExpressions() []string
+	PopulateProtobuf(entry *extpb.ActionEntry)
 }
 
 // GRPCMethodAction invokes a registered gRPC action method and optionally
@@ -27,6 +33,20 @@ type GRPCMethodAction struct {
 }
 
 func (a GRPCMethodAction) actionType() ActionType { return ActionTypeGRPCMethod }
+
+func (a GRPCMethodAction) CelExpressions() []string {
+	if a.Predicate != "" {
+		return []string{a.Predicate}
+	}
+	return nil
+}
+
+func (a GRPCMethodAction) PopulateProtobuf(entry *extpb.ActionEntry) {
+	entry.ActionType = extpb.ActionType_ACTION_TYPE_GRPC_METHOD
+	entry.Predicate = a.Predicate
+	entry.Method = a.Method
+	entry.Var = a.Var
+}
 
 // DenyAction denies the request or response when the predicate evaluates
 // to true. All response fields are optional.
@@ -45,6 +65,25 @@ type DenyAction struct {
 
 func (a DenyAction) actionType() ActionType { return ActionTypeDeny }
 
+func (a DenyAction) CelExpressions() []string {
+	var exprs []string
+	if a.Predicate != "" {
+		exprs = append(exprs, a.Predicate)
+	}
+	if a.WithHeaders != "" {
+		exprs = append(exprs, a.WithHeaders)
+	}
+	return exprs
+}
+
+func (a DenyAction) PopulateProtobuf(entry *extpb.ActionEntry) {
+	entry.ActionType = extpb.ActionType_ACTION_TYPE_DENY
+	entry.Predicate = a.Predicate
+	entry.WithStatus = int32(a.WithStatus) //nolint:gosec
+	entry.WithHeaders = a.WithHeaders
+	entry.WithBody = a.WithBody
+}
+
 // FailAction logs an error message and terminates the action chain when
 // the predicate evaluates to true. Maps to the wasm-shim's "fail" type.
 type FailAction struct {
@@ -53,6 +92,19 @@ type FailAction struct {
 }
 
 func (a FailAction) actionType() ActionType { return ActionTypeFail }
+
+func (a FailAction) CelExpressions() []string {
+	if a.Predicate != "" {
+		return []string{a.Predicate}
+	}
+	return nil
+}
+
+func (a FailAction) PopulateProtobuf(entry *extpb.ActionEntry) {
+	entry.ActionType = extpb.ActionType_ACTION_TYPE_FAIL
+	entry.Predicate = a.Predicate
+	entry.LogMessage = a.LogMessage
+}
 
 // AddHeadersAction adds headers to the request or response depending on
 // the phase in which it is used, when the predicate evaluates to true.
@@ -66,6 +118,23 @@ type AddHeadersAction struct {
 }
 
 func (a AddHeadersAction) actionType() ActionType { return ActionTypeAddHeaders }
+
+func (a AddHeadersAction) CelExpressions() []string {
+	var exprs []string
+	if a.Predicate != "" {
+		exprs = append(exprs, a.Predicate)
+	}
+	if a.HeadersToAdd != "" {
+		exprs = append(exprs, a.HeadersToAdd)
+	}
+	return exprs
+}
+
+func (a AddHeadersAction) PopulateProtobuf(entry *extpb.ActionEntry) {
+	entry.ActionType = extpb.ActionType_ACTION_TYPE_ADD_HEADERS
+	entry.Predicate = a.Predicate
+	entry.HeadersToAdd = a.HeadersToAdd
+}
 
 // Pipeline provides a builder for composing ordered actions on HTTP request
 // and response phases. Actions accumulate locally with immediate ordering

--- a/pkg/extension/types/actions_test.go
+++ b/pkg/extension/types/actions_test.go
@@ -12,8 +12,8 @@ func TestDenyAction_ImplementsAction(t *testing.T) {
 	var _ Action = DenyAction{}
 }
 
-func TestFailureAction_ImplementsAction(t *testing.T) {
-	var _ Action = FailureAction{}
+func TestFailAction_ImplementsAction(t *testing.T) {
+	var _ Action = FailAction{}
 }
 
 func TestAddHeadersAction_ImplementsAction(t *testing.T) {
@@ -33,22 +33,22 @@ func TestGRPCMethodAction_ActionType(t *testing.T) {
 
 func TestDenyAction_ActionType(t *testing.T) {
 	a := DenyAction{
-		Predicate: "request.url_path == '/blocked'",
-		DenyWith:  "403",
+		Predicate:  "request.url_path == '/blocked'",
+		WithStatus: 403,
+		WithBody:   "Forbidden",
 	}
 	if a.actionType() != ActionTypeDeny {
 		t.Errorf("actionType() = %q, want %q", a.actionType(), ActionTypeDeny)
 	}
 }
 
-func TestFailureAction_ActionType(t *testing.T) {
-	a := FailureAction{
-		Predicate:      "request.headers['x-debug'] == 'true'",
-		FailureMessage: "Request blocked by threat policy",
-		FailureCode:    "500",
+func TestFailAction_ActionType(t *testing.T) {
+	a := FailAction{
+		Predicate:  "threatResponse.error_code != 0",
+		LogMessage: "Threat service returned unexpected error",
 	}
-	if a.actionType() != ActionTypeFailure {
-		t.Errorf("actionType() = %q, want %q", a.actionType(), ActionTypeFailure)
+	if a.actionType() != ActionTypeFail {
+		t.Errorf("actionType() = %q, want %q", a.actionType(), ActionTypeFail)
 	}
 }
 

--- a/pkg/extension/types/actions_test.go
+++ b/pkg/extension/types/actions_test.go
@@ -4,57 +4,60 @@ package types
 
 import "testing"
 
-func TestGRPCMethodAction_ImplementsRequestAction(t *testing.T) {
-	var _ RequestAction = GRPCMethodAction{}
+func TestGRPCMethodAction_ImplementsAction(t *testing.T) {
+	var _ Action = GRPCMethodAction{}
 }
 
-func TestAllowAction_ImplementsRequestAction(t *testing.T) {
-	var _ RequestAction = AllowAction{}
+func TestDenyAction_ImplementsAction(t *testing.T) {
+	var _ Action = DenyAction{}
 }
 
-func TestAddHeadersAction_ImplementsResponseAction(t *testing.T) {
-	var _ ResponseAction = AddHeadersAction{}
+func TestFailureAction_ImplementsAction(t *testing.T) {
+	var _ Action = FailureAction{}
 }
 
-func TestWithResponseCodeAction_ImplementsResponseAction(t *testing.T) {
-	var _ ResponseAction = WithResponseCodeAction{}
+func TestAddHeadersAction_ImplementsAction(t *testing.T) {
+	var _ Action = AddHeadersAction{}
 }
 
-func TestGRPCMethodAction_RequestActionType(t *testing.T) {
+func TestGRPCMethodAction_ActionType(t *testing.T) {
 	a := GRPCMethodAction{
 		Predicate: "request.headers['check'] == '1'",
-		Intention: "response.HeatLevel == 5",
 		Method:    "checkThreatLevel",
+		Var:       "threatResponse",
 	}
-	if a.requestActionType() != ActionTypeGRPCMethod {
-		t.Errorf("requestActionType() = %q, want %q", a.requestActionType(), ActionTypeGRPCMethod)
-	}
-}
-
-func TestAllowAction_RequestActionType(t *testing.T) {
-	a := AllowAction{
-		Predicate: "request.headers['x-bypass'] == 'true'",
-		Intention: "request.auth.identity.admin == true",
-	}
-	if a.requestActionType() != ActionTypeAllow {
-		t.Errorf("requestActionType() = %q, want %q", a.requestActionType(), ActionTypeAllow)
+	if a.actionType() != ActionTypeGRPCMethod {
+		t.Errorf("actionType() = %q, want %q", a.actionType(), ActionTypeGRPCMethod)
 	}
 }
 
-func TestAddHeadersAction_ResponseActionType(t *testing.T) {
+func TestDenyAction_ActionType(t *testing.T) {
+	a := DenyAction{
+		Predicate: "request.url_path == '/blocked'",
+		DenyWith:  "403",
+	}
+	if a.actionType() != ActionTypeDeny {
+		t.Errorf("actionType() = %q, want %q", a.actionType(), ActionTypeDeny)
+	}
+}
+
+func TestFailureAction_ActionType(t *testing.T) {
+	a := FailureAction{
+		Predicate:      "request.headers['x-debug'] == 'true'",
+		FailureMessage: "Request blocked by threat policy",
+		FailureCode:    "500",
+	}
+	if a.actionType() != ActionTypeFailure {
+		t.Errorf("actionType() = %q, want %q", a.actionType(), ActionTypeFailure)
+	}
+}
+
+func TestAddHeadersAction_ActionType(t *testing.T) {
 	a := AddHeadersAction{
-		HeadersToAdd: "{'x-threat-checked': 'true'}",
+		Predicate:    "true",
+		HeadersToAdd: `{"x-threat-checked": "true"}`,
 	}
-	if a.responseActionType() != ActionTypeAddHeaders {
-		t.Errorf("responseActionType() = %q, want %q", a.responseActionType(), ActionTypeAddHeaders)
-	}
-}
-
-func TestWithResponseCodeAction_ResponseActionType(t *testing.T) {
-	a := WithResponseCodeAction{
-		NewResponseCode: 403,
-	}
-	if a.responseActionType() != ActionTypeWithResponseCode {
-		t.Errorf("responseActionType() = %q, want %q", a.responseActionType(), ActionTypeWithResponseCode)
+	if a.actionType() != ActionTypeAddHeaders {
+		t.Errorf("actionType() = %q, want %q", a.actionType(), ActionTypeAddHeaders)
 	}
 }


### PR DESCRIPTION
## Summary

Requires: https://github.com/Kuadrant/threat-assessment-service/pull/4 for local testing of FailAction.

Implements #1958 — Extension SDK Action Pipeline Improvements.

- Unify action types under a single `Action` interface with `GRPCMethodAction`, `DenyAction`, `FailAction`, and `AddHeadersAction`
- Replace per-type proto messages with a unified `ActionEntry` and `ActionType` enum
- Add client-side pipeline ordering validation: phase ordering, variable availability, duplicate variable detection
- Implement server-side `PipelineCommit` handler with full validation and `PipelineActionStore`
- Translate pipeline actions to wasm `TypedAction` with automatic `onReply` nesting for var-dependent actions
- Enhance `DenyAction` with optional `WithStatus`, `WithHeaders`, and `WithBody` fields that build a `DenyResponse{}` CEL expression for the wasm-shim
- Rename `FailureAction` to `FailAction` aligned with wasm-shim's `fail` type (log message only)
- Add `EXTRA_EXTENSIONS` build arg for optionally including additional extensions (e.g. `threat-policy`)
- Update threat-policy demo extension to exercise all action types

## Test plan

- [x] Unit tests pass (`make test-unit`)
- [x] Proto tests verify serialization of unified `ActionEntry`
- [x] Pipeline ordering validation tests cover forward references, phase ordering, duplicate vars
- [x] Registry tests verify `onReply` nesting and `DenyResponse{}` expression construction
- [x] End-to-end verified on local Kind cluster with Istio, wasm-shim (main), and threat-policy extension

Closes #1958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure and build extra extensions via EXTRA_EXTENSIONS and deploy a shim image; operator can fetch wasm via OCI.
  * Unified action model with DENY/FAIL/ADD_HEADERS/GRPC_METHOD, stricter cross-action validation and atomic pipeline updates.
  * Threat‑policy now enforces mandatory assessment, consistent threat headers and explicit 403 deny behaviour.

* **Documentation**
  * Local development guide expanded with step‑by‑step shim build, tag/push and operator configuration.

* **Tests**
  * Expanded tests covering unified actions, validation, translation and typed-action behaviours.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->