### PR TITLE
fix: pass dependency versions to make bundle in release script

### DIFF
--- a/utils/release/operator/make_bundles.sh
+++ b/utils/release/operator/make_bundles.sh
@@ -11,6 +11,18 @@ mod_version() {
   fi
 }
 
+# Pass version to Make as-is, but map 0.0.0 to "latest" to match the
+# Makefile's ifeq(latest,...) check. Without this, 0.0.0 would hit the
+# semantic version branch and produce GITREF=v0.0.0 (a non-existent tag).
+mod_version_for_make() {
+  version=$1
+  if [ "$version" == "0.0.0" ]; then
+    echo "latest"
+  else
+    echo "$version"
+  fi
+}
+
 echo "make bundle"
 root=$(pwd)
 cd $env
@@ -55,10 +67,10 @@ make bundle \
   LIMITADOR_OPERATOR_BUNDLE_IMG=$limitador_image \
   AUTHORINO_OPERATOR_BUNDLE_IMG=$authorino_image \
   DNS_OPERATOR_BUNDLE_IMG=$dns_image \
-  AUTHORINO_OPERATOR_VERSION=$AUTHORINO_OPERATOR_VERSION \
-  LIMITADOR_OPERATOR_VERSION=$LIMITADOR_OPERATOR_VERSION \
-  DNS_OPERATOR_VERSION=$DNS_OPERATOR_VERSION \
-  DEVELOPERPORTAL_VERSION=$DEVELOPERPORTAL_VERSION
+  AUTHORINO_OPERATOR_VERSION=$(mod_version_for_make $AUTHORINO_OPERATOR_VERSION) \
+  LIMITADOR_OPERATOR_VERSION=$(mod_version_for_make $LIMITADOR_OPERATOR_VERSION) \
+  DNS_OPERATOR_VERSION=$(mod_version_for_make $DNS_OPERATOR_VERSION) \
+  DEVELOPERPORTAL_VERSION=$(mod_version_for_make $DEVELOPERPORTAL_VERSION)
 
 operator-sdk bundle validate $env/bundle
 git diff --quiet -I'^    createdAt: ' ./bundle && git checkout ./bundle || true

--- a/utils/release/operator/make_bundles.sh
+++ b/utils/release/operator/make_bundles.sh
@@ -45,7 +45,20 @@ authorino_image=quay.io/kuadrant/authorino-operator-bundle:$authorino_version
 dns_version=$(mod_version $DNS_OPERATOR_VERSION)
 dns_image=quay.io/kuadrant/dns-operator-bundle:$dns_version
 
-make bundle BUNDLE_VERSION=$KUADRANT_OPERATOR_VERSION BUNDLE_METADATA_OPTS="--channels $OLM_CHANNELS $default_channel_opt" IMG=$operator_image RELATED_IMAGE_WASMSHIM=$wasm_shim_image RELATED_IMAGE_DEVELOPERPORTAL=$developerportal_image RELATED_IMAGE_CONSOLE_PLUGIN_LATEST=$consoleplugin_image LIMITADOR_OPERATOR_BUNDLE_IMG=$limitador_image AUTHORINO_OPERATOR_BUNDLE_IMG=$authorino_image DNS_OPERATOR_BUNDLE_IMG=$dns_image
+make bundle \
+  BUNDLE_VERSION=$KUADRANT_OPERATOR_VERSION \
+  BUNDLE_METADATA_OPTS="--channels $OLM_CHANNELS $default_channel_opt" \
+  IMG=$operator_image \
+  RELATED_IMAGE_WASMSHIM=$wasm_shim_image \
+  RELATED_IMAGE_DEVELOPERPORTAL=$developerportal_image \
+  RELATED_IMAGE_CONSOLE_PLUGIN_LATEST=$consoleplugin_image \
+  LIMITADOR_OPERATOR_BUNDLE_IMG=$limitador_image \
+  AUTHORINO_OPERATOR_BUNDLE_IMG=$authorino_image \
+  DNS_OPERATOR_BUNDLE_IMG=$dns_image \
+  AUTHORINO_OPERATOR_VERSION=$AUTHORINO_OPERATOR_VERSION \
+  LIMITADOR_OPERATOR_VERSION=$LIMITADOR_OPERATOR_VERSION \
+  DNS_OPERATOR_VERSION=$DNS_OPERATOR_VERSION \
+  DEVELOPERPORTAL_VERSION=$DEVELOPERPORTAL_VERSION
 
 operator-sdk bundle validate $env/bundle
 git diff --quiet -I'^    createdAt: ' ./bundle && git checkout ./bundle || true


### PR DESCRIPTION
## Problem

During the 1.4.4 patch release, the generated bundle included CRD schemas from `main` instead of the tagged release version (`v0.1.1`). This caused 1.5-era CRDs (`apikeyrequests`, `apikeyapprovals`) to appear in a 1.4.x patch release.

### Root cause

The release pipeline has two phases that generate dependency kustomization files:

1. **`dependencies-manifests.sh`** (dependencies phase) — reads versions from `release.yaml`, runs `envsubst` on templates. Produces correct refs (e.g., `v0.1.1`).

2. **`make bundle`** (operator phase, called by `make_bundles.sh`) — depends on the `dependencies-manifests` Make target, which runs `envsubst` AGAIN. But the Makefile's `ifeq` blocks evaluate at parse time with the default `?= latest`, so `DEVELOPERPORTAL_GITREF` resolves to `main`, overwriting the correct refs from step 1.

This went unnoticed because `main` and release tags typically had identical CRD schemas. It became visible when developer-portal-controller `main` added new CRDs that don't exist at `v0.1.1`.

### Fix

Pass `AUTHORINO_OPERATOR_VERSION`, `LIMITADOR_OPERATOR_VERSION`, `DNS_OPERATOR_VERSION`, and `DEVELOPERPORTAL_VERSION` on the `make bundle` command line. GNU Make command-line variables override `?=` and are visible to `ifeq` at parse time, so the correct version branch is selected.

### Verification

```
$ echo 'FOO ?= default
ifeq (default,$(FOO))
BAR = was-default
else
BAR = was-overridden
endif
all:
	@echo FOO=$(FOO) BAR=$(BAR)' > /tmp/test.mk
$ make -f /tmp/test.mk FOO=custom
FOO=custom BAR=was-overridden
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved operator version mapping to ensure consistent component versioning across release bundles, enhancing overall release reliability and clarity.
  * Enhanced bundle parameter organisation for simplified configuration management and improved maintainability throughout the release process.
  * Standardised version handling across multiple operator components for better consistency and predictability in release workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1991?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->