### PR TITLE
Use kustomize directory ref for developer-portal CRDs

### DIFF
--- a/config/dependencies/developer-portal/kustomization.template.yaml
+++ b/config/dependencies/developer-portal/kustomization.template.yaml
@@ -7,11 +7,8 @@ kind: Kustomization
 namePrefix: developer-portal-
 
 resources:
-# CRDs
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/crd/bases/devportal.kuadrant.io_apikeys.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/crd/bases/devportal.kuadrant.io_apiproducts.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/crd/bases/devportal.kuadrant.io_apikeyrequests.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/crd/bases/devportal.kuadrant.io_apikeyapprovals.yaml
+# CRDs - directory ref adapts to whatever CRDs exist at the given ref
+- github.com/Kuadrant/developer-portal-controller/config/crd?ref=${DEVELOPERPORTAL_GITREF}
 # RBAC resources
 - https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/rbac/service_account.yaml
 - https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/${DEVELOPERPORTAL_GITREF}/config/rbac/role.yaml

--- a/config/dependencies/developer-portal/kustomization.yaml
+++ b/config/dependencies/developer-portal/kustomization.yaml
@@ -7,11 +7,8 @@ kind: Kustomization
 namePrefix: developer-portal-
 
 resources:
-# CRDs
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/crd/bases/devportal.kuadrant.io_apikeys.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/crd/bases/devportal.kuadrant.io_apiproducts.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/crd/bases/devportal.kuadrant.io_apikeyrequests.yaml
-- https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/crd/bases/devportal.kuadrant.io_apikeyapprovals.yaml
+# CRDs - directory ref adapts to whatever CRDs exist at the given ref
+- github.com/Kuadrant/developer-portal-controller/config/crd?ref=main
 # RBAC resources
 - https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/rbac/service_account.yaml
 - https://raw.githubusercontent.com/Kuadrant/developer-portal-controller/main/config/rbac/role.yaml


### PR DESCRIPTION
## Summary

Replace explicit CRD file URLs in the developer-portal kustomization template with a kustomize directory ref (`config/crd`). This automatically picks up whatever CRDs exist at the given git ref.

## Problem

The template explicitly listed CRD files by name:
```yaml
- .../config/crd/bases/devportal.kuadrant.io_apikeys.yaml
- .../config/crd/bases/devportal.kuadrant.io_apiproducts.yaml
- .../config/crd/bases/devportal.kuadrant.io_apikeyrequests.yaml
- .../config/crd/bases/devportal.kuadrant.io_apikeyapprovals.yaml
```

When `make prepare-release` runs for a patch release pointing at an older tag (e.g., `v0.1.1`), kustomize fails because `apikeyrequests` and `apikeyapprovals` CRDs don't exist at that ref — they were added on main later.

The other operators (authorino, limitador, dns) use directory refs which adapt automatically.

## Fix

CRDs now use a directory ref:
```yaml
- github.com/Kuadrant/developer-portal-controller/config/crd?ref=${DEVELOPERPORTAL_GITREF}
```

RBAC remains as explicit file URLs to avoid pulling extra scaffolded roles (admin/editor/viewer, metrics) from `config/rbac/kustomization.yaml`.

Tested locally: `v0.1.1` → 2 CRDs, `main` → 4 CRDs. Resource names and namePrefix behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated developer portal controller configuration to source Custom Resource Definitions from a referenced repository location rather than listing each CRD explicitly, enabling dynamic discovery of available CRDs at the chosen revision; RBAC entries remain unchanged and existing name-prefix behaviour to avoid role naming conflicts is preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->