### PR TITLE
developer-portal-controller: delete permission on apikeyapproval

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2026-05-19T14:09:29Z"
+    createdAt: "2026-05-21T16:01:37Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -314,8 +314,11 @@ spec:
           - devportal.kuadrant.io
           resources:
           - apikeyapprovals
+          - apikeyrequests
+          - apiproducts
           verbs:
           - create
+          - delete
           - get
           - list
           - patch
@@ -332,19 +335,6 @@ spec:
           - get
           - patch
           - update
-        - apiGroups:
-          - devportal.kuadrant.io
-          resources:
-          - apikeyrequests
-          - apiproducts
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - devportal.kuadrant.io
           resources:

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -13916,8 +13916,11 @@ rules:
   - devportal.kuadrant.io
   resources:
   - apikeyapprovals
+  - apikeyrequests
+  - apiproducts
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -13934,19 +13937,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - devportal.kuadrant.io
-  resources:
-  - apikeyrequests
-  - apiproducts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - devportal.kuadrant.io
   resources:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator metadata timestamps
  * Modified RBAC permissions for the developer portal controller manager service account, expanding access to additional resources within the developer portal API group
  * Restructured RBAC rules for the kuadrant operator controller manager, adjusting permission scopes for the developer portal API group resources

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->