### PR TITLE
feat(wasm): `allow_on_headers_stop_iteration` on our `PluginConfig`

### DIFF
--- a/internal/istio/utils.go
+++ b/internal/istio/utils.go
@@ -131,6 +131,7 @@ func buildWasmFilterConfig(wasmURL, imagePullSecret, imageSHA, clusterName strin
 			},
 			"allow_precompiled": true,
 		},
+		"allow_on_headers_stop_iteration": true,
 	}
 
 	if pluginConfig != nil {


### PR DESCRIPTION
Sets it to `true` so that we can move on to the request/response phase while "`Action::Pause`" the request in the headers. See [this](https://www.envoyproxy.io/docs/envoy/v1.35.0/api-v3/extensions/wasm/v3/wasm.proto#extensions-wasm-v3-pluginconfig)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * ~~Updated Envoy proxy configuration for Istio to enhance header iteration handling in service mesh sidecar plugins and middleware components~~ I don't think so.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/1993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->