### PR TITLE
[ON HOLD - CODE FREEZE] feat: Convert auth policy reconciler to TypedAction format

### DIFF
--- a/internal/cel/kuadrant_validator.go
+++ b/internal/cel/kuadrant_validator.go
@@ -120,6 +120,26 @@ func ValidateWasmAction(action wasm.Action, validator *Validator) error {
 	return nil
 }
 
+func ValidateTypedAction(action wasm.TypedAction, validator *Validator) error {
+	pol := policyKindFromWasmServiceName(action.Service)
+	if action.Predicate != "" {
+		if _, err := validator.Validate(pol, action.Predicate); err != nil {
+			return err
+		}
+	}
+	// OnReply predicates reference wasm-shim runtime variables (e.g. auth_response.denied_response)
+	// that are not available in the CEL validation environment, so skip them.
+	return nil
+}
+
+func NewTypedActionIssue(action wasm.TypedAction, pathID string, err error) *Issue {
+	return &Issue{
+		policyKind: policyKindFromWasmServiceName(action.Service),
+		pathID:     pathID,
+		err:        err,
+	}
+}
+
 func policyKindFromWasmServiceName(serviceName string) string {
 	switch serviceName {
 	case wasm.AuthServiceName:

--- a/internal/controller/auth_workflow_helpers.go
+++ b/internal/controller/auth_workflow_helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	authorinooperatorv1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
@@ -89,17 +90,114 @@ func AuthConfigNameForPath(pathID string) string {
 	return hex.EncodeToString(hash[:])
 }
 
-func buildWasmActionsForAuth(pathID string, effectivePolicy EffectiveAuthPolicy) []wasm.Action {
-	spec := effectivePolicy.Spec.Spec.Proper()
+const authResponseVar = "auth_response"
 
-	action := wasm.Action{
-		ServiceName:          wasm.AuthServiceName,
-		Scope:                AuthConfigNameForPath(pathID),
-		Predicates:           spec.Predicates.Into(),
+func buildWasmTypedActionsForAuth(pathID string, effectivePolicy EffectiveAuthPolicy) []wasm.TypedAction {
+	spec := effectivePolicy.Spec.Spec.Proper()
+	scope := AuthConfigNameForPath(pathID)
+	predicate := joinPredicates(spec.Predicates.Into())
+	if predicate == "" {
+		predicate = "true"
+	}
+
+	action := wasm.TypedAction{
+		Type:                 "grpc",
+		Predicate:            predicate,
+		Var:                  authResponseVar,
+		Service:              wasm.AuthServiceName,
+		MessageBuilder:       buildAuthMessageBuilder(scope),
+		OnReply:              buildAuthOnReply(authResponseVar),
 		SourcePolicyLocators: effectivePolicy.SourcePolicies,
 	}
 
-	return []wasm.Action{action}
+	return []wasm.TypedAction{action}
+}
+
+func joinPredicates(predicates []string) string {
+	if len(predicates) == 0 {
+		return ""
+	}
+	if len(predicates) == 1 {
+		return predicates[0]
+	}
+	return strings.Join(predicates, " && ")
+}
+
+func buildAuthMessageBuilder(scope string) string {
+	return fmt.Sprintf(`envoy.service.auth.v3.CheckRequest {
+  attributes: envoy.service.auth.v3.AttributeContext {
+    request: envoy.service.auth.v3.AttributeContext.Request {
+      time: request.time,
+      http: envoy.service.auth.v3.AttributeContext.HttpRequest {
+        host: request.host,
+        method: request.method,
+        scheme: request.scheme,
+        path: request.path,
+        protocol: request.protocol,
+        headers: request.headers
+      }
+    },
+    destination: envoy.service.auth.v3.AttributeContext.Peer {
+      address: envoy.config.core.v3.Address {
+        socket_address: envoy.config.core.v3.SocketAddress {
+          address: destination.address,
+          port_value: uint(destination.port)
+        }
+      }
+    },
+    source: envoy.service.auth.v3.AttributeContext.Peer {
+      address: envoy.config.core.v3.Address {
+        socket_address: envoy.config.core.v3.SocketAddress {
+          address: source.address,
+          port_value: uint(source.port)
+        }
+      }
+    },
+    context_extensions: {"host": "%s"},
+    metadata_context: envoy.config.core.v3.Metadata{}
+  }
+}`, scope)
+}
+
+func buildAuthOnReply(varName string) []wasm.TypedAction {
+	return []wasm.TypedAction{
+		{
+			Type:      "deny",
+			Predicate: fmt.Sprintf("has(%s.denied_response)", varName),
+			Terminal:  true,
+			DenyWith: fmt.Sprintf(
+				`DenyResponse{status: (%s.denied_response.status.code != 0) ? uint(%s.denied_response.status.code) : 403u, headers: %s.denied_response.headers, body: %s.denied_response.body}`,
+				varName, varName, varName, varName,
+			),
+		},
+		{
+			Type: "fail",
+			Predicate: fmt.Sprintf(
+				"has(%s.ok_response) && (%s.ok_response.response_headers_to_add.size() > 0 || %s.ok_response.headers_to_remove.size() > 0 || %s.ok_response.query_parameters_to_set.size() > 0 || %s.ok_response.query_parameters_to_remove.size() > 0)",
+				varName, varName, varName, varName, varName,
+			),
+			Terminal:   true,
+			LogMessage: "Unsupported field in OkHttpResponse",
+		},
+		{
+			Type:      "store",
+			Predicate: fmt.Sprintf("has(%s.ok_response) && has(%s.dynamic_metadata)", varName, varName),
+			Path:      "auth",
+			Value:     fmt.Sprintf("%s.dynamic_metadata", varName),
+		},
+		{
+			Type:      "headers",
+			Predicate: fmt.Sprintf("has(%s.ok_response)", varName),
+			Target:    "request",
+			Headers:   fmt.Sprintf("%s.ok_response.headers", varName),
+		},
+		{
+			Type:       "fail",
+			Predicate:  fmt.Sprintf("!has(%s.denied_response) && !has(%s.ok_response)", varName, varName),
+			Terminal:   true,
+			LogMessage: fmt.Sprintf("Auth response contained no http_response from %s", varName),
+		},
+	}
 }
 
 func isAuthPolicyAcceptedAndNotDeletedFunc(state *sync.Map) func(machinery.Policy) bool {

--- a/internal/controller/auth_workflow_helpers.go
+++ b/internal/controller/auth_workflow_helpers.go
@@ -120,7 +120,11 @@ func joinPredicates(predicates []string) string {
 	if len(predicates) == 1 {
 		return predicates[0]
 	}
-	return strings.Join(predicates, " && ")
+	wrapped := make([]string, len(predicates))
+	for i, p := range predicates {
+		wrapped[i] = "(" + p + ")"
+	}
+	return strings.Join(wrapped, " && ")
 }
 
 func buildAuthMessageBuilder(scope string) string {

--- a/internal/controller/auth_workflow_helpers_test.go
+++ b/internal/controller/auth_workflow_helpers_test.go
@@ -79,7 +79,7 @@ func TestBuildWasmTypedActionsForAuth_WithPredicates(t *testing.T) {
 	actions := buildWasmTypedActionsForAuth(pathID, policy)
 	action := actions[0]
 
-	if action.Predicate != "request.method == 'GET' && request.path.startsWith('/api')" {
+	if action.Predicate != "(request.method == 'GET') && (request.path.startsWith('/api'))" {
 		t.Errorf("unexpected predicate: %q", action.Predicate)
 	}
 }
@@ -155,7 +155,7 @@ func TestJoinPredicates(t *testing.T) {
 	}{
 		{"empty", nil, ""},
 		{"single", []string{"a == b"}, "a == b"},
-		{"multiple", []string{"a == b", "c == d"}, "a == b && c == d"},
+		{"multiple", []string{"a == b", "c == d"}, "(a == b) && (c == d)"},
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/auth_workflow_helpers_test.go
+++ b/internal/controller/auth_workflow_helpers_test.go
@@ -1,0 +1,240 @@
+//go:build unit
+
+package controllers
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	"github.com/kuadrant/kuadrant-operator/internal/wasm"
+)
+
+func TestBuildWasmTypedActionsForAuth(t *testing.T) {
+	pathID := "test-gateway#test-listener#test-route#rule-0"
+	policy := EffectiveAuthPolicy{
+		SourcePolicies: []string{"AuthPolicy/test-ns/test-policy"},
+		Spec:           kuadrantv1.AuthPolicy{},
+	}
+
+	actions := buildWasmTypedActionsForAuth(pathID, policy)
+
+	if len(actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(actions))
+	}
+
+	action := actions[0]
+
+	if action.Type != "grpc" {
+		t.Errorf("expected type 'grpc', got %q", action.Type)
+	}
+	if action.Service != wasm.AuthServiceName {
+		t.Errorf("expected service %q, got %q", wasm.AuthServiceName, action.Service)
+	}
+	if action.Var != "auth_response" {
+		t.Errorf("expected var 'auth_response', got %q", action.Var)
+	}
+	if action.Predicate != "true" {
+		t.Errorf("expected predicate 'true' when no when-predicates, got %q", action.Predicate)
+	}
+	if action.Terminal {
+		t.Error("expected terminal to be false")
+	}
+
+	expectedScope := AuthConfigNameForPath(pathID)
+	if !strings.Contains(action.MessageBuilder, expectedScope) {
+		t.Errorf("expected message builder to contain scope %q", expectedScope)
+	}
+	if !strings.Contains(action.MessageBuilder, "envoy.service.auth.v3.CheckRequest") {
+		t.Error("expected message builder to contain CheckRequest type")
+	}
+	if !strings.Contains(action.MessageBuilder, "context_extensions") {
+		t.Error("expected message builder to contain context_extensions")
+	}
+
+	if len(action.SourcePolicyLocators) != 1 || action.SourcePolicyLocators[0] != "AuthPolicy/test-ns/test-policy" {
+		t.Errorf("unexpected source policy locators: %v", action.SourcePolicyLocators)
+	}
+}
+
+func TestBuildWasmTypedActionsForAuth_WithPredicates(t *testing.T) {
+	pathID := "test-gateway#test-listener#test-route#rule-0"
+	policy := EffectiveAuthPolicy{
+		SourcePolicies: []string{"AuthPolicy/test-ns/test-policy"},
+		Spec: kuadrantv1.AuthPolicy{
+			Spec: kuadrantv1.AuthPolicySpec{
+				AuthPolicySpecProper: kuadrantv1.AuthPolicySpecProper{
+					MergeableWhenPredicates: kuadrantv1.MergeableWhenPredicates{
+						Predicates: kuadrantv1.WhenPredicates{
+							{Predicate: "request.method == 'GET'"},
+							{Predicate: "request.path.startsWith('/api')"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	actions := buildWasmTypedActionsForAuth(pathID, policy)
+	action := actions[0]
+
+	if action.Predicate != "request.method == 'GET' && request.path.startsWith('/api')" {
+		t.Errorf("unexpected predicate: %q", action.Predicate)
+	}
+}
+
+func TestBuildAuthOnReply(t *testing.T) {
+	onReply := buildAuthOnReply("auth_response")
+
+	if len(onReply) != 5 {
+		t.Fatalf("expected 5 onReply actions, got %d", len(onReply))
+	}
+
+	// denied response → deny
+	if onReply[0].Type != "deny" {
+		t.Errorf("onReply[0]: expected type 'deny', got %q", onReply[0].Type)
+	}
+	if !onReply[0].Terminal {
+		t.Error("onReply[0]: expected terminal")
+	}
+	if onReply[0].Predicate != "has(auth_response.denied_response)" {
+		t.Errorf("onReply[0]: unexpected predicate: %q", onReply[0].Predicate)
+	}
+	if !strings.Contains(onReply[0].DenyWith, "403u") {
+		t.Error("onReply[0]: expected DenyWith to contain 403u default")
+	}
+
+	// unsupported fields → fail
+	if onReply[1].Type != "fail" {
+		t.Errorf("onReply[1]: expected type 'fail', got %q", onReply[1].Type)
+	}
+	if !onReply[1].Terminal {
+		t.Error("onReply[1]: expected terminal")
+	}
+	if onReply[1].LogMessage != "Unsupported field in OkHttpResponse" {
+		t.Errorf("onReply[1]: unexpected log message: %q", onReply[1].LogMessage)
+	}
+
+	// dynamic metadata → store
+	if onReply[2].Type != "store" {
+		t.Errorf("onReply[2]: expected type 'store', got %q", onReply[2].Type)
+	}
+	if onReply[2].Terminal {
+		t.Error("onReply[2]: expected non-terminal")
+	}
+	if onReply[2].Path != "auth" {
+		t.Errorf("onReply[2]: expected path 'auth', got %q", onReply[2].Path)
+	}
+	if onReply[2].Value != "auth_response.dynamic_metadata" {
+		t.Errorf("onReply[2]: unexpected value: %q", onReply[2].Value)
+	}
+
+	// ok response → headers
+	if onReply[3].Type != "headers" {
+		t.Errorf("onReply[3]: expected type 'headers', got %q", onReply[3].Type)
+	}
+	if onReply[3].Target != "request" {
+		t.Errorf("onReply[3]: expected target 'request', got %q", onReply[3].Target)
+	}
+
+	// fallback → fail
+	if onReply[4].Type != "fail" {
+		t.Errorf("onReply[4]: expected type 'fail', got %q", onReply[4].Type)
+	}
+	if !onReply[4].Terminal {
+		t.Error("onReply[4]: expected terminal")
+	}
+}
+
+func TestJoinPredicates(t *testing.T) {
+	tests := []struct {
+		name       string
+		predicates []string
+		expected   string
+	}{
+		{"empty", nil, ""},
+		{"single", []string{"a == b"}, "a == b"},
+		{"multiple", []string{"a == b", "c == d"}, "a == b && c == d"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := joinPredicates(tt.predicates)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestBuildAuthMessageBuilder(t *testing.T) {
+	scope := "abc123hash"
+	mb := buildAuthMessageBuilder(scope)
+
+	if !strings.Contains(mb, `"host": "abc123hash"`) {
+		t.Errorf("expected scope in context_extensions, got:\n%s", mb)
+	}
+	if !strings.Contains(mb, "envoy.service.auth.v3.CheckRequest") {
+		t.Error("expected CheckRequest message type")
+	}
+	if !strings.Contains(mb, "request.time") {
+		t.Error("expected request.time in message builder")
+	}
+	if !strings.Contains(mb, "destination.address") {
+		t.Error("expected destination.address in message builder")
+	}
+	if !strings.Contains(mb, "source.address") {
+		t.Error("expected source.address in message builder")
+	}
+	if !strings.Contains(mb, "envoy.config.core.v3.Metadata{}") {
+		t.Error("expected empty metadata_context")
+	}
+}
+
+func TestAuthTypedActionJSON(t *testing.T) {
+	pathID := "test-gateway#test-listener#test-route#rule-0"
+	policy := EffectiveAuthPolicy{
+		SourcePolicies: []string{"AuthPolicy/test-ns/test-policy"},
+		Spec:           kuadrantv1.AuthPolicy{},
+	}
+
+	actions := buildWasmTypedActionsForAuth(pathID, policy)
+	action := actions[0]
+
+	data, err := json.Marshal(action)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if parsed["type"] != "grpc" {
+		t.Errorf("expected type 'grpc' in JSON, got %v", parsed["type"])
+	}
+	if parsed["service"] != wasm.AuthServiceName {
+		t.Errorf("expected service %q in JSON, got %v", wasm.AuthServiceName, parsed["service"])
+	}
+	if parsed["var"] != "auth_response" {
+		t.Errorf("expected var 'auth_response' in JSON, got %v", parsed["var"])
+	}
+
+	onReply, ok := parsed["onReply"].([]any)
+	if !ok || len(onReply) != 5 {
+		t.Fatalf("expected 5 onReply items in JSON, got %v", parsed["onReply"])
+	}
+
+	storeAction := onReply[2].(map[string]any)
+	if storeAction["type"] != "store" {
+		t.Errorf("expected onReply[2] type 'store', got %v", storeAction["type"])
+	}
+	if storeAction["path"] != "auth" {
+		t.Errorf("expected store path 'auth', got %v", storeAction["path"])
+	}
+	if storeAction["value"] != "auth_response.dynamic_metadata" {
+		t.Errorf("expected store value, got %v", storeAction["value"])
+	}
+}

--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -191,10 +191,6 @@ func (r *EnvoyGatewayExtensionReconciler) reconcileUpstreamClusters(ctx context.
 		// Also collect upstreams registered for routes attached to this gateway
 		gatewayUpstreams = append(gatewayUpstreams, extension.CollectRouteUpstreams(topology, gateway)...)
 
-		if len(gatewayUpstreams) == 0 {
-			continue
-		}
-
 		desiredPolicy, err := buildUpstreamEnvoyPatchPolicy(logger, gateway, gatewayUpstreams)
 		if err != nil {
 			logger.Error(err, "failed to build upstream envoy patch policy", "gateway", gatewayKey.String())

--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -191,6 +191,10 @@ func (r *EnvoyGatewayExtensionReconciler) reconcileUpstreamClusters(ctx context.
 		// Also collect upstreams registered for routes attached to this gateway
 		gatewayUpstreams = append(gatewayUpstreams, extension.CollectRouteUpstreams(topology, gateway)...)
 
+		if len(gatewayUpstreams) == 0 {
+			continue
+		}
+
 		desiredPolicy, err := buildUpstreamEnvoyPatchPolicy(logger, gateway, gatewayUpstreams)
 		if err != nil {
 			logger.Error(err, "failed to build upstream envoy patch policy", "gateway", gatewayKey.String())

--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -409,10 +409,11 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 		validatorBuilder := celvalidator.NewRootValidatorBuilder()
 
 		var actions []wasm.Action
+		var typedActions []wasm.TypedAction
 
 		// auth
 		if effectivePolicy, ok := effectiveAuthPoliciesMap[pathID]; ok {
-			actions = append(actions, buildWasmActionsForAuth(pathID, effectivePolicy)...)
+			typedActions = append(typedActions, buildWasmTypedActionsForAuth(pathID, effectivePolicy)...)
 			validatorBuilder.PushPolicyBinding(celvalidator.AuthPolicyKind, celvalidator.AuthPolicyName, cel.AnyType)
 		}
 
@@ -422,7 +423,6 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 			if hasAuthAccess(rlAction) {
 				actions = append(actions, rlAction...)
 			} else {
-				// pre auth rate limiting
 				actions = append(rlAction, actions...)
 			}
 			validatorBuilder.PushPolicyBinding(celvalidator.RateLimitPolicyKind, celvalidator.RateLimitName, cel.AnyType)
@@ -433,7 +433,6 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 			if hasAuthAccess(trlAction) {
 				actions = append(actions, trlAction...)
 			} else {
-				// pre auth rate limiting
 				actions = append(trlAction, actions...)
 			}
 			validatorBuilder.PushPolicyBinding(celvalidator.TokenRateLimitPolicyKind, celvalidator.RateLimitName, cel.AnyType)
@@ -445,6 +444,10 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 		sourcePolicies := lo.Uniq(lo.FlatMap(actions, func(a wasm.Action, _ int) []string {
 			return a.SourcePolicyLocators
 		}))
+		typedSourcePolicies := lo.Uniq(lo.FlatMap(typedActions, func(a wasm.TypedAction, _ int) []string {
+			return a.SourcePolicyLocators
+		}))
+		sourcePolicies = lo.Uniq(append(sourcePolicies, typedSourcePolicies...))
 		if len(sourcePolicies) > 0 {
 			pathSpan.SetAttributes(attribute.StringSlice("source_policies", sourcePolicies))
 		}
@@ -457,7 +460,7 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 			return nil, fmt.Errorf("failed to merge/verify actions for path %s: %w", pathID, err)
 		}
 
-		if len(actions) == 0 {
+		if len(actions) == 0 && len(typedActions) == 0 {
 			pathSpan.SetStatus(codes.Ok, "no actions after merge")
 			pathSpan.End()
 			continue
@@ -481,19 +484,29 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 			}
 		}
 
+		var validatedTypedActions []wasm.TypedAction
+		for _, action := range typedActions {
+			if err := celvalidator.ValidateTypedAction(action, validator); err != nil {
+				logger.V(1).Info("typed WASM action is invalid", "action", action, "path", pathID, "error", err)
+				celValidationIssues.Add(celvalidator.NewTypedActionIssue(action, pathID, err))
+			} else {
+				validatedTypedActions = append(validatedTypedActions, action)
+			}
+		}
+
 		pathSpan.SetAttributes(
 			attribute.Int("actions.after_merge", len(actions)),
 			attribute.Int("actions.validated", len(validatedActions)),
 			attribute.Int("actions.invalid", len(actions)-len(validatedActions)),
 		)
 
-		if len(validatedActions) == 0 {
+		if len(validatedActions) == 0 && len(validatedTypedActions) == 0 {
 			pathSpan.SetStatus(codes.Ok, "no validated actions")
 			pathSpan.End()
 			continue
 		}
 
-		wasmActionSetsForPath, err := wasm.BuildActionSetsForPath(pathCtx, pathID, path, validatedActions)
+		wasmActionSetsForPath, err := wasm.BuildActionSetsForPath(pathCtx, pathID, path, validatedActions, validatedTypedActions)
 		if err != nil {
 			logger.Error(err, "failed to build wasm policies for path", "pathID", pathID)
 			pathSpan.RecordError(err)

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -198,6 +198,10 @@ func (r *IstioExtensionReconciler) reconcileUpstreamClusters(ctx context.Context
 		// Also collect upstreams registered for routes attached to this gateway
 		gatewayUpstreams = append(gatewayUpstreams, extension.CollectRouteUpstreams(topology, gateway)...)
 
+		if len(gatewayUpstreams) == 0 {
+			continue
+		}
+
 		desiredEnvoyFilter, err := buildUpstreamEnvoyFilter(logger, gateway, gatewayUpstreams)
 		if err != nil {
 			logger.Error(err, "failed to build upstream envoy filter", "gateway", gatewayKey.String())

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -198,10 +198,6 @@ func (r *IstioExtensionReconciler) reconcileUpstreamClusters(ctx context.Context
 		// Also collect upstreams registered for routes attached to this gateway
 		gatewayUpstreams = append(gatewayUpstreams, extension.CollectRouteUpstreams(topology, gateway)...)
 
-		if len(gatewayUpstreams) == 0 {
-			continue
-		}
-
 		desiredEnvoyFilter, err := buildUpstreamEnvoyFilter(logger, gateway, gatewayUpstreams)
 		if err != nil {
 			logger.Error(err, "failed to build upstream envoy filter", "gateway", gatewayKey.String())
@@ -427,10 +423,11 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 		validatorBuilder := celvalidator.NewRootValidatorBuilder()
 
 		var actions []wasm.Action
+		var typedActions []wasm.TypedAction
 
 		// auth
 		if effectivePolicy, ok := effectiveAuthPoliciesMap[pathID]; ok {
-			actions = append(actions, buildWasmActionsForAuth(pathID, effectivePolicy)...)
+			typedActions = append(typedActions, buildWasmTypedActionsForAuth(pathID, effectivePolicy)...)
 			validatorBuilder.PushPolicyBinding(celvalidator.AuthPolicyKind, celvalidator.AuthPolicyName, cel.AnyType)
 		}
 
@@ -440,7 +437,6 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 			if hasAuthAccess(rlAction) {
 				actions = append(actions, rlAction...)
 			} else {
-				// pre auth rate limiting
 				actions = append(rlAction, actions...)
 			}
 			validatorBuilder.PushPolicyBinding(celvalidator.RateLimitPolicyKind, celvalidator.RateLimitName, cel.AnyType)
@@ -451,7 +447,6 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 			if hasAuthAccess(trlAction) {
 				actions = append(actions, trlAction...)
 			} else {
-				// pre auth rate limiting
 				actions = append(trlAction, actions...)
 			}
 			validatorBuilder.PushPolicyBinding(celvalidator.TokenRateLimitPolicyKind, celvalidator.RateLimitName, cel.AnyType)
@@ -463,6 +458,10 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 		sourcePolicies := lo.Uniq(lo.FlatMap(actions, func(a wasm.Action, _ int) []string {
 			return a.SourcePolicyLocators
 		}))
+		typedSourcePolicies := lo.Uniq(lo.FlatMap(typedActions, func(a wasm.TypedAction, _ int) []string {
+			return a.SourcePolicyLocators
+		}))
+		sourcePolicies = lo.Uniq(append(sourcePolicies, typedSourcePolicies...))
 		if len(sourcePolicies) > 0 {
 			pathSpan.SetAttributes(attribute.StringSlice("source_policies", sourcePolicies))
 		}
@@ -475,7 +474,7 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 			return nil, fmt.Errorf("failed to merge/verify actions for path %s: %w", pathID, err)
 		}
 
-		if len(actions) == 0 {
+		if len(actions) == 0 && len(typedActions) == 0 {
 			pathSpan.SetStatus(codes.Ok, "no actions after merge")
 			pathSpan.End()
 			continue
@@ -499,19 +498,29 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 			}
 		}
 
+		var validatedTypedActions []wasm.TypedAction
+		for _, action := range typedActions {
+			if err := celvalidator.ValidateTypedAction(action, validator); err != nil {
+				logger.V(1).Info("typed WASM action is invalid", "action", action, "path", pathID, "error", err)
+				celValidationIssues.Add(celvalidator.NewTypedActionIssue(action, pathID, err))
+			} else {
+				validatedTypedActions = append(validatedTypedActions, action)
+			}
+		}
+
 		pathSpan.SetAttributes(
 			attribute.Int("actions.after_merge", len(actions)),
 			attribute.Int("actions.validated", len(validatedActions)),
 			attribute.Int("actions.invalid", len(actions)-len(validatedActions)),
 		)
 
-		if len(validatedActions) == 0 {
+		if len(validatedActions) == 0 && len(validatedTypedActions) == 0 {
 			pathSpan.SetStatus(codes.Ok, "no validated actions")
 			pathSpan.End()
 			continue
 		}
 
-		wasmActionSetsForPath, err := wasm.BuildActionSetsForPath(pathCtx, pathID, path, validatedActions)
+		wasmActionSetsForPath, err := wasm.BuildActionSetsForPath(pathCtx, pathID, path, validatedActions, validatedTypedActions)
 		if err != nil {
 			if errors.As(err, &kuadrantpolicymachinery.ErrInvalidPath{}) {
 				logger.V(1).Info("ingoring invalid paths", "error", err.Error(), "status", "skipping", "pathID", pathID)

--- a/internal/wasm/types.go
+++ b/internal/wasm/types.go
@@ -472,7 +472,7 @@ type Expression struct {
 }
 
 // TypedAction represents an extension pipeline action in the new wasm-shim format.
-// The "type" field discriminates the action kind (grpc, deny, headers).
+// The "type" field discriminates the action kind (grpc, deny, headers, store, fail).
 type TypedAction struct {
 	Type           string        `json:"type"`
 	Predicate      string        `json:"predicate"`
@@ -484,6 +484,8 @@ type TypedAction struct {
 	DenyWith       string        `json:"denyWith,omitempty"`
 	Target         string        `json:"target,omitempty"`
 	Headers        string        `json:"headers,omitempty"`
+	Path           string        `json:"path,omitempty"`
+	Value          string        `json:"value,omitempty"`
 	LogMessage     string        `json:"logMessage,omitempty"`
 	// SourcePolicyLocators tracks all policies that contributed to this action.
 	// Format: "kind/namespace/name"
@@ -500,6 +502,8 @@ func (t TypedAction) EqualTo(other TypedAction) bool {
 		t.DenyWith != other.DenyWith ||
 		t.Target != other.Target ||
 		t.Headers != other.Headers ||
+		t.Path != other.Path ||
+		t.Value != other.Value ||
 		t.LogMessage != other.LogMessage ||
 		!slices.Equal(t.SourcePolicyLocators, other.SourcePolicyLocators) ||
 		len(t.OnReply) != len(other.OnReply) {

--- a/internal/wasm/types_test.go
+++ b/internal/wasm/types_test.go
@@ -2009,3 +2009,60 @@ func TestAction_EqualTo(t *testing.T) {
 		})
 	}
 }
+
+func TestTypedAction_StoreType_JSON(t *testing.T) {
+	ta := TypedAction{
+		Type:      "store",
+		Predicate: "has(auth_response.ok_response) && has(auth_response.dynamic_metadata)",
+		Path:      "auth",
+		Value:     "auth_response.dynamic_metadata",
+	}
+
+	data, err := json.Marshal(ta)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var roundTripped TypedAction
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if !ta.EqualTo(roundTripped) {
+		t.Fatalf("round-tripped store TypedAction not equal:\n  got:  %+v\n  want: %+v", roundTripped, ta)
+	}
+
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+	if raw["type"] != "store" {
+		t.Errorf("expected type 'store', got %v", raw["type"])
+	}
+	if raw["path"] != "auth" {
+		t.Errorf("expected path 'auth', got %v", raw["path"])
+	}
+	if raw["value"] != "auth_response.dynamic_metadata" {
+		t.Errorf("expected value 'auth_response.dynamic_metadata', got %v", raw["value"])
+	}
+}
+
+func TestTypedAction_EqualTo_StoreFields(t *testing.T) {
+	a := TypedAction{Type: "store", Predicate: "true", Path: "auth", Value: "resp.metadata"}
+	b := TypedAction{Type: "store", Predicate: "true", Path: "auth", Value: "resp.metadata"}
+	if !a.EqualTo(b) {
+		t.Fatal("identical store TypedActions should be equal")
+	}
+
+	diffPath := b
+	diffPath.Path = "other"
+	if a.EqualTo(diffPath) {
+		t.Fatal("TypedActions with different Path should not be equal")
+	}
+
+	diffValue := b
+	diffValue.Value = "resp.other"
+	if a.EqualTo(diffValue) {
+		t.Fatal("TypedActions with different Value should not be equal")
+	}
+}

--- a/internal/wasm/utils.go
+++ b/internal/wasm/utils.go
@@ -173,6 +173,8 @@ func NewServiceBuilder(logger *logr.Logger) *ServiceBuilder {
 				Endpoint:    kuadrant.KuadrantAuthClusterName,
 				FailureMode: AuthServiceFailureMode(logger),
 				Timeout:     ptr.To(AuthServiceTimeout()),
+				GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
+				GrpcMethod:  ptr.To("Check"),
 			},
 			RateLimitServiceName: {
 				Type:        RateLimitServiceType,
@@ -239,7 +241,7 @@ func BuildConfigForActionSet(actionSets []ActionSet, logger *logr.Logger, observ
 // gRPC methods map to HTTP/2 paths (/{service}/{method}). This conversion enables sorting
 // with HTTP routes and reflects the wire-level protocol. The actual predicates sent to
 // the WASM plugin are generated from the original GRPCRouteMatch.
-func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery.Targetable, actions []Action) ([]kuadrantgatewayapi.HTTPRouteMatchConfig, error) {
+func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery.Targetable, actions []Action, typedActions []TypedAction) ([]kuadrantgatewayapi.HTTPRouteMatchConfig, error) {
 	tracer := controller.TracerFromContext(ctx)
 	_, span := tracer.Start(ctx, "wasm.BuildActionSetsForPath")
 	defer span.End()
@@ -292,9 +294,10 @@ func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery
 				}
 
 				actionSet := ActionSet{
-					Name:        ActionSetNameForPath(pathID, j, string(hostname)),
-					Actions:     actions,
-					SourceRoute: fmt.Sprintf("HTTPRoute/%s/%s", parsed.HTTPRoute.GetNamespace(), parsed.HTTPRoute.GetName()),
+					Name:         ActionSetNameForPath(pathID, j, string(hostname)),
+					Actions:      actions,
+					TypedActions: typedActions,
+					SourceRoute:  fmt.Sprintf("HTTPRoute/%s/%s", parsed.HTTPRoute.GetNamespace(), parsed.HTTPRoute.GetName()),
 				}
 				routeRuleConditions := RouteRuleConditions{
 					Hostnames: []string{string(hostname)},
@@ -361,9 +364,10 @@ func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery
 				}
 
 				actionSet := ActionSet{
-					Name:        ActionSetNameForPath(pathID, j, string(hostname)),
-					Actions:     actions,
-					SourceRoute: fmt.Sprintf("GRPCRoute/%s/%s", parsed.GRPCRoute.GetNamespace(), parsed.GRPCRoute.GetName()),
+					Name:         ActionSetNameForPath(pathID, j, string(hostname)),
+					Actions:      actions,
+					TypedActions: typedActions,
+					SourceRoute:  fmt.Sprintf("GRPCRoute/%s/%s", parsed.GRPCRoute.GetNamespace(), parsed.GRPCRoute.GetName()),
 				}
 				routeRuleConditions := RouteRuleConditions{
 					Hostnames: []string{string(hostname)},

--- a/internal/wasm/utils.go
+++ b/internal/wasm/utils.go
@@ -173,8 +173,6 @@ func NewServiceBuilder(logger *logr.Logger) *ServiceBuilder {
 				Endpoint:    kuadrant.KuadrantAuthClusterName,
 				FailureMode: AuthServiceFailureMode(logger),
 				Timeout:     ptr.To(AuthServiceTimeout()),
-				GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
-				GrpcMethod:  ptr.To("Check"),
 			},
 			RateLimitServiceName: {
 				Type:        RateLimitServiceType,

--- a/tests/envoygateway/extension_reconciler_test.go
+++ b/tests/envoygateway/extension_reconciler_test.go
@@ -179,6 +179,8 @@ var _ = Describe("wasm controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
+						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,
@@ -362,6 +364,8 @@ var _ = Describe("wasm controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
+						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,

--- a/tests/envoygateway/extension_reconciler_test.go
+++ b/tests/envoygateway/extension_reconciler_test.go
@@ -179,8 +179,6 @@ var _ = Describe("wasm controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
-						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
-						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,
@@ -364,8 +362,6 @@ var _ = Describe("wasm controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
-						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
-						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,

--- a/tests/envoygateway/extension_reconciler_test.go
+++ b/tests/envoygateway/extension_reconciler_test.go
@@ -518,9 +518,9 @@ var _ = Describe("wasm controller", func() {
 				existingWASMConfig, err := wasm.ConfigFromJSON(existingExt.Spec.Wasm[0].Config)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).ToNot(BeEmpty())
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).ToNot(BeEmpty())
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).ToNot(BeEmpty())
 				// Single policy source for auth action
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -567,19 +567,19 @@ var _ = Describe("wasm controller", func() {
 			Eventually(tests.IsAuthPolicyAccepted(ctx, testClient(), routeAuthPolicy)).WithContext(ctx).Should(BeTrue())
 
 			// Check EnvoyExtensionPolicy config now has BOTH policies in sources (merged)
-			// Note: AuthPolicy creates a single auth action that includes all merged policies
+			// Note: AuthPolicy creates a single auth typed action that includes all merged policies
 			Eventually(func(g Gomega) {
 				g.Expect(testClient().Get(ctx, extKey, existingExt)).To(Succeed())
 				existingWASMConfig, err := wasm.ConfigFromJSON(existingExt.Spec.Wasm[0].Config)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).ToNot(BeEmpty())
 
-				// Should still have 1 auth action (auth actions are not split per policy)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).ToNot(BeEmpty())
+				// Should still have 1 auth typed action (auth actions are not split per policy)
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).ToNot(BeEmpty())
 
-				// The single auth action should list BOTH policy sources
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].ServiceName).To(Equal(wasm.AuthServiceName))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(ConsistOf(
+				// The single auth typed action should list BOTH policy sources
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].Service).To(Equal(wasm.AuthServiceName))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(ConsistOf(
 					"authpolicy.kuadrant.io:"+gwAuthPolicyKey.String(),
 					"authpolicy.kuadrant.io:"+routeAuthPolicyKey.String(),
 				))
@@ -649,9 +649,9 @@ var _ = Describe("wasm controller", func() {
 				existingWASMConfig, err := wasm.ConfigFromJSON(existingExt.Spec.Wasm[0].Config)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).ToNot(BeEmpty())
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).ToNot(BeEmpty())
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).ToNot(BeEmpty())
 				// Single policy source for auth action
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -704,12 +704,12 @@ var _ = Describe("wasm controller", func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).ToNot(BeEmpty())
 
-				// Should have 1 auth action with only route policy (atomic replacement)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).ToNot(BeEmpty())
+				// Should have 1 auth typed action with only route policy (atomic replacement)
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).ToNot(BeEmpty())
 
-				// The action should list ONLY the route policy source (atomic replaces gateway defaults)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].ServiceName).To(Equal(wasm.AuthServiceName))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				// The typed action should list ONLY the route policy source (atomic replaces gateway defaults)
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].Service).To(Equal(wasm.AuthServiceName))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + routeAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -778,9 +778,9 @@ var _ = Describe("wasm controller", func() {
 				existingWASMConfig, err := wasm.ConfigFromJSON(existingExt.Spec.Wasm[0].Config)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).ToNot(BeEmpty())
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).ToNot(BeEmpty())
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).ToNot(BeEmpty())
 				// Single policy source (gateway with overrides)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -832,12 +832,12 @@ var _ = Describe("wasm controller", func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).ToNot(BeEmpty())
 
-				// Should have 1 auth action with only gateway policy (atomic override)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).ToNot(BeEmpty())
+				// Should have 1 auth typed action with only gateway policy (atomic override)
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).ToNot(BeEmpty())
 
-				// The action should list ONLY the gateway policy source (atomic overrides route policy)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].ServiceName).To(Equal(wasm.AuthServiceName))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				// The typed action should list ONLY the gateway policy source (atomic overrides route policy)
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].Service).To(Equal(wasm.AuthServiceName))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -906,9 +906,9 @@ var _ = Describe("wasm controller", func() {
 				existingWASMConfig, err := wasm.ConfigFromJSON(existingExt.Spec.Wasm[0].Config)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).ToNot(BeEmpty())
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).ToNot(BeEmpty())
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).ToNot(BeEmpty())
 				// Single policy source (gateway with overrides)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -961,12 +961,12 @@ var _ = Describe("wasm controller", func() {
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).ToNot(BeEmpty())
 
-				// Should have 1 merged auth action with both policies
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).ToNot(BeEmpty())
+				// Should have 1 merged auth typed action with both policies
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).ToNot(BeEmpty())
 
-				// The action should list BOTH policy sources (merge overrides merges both policies)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].ServiceName).To(Equal(wasm.AuthServiceName))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(ConsistOf(
+				// The typed action should list BOTH policy sources (merge overrides merges both policies)
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].Service).To(Equal(wasm.AuthServiceName))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(ConsistOf(
 					"authpolicy.kuadrant.io:"+gwAuthPolicyKey.String(),
 					"authpolicy.kuadrant.io:"+routeAuthPolicyKey.String(),
 				))

--- a/tests/istio/extension_reconciler_test.go
+++ b/tests/istio/extension_reconciler_test.go
@@ -226,6 +226,8 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
+						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,
@@ -935,6 +937,8 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
+						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,
@@ -2760,6 +2764,8 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
+						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,
@@ -2857,6 +2863,8 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
+						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,

--- a/tests/istio/extension_reconciler_test.go
+++ b/tests/istio/extension_reconciler_test.go
@@ -226,8 +226,6 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
-						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
-						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,
@@ -937,8 +935,6 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
-						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
-						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,
@@ -2764,8 +2760,6 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
-						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
-						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,
@@ -2863,8 +2857,6 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
-						GrpcService: ptr.To("envoy.service.auth.v3.Authorization"),
-						GrpcMethod:  ptr.To("Check"),
 					},
 					wasm.RateLimitCheckServiceName: {
 						Type:        wasm.RateLimitCheckServiceType,

--- a/tests/istio/extension_reconciler_test.go
+++ b/tests/istio/extension_reconciler_test.go
@@ -529,10 +529,10 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 			Expect(actionSet.RouteRuleConditions.Predicates).To(ContainElements(
 				"request.url_path == '/assets'",
 			))
-			Expect(actionSet.Actions).To(HaveLen(2))
-			Expect(actionSet.Actions[1].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
-			Expect(actionSet.Actions[1].ServiceName).To(Equal(wasm.RateLimitServiceName))
-			Expect(actionSet.Actions[1].ConditionalData).To(ContainElements(
+			Expect(actionSet.Actions).To(HaveLen(1))
+			Expect(actionSet.Actions[0].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
+			Expect(actionSet.Actions[0].ServiceName).To(Equal(wasm.RateLimitServiceName))
+			Expect(actionSet.Actions[0].ConditionalData).To(ContainElements(
 				[]wasm.ConditionalData{
 					{
 						Predicates: []string{
@@ -587,10 +587,10 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				"request.method == 'GET'",
 				"request.url_path.startsWith('/toys')",
 			))
-			Expect(actionSet.Actions).To(HaveLen(2))
-			Expect(actionSet.Actions[1].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
-			Expect(actionSet.Actions[1].ServiceName).To(Equal(wasm.RateLimitServiceName))
-			Expect(actionSet.Actions[1].ConditionalData).To(ContainElements(
+			Expect(actionSet.Actions).To(HaveLen(1))
+			Expect(actionSet.Actions[0].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
+			Expect(actionSet.Actions[0].ServiceName).To(Equal(wasm.RateLimitServiceName))
+			Expect(actionSet.Actions[0].ConditionalData).To(ContainElements(
 				[]wasm.ConditionalData{
 					{
 						Predicates: []string{
@@ -645,10 +645,10 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				"request.method == 'POST'",
 				"request.url_path.startsWith('/toys')",
 			))
-			Expect(actionSet.Actions).To(HaveLen(2))
-			Expect(actionSet.Actions[1].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
-			Expect(actionSet.Actions[1].ServiceName).To(Equal(wasm.RateLimitServiceName))
-			Expect(actionSet.Actions[1].ConditionalData).To(ContainElements(
+			Expect(actionSet.Actions).To(HaveLen(1))
+			Expect(actionSet.Actions[0].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
+			Expect(actionSet.Actions[0].ServiceName).To(Equal(wasm.RateLimitServiceName))
+			Expect(actionSet.Actions[0].ConditionalData).To(ContainElements(
 				[]wasm.ConditionalData{
 					{
 						Predicates: []string{
@@ -702,10 +702,10 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 			Expect(actionSet.RouteRuleConditions.Predicates).To(ContainElements(
 				"request.url_path == '/assets'",
 			))
-			Expect(actionSet.Actions).To(HaveLen(2))
-			Expect(actionSet.Actions[1].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
-			Expect(actionSet.Actions[1].ServiceName).To(Equal(wasm.RateLimitServiceName))
-			Expect(actionSet.Actions[1].ConditionalData).To(ContainElements(
+			Expect(actionSet.Actions).To(HaveLen(1))
+			Expect(actionSet.Actions[0].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
+			Expect(actionSet.Actions[0].ServiceName).To(Equal(wasm.RateLimitServiceName))
+			Expect(actionSet.Actions[0].ConditionalData).To(ContainElements(
 				[]wasm.ConditionalData{
 					{
 						Predicates: []string{
@@ -760,10 +760,10 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				"request.method == 'GET'",
 				"request.url_path.startsWith('/toys')",
 			))
-			Expect(actionSet.Actions).To(HaveLen(2))
-			Expect(actionSet.Actions[1].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
-			Expect(actionSet.Actions[1].ServiceName).To(Equal(wasm.RateLimitServiceName))
-			Expect(actionSet.Actions[1].ConditionalData).To(ContainElements(
+			Expect(actionSet.Actions).To(HaveLen(1))
+			Expect(actionSet.Actions[0].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
+			Expect(actionSet.Actions[0].ServiceName).To(Equal(wasm.RateLimitServiceName))
+			Expect(actionSet.Actions[0].ConditionalData).To(ContainElements(
 				[]wasm.ConditionalData{
 					{
 						Predicates: []string{
@@ -818,10 +818,10 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				"request.method == 'POST'",
 				"request.url_path.startsWith('/toys')",
 			))
-			Expect(actionSet.Actions).To(HaveLen(2))
-			Expect(actionSet.Actions[1].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
-			Expect(actionSet.Actions[1].ServiceName).To(Equal(wasm.RateLimitServiceName))
-			Expect(actionSet.Actions[1].ConditionalData).To(ContainElements(
+			Expect(actionSet.Actions).To(HaveLen(1))
+			Expect(actionSet.Actions[0].Scope).To(Equal(controllers.LimitsNamespaceFromRoute(httpRoute)))
+			Expect(actionSet.Actions[0].ServiceName).To(Equal(wasm.RateLimitServiceName))
+			Expect(actionSet.Actions[0].ConditionalData).To(ContainElements(
 				[]wasm.ConditionalData{
 					{
 						Predicates: []string{
@@ -3109,9 +3109,9 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				existingWASMConfig, err := extractWasmConfigFromEnvoyFilter(existingEnvoyFilter)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).To(HaveLen(1))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).To(HaveLen(1))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).To(HaveLen(1))
 				// Single policy source for auth action
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -3166,11 +3166,11 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				g.Expect(existingWASMConfig.ActionSets).To(HaveLen(1))
 
 				// Should still have 1 auth action (auth actions are not split per policy)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).To(HaveLen(1))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).To(HaveLen(1))
 
 				// The single auth action should list BOTH policy sources
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].ServiceName).To(Equal(wasm.AuthServiceName))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(ConsistOf(
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].Service).To(Equal(wasm.AuthServiceName))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(ConsistOf(
 					"authpolicy.kuadrant.io:"+gwAuthPolicyKey.String(),
 					"authpolicy.kuadrant.io:"+routeAuthPolicyKey.String(),
 				))
@@ -3236,9 +3236,9 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				existingWASMConfig, err := extractWasmConfigFromEnvoyFilter(existingEnvoyFilter)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).To(HaveLen(1))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).To(HaveLen(1))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).To(HaveLen(1))
 				// Single policy source for auth action
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -3292,11 +3292,11 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				g.Expect(existingWASMConfig.ActionSets).To(HaveLen(1))
 
 				// Should have 1 auth action with only route policy (atomic replacement)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).To(HaveLen(1))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).To(HaveLen(1))
 
 				// The action should list ONLY the route policy source (atomic replaces gateway defaults)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].ServiceName).To(Equal(wasm.AuthServiceName))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].Service).To(Equal(wasm.AuthServiceName))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + routeAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -3361,9 +3361,9 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				existingWASMConfig, err := extractWasmConfigFromEnvoyFilter(existingEnvoyFilter)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).To(HaveLen(1))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).To(HaveLen(1))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).To(HaveLen(1))
 				// Single policy source (gateway with overrides)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -3416,11 +3416,11 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				g.Expect(existingWASMConfig.ActionSets).To(HaveLen(1))
 
 				// Should have 1 auth action with only gateway policy (atomic override)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).To(HaveLen(1))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).To(HaveLen(1))
 
 				// The action should list ONLY the gateway policy source (atomic overrides route policy)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].ServiceName).To(Equal(wasm.AuthServiceName))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].Service).To(Equal(wasm.AuthServiceName))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -3485,9 +3485,9 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				existingWASMConfig, err := extractWasmConfigFromEnvoyFilter(existingEnvoyFilter)
 				g.Expect(err).ToNot(HaveOccurred())
 				g.Expect(existingWASMConfig.ActionSets).To(HaveLen(1))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).To(HaveLen(1))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).To(HaveLen(1))
 				// Single policy source (gateway with overrides)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(Equal([]string{
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(Equal([]string{
 					"authpolicy.kuadrant.io:" + gwAuthPolicyKey.String(),
 				}))
 			}).WithContext(ctx).Should(Succeed())
@@ -3541,11 +3541,11 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				g.Expect(existingWASMConfig.ActionSets).To(HaveLen(1))
 
 				// Should have 1 merged auth action with both policies
-				g.Expect(existingWASMConfig.ActionSets[0].Actions).To(HaveLen(1))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions).To(HaveLen(1))
 
 				// The action should list BOTH policy sources (merge overrides merges both policies)
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].ServiceName).To(Equal(wasm.AuthServiceName))
-				g.Expect(existingWASMConfig.ActionSets[0].Actions[0].SourcePolicyLocators).To(ConsistOf(
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].Service).To(Equal(wasm.AuthServiceName))
+				g.Expect(existingWASMConfig.ActionSets[0].TypedActions[0].SourcePolicyLocators).To(ConsistOf(
 					"authpolicy.kuadrant.io:"+gwAuthPolicyKey.String(),
 					"authpolicy.kuadrant.io:"+routeAuthPolicyKey.String(),
 				))


### PR DESCRIPTION
## Summary
- Replace legacy `wasm.Action` with `wasm.TypedAction` for auth policies. The auth action is now a `type:"grpc"` TypedAction with a CheckRequest `messageBuilder`, `onReply` handlers (deny/fail/store/headers/fail), and `grpcService`/`grpcMethod` on the auth service config.
- Add `Path` and `Value` fields to `TypedAction` for the `store` action type used in auth's onReply chain (dynamic metadata from Authorino).
- Add `ValidateTypedAction` for CEL validation of typed actions (validates top-level predicate, skips onReply predicates which reference wasm-shim runtime variables).
- Update both Istio and Envoy Gateway extension reconcilers to collect auth TypedActions separately from legacy Actions, validate them, and pass both to `BuildActionSetsForPath`.
- Always create the upstream EnvoyFilter (descriptor service cluster) even without extensions, since the DynamicService for auth requires proto descriptors.

Closes #1996

## Test plan
- [x] `make test-unit` — all tests pass
- [x] `make run-lint` — no lint issues
- [x] Unit tests for `buildWasmTypedActionsForAuth`, `buildAuthOnReply`, `buildAuthMessageBuilder`, `joinPredicates`, and JSON round-trip
- [x] End-to-end test on local Kind cluster with Istio: AuthPolicy with API key auth returns 200 with correct credentials via the new TypedAction format
- [x] Verified Authorino receives correct CheckRequest with headers, context_extensions, and metadata_context via debug logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typed WASM auth actions added (including store/fail kinds) with gRPC auth support and runtime validation; validated typed actions are now included in WASM configuration.

* **Behaviour Changes**
  * Reconcilers continue building upstream/patch objects even when no upstreams are discovered; action merging and validation now consider both untyped and typed actions.

* **Tests**
  * New and updated unit/integration tests for typed auth actions, predicates, on-reply flows and JSON round-trips.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/2007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->