### PR TITLE
Remove oauth_token response header from console plugin nginx config

### DIFF
--- a/internal/openshift/consoleplugin/nginx_configmap.go
+++ b/internal/openshift/consoleplugin/nginx_configmap.go
@@ -30,7 +30,6 @@ http {
 		listen              [::]:9443 ssl;
 		ssl_certificate     /var/serving-cert/tls.crt;
 		ssl_certificate_key /var/serving-cert/tls.key;
-		add_header oauth_token "$http_Authorization";
 		location / {
 			root                /usr/share/nginx/html;
 		}


### PR DESCRIPTION
## Summary
- Remove `add_header oauth_token "$http_Authorization"` from the operator-managed console plugin nginx configmap
- This directive reflected the incoming Authorization header back in every HTTP response, which serves no purpose

This was carried over from the console-plugin's `install.yaml` when the operator-managed nginx config was created. The console-plugin's Helm chart already omits this directive.

Companion PR in console-plugin: https://github.com/Kuadrant/kuadrant-console-plugin/pull/493

## Test plan
- [ ] Deploy operator on OpenShift, verify console plugin loads correctly
- [ ] Confirm no `oauth_token` response header in browser DevTools when accessing the console plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)