### PR TITLE
Fix version regex to reject bare + or - suffix

### DIFF
--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -73,7 +73,7 @@ jobs:
         shell: bash
         run: |
           version="${{ github.event.inputs.kuadrantOperatorVersion }}"
-          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].*)?$'; then
+          if ! echo "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([+-].+)?$'; then
             echo "Error: version must be semver format (e.g., 1.4.1, 1.5.0-rc1)"
             exit 1
           fi


### PR DESCRIPTION
Change `([+-].*)` to `([+-].+)` in automated-release.yaml version validation. Without this, `1.5.0+` or `1.5.0-` would pass validation. Already fixed on `release-1.4` via #1988.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved semantic version validation in the release workflow to strengthen format enforcement. Version identifiers with incomplete pre-release or build metadata suffixes are now rejected during the release process. Standard semantic version formats (such as x.y.z and properly formatted variants) continue to be fully supported throughout the release pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->