### PR TITLE
[Release] Kuadrant Operator v1.4.4-rc1

### DIFF
--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -72,7 +72,7 @@ jobs:
         id: create-release-branch
         shell: bash
         run: |
-          base_branch=release-v$(echo "${{ github.event.inputs.kuadrantOperatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          base_branch=release-$(echo "${{ github.event.inputs.kuadrantOperatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo BASE_BRANCH=$base_branch >> $GITHUB_ENV
           
           if git ls-remote --exit-code --heads origin $base_branch ; then
@@ -125,7 +125,7 @@ jobs:
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: true
           base: ${{ env.BASE_BRANCH }}
-          branch: release-v${{ github.event.inputs.kuadrantOperatorVersion }}
+          branch: release-${{ github.event.inputs.kuadrantOperatorVersion }}
           delete-branch: true
           title: '[Release] Kuadrant Operator v${{ github.event.inputs.kuadrantOperatorVersion }}'
           body: |

--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: |
           version="${{ github.event.inputs.kuadrantOperatorVersion }}"
-          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].+)?$'; then
             echo "Error: version must be semver format (e.g., 1.4.1, 1.5.0-rc1)"
             exit 1
           fi

--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -72,7 +72,14 @@ jobs:
         id: create-release-branch
         shell: bash
         run: |
-          base_branch=release-$(echo "${{ github.event.inputs.kuadrantOperatorVersion }}" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          version="${{ github.event.inputs.kuadrantOperatorVersion }}"
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+            echo "Error: version must be semver format (e.g., 1.4.1, 1.5.0-rc1)"
+            exit 1
+          fi
+          # Extract major.minor from version (e.g., 1.4.1 → 1.4)
+          # Removes: pre-release suffix ([+-].*) and patch version (\.[0-9]*$)
+          base_branch=release-$(echo "$version" | sed 's/[+-].*//; s/\.[0-9]*$//')
           echo BASE_BRANCH=$base_branch >> $GITHUB_ENV
           
           if git ls-remote --exit-code --heads origin $base_branch ; then

--- a/.github/workflows/release-operator.yaml
+++ b/.github/workflows/release-operator.yaml
@@ -6,6 +6,7 @@ on:
     - closed
     branches:
       - 'release-v[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,7 @@ name: Test
 on:
   workflow_dispatch:
   push:
-    branches: [ 'main', 'release-v*' ]
+    branches: [ 'main', 'release-*' ]
   pull_request:
     branches: [ '*' ]
   merge_group:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,16 +32,16 @@ Reference [slack Chat](https://kubernetes.slack.com/archives/C05J0D0V525/p174419
 
 ### Local steps
 
-1. Create the `release-vX.Y` branch, if the branch does not already exist. 
-2. Push the `release-vX.Y` to the remote (kuadrant/kuadrant-operator)
-3. Create the `release-vX.Y.Z-rc(n)` branch with `release-vX.Y` as the base.
-4. Cherry-pick commits to the `kudrant-vX.Y.Z-rc(n)` from the relevant sources, i.e. `main`.
+1. Create the `release-X.Y` branch, if the branch does not already exist. 
+2. Push the `release-X.Y` to the remote (kuadrant/kuadrant-operator)
+3. Create the `release-X.Y.Z-rc(n)` branch with `release-X.Y` as the base.
+4. Cherry-pick commits to the `release-X.Y.Z-rc(n)` from the relevant sources, i.e. `main`.
 5. Update the applicable version in the [release.yaml](https://github.com/Kuadrant/kuadrant-operator/blob/main/RELEASE.md#release-file-format).
-6. Run `make prepare-release` on the `release-vX.Y.Z-rc(n)`. If you run into rate limit errors, set the env `GITHUB_TOKEN` with your PAT.
+6. Run `make prepare-release` on the `release-X.Y.Z-rc(n)`. If you run into rate limit errors, set the env `GITHUB_TOKEN` with your PAT.
 
 ### Remote steps
 
-1. Open a PR against the `release-vX.Y` branch with the changes from `release-vX.Y.Z-rc(n)` branch.
+1. Open a PR against the `release-X.Y` branch with the changes from `release-X.Y.Z-rc(n)` branch.
 2. PR verification checks will run.
 3. Get manual review of PR with focus on changes in these areas:
    * `./bundle.Dockerfile`
@@ -50,7 +50,7 @@ Reference [slack Chat](https://kubernetes.slack.com/archives/C05J0D0V525/p174419
    * `./charts/`
 > NOTE: **The PR must receive approval from at least one member of the QE team.**
 4. Merge PR
-5. Run the Release Workflow on the `release-vX.Y`. This does the following:
+5. Run the Release Workflow on the `release-X.Y`. This does the following:
    * Creates the GitHub release
    * Creates tags
 6. Verify that the build [release tag workflow](https://github.com/Kuadrant/kuadrant-operator/actions/workflows/build-images-for-tag-release.yaml) is triggered and completes for the new tag.
@@ -63,7 +63,7 @@ Resolution of this issue is tracked in [Auto generation of release notes failure
 ## Creating the RC2+
 
 1. Create a local branch based off the, targeted release branch. 
-Example: `git checkout -B release-v1.2.0-rc2 release-v1.2`
+Example: `git checkout -B release-1.2.0-rc2 release-1.2`
 2. Cherry pick the changes required to fix which ever issue justified the creation of a new RC.
 Example: `git cherry-pick <commit sha>`
 3. Update the `release.yaml` with the new version of the kuadrant-operator. 

--- a/bundle/manifests/devportal.kuadrant.io_apikeys.yaml
+++ b/bundle/manifests/devportal.kuadrant.io_apikeys.yaml
@@ -17,8 +17,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.phase
-      name: Phase
+    - jsonPath: .status.conditions[?(@.type=="Approved")].status
+      name: Approved
       type: string
     - jsonPath: .spec.apiProductRef.name
       name: API
@@ -62,6 +62,8 @@ spec:
                 properties:
                   name:
                     type: string
+                  namespace:
+                    type: string
                 required:
                 - name
                 type: object
@@ -85,6 +87,24 @@ spec:
                 - email
                 - userId
                 type: object
+              secretRef:
+                description: |-
+                  SecretRef is a reference to the secret containing the API key
+                  Consumer creates this secret in their own namespace before creating APIKey
+                  The secret must contain an "api_key" entry with the value of the API key
+                  Controller reads API key from this secret on approval
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               useCase:
                 description: UseCase describes how the API key will be used
                 type: string
@@ -92,7 +112,7 @@ spec:
             - apiProductRef
             - planTier
             - requestedBy
-            - useCase
+            - secretRef
             type: object
           status:
             description: APIKeyStatus defines the observed state of APIKey.
@@ -193,11 +213,6 @@ spec:
                         type: object
                     type: object
                 type: object
-              canReadSecret:
-                default: true
-                description: CanReadSecret expresses the permission to read the APIKey's
-                  secret
-                type: boolean
               conditions:
                 description: Conditions represent the latest available observations
                   of the APIKey's state
@@ -293,37 +308,11 @@ spec:
                     description: Yearly limit of requests for this plan.
                     type: integer
                 type: object
-              phase:
-                description: |-
-                  Phase represents the current phase of the APIKey
-                  Valid values are "Pending", "Approved", or "Rejected"
-                enum:
-                - Pending
-                - Approved
-                - Rejected
-                type: string
-              reviewedAt:
-                description: ReviewedAt is the timestamp when the request was reviewed
-                format: date-time
-                type: string
-              reviewedBy:
-                description: ReviewedBy indicates who approved or rejected the request
-                type: string
-              secretRef:
-                description: SecretRef is a reference to the created Secret
-                properties:
-                  key:
-                    description: The key of the secret to select from.  Must be a
-                      valid secret key.
-                    type: string
-                  name:
-                    description: The name of the secret in the Authorino's namespace
-                      to select from.
-                    type: string
-                required:
-                - key
-                - name
-                type: object
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/bundle/manifests/devportal.kuadrant.io_apikeys.yaml
+++ b/bundle/manifests/devportal.kuadrant.io_apikeys.yaml
@@ -17,8 +17,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Approved")].status
-      name: Approved
+    - jsonPath: .status.phase
+      name: Phase
       type: string
     - jsonPath: .spec.apiProductRef.name
       name: API
@@ -62,8 +62,6 @@ spec:
                 properties:
                   name:
                     type: string
-                  namespace:
-                    type: string
                 required:
                 - name
                 type: object
@@ -87,24 +85,6 @@ spec:
                 - email
                 - userId
                 type: object
-              secretRef:
-                description: |-
-                  SecretRef is a reference to the secret containing the API key
-                  Consumer creates this secret in their own namespace before creating APIKey
-                  The secret must contain an "api_key" entry with the value of the API key
-                  Controller reads API key from this secret on approval
-                properties:
-                  name:
-                    default: ""
-                    description: |-
-                      Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
               useCase:
                 description: UseCase describes how the API key will be used
                 type: string
@@ -112,7 +92,7 @@ spec:
             - apiProductRef
             - planTier
             - requestedBy
-            - secretRef
+            - useCase
             type: object
           status:
             description: APIKeyStatus defines the observed state of APIKey.
@@ -213,6 +193,11 @@ spec:
                         type: object
                     type: object
                 type: object
+              canReadSecret:
+                default: true
+                description: CanReadSecret expresses the permission to read the APIKey's
+                  secret
+                type: boolean
               conditions:
                 description: Conditions represent the latest available observations
                   of the APIKey's state
@@ -308,11 +293,37 @@ spec:
                     description: Yearly limit of requests for this plan.
                     type: integer
                 type: object
-              observedGeneration:
-                description: ObservedGeneration reflects the generation of the most
-                  recently observed spec.
-                format: int64
-                type: integer
+              phase:
+                description: |-
+                  Phase represents the current phase of the APIKey
+                  Valid values are "Pending", "Approved", or "Rejected"
+                enum:
+                - Pending
+                - Approved
+                - Rejected
+                type: string
+              reviewedAt:
+                description: ReviewedAt is the timestamp when the request was reviewed
+                format: date-time
+                type: string
+              reviewedBy:
+                description: ReviewedBy indicates who approved or rejected the request
+                type: string
+              secretRef:
+                description: SecretRef is a reference to the created Secret
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: The name of the secret in the Authorino's namespace
+                      to select from.
+                    type: string
+                required:
+                - key
+                - name
+                type: object
             type: object
         type: object
     served: true

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -224,14 +224,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.4
-    createdAt: "2026-05-22T10:24:15Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.4-rc1
+    createdAt: "2026-05-22T10:26:17Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.4
+  name: kuadrant-operator.v1.4.4-rc1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -753,7 +753,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.4.4
+                image: quay.io/kuadrant/kuadrant-operator:v1.4.4-rc1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -906,4 +906,4 @@ spec:
     name: console-plugin-latest
   - image: quay.io/kuadrant/console-plugin:v0.1.5
     name: console-plugin-pf5
-  version: 1.4.4
+  version: 1.4.4-rc1

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -224,14 +224,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.3
-    createdAt: "2026-03-31T14:00:33Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.4
+    createdAt: "2026-05-21T20:58:15Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.3
+  name: kuadrant-operator.v1.4.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -303,13 +303,12 @@ spec:
           - delete
           - get
           - list
-          - patch
-          - update
           - watch
         - apiGroups:
           - devportal.kuadrant.io
           resources:
-          - apikeys
+          - apikeyapprovals
+          - apikeyrequests
           - apiproducts
           verbs:
           - create
@@ -322,19 +321,22 @@ spec:
         - apiGroups:
           - devportal.kuadrant.io
           resources:
-          - apikeys/finalizers
-          - apiproducts/finalizers
-          verbs:
-          - update
-        - apiGroups:
-          - devportal.kuadrant.io
-          resources:
+          - apikeyapprovals/status
+          - apikeyrequests/status
           - apikeys/status
           - apiproducts/status
           verbs:
           - get
           - patch
           - update
+        - apiGroups:
+          - devportal.kuadrant.io
+          resources:
+          - apikeys
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - extensions.kuadrant.io
           resources:
@@ -367,6 +369,7 @@ spec:
           - kuadrant.io
           resources:
           - authpolicies
+          - kuadrants
           verbs:
           - get
           - list
@@ -744,16 +747,16 @@ spec:
                 - name: RELATED_IMAGE_WASMSHIM
                   value: quay.io/kuadrant/wasm-shim:v0.12.3
                 - name: RELATED_IMAGE_DEVELOPERPORTAL
-                  value: quay.io/kuadrant/developer-portal-controller:v0.1.0
+                  value: quay.io/kuadrant/developer-portal-controller:v0.1.1
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN_LATEST
-                  value: quay.io/kuadrant/console-plugin:v0.3.4
+                  value: quay.io/kuadrant/console-plugin:v0.3.7
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN_PF5
                   value: quay.io/kuadrant/console-plugin:v0.1.5
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.4.3
+                image: quay.io/kuadrant/kuadrant-operator:v1.4.4
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -900,10 +903,10 @@ spec:
   relatedImages:
   - image: quay.io/kuadrant/wasm-shim:v0.12.3
     name: wasmshim
-  - image: quay.io/kuadrant/developer-portal-controller:v0.1.0
+  - image: quay.io/kuadrant/developer-portal-controller:v0.1.1
     name: developerportal
-  - image: quay.io/kuadrant/console-plugin:v0.3.4
+  - image: quay.io/kuadrant/console-plugin:v0.3.7
     name: console-plugin-latest
   - image: quay.io/kuadrant/console-plugin:v0.1.5
     name: console-plugin-pf5
-  version: 1.4.3
+  version: 1.4.4

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.4
-    createdAt: "2026-05-21T20:58:15Z"
+    createdAt: "2026-05-22T10:24:15Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -303,12 +303,13 @@ spec:
           - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - devportal.kuadrant.io
           resources:
-          - apikeyapprovals
-          - apikeyrequests
+          - apikeys
           - apiproducts
           verbs:
           - create
@@ -321,22 +322,19 @@ spec:
         - apiGroups:
           - devportal.kuadrant.io
           resources:
-          - apikeyapprovals/status
-          - apikeyrequests/status
+          - apikeys/finalizers
+          - apiproducts/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - devportal.kuadrant.io
+          resources:
           - apikeys/status
           - apiproducts/status
           verbs:
           - get
           - patch
           - update
-        - apiGroups:
-          - devportal.kuadrant.io
-          resources:
-          - apikeys
-          verbs:
-          - get
-          - list
-          - watch
         - apiGroups:
           - extensions.kuadrant.io
           resources:
@@ -369,7 +367,6 @@ spec:
           - kuadrant.io
           resources:
           - authpolicies
-          - kuadrants
           verbs:
           - get
           - list

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -2,12 +2,12 @@ dependencies:
   - type: olm.package
     value:
       packageName: authorino-operator
-      version: "0.23.1"
+      version: "0.23.2"
   - type: olm.package
     value:
       packageName: limitador-operator
-      version: "0.17.1"
+      version: "0.17.2"
   - type: olm.package
     value:
       packageName: dns-operator
-      version: "0.16.0"
+      version: "0.16.2"

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,17 +20,17 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.4.3"
-appVersion: "1.4.3"
+version: "1.4.4"
+appVersion: "1.4.4"
 dependencies:
   - name: authorino-operator
-    version: 0.23.1
+    version: 0.23.2
     repository: https://kuadrant.io/helm-charts/
   - name: limitador-operator
-    version: 0.17.1
+    version: 0.17.2
     repository: https://kuadrant.io/helm-charts/
   - name: dns-operator
-    version: 0.16.0
+    version: 0.16.2
     repository: https://kuadrant.io/helm-charts/
 maintainers:
   - email: acatterm@redhat.com

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.4.4"
-appVersion: "1.4.4"
+version: "1.4.4-rc1"
+appVersion: "1.4.4-rc1"
 dependencies:
   - name: authorino-operator
     version: 0.23.2

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14059,7 +14059,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.4.4
+        image: quay.io/kuadrant/kuadrant-operator:v1.4.4-rc1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -18,8 +18,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.phase
-      name: Phase
+    - jsonPath: .status.conditions[?(@.type=="Approved")].status
+      name: Approved
       type: string
     - jsonPath: .spec.apiProductRef.name
       name: API
@@ -63,6 +63,8 @@ spec:
                 properties:
                   name:
                     type: string
+                  namespace:
+                    type: string
                 required:
                 - name
                 type: object
@@ -86,6 +88,24 @@ spec:
                 - email
                 - userId
                 type: object
+              secretRef:
+                description: |-
+                  SecretRef is a reference to the secret containing the API key
+                  Consumer creates this secret in their own namespace before creating APIKey
+                  The secret must contain an "api_key" entry with the value of the API key
+                  Controller reads API key from this secret on approval
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               useCase:
                 description: UseCase describes how the API key will be used
                 type: string
@@ -93,7 +113,7 @@ spec:
             - apiProductRef
             - planTier
             - requestedBy
-            - useCase
+            - secretRef
             type: object
           status:
             description: APIKeyStatus defines the observed state of APIKey.
@@ -194,11 +214,6 @@ spec:
                         type: object
                     type: object
                 type: object
-              canReadSecret:
-                default: true
-                description: CanReadSecret expresses the permission to read the APIKey's
-                  secret
-                type: boolean
               conditions:
                 description: Conditions represent the latest available observations
                   of the APIKey's state
@@ -294,37 +309,11 @@ spec:
                     description: Yearly limit of requests for this plan.
                     type: integer
                 type: object
-              phase:
-                description: |-
-                  Phase represents the current phase of the APIKey
-                  Valid values are "Pending", "Approved", or "Rejected"
-                enum:
-                - Pending
-                - Approved
-                - Rejected
-                type: string
-              reviewedAt:
-                description: ReviewedAt is the timestamp when the request was reviewed
-                format: date-time
-                type: string
-              reviewedBy:
-                description: ReviewedBy indicates who approved or rejected the request
-                type: string
-              secretRef:
-                description: SecretRef is a reference to the created Secret
-                properties:
-                  key:
-                    description: The key of the secret to select from.  Must be a
-                      valid secret key.
-                    type: string
-                  name:
-                    description: The name of the secret in the Authorino's namespace
-                      to select from.
-                    type: string
-                required:
-                - key
-                - name
-                type: object
+              observedGeneration:
+                description: ObservedGeneration reflects the generation of the most
+                  recently observed spec.
+                format: int64
+                type: integer
             type: object
         type: object
     served: true
@@ -13514,13 +13503,12 @@ rules:
   - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - devportal.kuadrant.io
   resources:
-  - apikeys
+  - apikeyapprovals
+  - apikeyrequests
   - apiproducts
   verbs:
   - create
@@ -13533,19 +13521,22 @@ rules:
 - apiGroups:
   - devportal.kuadrant.io
   resources:
-  - apikeys/finalizers
-  - apiproducts/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - devportal.kuadrant.io
-  resources:
+  - apikeyapprovals/status
+  - apikeyrequests/status
   - apikeys/status
   - apiproducts/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeys
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - extensions.kuadrant.io
   resources:
@@ -13578,6 +13569,7 @@ rules:
   - kuadrant.io
   resources:
   - authpolicies
+  - kuadrants
   verbs:
   - get
   - list
@@ -14050,16 +14042,16 @@ spec:
         - name: RELATED_IMAGE_WASMSHIM
           value: quay.io/kuadrant/wasm-shim:v0.12.3
         - name: RELATED_IMAGE_DEVELOPERPORTAL
-          value: quay.io/kuadrant/developer-portal-controller:v0.1.0
+          value: quay.io/kuadrant/developer-portal-controller:v0.1.1
         - name: RELATED_IMAGE_CONSOLE_PLUGIN_LATEST
-          value: quay.io/kuadrant/console-plugin:v0.3.4
+          value: quay.io/kuadrant/console-plugin:v0.3.7
         - name: RELATED_IMAGE_CONSOLE_PLUGIN_PF5
           value: quay.io/kuadrant/console-plugin:v0.1.5
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.4.3
+        image: quay.io/kuadrant/kuadrant-operator:v1.4.4
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -18,8 +18,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=="Approved")].status
-      name: Approved
+    - jsonPath: .status.phase
+      name: Phase
       type: string
     - jsonPath: .spec.apiProductRef.name
       name: API
@@ -63,8 +63,6 @@ spec:
                 properties:
                   name:
                     type: string
-                  namespace:
-                    type: string
                 required:
                 - name
                 type: object
@@ -88,24 +86,6 @@ spec:
                 - email
                 - userId
                 type: object
-              secretRef:
-                description: |-
-                  SecretRef is a reference to the secret containing the API key
-                  Consumer creates this secret in their own namespace before creating APIKey
-                  The secret must contain an "api_key" entry with the value of the API key
-                  Controller reads API key from this secret on approval
-                properties:
-                  name:
-                    default: ""
-                    description: |-
-                      Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
               useCase:
                 description: UseCase describes how the API key will be used
                 type: string
@@ -113,7 +93,7 @@ spec:
             - apiProductRef
             - planTier
             - requestedBy
-            - secretRef
+            - useCase
             type: object
           status:
             description: APIKeyStatus defines the observed state of APIKey.
@@ -214,6 +194,11 @@ spec:
                         type: object
                     type: object
                 type: object
+              canReadSecret:
+                default: true
+                description: CanReadSecret expresses the permission to read the APIKey's
+                  secret
+                type: boolean
               conditions:
                 description: Conditions represent the latest available observations
                   of the APIKey's state
@@ -309,11 +294,37 @@ spec:
                     description: Yearly limit of requests for this plan.
                     type: integer
                 type: object
-              observedGeneration:
-                description: ObservedGeneration reflects the generation of the most
-                  recently observed spec.
-                format: int64
-                type: integer
+              phase:
+                description: |-
+                  Phase represents the current phase of the APIKey
+                  Valid values are "Pending", "Approved", or "Rejected"
+                enum:
+                - Pending
+                - Approved
+                - Rejected
+                type: string
+              reviewedAt:
+                description: ReviewedAt is the timestamp when the request was reviewed
+                format: date-time
+                type: string
+              reviewedBy:
+                description: ReviewedBy indicates who approved or rejected the request
+                type: string
+              secretRef:
+                description: SecretRef is a reference to the created Secret
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    description: The name of the secret in the Authorino's namespace
+                      to select from.
+                    type: string
+                required:
+                - key
+                - name
+                type: object
             type: object
         type: object
     served: true
@@ -13503,12 +13514,13 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - devportal.kuadrant.io
   resources:
-  - apikeyapprovals
-  - apikeyrequests
+  - apikeys
   - apiproducts
   verbs:
   - create
@@ -13521,22 +13533,19 @@ rules:
 - apiGroups:
   - devportal.kuadrant.io
   resources:
-  - apikeyapprovals/status
-  - apikeyrequests/status
+  - apikeys/finalizers
+  - apiproducts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
   - apikeys/status
   - apiproducts/status
   verbs:
   - get
   - patch
   - update
-- apiGroups:
-  - devportal.kuadrant.io
-  resources:
-  - apikeys
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - extensions.kuadrant.io
   resources:
@@ -13569,7 +13578,6 @@ rules:
   - kuadrant.io
   resources:
   - authpolicies
-  - kuadrants
   verbs:
   - get
   - list

--- a/config/dependencies/authorino/kustomization.yaml
+++ b/config/dependencies/authorino/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-- github.com/Kuadrant/authorino-operator/config/deploy?ref=main
+- github.com/Kuadrant/authorino-operator/config/deploy?ref=v0.23.2

--- a/config/dependencies/developer-portal/kustomization.template.yaml
+++ b/config/dependencies/developer-portal/kustomization.template.yaml
@@ -7,9 +7,8 @@ kind: Kustomization
 namePrefix: developer-portal-
 
 resources:
-# CRDs
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/crd/bases/devportal.kuadrant.io_apikeys.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/crd/bases/devportal.kuadrant.io_apiproducts.yaml
+# CRDs - directory ref adapts to whatever CRDs exist at the given ref
+- github.com/Kuadrant/developer-portal-controller/config/crd?ref=${DEVELOPERPORTAL_GITREF}
 # RBAC resources
 - https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/rbac/service_account.yaml
 - https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/rbac/role.yaml

--- a/config/dependencies/developer-portal/kustomization.yaml
+++ b/config/dependencies/developer-portal/kustomization.yaml
@@ -7,12 +7,11 @@ kind: Kustomization
 namePrefix: developer-portal-
 
 resources:
-# CRDs
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/crd/bases/devportal.kuadrant.io_apikeys.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/crd/bases/devportal.kuadrant.io_apiproducts.yaml
+# CRDs - directory ref adapts to whatever CRDs exist at the given ref
+- github.com/Kuadrant/developer-portal-controller/config/crd?ref=v0.1.1
 # RBAC resources
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/rbac/service_account.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/rbac/role.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/rbac/role_binding.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/rbac/leader_election_role.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/rbac/leader_election_role_binding.yaml
+- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/v0.1.1/config/rbac/service_account.yaml
+- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/v0.1.1/config/rbac/role.yaml
+- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/v0.1.1/config/rbac/role_binding.yaml
+- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/v0.1.1/config/rbac/leader_election_role.yaml
+- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/v0.1.1/config/rbac/leader_election_role_binding.yaml

--- a/config/dependencies/dns/kustomization.yaml
+++ b/config/dependencies/dns/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- github.com/kuadrant/dns-operator/config/default?ref=main
+- github.com/kuadrant/dns-operator/config/default?ref=v0.16.2
 
 patches:
   - path: deployment_patch.yaml

--- a/config/dependencies/limitador/kustomization.yaml
+++ b/config/dependencies/limitador/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-- github.com/Kuadrant/limitador-operator/config/default?ref=main
+- github.com/Kuadrant/limitador-operator/config/default?ref=v0.17.2

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.4
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.4-rc1
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.3
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.4
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.4.4
+  newTag: v1.4.4-rc1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.4.3
+  newTag: v1.4.4

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,9 +36,9 @@ spec:
             - name: RELATED_IMAGE_WASMSHIM
               value: "quay.io/kuadrant/wasm-shim:v0.12.3"
             - name: RELATED_IMAGE_DEVELOPERPORTAL
-              value: "quay.io/kuadrant/developer-portal-controller:v0.1.0"
+              value: "quay.io/kuadrant/developer-portal-controller:v0.1.1"
             - name: RELATED_IMAGE_CONSOLE_PLUGIN_LATEST
-              value: "quay.io/kuadrant/console-plugin:v0.3.4"
+              value: "quay.io/kuadrant/console-plugin:v0.3.7"
             - name: RELATED_IMAGE_CONSOLE_PLUGIN_PF5
               value: "quay.io/kuadrant/console-plugin:v0.1.5"
             - name: OPERATOR_NAMESPACE

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.3
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.4
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.3
+  name: kuadrant-operator.v1.4.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,4 +88,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.4.3
+  version: 1.4.4

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.4
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.4-rc1
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.4
+  name: kuadrant-operator.v1.4.4-rc1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,4 +88,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.4.4
+  version: 1.4.4-rc1

--- a/doc/overviews/helm-charts-release-process.md
+++ b/doc/overviews/helm-charts-release-process.md
@@ -97,9 +97,9 @@ sequenceDiagram
     Dev->>GHA: Trigger Automated Release Workflow
     GHA->>GHA: Update release.yaml with versions
     GHA->>GHA: Run make prepare-release<br/>• Execute make_chart.sh script<br/>• Build helm templates<br/>• Update Chart.yaml with versions
-    GHA->>GitHub: Create release-v{MAJOR.MINOR} base branch<br/>(if it doesn't exist)
+    GHA->>GitHub: Create release-{MAJOR.MINOR} base branch<br/>(if it doesn't exist)
     GHA->>CreatePR: Invoke create-pull-request
-    CreatePR->>GitHub: Auto-create release-v{FULL_VERSION} branch
+    CreatePR->>GitHub: Auto-create release-{FULL_VERSION} branch
     CreatePR->>GitHub: Commit chart changes to working branch
     CreatePR->>GitHub: Create PR (working → base branch)
 
@@ -161,9 +161,9 @@ sequenceDiagram
         - Updates Chart.yaml with version and dependency versions
 
 3. **Creates Pull Request**:
-    - Creates base branch `release-v{MAJOR.MINOR}` (e.g., `release-v1.0`) if it doesn't exist
+    - Creates base branch `release-{MAJOR.MINOR}` (e.g., `release-v1.0`) if it doesn't exist
     - Uses `peter-evans/create-pull-request` action which automatically:
-      - Creates working branch `release-v{FULL_VERSION}` (e.g., `release-v1.0.0`)
+      - Creates working branch `release-{FULL_VERSION}` (e.g., `release-v1.0.0`)
       - Commits all changes from `make prepare-release`
       - Opens PR from working branch to base branch
 
@@ -171,7 +171,7 @@ sequenceDiagram
 
 **Overview**: Once the release PR is merged the release creation will be triggered.
 
-**Trigger**: Release PR is merged (from `release-v{FULL_VERSION}` to `release-v{MAJOR.MINOR}` branch)
+**Trigger**: Release PR is merged (from `release-{FULL_VERSION}` to `release-{MAJOR.MINOR}` branch)
 
 **Workflow**: [release-operator.yaml](../../.github/workflows/release-operator.yaml)
 

--- a/doc/overviews/helm-charts-release-process.md
+++ b/doc/overviews/helm-charts-release-process.md
@@ -161,9 +161,9 @@ sequenceDiagram
         - Updates Chart.yaml with version and dependency versions
 
 3. **Creates Pull Request**:
-    - Creates base branch `release-{MAJOR.MINOR}` (e.g., `release-v1.0`) if it doesn't exist
+    - Creates base branch `release-{MAJOR.MINOR}` (e.g., `release-1.0`) if it doesn't exist
     - Uses `peter-evans/create-pull-request` action which automatically:
-      - Creates working branch `release-{FULL_VERSION}` (e.g., `release-v1.0.0`)
+      - Creates working branch `release-{FULL_VERSION}` (e.g., `release-1.0.0`)
       - Commits all changes from `make prepare-release`
       - Opens PR from working branch to base branch
 

--- a/release.yaml
+++ b/release.yaml
@@ -1,13 +1,13 @@
 kuadrant-operator:
-  version: "1.4.3"
+  version: "1.4.4"
 olm:
   channels:
     - "stable"
   default-channel: "stable"
 dependencies:
-  authorino-operator: "0.23.1"
-  console-plugin: "0.3.4"
-  developer-portal-controller: "0.1.0"
-  dns-operator: "0.16.0"
-  limitador-operator: "0.17.1"
+  authorino-operator: "0.23.2"
+  console-plugin: "0.3.7"
+  developer-portal-controller: "0.1.1"
+  dns-operator: "0.16.2"
+  limitador-operator: "0.17.2"
   wasm-shim: "0.12.3"

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.4.4"
+  version: "1.4.4-rc1"
 olm:
   channels:
     - "stable"

--- a/utils/release/operator/make_bundles.sh
+++ b/utils/release/operator/make_bundles.sh
@@ -11,6 +11,18 @@ mod_version() {
   fi
 }
 
+# Pass version to Make as-is, but map 0.0.0 to "latest" to match the
+# Makefile's ifeq(latest,...) check. Without this, 0.0.0 would hit the
+# semantic version branch and produce GITREF=v0.0.0 (a non-existent tag).
+mod_version_for_make() {
+  version=$1
+  if [ "$version" == "0.0.0" ]; then
+    echo "latest"
+  else
+    echo "$version"
+  fi
+}
+
 echo "make bundle"
 root=$(pwd)
 cd $env
@@ -55,10 +67,10 @@ make bundle \
   LIMITADOR_OPERATOR_BUNDLE_IMG=$limitador_image \
   AUTHORINO_OPERATOR_BUNDLE_IMG=$authorino_image \
   DNS_OPERATOR_BUNDLE_IMG=$dns_image \
-  AUTHORINO_OPERATOR_VERSION=$AUTHORINO_OPERATOR_VERSION \
-  LIMITADOR_OPERATOR_VERSION=$LIMITADOR_OPERATOR_VERSION \
-  DNS_OPERATOR_VERSION=$DNS_OPERATOR_VERSION \
-  DEVELOPERPORTAL_VERSION=$DEVELOPERPORTAL_VERSION
+  AUTHORINO_OPERATOR_VERSION=$(mod_version_for_make $AUTHORINO_OPERATOR_VERSION) \
+  LIMITADOR_OPERATOR_VERSION=$(mod_version_for_make $LIMITADOR_OPERATOR_VERSION) \
+  DNS_OPERATOR_VERSION=$(mod_version_for_make $DNS_OPERATOR_VERSION) \
+  DEVELOPERPORTAL_VERSION=$(mod_version_for_make $DEVELOPERPORTAL_VERSION)
 
 operator-sdk bundle validate $env/bundle
 git diff --quiet -I'^    createdAt: ' ./bundle && git checkout ./bundle || true

--- a/utils/release/operator/make_bundles.sh
+++ b/utils/release/operator/make_bundles.sh
@@ -45,7 +45,20 @@ authorino_image=quay.io/kuadrant/authorino-operator-bundle:$authorino_version
 dns_version=$(mod_version $DNS_OPERATOR_VERSION)
 dns_image=quay.io/kuadrant/dns-operator-bundle:$dns_version
 
-make bundle BUNDLE_VERSION=$KUADRANT_OPERATOR_VERSION BUNDLE_METADATA_OPTS="--channels $OLM_CHANNELS $default_channel_opt" IMG=$operator_image RELATED_IMAGE_WASMSHIM=$wasm_shim_image RELATED_IMAGE_DEVELOPERPORTAL=$developerportal_image RELATED_IMAGE_CONSOLE_PLUGIN_LATEST=$consoleplugin_image LIMITADOR_OPERATOR_BUNDLE_IMG=$limitador_image AUTHORINO_OPERATOR_BUNDLE_IMG=$authorino_image DNS_OPERATOR_BUNDLE_IMG=$dns_image
+make bundle \
+  BUNDLE_VERSION=$KUADRANT_OPERATOR_VERSION \
+  BUNDLE_METADATA_OPTS="--channels $OLM_CHANNELS $default_channel_opt" \
+  IMG=$operator_image \
+  RELATED_IMAGE_WASMSHIM=$wasm_shim_image \
+  RELATED_IMAGE_DEVELOPERPORTAL=$developerportal_image \
+  RELATED_IMAGE_CONSOLE_PLUGIN_LATEST=$consoleplugin_image \
+  LIMITADOR_OPERATOR_BUNDLE_IMG=$limitador_image \
+  AUTHORINO_OPERATOR_BUNDLE_IMG=$authorino_image \
+  DNS_OPERATOR_BUNDLE_IMG=$dns_image \
+  AUTHORINO_OPERATOR_VERSION=$AUTHORINO_OPERATOR_VERSION \
+  LIMITADOR_OPERATOR_VERSION=$LIMITADOR_OPERATOR_VERSION \
+  DNS_OPERATOR_VERSION=$DNS_OPERATOR_VERSION \
+  DEVELOPERPORTAL_VERSION=$DEVELOPERPORTAL_VERSION
 
 operator-sdk bundle validate $env/bundle
 git diff --quiet -I'^    createdAt: ' ./bundle && git checkout ./bundle || true


### PR DESCRIPTION
## Summary

Release preparation for v1.4.4-rc1. Validates RFC 0018 release branch naming migration (Phase 3 of #1981).

## Changes

- Cherry-pick Phase 1 workflow changes (dual branch patterns in release-operator.yaml, automated-release.yaml)
- `load_github_envvar.sh` fix (strip v prefix per RFC 0018) — from #1985
- Go 1.25.9 — from #1985
- Version format validation for release branch derivation
- Cherry-pick #1990 (kustomize directory ref for developer-portal CRDs)
- Cherry-pick #1991 (pass dependency versions to make bundle)
- Updated `release.yaml` and regenerated manifests via `make prepare-release`

## Component versions for 1.4.4
| Component | 1.4.3 | 1.4.4 |
|-----------|-------|-------|
| authorino-operator | 0.23.1 | 0.23.2 |
| dns-operator | 0.16.0 | 0.16.2 |
| limitador-operator | 0.17.1 | 0.17.2 |
| console-plugin | 0.3.4 | 0.3.7 |
| developer-portal-controller | 0.1.0 | 0.1.1 |
| wasm-shim | 0.12.3 | 0.12.3 (unchanged) |

## RFC 0018 validation

When this PR merges to `release-1.4`, the `release-operator.yaml` workflow should trigger via the new `release-[0-9]+.[0-9]+` pattern and exercise the full pipeline:
- Workflow matches `release-1.4`
- `load_github_envvar.sh` produces `releaseBranch=release-1.4`
- Tag creation and GitHub Release use correct `target_commitish`

## Release process

This is **rc1**. After QE approval, a follow-up PR bumps version from `1.4.4-rc1` to `1.4.4` for GA.

Part of #1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)