### PR TITLE
test: add disconnected OpenShift install test scripts

### DIFF
--- a/utils/disconnected-openshift-install/README.md
+++ b/utils/disconnected-openshift-install/README.md
@@ -1,0 +1,192 @@
+# Kuadrant Disconnected Installation Test Scripts
+
+> **⚠️ FOR TESTING PURPOSES ONLY**
+>
+> These scripts are designed for **testing and validating** Kuadrant's disconnected installation capabilities.
+> They use a **local in-cluster mirror** to simulate a disconnected environment.
+>
+> **This is NOT the recommended approach for production disconnected installations.**
+>
+> For production disconnected clusters, use a proper external mirror registry.
+
+Scripts for testing Kuadrant installation in disconnected (air-gapped) OpenShift and OKD clusters using
+an in-cluster image mirror for validation purposes.
+
+## Test Environment
+
+These scripts create an **in-cluster mirror** to simulate a disconnected environment for testing purposes.
+This approach:
+- ✅ Validates that Kuadrant operators work in disconnected environments
+- ✅ Tests image mirroring and digest-based references
+- ✅ Simulates air-gap constraints for development
+- ❌ Is NOT suitable for production (uses cluster resources for the mirror)
+- ❌ Does NOT represent best practices for real disconnected deployments
+
+## Prerequisites
+
+- OpenShift or OKD cluster (4.12+) with `oc` CLI authenticated
+- `opm`, `docker` or `podman`
+- Registry access (default: quay.io)
+- Istio (installed via `install-istio.sh`) for full validation
+
+**Supported Platforms:**
+- OpenShift Container Platform (OCP) 4.12+
+- OKD (OpenShift Kubernetes Distribution) 4.12+
+- CodeReady Containers (CRC) with either OpenShift or OKD preset
+
+Both platforms use the same Operator Lifecycle Manager (OLM) and catalog mechanisms, so these scripts work identically on both.
+
+## Building Custom Catalog (Optional)
+
+If you want to build and push your own catalog images (e.g., for development or custom versions):
+
+```bash
+# Build and push with default tag (dev)
+./utils/disconnected-openshift-install/build-catalogs.sh
+
+# Or build and push with custom tag
+IMAGE_TAG=v0.11.0 ./utils/disconnected-openshift-install/build-catalogs.sh
+
+# Or build and push to custom registry (recommended for development)
+REGISTRY=registry.example.com ORG=myorg IMAGE_TAG=dev ./utils/disconnected-openshift-install/build-catalogs.sh
+```
+
+**Important Notes:**
+- This script builds **and pushes** images to the registry - ensure you have push access
+- **Builds and pushes images for all four operators:**
+  - Operator images: kuadrant-operator, dns-operator, authorino-operator, limitador-operator
+  - Bundle images for each operator
+  - One combined catalog image: kuadrant-operator-catalog
+- **All images will use the same IMAGE_TAG** - this is for testing purposes only
+- The default tag is `dev` to avoid accidentally overwriting official `latest` images in quay.io
+- If pushing to quay.io/kuadrant, use a unique tag (e.g., your username or feature branch name)
+- For testing, consider using a private registry or different organization
+- This step is only needed if building custom catalogs. For testing with published releases, skip to E2E Test.
+
+## E2E Test
+
+### Automated
+
+Run all steps automatically:
+
+```bash
+# Basic run (assumes Istio already installed)
+./utils/disconnected-openshift-install/run-e2e-test.sh
+
+# Install Istio as part of the run
+./utils/disconnected-openshift-install/run-e2e-test.sh --install-istio
+
+# Full air-gap simulation with Istio installation
+./utils/disconnected-openshift-install/run-e2e-test.sh --install-istio --disconnect
+
+# Custom options
+./utils/disconnected-openshift-install/run-e2e-test.sh --install-istio --image-tag=dev --disable-sources
+```
+
+### Manual Steps
+
+Test disconnected installation using published catalog images:
+
+```bash
+# 1. Install Istio (Gateway API provider)
+./utils/disconnected-openshift-install/install-istio.sh
+
+# 2. Configure cluster mirrors and create CatalogSource
+#    Uses quay.io/kuadrant/kuadrant-operator-catalog:latest by default
+DISABLE_DEFAULT_SOURCES=true IMAGE_TAG=latest ./utils/disconnected-openshift-install/setup.sh
+
+# 3. (Optional) Simulate air-gap by disconnecting cluster
+./utils/disconnected-openshift-install/cluster-disconnect.sh disconnect
+
+# 4. Install Kuadrant
+./utils/disconnected-openshift-install/tmp/install/install.sh
+
+# 5. Validate installation
+./utils/disconnected-openshift-install/smoke-test.sh --cleanup
+
+# 6. (Optional) Reconnect cluster
+./utils/disconnected-openshift-install/cluster-disconnect.sh reconnect
+
+# 7. Cleanup
+./utils/disconnected-openshift-install/cleanup.sh
+```
+
+## Environment Variables
+
+```bash
+# Setup (setup.sh)
+REGISTRY=quay.io                 # Registry (default: quay.io)
+ORG=kuadrant                     # Organization (default: kuadrant)
+IMAGE_TAG=latest                 # Catalog tag (default: latest)
+DISABLE_DEFAULT_SOURCES=true     # Disable default OperatorHub sources
+
+# Build and Push (build-catalogs.sh) - optional, only for custom builds
+REGISTRY=quay.io/myorg           # Registry to push to (default: quay.io)
+ORG=myteam                       # Organization (default: kuadrant)
+IMAGE_TAG=v0.11.0                # Tag (default: dev)
+```
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `run-e2e-test.sh` | Execute complete E2E Test workflow automatically |
+| `build-catalogs.sh` | Build and push operators and catalog with digest references |
+| `install-istio.sh` | Install Istio via Sail operator (Gateway API provider) |
+| `setup.sh` | Configure mirrors, create CatalogSource, generate install manifests |
+| `cluster-disconnect.sh` | Simulate air-gap by blocking external network |
+| `smoke-test.sh` | Validate operators, policies, and digest references |
+| `cleanup.sh` | Restore cluster to original state (use `--yes` to skip prompts) |
+
+## What Gets Installed
+
+**Istio (Gateway API Provider):**
+- **Sail operator** - Istio lifecycle manager (in `istio-system`)
+- **IstioCNI** - CNI plugin for pod networking
+- **Istio control plane** - istiod deployment
+- **GatewayClass `istio`** - Gateway API implementation
+
+**Kuadrant Operators:**
+- **kuadrant-operator** - Policy attachment controller
+- **authorino-operator** - Authentication/authorization  
+- **limitador-operator** - Rate limiting
+- **dns-operator** - DNS management
+
+All Kuadrant operators installed in `kuadrant-system` namespace (cluster-scoped).
+
+## Generated Files
+
+`setup.sh` generates installation manifests in `utils/disconnected-openshift-install/tmp/install/`:
+
+- `01-namespace.yaml` - kuadrant-system namespace
+- `02-operatorgroup.yaml` - OperatorGroup (AllNamespaces)
+- `03-subscription.yaml` - Subscription (auto-detects channel)
+- `04-kuadrant.yaml` - Kuadrant CR
+- `install.sh` / `uninstall.sh` - Automated scripts
+
+## Troubleshooting
+
+**CatalogSource not ready:**
+```bash
+oc get catalogsource -n openshift-marketplace
+oc logs -n openshift-marketplace -l olm.catalogSource=kuadrant-disconnected-operator-catalog
+```
+
+**Subscription stuck:**
+```bash
+oc get installplan -n kuadrant-system
+oc patch installplan <name> -n kuadrant-system --type merge -p '{"spec":{"approved":true}}'
+```
+
+**Images not pulling:**
+```bash
+oc get imagedigestmirrorset,imagetagmirrorset
+oc debug node/<node> -- chroot /host cat /etc/containers/registries.conf.d/99-*
+```
+
+## Related Documentation
+
+- [OLM Disconnected Environments](https://olm.operatorframework.io/docs/tasks/disconnected/)
+- [OpenShift Mirroring Images](https://docs.openshift.com/container-platform/latest/installing/disconnected_install/installing-mirroring-installation-images.html)
+- [OKD Mirroring Images](https://docs.okd.io/latest/installing/disconnected_install/installing-mirroring-installation-images.html)
+- [Kuadrant Documentation](https://docs.kuadrant.io/)

--- a/utils/disconnected-openshift-install/build-catalogs.sh
+++ b/utils/disconnected-openshift-install/build-catalogs.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Script to build and push all Kuadrant operator images to a container registry
+#
+# This script builds all four Kuadrant operators (authorino, limitador, dns, kuadrant)
+# along with their OLM bundles and a combined catalog, then pushes all images to the
+# specified registry. All images use digest-based references for disconnected/air-gapped
+# OpenShift cluster installations.
+#
+# IMPORTANT: This script PUSHES images to the registry - ensure you have push access
+#            and are logged in before running.
+#
+# Usage:
+#   ./utils/disconnected-openshift-install/build-catalogs.sh [IMAGE_TAG]
+#
+# Arguments:
+#   IMAGE_TAG  - Optional image tag (default: dev)
+#
+# Environment Variables:
+#   REGISTRY        - Container registry (default: quay.io)
+#   ORG             - Organization/namespace (default: kuadrant)
+#   IMAGE_TAG       - Image tag for all operators
+#
+# Examples:
+#   # Build and push with default tag
+#   ./utils/disconnected-openshift-install/build-catalogs.sh
+#
+#   # Build and push with custom tag
+#   IMAGE_TAG=v0.11.0 ./utils/disconnected-openshift-install/build-catalogs.sh
+#
+#   # Build and push to custom registry
+#   REGISTRY=registry.example.com ORG=myorg IMAGE_TAG=v1.0.0 ./utils/disconnected-openshift-install/build-catalogs.sh
+#
+# Requirements:
+#   - Must be run from kuadrant-operator directory
+#   - Requires authorino-operator, limitador-operator, dns-operator as sibling directories
+#   - Requires registry login (e.g., docker login quay.io)
+#   - Requires make, docker/podman, operator-sdk, opm, yq
+#
+# Output:
+#   Builds and pushes 10 images total:
+#     - 1 CoreDNS image
+#     - 4 operator images (with digest references)
+#     - 4 operator bundles (with digest references in CSV)
+#     - 1 combined catalog (File-Based Catalog with digest references)
+
+# Configuration
+IMAGE_TAG="${IMAGE_TAG:-${1:-dev}}"
+REGISTRY="${REGISTRY:-quay.io}"
+ORG="${ORG:-kuadrant}"
+
+echo "=========================================="
+echo "Building Kuadrant Disconnected Catalog"
+echo "=========================================="
+echo ""
+echo "Configuration:"
+echo "  Registry: ${REGISTRY}"
+echo "  Organization: ${ORG}"
+echo "  Image Tag: ${IMAGE_TAG}"
+echo "  Workspace: $(pwd)"
+echo ""
+
+# Check we're in the kuadrant-operator directory
+if [ ! -f "Makefile" ] || [ ! -d "../authorino-operator" ]; then
+    echo "ERROR: This script must be run from the kuadrant-operator directory"
+    echo "       with authorino-operator, limitador-operator, and dns-operator"
+    echo "       as sibling directories."
+    exit 1
+fi
+
+# Function to build an operator
+build_operator() {
+    local OPERATOR_NAME=$1
+    local OPERATOR_DIR=$2
+    local BUILD_CMD=$3
+
+    echo ""
+    echo "=========================================="
+    echo "Building ${OPERATOR_NAME}"
+    echo "=========================================="
+    echo ""
+
+    if [ ! -d "$OPERATOR_DIR" ]; then
+        echo "ERROR: ${OPERATOR_DIR} not found"
+        exit 1
+    fi
+
+    cd "$OPERATOR_DIR"
+
+    echo "Running: $BUILD_CMD"
+    echo ""
+
+    eval "$BUILD_CMD"
+
+    if [ $? -eq 0 ]; then
+        echo ""
+        echo "✓ ${OPERATOR_NAME} build complete"
+    else
+        echo ""
+        echo "✗ ${OPERATOR_NAME} build failed"
+        exit 1
+    fi
+
+    cd - > /dev/null
+}
+
+START_TIME=$(date +%s)
+
+# Build CoreDNS image first (required by dns-operator)
+echo ""
+echo "=========================================="
+echo "Building CoreDNS"
+echo "=========================================="
+echo ""
+
+COREDNS_IMAGE="${REGISTRY}/${ORG}/coredns-kuadrant:${IMAGE_TAG}"
+
+# Build CoreDNS using dns-operator's make targets (which delegate to coredns plugin)
+cd ../dns-operator
+
+echo "Building and pushing CoreDNS image: ${COREDNS_IMAGE}"
+make coredns-docker-build coredns-docker-push COREDNS_IMG=${COREDNS_IMAGE}
+
+if [ $? -eq 0 ]; then
+    echo "✓ CoreDNS build and push complete"
+else
+    echo "✗ CoreDNS build/push failed"
+    exit 1
+fi
+
+cd - > /dev/null
+
+# Build dependency operators first (they can be built in any order since they don't depend on each other)
+
+build_operator \
+    "authorino-operator" \
+    "../authorino-operator" \
+    "make docker-build docker-push bundle bundle-build bundle-push \
+        IMAGE_TAG_BASE=${REGISTRY}/${ORG}/authorino-operator \
+        IMAGE_TAG=${IMAGE_TAG} \
+        USE_IMAGE_DIGESTS=true"
+
+build_operator \
+    "limitador-operator" \
+    "../limitador-operator" \
+    "make docker-build docker-push bundle bundle-build bundle-push \
+        IMAGE_TAG_BASE=${REGISTRY}/${ORG}/limitador-operator \
+        IMAGE_TAG=${IMAGE_TAG} \
+        USE_IMAGE_DIGESTS=true"
+
+build_operator \
+    "dns-operator" \
+    "../dns-operator" \
+    "make docker-build docker-push bundle bundle-build bundle-push \
+        IMAGE_TAG_BASE=${REGISTRY}/${ORG}/dns-operator \
+        IMAGE_TAG=${IMAGE_TAG} \
+        COREDNS_IMG=${REGISTRY}/${ORG}/coredns-kuadrant:${IMAGE_TAG} \
+        USE_IMAGE_DIGESTS=true"
+
+# Build kuadrant-operator last (depends on the other three bundles)
+build_operator \
+    "kuadrant-operator" \
+    "." \
+    "make docker-build docker-push bundle bundle-build bundle-push catalog catalog-build catalog-push \
+        IMAGE_TAG=${IMAGE_TAG} \
+        LIMITADOR_OPERATOR_BUNDLE_IMG=${REGISTRY}/${ORG}/limitador-operator-bundle:${IMAGE_TAG} \
+        AUTHORINO_OPERATOR_BUNDLE_IMG=${REGISTRY}/${ORG}/authorino-operator-bundle:${IMAGE_TAG} \
+        DNS_OPERATOR_BUNDLE_IMG=${REGISTRY}/${ORG}/dns-operator-bundle:${IMAGE_TAG} \
+        USE_IMAGE_DIGESTS=true"
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+echo ""
+echo "=========================================="
+echo "✓ Build and Push Complete"
+echo "=========================================="
+echo ""
+echo "Successfully built and pushed 10 images to ${REGISTRY}/${ORG}:"
+echo ""
+echo "CoreDNS:"
+echo "  ${REGISTRY}/${ORG}/coredns-kuadrant:${IMAGE_TAG}"
+echo ""
+echo "Authorino Operator:"
+echo "  ${REGISTRY}/${ORG}/authorino-operator:${IMAGE_TAG}"
+echo "  ${REGISTRY}/${ORG}/authorino-operator-bundle:${IMAGE_TAG}"
+echo ""
+echo "Limitador Operator:"
+echo "  ${REGISTRY}/${ORG}/limitador-operator:${IMAGE_TAG}"
+echo "  ${REGISTRY}/${ORG}/limitador-operator-bundle:${IMAGE_TAG}"
+echo ""
+echo "DNS Operator:"
+echo "  ${REGISTRY}/${ORG}/dns-operator:${IMAGE_TAG}"
+echo "  ${REGISTRY}/${ORG}/dns-operator-bundle:${IMAGE_TAG}"
+echo ""
+echo "Kuadrant Operator:"
+echo "  ${REGISTRY}/${ORG}/kuadrant-operator:${IMAGE_TAG}"
+echo "  ${REGISTRY}/${ORG}/kuadrant-operator-bundle:${IMAGE_TAG}"
+echo "  ${REGISTRY}/${ORG}/kuadrant-operator-catalog:${IMAGE_TAG}"
+echo ""
+echo "Build time: ${DURATION} seconds"
+echo ""

--- a/utils/disconnected-openshift-install/cleanup.sh
+++ b/utils/disconnected-openshift-install/cleanup.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Script to cleanup resources created by setup.sh
+# Removes both cluster resources (if accessible) and local files
+# Restores cluster to original state (reconnects network, removes mirrors, etc.)
+#
+# Usage:
+#   ./cleanup.sh [--yes]
+#
+# Options:
+#   --yes, -y    Skip all prompts and clean everything automatically
+
+# Parse arguments
+AUTO_YES=false
+if [ "${1:-}" = "--yes" ] || [ "${1:-}" = "-y" ]; then
+    AUTO_YES=true
+fi
+
+echo "==> Cleanup Disconnected Installation Test Resources"
+echo ""
+
+# Configuration
+WORK_DIR="${WORK_DIR:-./utils/disconnected-openshift-install/tmp}"
+MIRROR_NAMESPACE="mirror-registry"
+
+# Check if cluster is accessible
+CLUSTER_ACCESSIBLE=false
+if oc whoami &>/dev/null; then
+    echo "✓ OpenShift cluster accessible"
+    CLUSTER_ACCESSIBLE=true
+else
+    echo "✗ OpenShift cluster not accessible (skipping cluster cleanup)"
+fi
+
+# Cluster Cleanup
+if [ "$CLUSTER_ACCESSIBLE" = true ]; then
+    echo ""
+    echo "==> Cleaning up cluster resources"
+
+    # Find all Kuadrant disconnected test CatalogSources (using the label)
+    echo "  Finding Kuadrant disconnected test CatalogSources..."
+    CATALOG_NAMES=$(oc get catalogsource -n openshift-marketplace -l kuadrant.io/disconnected-test=true -o name 2>/dev/null | \
+        cut -d'/' -f2 || echo "")
+
+    if [ -n "$CATALOG_NAMES" ]; then
+        echo "  Removing CatalogSources:"
+        for catalog_name in ${CATALOG_NAMES}; do
+            echo "    - ${catalog_name}"
+            oc delete catalogsource ${catalog_name} -n openshift-marketplace --ignore-not-found=true
+        done
+    else
+        echo "  No Kuadrant CatalogSources found"
+    fi
+
+    # Remove kuadrant-system namespace if it exists
+    echo ""
+    echo "  Checking for kuadrant-system namespace..."
+    if oc get namespace kuadrant-system &>/dev/null; then
+        echo "  Found namespace kuadrant-system"
+
+        # Check if uninstall script exists
+        if [ -d "${WORK_DIR}/install" ] && [ -f "${WORK_DIR}/install/uninstall.sh" ]; then
+            echo "  Automated uninstall script available"
+            if [ "$AUTO_YES" = true ]; then
+                REPLY="y"
+            else
+                read -p "  Run automated uninstall script? [y/N] " -n 1 -r
+                echo
+            fi
+            if [[ $REPLY =~ ^[Yy]$ ]]; then
+                ${WORK_DIR}/install/uninstall.sh
+                echo "  ✓ Automated uninstall complete"
+            else
+                echo "  Skipped automated uninstall"
+                if [ "$AUTO_YES" = true ]; then
+                    REPLY="y"
+                else
+                    read -p "  Delete kuadrant-system namespace manually? [y/N] " -n 1 -r
+                    echo
+                fi
+                if [[ $REPLY =~ ^[Yy]$ ]]; then
+                    oc delete namespace kuadrant-system
+                    echo "  ✓ Removed kuadrant-system namespace"
+                else
+                    echo "  Skipped namespace removal"
+                fi
+            fi
+        else
+            if [ "$AUTO_YES" = true ]; then
+                REPLY="y"
+            else
+                read -p "  Delete kuadrant-system namespace? [y/N] " -n 1 -r
+                echo
+            fi
+            if [[ $REPLY =~ ^[Yy]$ ]]; then
+                # Delete subscription first
+                oc delete subscription kuadrant-operator -n kuadrant-system --ignore-not-found=true 2>/dev/null || true
+                # Delete CSVs
+                oc delete csv --all -n kuadrant-system --ignore-not-found=true 2>/dev/null || true
+                # Wait for pods to terminate
+                oc wait --for=delete pod --all -n kuadrant-system --timeout=60s 2>/dev/null || true
+                # Delete namespace
+                oc delete namespace kuadrant-system
+                echo "  ✓ Removed kuadrant-system namespace"
+            else
+                echo "  Skipped namespace removal"
+            fi
+        fi
+    else
+        echo "  Namespace kuadrant-system not found"
+    fi
+
+    # Remove ImageDigestMirrorSets
+    echo ""
+    echo "  Checking for ImageDigestMirrorSets..."
+    IDMS_COUNT=$(oc get imagedigestmirrorset -o name 2>/dev/null | wc -l || echo "0")
+    IDMS_REMOVED=false
+    if [ "$IDMS_COUNT" -gt 0 ]; then
+        echo "  Found ${IDMS_COUNT} ImageDigestMirrorSet(s)"
+        if [ "$AUTO_YES" = false ]; then
+            echo "  WARNING: This will remove ALL ImageDigestMirrorSets on the cluster"
+            echo "           Removal triggers control plane restart (cluster may be briefly unstable)"
+            read -p "  Remove all ImageDigestMirrorSets? [y/N] " -n 1 -r
+            echo
+        else
+            REPLY="y"
+        fi
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            oc delete imagedigestmirrorset --all
+            echo "  ✓ Removed ImageDigestMirrorSets"
+            IDMS_REMOVED=true
+        else
+            echo "  Skipped ImageDigestMirrorSet removal"
+        fi
+    else
+        echo "  No ImageDigestMirrorSets found"
+    fi
+
+    # Remove ImageTagMirrorSets
+    echo ""
+    echo "  Checking for ImageTagMirrorSets..."
+    ITMS_COUNT=$(oc get imagetagmirrorset -o name 2>/dev/null | wc -l || echo "0")
+    ITMS_REMOVED=false
+    if [ "$ITMS_COUNT" -gt 0 ]; then
+        echo "  Found ${ITMS_COUNT} ImageTagMirrorSet(s)"
+        if [ "$AUTO_YES" = false ]; then
+            echo "  WARNING: This will remove ALL ImageTagMirrorSets on the cluster"
+            echo "           Removal triggers control plane restart (cluster may be briefly unstable)"
+            read -p "  Remove all ImageTagMirrorSets? [y/N] " -n 1 -r
+            echo
+        else
+            REPLY="y"
+        fi
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            oc delete imagetagmirrorset --all
+            echo "  ✓ Removed ImageTagMirrorSets"
+            ITMS_REMOVED=true
+        else
+            echo "  Skipped ImageTagMirrorSet removal"
+        fi
+    else
+        echo "  No ImageTagMirrorSets found"
+    fi
+
+    # If we removed IDMS or ITMS, wait for cluster to stabilize
+    if [ "$IDMS_REMOVED" = true ] || [ "$ITMS_REMOVED" = true ]; then
+        echo ""
+        echo "  Waiting for cluster to stabilize after removing image mirror configuration..."
+
+        # Check if single-node cluster
+        NODE_COUNT=$(oc get nodes --no-headers 2>/dev/null | wc -l || echo "0")
+        if [ "$NODE_COUNT" -eq 1 ]; then
+            echo "  (Single-node cluster detected - API server may restart)"
+        fi
+
+        # Give cluster a moment to start processing
+        sleep 5
+
+        # Wait for openshift-apiserver to stabilize (with shorter timeout for cleanup)
+        WAIT_TIMEOUT=180  # 3 minutes
+        APISERVER_STABLE=false
+        START_TIME=$(date +%s)
+
+        while [ $(($(date +%s) - START_TIME)) -lt $WAIT_TIMEOUT ]; do
+            APISERVER_AVAILABLE=$(oc get co openshift-apiserver -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)
+            APISERVER_PROGRESSING=$(oc get co openshift-apiserver -o jsonpath='{.status.conditions[?(@.type=="Progressing")].status}' 2>/dev/null)
+
+            if [ "$APISERVER_AVAILABLE" = "True" ] && [ "$APISERVER_PROGRESSING" = "False" ]; then
+                APISERVER_STABLE=true
+                echo "  ✓ Cluster stabilized"
+                break
+            fi
+
+            # On single-node, auto-fix stuck pods
+            if [ "$NODE_COUNT" -eq 1 ]; then
+                PENDING_PODS=$(oc get pods -n openshift-apiserver --no-headers 2>/dev/null | grep -c "Pending" || echo "0")
+                TERMINATING_PODS=$(oc get pods -n openshift-apiserver --no-headers 2>/dev/null | grep -c "Terminating" || echo "0")
+
+                if [ "$PENDING_PODS" -gt 0 ] && [ "$TERMINATING_PODS" -gt 0 ]; then
+                    echo "  Auto-fixing stuck apiserver pods..."
+                    oc get pods -n openshift-apiserver --no-headers 2>/dev/null | grep "Terminating" | awk '{print $1}' | while read pod; do
+                        oc delete pod -n openshift-apiserver "$pod" --force --grace-period=0 2>/dev/null || true
+                    done
+                    sleep 10
+                fi
+            fi
+
+            sleep 5
+        done
+
+        if [ "$APISERVER_STABLE" = false ]; then
+            echo "  ⚠ Cluster did not stabilize within ${WAIT_TIMEOUT}s (this is normal)"
+            echo "    Background MachineConfig update may still be in progress"
+        fi
+    fi
+
+    # Remove mirror-registry namespace
+    echo ""
+    echo "  Checking for mirror-registry namespace..."
+    if oc get namespace ${MIRROR_NAMESPACE} &>/dev/null; then
+        echo "  Found namespace ${MIRROR_NAMESPACE}"
+        if [ "$AUTO_YES" = true ]; then
+            REPLY="y"
+        else
+            echo "  This will delete the test Docker registry and all its data"
+            read -p "  Remove mirror-registry namespace? [y/N] " -n 1 -r
+            echo
+        fi
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            oc delete namespace ${MIRROR_NAMESPACE}
+            echo "  ✓ Removed ${MIRROR_NAMESPACE} namespace"
+        else
+            echo "  Skipped namespace removal"
+        fi
+    else
+        echo "  Namespace ${MIRROR_NAMESPACE} not found"
+    fi
+
+    # Re-enable default OperatorHub sources if they were disabled
+    echo ""
+    echo "  Checking OperatorHub default sources..."
+    SOURCES_DISABLED=$(oc get operatorhub cluster -o jsonpath='{.spec.disableAllDefaultSources}' 2>/dev/null || echo "false")
+
+    if [ "$SOURCES_DISABLED" = "true" ]; then
+        echo "  Default OperatorHub sources are currently disabled"
+        if [ "$AUTO_YES" = true ]; then
+            REPLY="y"
+        else
+            read -p "  Re-enable default sources (Red Hat Operators, Community Operators, etc.)? [y/N] " -n 1 -r
+            echo
+        fi
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            oc patch operatorhub cluster --type json \
+                -p '[{"op": "replace", "path": "/spec/disableAllDefaultSources", "value": false}]'
+            echo "  ✓ Default OperatorHub sources re-enabled"
+        else
+            echo "  Skipped re-enabling default sources"
+        fi
+    else
+        echo "  Default OperatorHub sources are enabled (no change needed)"
+    fi
+
+    echo ""
+    echo "✓ Cluster cleanup complete"
+fi
+
+# Local Files Cleanup
+echo ""
+echo "==> Cleaning up local files"
+
+if [ -d "$WORK_DIR" ]; then
+    # Calculate size
+    SIZE=$(du -sh "$WORK_DIR" 2>/dev/null | cut -f1 || echo "unknown")
+    echo "  Found working directory: ${WORK_DIR} (${SIZE})"
+
+    if [ "$AUTO_YES" = false ]; then
+        # List contents
+        echo "  Contents:"
+        ls -lh "${WORK_DIR}" 2>/dev/null | tail -n +2 | awk '{printf "    %s  %s\n", $5, $9}' || echo "    (empty or inaccessible)"
+
+        echo ""
+        read -p "  Remove ${WORK_DIR}? [y/N] " -n 1 -r
+        echo
+    else
+        REPLY="y"
+    fi
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm -rf "$WORK_DIR"
+        echo "  ✓ Removed ${WORK_DIR}"
+    else
+        echo "  Skipped local files removal"
+    fi
+else
+    echo "  Working directory ${WORK_DIR} not found"
+fi
+
+# Network Connectivity Cleanup
+if [ "$CLUSTER_ACCESSIBLE" = true ]; then
+    echo ""
+    echo "==> Restoring network connectivity"
+
+    # Get node name
+    NODE_NAME=$(oc get nodes -o name | head -1 | cut -d'/' -f2)
+
+    if [ -z "$NODE_NAME" ]; then
+        echo "  ⚠ Could not determine node name (skipping network restore)"
+    else
+        # Test if cluster is disconnected (check external connectivity)
+        echo "  Checking current connectivity status..."
+        if oc debug -n default node/${NODE_NAME} -- chroot /host timeout 5 curl -I https://quay.io 2>/dev/null > /dev/null 2>&1; then
+            echo "  ✓ Cluster already connected to external network"
+        else
+            echo "  ⚠ Cluster disconnected - restoring connectivity..."
+
+            # Check if iptables backup exists (indicates disconnect.sh was used)
+            HAS_BACKUP=$(oc debug -n default node/${NODE_NAME} -- chroot /host test -f /tmp/iptables-before-disconnect.rules 2>/dev/null && echo "yes" || echo "no")
+
+            if [ "$HAS_BACKUP" = "yes" ]; then
+                echo "  Restoring original iptables rules..."
+                oc debug -n default node/${NODE_NAME} -- chroot /host /bin/bash -c "
+                    iptables-restore < /tmp/iptables-before-disconnect.rules 2>/dev/null
+                    rm -f /tmp/iptables-before-disconnect.rules
+                " 2>/dev/null || echo "  ⚠ Failed to restore iptables (may already be restored)"
+            else
+                echo "  Flushing iptables OUTPUT chain..."
+                oc debug -n default node/${NODE_NAME} -- chroot /host /bin/bash -c "
+                    iptables -F OUTPUT 2>/dev/null
+                    iptables -P OUTPUT ACCEPT 2>/dev/null
+                " 2>/dev/null || echo "  ⚠ Failed to flush iptables"
+            fi
+
+            # Verify reconnection worked
+            sleep 2
+            if oc debug -n default node/${NODE_NAME} -- chroot /host timeout 5 curl -I https://quay.io 2>/dev/null > /dev/null 2>&1; then
+                echo "  ✓ Cluster reconnected to external network"
+            else
+                echo "  ⚠ Cluster may still be disconnected (check manually)"
+            fi
+        fi
+    fi
+fi
+
+echo ""
+echo "=========================================="
+echo "✓ Cleanup Complete"
+echo "=========================================="
+echo ""
+
+if [ "$CLUSTER_ACCESSIBLE" = true ]; then
+    REMAINING_IDMS=$(oc get imagedigestmirrorset --no-headers 2>/dev/null | wc -l || echo "0")
+    REMAINING_ITMS=$(oc get imagetagmirrorset --no-headers 2>/dev/null | wc -l || echo "0")
+
+    if [ "$REMAINING_IDMS" -eq 0 ] && [ "$REMAINING_ITMS" -eq 0 ]; then
+        echo "Cluster restored to normal operation:"
+        echo "  ✓ All image pulls use original registries"
+        echo "  ✓ Disconnected mode disabled"
+    else
+        echo "Image pull behavior:"
+        echo "  ⚠ Some mirror sets still present"
+        echo "    IDMS: ${REMAINING_IDMS} | ITMS: ${REMAINING_ITMS}"
+        if [ "$REMAINING_IDMS" -gt 0 ] || [ "$REMAINING_ITMS" -gt 0 ]; then
+            echo ""
+            echo "  MachineConfigPool updating (may take 10-20 minutes)"
+            echo "  Monitor: oc get mcp"
+        fi
+    fi
+else
+    echo "Cluster not accessible - local files cleaned up only"
+fi
+echo ""

--- a/utils/disconnected-openshift-install/cluster-disconnect.sh
+++ b/utils/disconnected-openshift-install/cluster-disconnect.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Script to disconnect/reconnect cluster from external network
+# Simulates a true air-gapped environment for disconnected installation testing
+
+ACTION="${1:-disconnect}"
+
+# Check if oc is available
+if ! command -v oc &>/dev/null; then
+    echo "ERROR: oc command not found. Please install OpenShift CLI."
+    exit 1
+fi
+
+# Check if cluster is accessible
+if ! oc whoami &>/dev/null; then
+    echo "ERROR: Not connected to OpenShift cluster. Please login first."
+    exit 1
+fi
+
+# Get the node name (for CRC there's only one)
+NODE_NAME=$(oc get nodes -o name | head -1 | cut -d'/' -f2)
+
+if [ -z "$NODE_NAME" ]; then
+    echo "ERROR: Could not find any nodes in the cluster"
+    exit 1
+fi
+
+case "$ACTION" in
+    disconnect)
+        echo "==> Disconnecting cluster from external network"
+        echo "  Node: ${NODE_NAME}"
+        echo ""
+
+        echo "Applying iptables rules to block external access..."
+        echo ""
+
+        # Apply disconnect rules
+        oc debug -n default node/${NODE_NAME} -- chroot /host /bin/bash -c "
+            # Save current rules
+            iptables-save > /tmp/iptables-before-disconnect.rules
+
+            # Clear OUTPUT chain
+            iptables -F OUTPUT
+
+            # Allow established connections and loopback
+            iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+            iptables -A OUTPUT -o lo -j ACCEPT
+
+            # Allow DNS to cluster DNS (needed for internal resolution)
+            iptables -A OUTPUT -p udp --dport 53 -d 10.0.0.0/8 -j ACCEPT
+            iptables -A OUTPUT -p tcp --dport 53 -d 10.0.0.0/8 -j ACCEPT
+
+            # Allow access to local networks (RFC 1918 private networks)
+            iptables -A OUTPUT -d 10.0.0.0/8 -j ACCEPT
+            iptables -A OUTPUT -d 172.16.0.0/12 -j ACCEPT
+            iptables -A OUTPUT -d 192.168.0.0/16 -j ACCEPT
+
+            # Allow access to link-local (needed for some internal services)
+            iptables -A OUTPUT -d 169.254.0.0/16 -j ACCEPT
+
+            # Log blocked external attempts (optional, for debugging)
+            iptables -A OUTPUT -m limit --limit 5/min -j LOG --log-prefix 'BLOCKED-EXT: ' --log-level 4
+
+            # Block everything else (external internet)
+            iptables -A OUTPUT -j REJECT --reject-with icmp-host-unreachable
+
+            echo '✓ iptables rules applied'
+            iptables -L OUTPUT -v -n | head -20
+        "
+
+        echo ""
+        echo "==> Testing disconnected state"
+
+        # Test that external access is blocked
+        echo -n "  Testing external access (should fail): "
+        if oc debug -n default node/${NODE_NAME} -- chroot /host timeout 5 curl -I https://quay.io 2>/dev/null > /dev/null 2>&1; then
+            echo "✗ FAILED - External access still works!"
+            echo "    Disconnect may not have worked properly"
+        else
+            echo "✓ BLOCKED (as expected)"
+        fi
+
+        # Test that internal access works
+        echo -n "  Testing internal access (should work): "
+        INTERNAL_TEST=$(oc get --raw /healthz 2>/dev/null && echo "ok" || echo "failed")
+        if [ "$INTERNAL_TEST" = "ok" ]; then
+            echo "✓ WORKS (as expected)"
+        else
+            echo "✗ FAILED - Internal access blocked!"
+            echo "    This may cause cluster issues"
+        fi
+
+        echo ""
+        echo "=========================================="
+        echo "✓ Cluster Disconnected"
+        echo "=========================================="
+        echo ""
+        echo "  ✓ External registries blocked"
+        echo "  ✓ Internal networking operational"
+        echo ""
+        ;;
+
+    reconnect)
+        echo "==> Reconnecting cluster to external network"
+        echo "  Node: ${NODE_NAME}"
+        echo ""
+
+        echo "Restoring original iptables rules..."
+
+        oc debug -n default node/${NODE_NAME} -- chroot /host /bin/bash -c "
+            if [ -f /tmp/iptables-before-disconnect.rules ]; then
+                iptables-restore < /tmp/iptables-before-disconnect.rules
+                rm -f /tmp/iptables-before-disconnect.rules
+                echo '✓ Original iptables rules restored'
+            else
+                # If backup doesn't exist, just flush OUTPUT chain (restore default ACCEPT)
+                iptables -F OUTPUT
+                iptables -P OUTPUT ACCEPT
+                echo '✓ iptables OUTPUT chain flushed (default ACCEPT policy)'
+            fi
+
+            iptables -L OUTPUT -v -n | head -10
+        "
+
+        echo ""
+        echo "==> Testing reconnected state"
+
+        # Test that external access works
+        echo -n "  Testing external access (should work): "
+        if oc debug -n default node/${NODE_NAME} -- chroot /host timeout 5 curl -I https://quay.io 2>/dev/null > /dev/null 2>&1; then
+            echo "✓ WORKS (reconnected)"
+        else
+            echo "✗ FAILED - Still blocked!"
+        fi
+
+        echo ""
+        echo "=========================================="
+        echo "✓ Cluster Reconnected"
+        echo "=========================================="
+        echo ""
+        echo "  ✓ External registries accessible"
+        echo ""
+        ;;
+
+    status)
+        echo "==> Checking network connectivity"
+        echo "  Node: ${NODE_NAME}"
+        echo ""
+
+        echo "Testing connectivity:"
+        echo ""
+
+        echo -n "  External (quay.io): "
+        if oc debug -n default node/${NODE_NAME} -- chroot /host timeout 5 curl -I https://quay.io 2>/dev/null > /dev/null 2>&1; then
+            echo "✓ CONNECTED"
+        else
+            echo "✗ DISCONNECTED"
+        fi
+
+        echo -n "  Internal (Kubernetes API): "
+        if oc get --raw /healthz &>/dev/null; then
+            echo "✓ CONNECTED"
+        else
+            echo "✗ DISCONNECTED (WARNING: cluster may have issues)"
+        fi
+
+        echo ""
+        echo "Current OUTPUT iptables rules:"
+        oc debug -n default node/${NODE_NAME} -- chroot /host iptables -L OUTPUT -v -n 2>/dev/null | head -20 || echo "  (unable to retrieve)"
+        echo ""
+        ;;
+
+    *)
+        echo "Usage: $0 [disconnect|reconnect|status]"
+        echo ""
+        echo "Actions:"
+        echo "  disconnect - Block external network access (simulate air-gapped)"
+        echo "  reconnect  - Restore external network access"
+        echo "  status     - Check current connectivity state"
+        echo ""
+        echo "Examples:"
+        echo "  $0 disconnect"
+        echo "  $0 status"
+        echo "  $0 reconnect"
+        exit 1
+        ;;
+esac

--- a/utils/disconnected-openshift-install/install-istio.sh
+++ b/utils/disconnected-openshift-install/install-istio.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Script to install Istio via Sail operator on OpenShift
+# Uses Community Operators catalog to install sailoperator
+# Then deploys Istio control plane with IstioCNI
+
+echo "=========================================="
+echo "Installing Istio via Sail Operator"
+echo "=========================================="
+echo ""
+
+# Check if oc is available
+if ! command -v oc &>/dev/null; then
+    echo "ERROR: oc command not found. Please install OpenShift CLI."
+    exit 1
+fi
+
+# Check if cluster is accessible
+if ! oc whoami &>/dev/null; then
+    echo "ERROR: Not connected to OpenShift cluster. Please login first."
+    exit 1
+fi
+
+# Check if Istio is already installed
+echo "==> Checking for existing Istio installation"
+if oc get gatewayclass istio &>/dev/null 2>&1; then
+    echo "  ✓ Istio GatewayClass already exists"
+    echo ""
+    echo "Istio is already installed. Skipping installation."
+    echo ""
+    oc get gatewayclass istio
+    echo ""
+    exit 0
+fi
+echo "  No Istio GatewayClass found"
+echo ""
+
+# Check if sailoperator package is available
+echo "==> Checking sailoperator availability"
+if ! oc get packagemanifest sailoperator -n openshift-marketplace &>/dev/null; then
+    echo "ERROR: sailoperator package not found in openshift-marketplace"
+    echo "       Make sure Community Operators catalog source is enabled"
+    exit 1
+fi
+
+SAIL_CHANNEL=$(oc get packagemanifest sailoperator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}' 2>/dev/null)
+echo "  ✓ sailoperator found (channel: ${SAIL_CHANNEL})"
+echo ""
+
+# Create istio-system namespace
+echo "==> Creating istio-system namespace"
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+EOF
+echo ""
+
+# Create OperatorGroup for Sail operator
+echo "==> Creating OperatorGroup for Sail operator"
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: sail-operator-group
+  namespace: istio-system
+spec: {}
+EOF
+echo ""
+
+# Create Subscription for Sail operator
+echo "==> Creating Subscription for sailoperator"
+cat <<EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sailoperator
+  namespace: istio-system
+spec:
+  channel: ${SAIL_CHANNEL}
+  name: sailoperator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
+echo ""
+
+# Wait for Sail operator CSV to be ready
+echo "==> Waiting for Sail operator installation (60s timeout)"
+TIMEOUT=60
+ELAPSED=0
+CSV_PHASE=""
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    # Get CSV name that starts with sailoperator (|| true to avoid pipefail exit)
+    CSV_NAME=$(oc get csv -n istio-system --no-headers 2>/dev/null | grep "^sailoperator" | awk '{print $1}' | head -1 || true)
+    if [ -n "$CSV_NAME" ]; then
+        CSV_PHASE=$(oc get csv "$CSV_NAME" -n istio-system -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+        if [ "$CSV_PHASE" = "Succeeded" ]; then
+            echo "  ✓ Sail operator CSV ready ($CSV_NAME)"
+            break
+        fi
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+    echo "  Waiting... (${ELAPSED}s)"
+done
+
+if [ "$CSV_PHASE" != "Succeeded" ]; then
+    echo "  ✗ FAILED - Sail operator CSV not ready after ${TIMEOUT}s"
+    echo ""
+    echo "CSV status:"
+    oc get csv -n istio-system
+    exit 1
+fi
+echo ""
+
+# Wait for Sail operator pod to be ready
+echo "==> Waiting for Sail operator pod to be ready (30s timeout)"
+TIMEOUT=30
+ELAPSED=0
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    READY=$(oc get pods -n istio-system -l control-plane=sail-operator -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+    if [ "$READY" = "True" ]; then
+        echo "  ✓ Sail operator pod ready"
+        break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+    echo "  Waiting... (${ELAPSED}s)"
+done
+
+if [ "$READY" != "True" ]; then
+    echo "  ✗ FAILED - Sail operator pod not ready after ${TIMEOUT}s"
+    echo ""
+    echo "Pod status:"
+    oc get pods -n istio-system
+    exit 1
+fi
+echo ""
+
+# Wait for Sail operator CRDs to be created
+echo "==> Waiting for Sail operator CRDs (30s timeout)"
+TIMEOUT=30
+ELAPSED=0
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    if oc get crd istiocnis.sailoperator.io &>/dev/null && oc get crd istios.sailoperator.io &>/dev/null; then
+        echo "  ✓ Sail operator CRDs ready"
+        break
+    fi
+    sleep 3
+    ELAPSED=$((ELAPSED + 3))
+    echo "  Waiting... (${ELAPSED}s)"
+done
+
+if ! oc get crd istiocnis.sailoperator.io &>/dev/null || ! oc get crd istios.sailoperator.io &>/dev/null; then
+    echo "  ✗ FAILED - CRDs not created after ${TIMEOUT}s"
+    echo ""
+    echo "Expected CRDs:"
+    echo "  - istiocnis.sailoperator.io"
+    echo "  - istios.sailoperator.io"
+    echo ""
+    echo "Available CRDs:"
+    oc get crd | grep sailoperator
+    exit 1
+fi
+echo ""
+
+# Create istio-cni namespace
+echo "==> Creating istio-cni namespace"
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-cni
+EOF
+echo ""
+
+# Create IstioCNI resource (required for OpenShift)
+echo "==> Creating IstioCNI resource"
+cat <<EOF | oc apply -f -
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  version: v1.29.2
+  namespace: istio-cni
+EOF
+echo ""
+
+# Wait for IstioCNI to be ready
+echo "==> Waiting for IstioCNI to be ready (60s timeout)"
+TIMEOUT=60
+ELAPSED=0
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    CNI_READY=$(oc get istiocni default -o jsonpath='{.status.state}' 2>/dev/null || echo "")
+    if [ "$CNI_READY" = "Healthy" ]; then
+        echo "  ✓ IstioCNI ready"
+        break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+    echo "  Waiting... (${ELAPSED}s) [status: ${CNI_READY}]"
+done
+
+if [ "$CNI_READY" != "Healthy" ]; then
+    echo "  ⚠ IstioCNI not healthy after ${TIMEOUT}s (status: ${CNI_READY})"
+    echo "  Continuing anyway - Istio may still work"
+fi
+echo ""
+
+# Create Istio resource (deploys control plane)
+echo "==> Creating Istio resource"
+cat <<EOF | oc apply -f -
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: default
+spec:
+  version: v1.29.2
+  namespace: istio-system
+EOF
+echo ""
+
+# Wait for Istio to be ready
+echo "==> Waiting for Istio control plane to be ready (120s timeout)"
+TIMEOUT=120
+ELAPSED=0
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    ISTIO_READY=$(oc get istio default -o jsonpath='{.status.state}' 2>/dev/null || echo "")
+    if [ "$ISTIO_READY" = "Healthy" ]; then
+        echo "  ✓ Istio control plane ready"
+        break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+    echo "  Waiting... (${ELAPSED}s) [status: ${ISTIO_READY}]"
+done
+
+if [ "$ISTIO_READY" != "Healthy" ]; then
+    echo "  ✗ FAILED - Istio not healthy after ${TIMEOUT}s (status: ${ISTIO_READY})"
+    echo ""
+    echo "Istio status:"
+    oc get istio default -o yaml
+    exit 1
+fi
+echo ""
+
+# Wait for istiod pod to be ready
+echo "==> Waiting for istiod pod to be ready (30s timeout)"
+TIMEOUT=30
+ELAPSED=0
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    ISTIOD_READY=$(oc get pods -n istio-system -l app=istiod -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "")
+    if [ "$ISTIOD_READY" = "True" ]; then
+        echo "  ✓ istiod pod ready"
+        break
+    fi
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+    echo "  Waiting... (${ELAPSED}s)"
+done
+
+if [ "$ISTIOD_READY" != "True" ]; then
+    echo "  ✗ FAILED - istiod pod not ready after ${TIMEOUT}s"
+    exit 1
+fi
+echo ""
+
+# Verify GatewayClass was created
+echo "==> Verifying GatewayClass creation"
+if oc get gatewayclass istio &>/dev/null; then
+    echo "  ✓ GatewayClass 'istio' created"
+    echo ""
+    oc get gatewayclass istio
+else
+    echo "  ✗ FAILED - GatewayClass 'istio' not found"
+    echo "  Istio is installed but GatewayClass not created"
+    exit 1
+fi
+echo ""
+
+echo "=========================================="
+echo "✓ Istio Installation Complete"
+echo "=========================================="
+echo ""
+echo "  GatewayClass 'istio' is available"
+echo ""

--- a/utils/disconnected-openshift-install/run-e2e-test.sh
+++ b/utils/disconnected-openshift-install/run-e2e-test.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Script to run the complete End-to-End Test workflow for disconnected installation testing
+#
+# This script executes all steps from the README End-to-End Test section:
+#   1. Install Istio via Sail operator
+#   2. Configure cluster mirrors and create CatalogSource
+#   3. (Optional) Disconnect cluster to simulate air-gap
+#   4. Install Kuadrant operator
+#   5. Run smoke tests to validate installation
+#   6. (Optional) Reconnect cluster
+#   7. (Optional) Cleanup all resources
+#
+# Usage:
+#   ./utils/disconnected-openshift-install/run-e2e-test.sh [options]
+#
+# Options:
+#   --install-istio       Install Istio (skip if already installed)
+#   --disconnect          Simulate air-gap by disconnecting cluster
+#   --skip-cleanup        Skip cleanup step at the end
+#   --image-tag=TAG       Catalog image tag (default: latest)
+#   --disable-sources     Disable default OperatorHub sources
+#
+# Environment Variables:
+#   IMAGE_TAG                 - Catalog image tag (default: latest)
+#   DISABLE_DEFAULT_SOURCES   - Set to "true" to disable default sources (default: false)
+#
+# Examples:
+#   # Basic run (assumes Istio already installed)
+#   ./utils/disconnected-openshift-install/run-e2e-test.sh
+#
+#   # Install Istio as part of the run
+#   ./utils/disconnected-openshift-install/run-e2e-test.sh --install-istio
+#
+#   # Full run with Istio installation and air-gap simulation
+#   ./utils/disconnected-openshift-install/run-e2e-test.sh --install-istio --disconnect
+#
+#   # Use custom catalog tag and disable default sources
+#   ./utils/disconnected-openshift-install/run-e2e-test.sh --image-tag=dev --disable-sources
+
+# Parse command-line arguments
+INSTALL_ISTIO=false
+DISCONNECT=false
+SKIP_CLEANUP=false
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+DISABLE_DEFAULT_SOURCES="${DISABLE_DEFAULT_SOURCES:-false}"
+
+for arg in "$@"; do
+    case $arg in
+        --install-istio)
+            INSTALL_ISTIO=true
+            shift
+            ;;
+        --disconnect)
+            DISCONNECT=true
+            shift
+            ;;
+        --skip-cleanup)
+            SKIP_CLEANUP=true
+            shift
+            ;;
+        --image-tag=*)
+            IMAGE_TAG="${arg#*=}"
+            shift
+            ;;
+        --disable-sources)
+            DISABLE_DEFAULT_SOURCES=true
+            shift
+            ;;
+        --help|-h)
+            grep '^#' "$0" | grep -v '#!/usr/bin/env' | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $arg"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Check we're in the right directory
+if [ ! -f "Makefile" ] || [ ! -d "utils/disconnected-openshift-install" ]; then
+    echo "ERROR: This script must be run from the kuadrant-operator directory"
+    exit 1
+fi
+
+# Check cluster access
+if ! oc whoami &>/dev/null; then
+    echo "ERROR: Not logged into OpenShift cluster"
+    echo "  Please login first: oc login ..."
+    exit 1
+fi
+
+START_TIME=$(date +%s)
+
+echo "=========================================="
+echo "Kuadrant Disconnected End-to-End Test"
+echo "=========================================="
+echo ""
+echo "Configuration:"
+echo "  Install Istio: ${INSTALL_ISTIO}"
+echo "  Catalog Tag: ${IMAGE_TAG}"
+echo "  Disable Default Sources: ${DISABLE_DEFAULT_SOURCES}"
+echo "  Disconnect Cluster: ${DISCONNECT}"
+echo "  Skip Cleanup: ${SKIP_CLEANUP}"
+echo ""
+echo "Cluster:"
+CLUSTER_API=$(oc whoami --show-server)
+CLUSTER_USER=$(oc whoami)
+echo "  API: ${CLUSTER_API}"
+echo "  User: ${CLUSTER_USER}"
+
+# Get OpenShift/OKD version
+OCP_VERSION=$(oc get clusterversion version -o jsonpath='{.status.desired.version}' 2>/dev/null || echo "Unknown")
+echo "  Version: ${OCP_VERSION}"
+
+# Get Kubernetes version
+K8S_VERSION=$(oc version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion' 2>/dev/null || echo "Unknown")
+echo "  Kubernetes: ${K8S_VERSION}"
+
+# Detect platform (OpenShift vs OKD)
+PLATFORM=$(oc get clusterversion version -o jsonpath='{.spec.channel}' 2>/dev/null | grep -q "okd" && echo "OKD" || echo "OpenShift")
+echo "  Platform: ${PLATFORM}"
+
+# Get node count
+NODE_COUNT=$(oc get nodes --no-headers 2>/dev/null | wc -l || echo "0")
+echo "  Nodes: ${NODE_COUNT}"
+echo ""
+read -p "Continue with end-to-end test? [y/N] " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted"
+    exit 0
+fi
+echo ""
+
+# Step 1: Install Istio (optional)
+if [ "$INSTALL_ISTIO" = true ]; then
+    echo "=========================================="
+    echo "Step 1/5: Installing Istio"
+    echo "=========================================="
+    echo ""
+    ./utils/disconnected-openshift-install/install-istio.sh
+
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo "✗ Istio installation failed"
+        exit 1
+    fi
+    echo ""
+else
+    echo "=========================================="
+    echo "Step 1/5: Skipping Istio Installation"
+    echo "=========================================="
+    echo ""
+    echo "  Checking for existing Istio installation..."
+    if oc get gatewayclass istio &>/dev/null 2>&1; then
+        echo "  ✓ Istio GatewayClass found"
+    else
+        echo "  ⚠ Istio GatewayClass 'istio' not found"
+        echo "    Kuadrant requires Istio to be installed"
+        echo "    Run with --install-istio flag or install manually:"
+        echo "      ./utils/disconnected-openshift-install/install-istio.sh"
+        echo ""
+        read -p "  Continue anyway? [y/N] " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            echo "Aborted"
+            exit 1
+        fi
+    fi
+    echo ""
+fi
+
+# Step 2: Configure cluster mirrors and CatalogSource
+echo "=========================================="
+echo "Step 2/5: Configuring Cluster Mirrors"
+echo "=========================================="
+echo ""
+DISABLE_DEFAULT_SOURCES=${DISABLE_DEFAULT_SOURCES} IMAGE_TAG=${IMAGE_TAG} ./utils/disconnected-openshift-install/setup.sh
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "✗ Setup failed"
+    exit 1
+fi
+echo ""
+
+# Step 3: Optional - Disconnect cluster
+if [ "$DISCONNECT" = true ]; then
+    echo "=========================================="
+    echo "Step 3/5: Disconnecting Cluster (Air-gap)"
+    echo "=========================================="
+    echo ""
+    ./utils/disconnected-openshift-install/cluster-disconnect.sh disconnect
+
+    if [ $? -ne 0 ]; then
+        echo ""
+        echo "✗ Cluster disconnect failed"
+        exit 1
+    fi
+    echo ""
+else
+    echo "=========================================="
+    echo "Step 3/5: Skipping Cluster Disconnect"
+    echo "=========================================="
+    echo ""
+    echo "  Running in connected mode (not simulating air-gap)"
+    echo "  Use --disconnect flag to simulate air-gapped environment"
+    echo ""
+fi
+
+# Step 4: Install Kuadrant
+echo "=========================================="
+echo "Step 4/5: Installing Kuadrant"
+echo "=========================================="
+echo ""
+
+INSTALL_SCRIPT="./utils/disconnected-openshift-install/tmp/install/install.sh"
+if [ ! -f "$INSTALL_SCRIPT" ]; then
+    echo "✗ Install script not found: ${INSTALL_SCRIPT}"
+    echo "  The setup script should have generated this file"
+    exit 1
+fi
+
+${INSTALL_SCRIPT}
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "✗ Kuadrant installation failed"
+    exit 1
+fi
+echo ""
+
+# Step 5: Run smoke tests
+echo "=========================================="
+echo "Step 5/5: Running Smoke Tests"
+echo "=========================================="
+echo ""
+./utils/disconnected-openshift-install/smoke-test.sh --cleanup
+
+SMOKE_TEST_RESULT=$?
+echo ""
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+MINUTES=$((DURATION / 60))
+SECONDS=$((DURATION % 60))
+
+# Final status
+echo "=========================================="
+if [ $SMOKE_TEST_RESULT -eq 0 ]; then
+    echo "✓ End-to-End Test Complete"
+else
+    echo "✗ End-to-End Test Failed"
+fi
+echo "=========================================="
+echo ""
+echo "Total time: ${MINUTES}m ${SECONDS}s"
+echo ""
+
+if [ $SMOKE_TEST_RESULT -eq 0 ]; then
+    echo "  ✓ Istio installed"
+    echo "  ✓ Kuadrant operators installed"
+    echo "  ✓ All tests passed"
+    echo ""
+
+    # Cleanup if not skipped (cleanup will handle reconnect)
+    if [ "$SKIP_CLEANUP" = false ]; then
+        echo "=========================================="
+        echo "Cleanup"
+        echo "=========================================="
+        echo ""
+        ./utils/disconnected-openshift-install/cleanup.sh --yes
+        echo ""
+    else
+        # If skipping cleanup but cluster was disconnected, reconnect it
+        if [ "$DISCONNECT" = true ]; then
+            echo "=========================================="
+            echo "Reconnecting Cluster"
+            echo "=========================================="
+            echo ""
+            ./utils/disconnected-openshift-install/cluster-disconnect.sh reconnect
+            if [ $? -ne 0 ]; then
+                echo "⚠ Cluster reconnect failed (non-fatal)"
+            fi
+            echo ""
+        fi
+    fi
+fi
+
+exit $SMOKE_TEST_RESULT

--- a/utils/disconnected-openshift-install/setup.sh
+++ b/utils/disconnected-openshift-install/setup.sh
@@ -1,0 +1,833 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Script to test disconnected installation using oc-mirror on CRC
+# Tests the full mirroring workflow: quay.io → in-cluster registry → OLM install
+#
+# Usage:
+#   ./setup.sh
+#
+# Environment Variables:
+#   DISABLE_DEFAULT_SOURCES - Set to "true" to disable default OperatorHub sources
+#                            (Red Hat Operators, Community Operators, etc.)
+#                            This simulates a true air-gapped environment.
+#                            Default: false (keep default catalogs for testing)
+#   REGISTRY                - Override registry (default: quay.io)
+#   ORG                     - Override organization (default: kuadrant)
+#   IMAGE_TAG               - Image tag for catalog (default: latest)
+
+DISABLE_DEFAULT_SOURCES="${DISABLE_DEFAULT_SOURCES:-false}"
+
+echo "==> Testing Disconnected Installation with oc-mirror"
+echo ""
+
+# Check CRC is running
+if ! oc whoami &>/dev/null; then
+    echo "ERROR: Not logged into OpenShift. Please start CRC and login first:"
+    echo "  crc start"
+    echo "  eval \$(crc oc-env)"
+    echo "  oc login -u kubeadmin https://api.crc.testing:6443"
+    exit 1
+fi
+
+# Check oc-mirror is installed
+if ! command -v oc-mirror &>/dev/null; then
+    echo "ERROR: oc-mirror not found. Please install it first:"
+    echo "  wget https://mirror.openshift.com/pub/cgw/mirror-registry/latest/mirror-registry-amd64.tar.gz"
+    echo "  tar xvf oc-mirror.tar.gz"
+    echo "  sudo install oc-mirror /usr/local/bin/"
+    exit 1
+fi
+
+# Configuration
+# Working directory for all generated files
+WORK_DIR="${WORK_DIR:-./utils/disconnected-openshift-install/tmp}"
+
+# Registry and organization
+REGISTRY="${REGISTRY:-quay.io}"
+ORG="${ORG:-kuadrant}"
+
+# Image tag for the catalogs
+IMAGE_TAG="${IMAGE_TAG:-latest}"
+
+# Catalog image - combined catalog containing all four operators
+CATALOG_IMG="${REGISTRY}/${ORG}/kuadrant-operator-catalog:${IMAGE_TAG}"
+
+MIRROR_NAMESPACE="mirror-registry"
+
+# Create working directory
+mkdir -p "${WORK_DIR}"
+
+echo "==> Configuration:"
+echo "  Working Directory: ${WORK_DIR}"
+echo "  Catalog Image: ${CATALOG_IMG}"
+echo "  Mirror Namespace: ${MIRROR_NAMESPACE}"
+echo ""
+
+# Step 1: Deploy simple Docker registry (same as OpenShift internal registry)
+echo "==> Setting up simple Docker registry for mirroring"
+
+echo "  Ensuring namespace exists..."
+oc new-project ${MIRROR_NAMESPACE} 2>/dev/null || echo "  Namespace ${MIRROR_NAMESPACE} already exists"
+
+# Check if Docker registry already deployed
+if oc get deployment docker-registry -n ${MIRROR_NAMESPACE} &>/dev/null; then
+    echo "  Docker registry already deployed"
+else
+    echo "  Deploying simple Docker registry..."
+    cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: registry-storage
+  namespace: ${MIRROR_NAMESPACE}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 30Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: docker-registry
+  namespace: ${MIRROR_NAMESPACE}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: docker-registry
+  template:
+    metadata:
+      labels:
+        app: docker-registry
+    spec:
+      containers:
+      - name: registry
+        # Use standard Docker registry (OpenShift image has permission issues in regular pods)
+        image: docker.io/library/registry:2
+        ports:
+        - containerPort: 5000
+        volumeMounts:
+        - name: registry-storage
+          mountPath: /var/lib/registry
+        env:
+        - name: REGISTRY_HTTP_ADDR
+          value: ":5000"
+        - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+          value: /var/lib/registry
+      volumes:
+      - name: registry-storage
+        persistentVolumeClaim:
+          claimName: registry-storage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: docker-registry
+  namespace: ${MIRROR_NAMESPACE}
+spec:
+  selector:
+    app: docker-registry
+  ports:
+  - port: 5000
+    targetPort: 5000
+EOF
+
+    # Create Route
+    if ! oc get route docker-registry -n ${MIRROR_NAMESPACE} &>/dev/null; then
+        oc create route edge docker-registry \
+          --service=docker-registry \
+          --port=5000 \
+          -n ${MIRROR_NAMESPACE}
+    fi
+
+    # Wait for registry to be ready
+    echo "  Waiting for registry to be ready..."
+    oc wait --for=condition=available deployment/docker-registry \
+      -n ${MIRROR_NAMESPACE} \
+      --timeout=5m
+fi
+
+# Get registry hostname
+REGISTRY_HOSTNAME=$(oc get route docker-registry -n ${MIRROR_NAMESPACE} -o jsonpath='{.spec.host}')
+
+if [ -z "$REGISTRY_HOSTNAME" ]; then
+    echo "  ERROR: Could not determine registry hostname"
+    echo "  Available routes:"
+    oc get routes -n ${MIRROR_NAMESPACE}
+    exit 1
+fi
+
+echo "  Docker registry route: ${REGISTRY_HOSTNAME}"
+echo ""
+
+# Wait for registry HTTP endpoint to be ready
+echo "  Waiting for registry HTTP endpoint to respond (90s timeout)..."
+TIMEOUT=90
+ELAPSED=0
+REGISTRY_READY=false
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    # Try to access the registry's /v2/ endpoint (Docker registry API health check)
+    HTTP_STATUS=$(curl -k -s -o /dev/null -w "%{http_code}" https://${REGISTRY_HOSTNAME}/v2/ 2>/dev/null || echo "000")
+
+    # 200 = OK, 401 = Unauthorized (but registry is responding)
+    if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "401" ]; then
+        echo "  ✓ Registry HTTP endpoint ready (HTTP ${HTTP_STATUS})"
+        REGISTRY_READY=true
+        break
+    fi
+
+    sleep 3
+    ELAPSED=$((ELAPSED + 3))
+    if [ $((ELAPSED % 15)) -eq 0 ]; then
+        echo "  Still waiting... (${ELAPSED}s) [HTTP ${HTTP_STATUS}]"
+    fi
+done
+
+if [ "$REGISTRY_READY" = false ]; then
+    echo "  ✗ Registry HTTP endpoint not ready after ${TIMEOUT}s"
+    echo ""
+    echo "  Deployment status:"
+    oc get deployment docker-registry -n ${MIRROR_NAMESPACE}
+    echo ""
+    echo "  Pod status:"
+    oc get pods -n ${MIRROR_NAMESPACE} -l app=docker-registry
+    echo ""
+    echo "  Recent pod logs:"
+    oc logs -n ${MIRROR_NAMESPACE} -l app=docker-registry --tail=20
+    exit 1
+fi
+
+echo "  (No authentication required)"
+echo ""
+
+# Step 1.5: Configure CA trust for mirror registry
+echo "==> Configuring CA trust for mirror registry"
+
+# Get the ingress CA certificate (same CA used by all routes in CRC)
+INGRESS_CA=$(oc get configmap -n openshift-config-managed default-ingress-cert -o jsonpath='{.data.ca-bundle\.crt}')
+
+if [ -z "$INGRESS_CA" ]; then
+    echo "  WARNING: Could not get ingress CA certificate"
+    echo "  Pods may fail to pull images from mirror registry due to TLS verification"
+else
+    # Check if registry-certs configmap exists
+    if oc get configmap registry-certs -n openshift-config &>/dev/null; then
+        echo "  Updating existing registry-certs configmap..."
+        # Create temp file with CA cert for patching
+        TEMP_CA_FILE="${WORK_DIR}/ca-bundle.crt"
+        echo "${INGRESS_CA}" > "${TEMP_CA_FILE}"
+        # Patch to add the new hostname entry
+        oc patch configmap registry-certs -n openshift-config --type merge \
+            --patch "{\"data\":{\"${REGISTRY_HOSTNAME}\":$(cat ${TEMP_CA_FILE} | jq -Rs .)}}"
+        rm -f "${TEMP_CA_FILE}"
+    else
+        echo "  Creating registry-certs configmap..."
+        TEMP_CA_FILE="${WORK_DIR}/ca-bundle.crt"
+        echo "${INGRESS_CA}" > "${TEMP_CA_FILE}"
+        oc create configmap registry-certs -n openshift-config \
+            --from-file="${REGISTRY_HOSTNAME}=${TEMP_CA_FILE}"
+        rm -f "${TEMP_CA_FILE}"
+    fi
+
+    # Update image.config.openshift.io/cluster to reference the configmap
+    if ! oc get image.config.openshift.io/cluster -o yaml | grep -q "registry-certs"; then
+        echo "  Configuring cluster to use registry-certs..."
+        oc patch image.config.openshift.io/cluster --type merge \
+            -p '{"spec":{"additionalTrustedCA":{"name":"registry-certs"}}}'
+    fi
+
+    echo "  ✓ CA trust configured for ${REGISTRY_HOSTNAME}"
+fi
+echo ""
+
+# Step 2: Create ImageSetConfiguration
+echo "==> Creating ImageSetConfiguration"
+IMAGESET_CONFIG="${WORK_DIR}/imageset-config.yaml"
+
+cat <<EOF > ${IMAGESET_CONFIG}
+kind: ImageSetConfiguration
+apiVersion: mirror.openshift.io/v2alpha1
+mirror:
+  operators:
+    - catalog: ${CATALOG_IMG}
+      full: true
+  additionalImages:
+    - name: quay.io/kuadrant/httpbin:latest
+    - name: registry.istio.io/release/pilot@sha256:3681fe197870abad5c953107e241e104a813ba2d6e63933ff53e0545348ff8b1
+    - name: registry.istio.io/release/proxyv2@sha256:69ca4585993f4057861954f18be88df8268b713d114e7036bf9b185458c7a2c1
+    - name: registry.istio.io/release/install-cni@sha256:c83945796021a2992ceec8b8e672b1c19771e3906555a3a1dd467eddf2b82b4d
+EOF
+
+cat ${IMAGESET_CONFIG}
+echo ""
+
+# Step 3: Run oc-mirror
+echo "==> Running oc-mirror v2 (this may take several minutes)..."
+echo "  Source Catalog: ${CATALOG_IMG}"
+echo "  Destination: ${REGISTRY_HOSTNAME}"
+echo ""
+
+# Authenticate to source registry
+echo "==> Authenticating to ${REGISTRY}..."
+echo "  You may need to login to ${REGISTRY} if this is a private catalog"
+podman login ${REGISTRY} || echo "  Continuing without ${REGISTRY} auth (assuming public catalog)"
+
+# Run oc-mirror v2
+# Note: v2 requires --workspace for mirror-to-mirror workflow
+# --dest-tls-verify=false because our test registry uses self-signed certs
+oc-mirror --v2 --config ${IMAGESET_CONFIG} \
+  --workspace file://${WORK_DIR}/oc-mirror-workspace \
+  --dest-tls-verify=false \
+  docker://${REGISTRY_HOSTNAME}
+
+echo ""
+echo "==> oc-mirror completed"
+echo ""
+
+# Step 4: Apply image mirror configuration
+echo "==> Applying image mirror configuration"
+
+# oc-mirror v2 puts files in working-dir/cluster-resources
+RESULTS_DIR="${WORK_DIR}/oc-mirror-workspace/working-dir/cluster-resources"
+
+if [ ! -d "$RESULTS_DIR" ]; then
+    echo "ERROR: Results directory not found at ${RESULTS_DIR}"
+    echo "  oc-mirror may have failed."
+    exit 1
+fi
+
+echo "  Results directory: ${RESULTS_DIR}"
+
+# oc-mirror v2 can generate IDMS, ITMS, or ICSP depending on how images were mirrored
+IDMS_FILE="${RESULTS_DIR}/idms-oc-mirror.yaml"
+ITMS_FILE="${RESULTS_DIR}/itms-oc-mirror.yaml"
+ICSP_FILE="${RESULTS_DIR}/icsp-oc-mirror.yaml"
+
+APPLIED_ANY=false
+
+if [ -f "$IDMS_FILE" ]; then
+    echo "  Applying ImageDigestMirrorSet..."
+    oc apply -f ${IDMS_FILE}
+    oc get imagedigestmirrorset
+    APPLIED_ANY=true
+fi
+
+if [ -f "$ITMS_FILE" ]; then
+    echo "  Applying ImageTagMirrorSet..."
+    echo "  (Note: ITMS handles tag-based pulls - needed for catalog images)"
+    oc apply -f ${ITMS_FILE}
+    oc get imagetagmirrorset
+    APPLIED_ANY=true
+fi
+
+if [ -f "$ICSP_FILE" ]; then
+    echo "  Applying ImageContentSourcePolicy..."
+    oc apply -f ${ICSP_FILE}
+    oc get imagecontentsourcepolicy
+    APPLIED_ANY=true
+fi
+
+if [ "$APPLIED_ANY" = false ]; then
+    echo "ERROR: No image mirror configuration found"
+    echo "  Available files:"
+    ls -la ${RESULTS_DIR}/
+    exit 1
+fi
+echo ""
+
+# Add ImageTagMirrorSet for Istio registry (needed for tag-based pulls like proxyv2:1.29.2)
+echo "  Creating additional ImageTagMirrorSet for Istio images..."
+cat <<EOF | oc apply -f -
+apiVersion: config.openshift.io/v1
+kind: ImageTagMirrorSet
+metadata:
+  name: itms-istio
+  labels:
+    kuadrant.io/disconnected-test: "true"
+spec:
+  imageTagMirrors:
+  - mirrors:
+    - ${REGISTRY_HOSTNAME}/release
+    source: registry.istio.io/release
+EOF
+echo "  ✓ Istio ImageTagMirrorSet created"
+echo ""
+
+# Step 5: Wait for cluster to stabilize after IDMS/ITMS changes
+echo "==> Waiting for cluster to stabilize after image mirror configuration"
+echo "  Note: Applying IDMS/ITMS triggers control plane restart"
+echo ""
+
+# Give the cluster a moment to start processing the changes
+sleep 5
+
+# Check if this is a single-node cluster (like CRC)
+NODE_COUNT=$(oc get nodes --no-headers 2>/dev/null | wc -l)
+IS_SINGLE_NODE=false
+if [ "$NODE_COUNT" -eq 1 ]; then
+    IS_SINGLE_NODE=true
+    echo "  Detected single-node cluster (e.g., CRC)"
+    echo "  API server pods may need special handling due to anti-affinity rules"
+fi
+echo ""
+
+# Wait for openshift-apiserver to stabilize (critical for API access)
+echo "  Waiting for openshift-apiserver to stabilize..."
+APISERVER_TIMEOUT=300  # 5 minutes
+APISERVER_STABLE=false
+START_TIME=$(date +%s)
+
+while [ $(($(date +%s) - START_TIME)) -lt $APISERVER_TIMEOUT ]; do
+    # Check if openshift-apiserver is available
+    APISERVER_AVAILABLE=$(oc get co openshift-apiserver -o jsonpath='{.status.conditions[?(@.type=="Available")].status}' 2>/dev/null)
+    APISERVER_PROGRESSING=$(oc get co openshift-apiserver -o jsonpath='{.status.conditions[?(@.type=="Progressing")].status}' 2>/dev/null)
+    APISERVER_DEGRADED=$(oc get co openshift-apiserver -o jsonpath='{.status.conditions[?(@.type=="Degraded")].status}' 2>/dev/null)
+
+    if [ "$APISERVER_AVAILABLE" = "True" ] && [ "$APISERVER_PROGRESSING" = "False" ] && [ "$APISERVER_DEGRADED" = "False" ]; then
+        APISERVER_STABLE=true
+        echo "  ✓ openshift-apiserver is stable"
+        break
+    fi
+
+    # On single-node clusters, check for stuck apiserver pods due to anti-affinity
+    if [ "$IS_SINGLE_NODE" = true ]; then
+        PENDING_PODS=$(oc get pods -n openshift-apiserver --no-headers 2>/dev/null | grep -c "Pending" || echo "0")
+        TERMINATING_PODS=$(oc get pods -n openshift-apiserver --no-headers 2>/dev/null | grep -c "Terminating" || echo "0")
+
+        if [ "$PENDING_PODS" -gt 0 ] && [ "$TERMINATING_PODS" -gt 0 ]; then
+            echo "  ⚠ Detected stuck pod transition (anti-affinity on single-node)"
+            echo "  Force-deleting terminating pods to unblock new pods..."
+            oc get pods -n openshift-apiserver --no-headers 2>/dev/null | grep "Terminating" | awk '{print $1}' | while read pod; do
+                oc delete pod -n openshift-apiserver "$pod" --force --grace-period=0 2>/dev/null || true
+            done
+            sleep 10
+        fi
+    fi
+
+    echo "  Waiting... (Available: $APISERVER_AVAILABLE, Progressing: $APISERVER_PROGRESSING, Degraded: $APISERVER_DEGRADED)"
+    sleep 10
+done
+
+if [ "$APISERVER_STABLE" = false ]; then
+    echo "  WARNING: openshift-apiserver did not stabilize within ${APISERVER_TIMEOUT}s"
+    echo "  Current status:"
+    oc get co openshift-apiserver 2>/dev/null || echo "  (unable to query cluster operator)"
+    echo ""
+    echo "  You may need to:"
+    echo "    1. Wait longer and retry: oc get co openshift-apiserver -w"
+    echo "    2. Check apiserver pods: oc get pods -n openshift-apiserver"
+    echo "    3. Check for terminating pods blocking new ones on single-node clusters"
+    echo ""
+    read -p "  Continue anyway? [y/N] " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+echo ""
+
+# Step 6: Wait for MachineConfig rollout (if needed)
+echo "==> Checking MachineConfig status"
+echo "  Note: On CRC, MachineConfig updates may take 10-20 minutes"
+echo "  Press Ctrl+C if you want to skip waiting and continue manually"
+echo ""
+
+# Check if any MCP is updating
+if oc get mcp -o json | jq -e '.items[] | select(.status.conditions[] | select(.type=="Updating" and .status=="True"))' &>/dev/null; then
+    echo "  MachineConfigPool is updating..."
+    echo "  Waiting for rollout (timeout: 30m)..."
+    oc wait mcp --all --for=condition=Updated --timeout=30m || {
+        echo "  WARNING: MachineConfig rollout timed out or failed"
+        echo "  You may need to wait longer or check manually with: oc get mcp"
+    }
+else
+    echo "  No MachineConfigPool updates needed"
+fi
+echo ""
+
+# Step 6: Apply CatalogSource
+echo "==> Creating CatalogSource"
+
+# oc-mirror v2 generates CatalogSource file for the catalog
+CATALOG_FILE=$(find ${RESULTS_DIR} -name "cs-*.yaml" -o -name "catalogSource-*.yaml" 2>/dev/null | head -1)
+
+if [ -z "$CATALOG_FILE" ]; then
+    echo "  ERROR: No CatalogSource file found in ${RESULTS_DIR}"
+    ls -la ${RESULTS_DIR}/
+    exit 1
+fi
+
+# Rename CatalogSource for clarity
+ORIGINAL_NAME=$(yq eval '.metadata.name' ${CATALOG_FILE})
+NEW_NAME="kuadrant-disconnected-operator-catalog"
+
+echo "  Renaming CatalogSource: ${ORIGINAL_NAME} → ${NEW_NAME}"
+
+# Update the name and add a label for easy identification
+yq eval ".metadata.name = \"${NEW_NAME}\" | .metadata.labels.\"kuadrant.io/disconnected-test\" = \"true\"" \
+    -i ${CATALOG_FILE}
+
+oc apply -f ${CATALOG_FILE}
+echo ""
+
+# Step 7: Wait for CatalogSource to be ready
+echo "==> Waiting for CatalogSource to be ready"
+
+# Give OLM a moment to process the CatalogSource
+sleep 5
+
+# Find the catalog name (using the label we added)
+CATALOG_NAME=$(oc get catalogsource -n openshift-marketplace -l kuadrant.io/disconnected-test=true -o name | cut -d'/' -f2)
+
+if [ -z "$CATALOG_NAME" ]; then
+    echo "  ERROR: Kuadrant CatalogSource not found"
+    echo "  Available CatalogSources:"
+    oc get catalogsource -n openshift-marketplace
+    exit 1
+fi
+
+echo "  Waiting for catalog: ${CATALOG_NAME}"
+
+# CatalogSource doesn't use standard conditions - check connectionState instead
+CATALOG_TIMEOUT=300  # 5 minutes
+CATALOG_READY=false
+START_TIME=$(date +%s)
+
+while [ $(($(date +%s) - START_TIME)) -lt $CATALOG_TIMEOUT ]; do
+    LAST_STATE=$(oc get catalogsource ${CATALOG_NAME} -n openshift-marketplace \
+        -o jsonpath='{.status.connectionState.lastObservedState}' 2>/dev/null || echo "")
+
+    if [ "$LAST_STATE" = "READY" ]; then
+        CATALOG_READY=true
+        echo "    ✓ READY"
+        break
+    fi
+
+    sleep 5
+done
+
+if [ "$CATALOG_READY" = false ]; then
+    echo "    ✗ ERROR: Timed out waiting for catalog to be READY"
+    echo "    Current state: ${LAST_STATE}"
+    echo "    Check pod logs:"
+    echo "      oc logs -n openshift-marketplace -l olm.catalogSource=${CATALOG_NAME}"
+    exit 1
+fi
+echo ""
+
+# Step 7.5: Optionally disable default OperatorHub sources
+if [ "$DISABLE_DEFAULT_SOURCES" = "true" ]; then
+    echo "==> Disabling default OperatorHub sources"
+    echo "  This simulates a true air-gapped environment where external registries are unreachable"
+    echo ""
+
+    # Check current state
+    CURRENT_STATE=$(oc get operatorhub cluster -o jsonpath='{.spec.disableAllDefaultSources}' 2>/dev/null || echo "false")
+
+    if [ "$CURRENT_STATE" = "true" ]; then
+        echo "  Default sources already disabled"
+    else
+        echo "  Disabling: redhat-operators, community-operators, certified-operators, redhat-marketplace"
+        oc patch operatorhub cluster --type json \
+            -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
+
+        echo "  ✓ Default OperatorHub sources disabled"
+        echo "  Note: In a real disconnected cluster, this would be done during installation"
+    fi
+    echo ""
+else
+    echo "==> Keeping default OperatorHub sources enabled"
+    echo "  (Set DISABLE_DEFAULT_SOURCES=true to simulate a true air-gapped environment)"
+    echo ""
+fi
+
+# Step 8: Verify packages are available
+echo "==> Verifying Kuadrant operator packages are available"
+echo "  Note: OLM needs time to index catalogs and create PackageManifests"
+echo ""
+
+EXPECTED_PACKAGES="kuadrant-operator authorino-operator limitador-operator dns-operator"
+PACKAGE_TIMEOUT=120  # 2 minutes for OLM to index
+ALL_FOUND=false
+START_TIME=$(date +%s)
+
+echo "  Waiting for PackageManifests to appear from disconnected catalogs..."
+
+while [ $(($(date +%s) - START_TIME)) -lt $PACKAGE_TIMEOUT ]; do
+    ALL_FOUND=true
+
+    for package in ${EXPECTED_PACKAGES}; do
+        # Check if package exists from any of our disconnected catalogs (kuadrant-disconnected-*)
+        # Note: Multiple PackageManifests can exist for the same package name from different catalogs
+        FOUND_COUNT=$(oc get packagemanifest -n openshift-marketplace -o json 2>/dev/null | \
+            jq -r ".items[] | select(.metadata.name==\"${package}\") | select(.status.catalogSource | startswith(\"kuadrant-disconnected-\")) | .metadata.name" 2>/dev/null | wc -l || echo "0")
+
+        if [ "$FOUND_COUNT" -eq 0 ]; then
+            ALL_FOUND=false
+            break
+        fi
+    done
+
+    if [ "$ALL_FOUND" = true ]; then
+        break
+    fi
+
+    sleep 5
+done
+
+# Final verification and reporting
+echo ""
+for package in ${EXPECTED_PACKAGES}; do
+    # Find the PackageManifest from our disconnected catalog
+    # (there may be multiple PackageManifests with the same name from different catalogs)
+    CATALOG_SOURCE=$(oc get packagemanifest -n openshift-marketplace -o json 2>/dev/null | \
+        jq -r ".items[] | select(.metadata.name==\"${package}\") | select(.status.catalogSource | startswith(\"kuadrant-disconnected-\")) | .status.catalogSource" 2>/dev/null | head -1)
+
+    if [ -n "$CATALOG_SOURCE" ]; then
+        echo "  ✓ ${package} (from ${CATALOG_SOURCE})"
+    else
+        echo "  ✗ ${package} (not found in disconnected catalogs)"
+        # Show what catalog it was found in (if any)
+        FALLBACK_CATALOG=$(oc get packagemanifest ${package} -n openshift-marketplace -o jsonpath='{.status.catalogSource}' 2>/dev/null || echo "NOT_FOUND")
+        echo "    Found in: ${FALLBACK_CATALOG}"
+        ALL_FOUND=false
+    fi
+done
+
+if [ "$ALL_FOUND" = false ]; then
+    echo ""
+    echo "  ERROR: Not all packages available from disconnected catalogs"
+    echo ""
+    echo "  Packages from disconnected catalogs (kuadrant-disconnected-*):"
+    oc get packagemanifest -n openshift-marketplace -o json | \
+        jq -r '.items[] | select(.status.catalogSource | startswith("kuadrant-disconnected-")) | "    \(.metadata.name) (\(.status.catalogSource))"' | \
+        sort || echo "    None"
+    echo ""
+    echo "  Troubleshooting:"
+    echo "    1. Check catalog pod logs: oc logs -n openshift-marketplace -l olm.catalogSource"
+    echo "    2. Check OLM catalog-operator logs: oc logs -n openshift-operator-lifecycle-manager -l app=catalog-operator"
+    echo "    3. Wait longer and retry - OLM indexing can take 2-3 minutes"
+    exit 1
+fi
+
+echo ""
+
+# Generate installation manifests
+INSTALL_DIR="${WORK_DIR}/install"
+mkdir -p "${INSTALL_DIR}"
+
+# Use the catalog name (should be kuadrant-disconnected-operator-catalog)
+KUADRANT_CATALOG="${CATALOG_NAME}"
+
+# Generate Namespace manifest
+cat > "${INSTALL_DIR}/01-namespace.yaml" <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  labels:
+    kuadrant.io/disconnected-test: "true"
+EOF
+
+# Generate OperatorGroup manifest
+# NOTE: Kuadrant operators only support AllNamespaces install mode (cluster-scoped)
+# Do NOT set targetNamespaces - this makes it cluster-scoped
+cat > "${INSTALL_DIR}/02-operatorgroup.yaml" <<EOF
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kuadrant-operator-group
+  namespace: kuadrant-system
+spec: {}
+EOF
+
+# Detect default channel for kuadrant-operator
+echo "Detecting default channel for kuadrant-operator..."
+# Wait a bit for packagemanifest to be available after CatalogSource is ready
+sleep 5
+DEFAULT_CHANNEL=$(oc get packagemanifest kuadrant-operator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}' 2>/dev/null || echo "")
+
+if [ -z "$DEFAULT_CHANNEL" ]; then
+    # Fallback: try to get channels from packagemanifest
+    AVAILABLE_CHANNELS=$(oc get packagemanifest kuadrant-operator -n openshift-marketplace -o jsonpath='{.status.channels[*].name}' 2>/dev/null || echo "")
+    if [ -n "$AVAILABLE_CHANNELS" ]; then
+        # Use first available channel
+        DEFAULT_CHANNEL=$(echo "$AVAILABLE_CHANNELS" | awk '{print $1}')
+        echo "  No default channel set, using first available: ${DEFAULT_CHANNEL}"
+    else
+        # Final fallback
+        DEFAULT_CHANNEL="alpha"
+        echo "  WARNING: Could not detect channel, defaulting to: ${DEFAULT_CHANNEL}"
+        echo "  If subscription fails, check available channels with:"
+        echo "    oc get packagemanifest kuadrant-operator -n openshift-marketplace -o jsonpath='{.status.channels[*].name}'"
+    fi
+else
+    echo "  Using default channel: ${DEFAULT_CHANNEL}"
+fi
+echo ""
+
+# Generate Subscription manifest
+cat > "${INSTALL_DIR}/03-subscription.yaml" <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kuadrant-operator
+  namespace: kuadrant-system
+spec:
+  channel: ${DEFAULT_CHANNEL}
+  name: kuadrant-operator
+  source: ${KUADRANT_CATALOG}
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic
+EOF
+
+# Generate Kuadrant CR manifest
+cat > "${INSTALL_DIR}/04-kuadrant.yaml" <<EOF
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  namespace: kuadrant-system
+spec: {}
+EOF
+
+# Generate install script
+cat > "${INSTALL_DIR}/install.sh" <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Installing Kuadrant from disconnected catalogs"
+echo ""
+
+echo "Step 1: Creating namespace..."
+oc apply -f "${SCRIPT_DIR}/01-namespace.yaml"
+echo ""
+
+echo "Step 2: Creating OperatorGroup..."
+oc apply -f "${SCRIPT_DIR}/02-operatorgroup.yaml"
+echo ""
+
+echo "Step 3: Creating Subscription..."
+oc apply -f "${SCRIPT_DIR}/03-subscription.yaml"
+echo ""
+
+echo "Step 4: Waiting for operator installation..."
+echo "  (This may take 2-3 minutes)"
+echo ""
+
+# Wait for kuadrant-operator CSV to appear
+echo "  Waiting for kuadrant-operator CSV..."
+for i in {1..60}; do
+    if oc get csv -n kuadrant-system 2>/dev/null | grep -q kuadrant-operator; then
+        break
+    fi
+    sleep 5
+done
+
+# Wait for all CSVs to be in Succeeded phase
+echo "  Waiting for all operators to be ready..."
+oc wait --for=jsonpath='{.status.phase}'=Succeeded csv --all -n kuadrant-system --timeout=300s
+
+echo ""
+echo "Step 5: Creating Kuadrant instance..."
+oc apply -f "${SCRIPT_DIR}/04-kuadrant.yaml"
+echo ""
+
+echo "  Waiting for Kuadrant CR to be created..."
+sleep 5
+
+echo ""
+echo "=========================================="
+echo "✓ Installation Complete"
+echo "=========================================="
+echo ""
+
+echo "Installed operators:"
+oc get csv -n kuadrant-system
+echo ""
+
+echo "Kuadrant instance:"
+oc get kuadrant -n kuadrant-system
+echo ""
+
+echo "Running pods:"
+oc get pods -n kuadrant-system
+echo ""
+
+echo "Kuadrant status:"
+oc get kuadrant kuadrant -n kuadrant-system -o jsonpath='{.status.conditions[?(@.type=="Ready")]}' | jq '.'
+echo ""
+
+READY_STATUS=$(oc get kuadrant kuadrant -n kuadrant-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+if [ "$READY_STATUS" != "True" ]; then
+    echo "⚠ Note: Kuadrant is not fully ready yet"
+    READY_MESSAGE=$(oc get kuadrant kuadrant -n kuadrant-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || echo "")
+    if [ -n "$READY_MESSAGE" ]; then
+        echo "  Reason: ${READY_MESSAGE}"
+    fi
+    echo ""
+    echo "  Deployments may still be starting up. This usually takes 1-2 minutes."
+    echo "  Monitor with: oc get pods -n kuadrant-system -w"
+    echo ""
+fi
+
+echo "Verify images are from mirror registry:"
+oc get pods -n kuadrant-system -o jsonpath='{range .items[*]}{"\n"}{.metadata.name}{"\n"}{range .spec.containers[*]}{" "}{.image}{"\n"}{end}{end}'
+echo ""
+SCRIPT
+
+chmod +x "${INSTALL_DIR}/install.sh"
+
+# Generate cleanup script
+cat > "${INSTALL_DIR}/uninstall.sh" <<'SCRIPT'
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "==> Uninstalling Kuadrant"
+echo ""
+
+echo "Deleting Kuadrant CR..."
+oc delete -f "${SCRIPT_DIR}/04-kuadrant.yaml" --ignore-not-found
+
+echo "Deleting Subscription..."
+oc delete -f "${SCRIPT_DIR}/03-subscription.yaml" --ignore-not-found
+
+echo "Deleting CSVs..."
+oc delete csv --all -n kuadrant-system --ignore-not-found
+
+echo "Deleting OperatorGroup..."
+oc delete -f "${SCRIPT_DIR}/02-operatorgroup.yaml" --ignore-not-found
+
+echo "Waiting for pods to terminate..."
+oc wait --for=delete pod --all -n kuadrant-system --timeout=60s 2>/dev/null || true
+
+echo "Deleting namespace..."
+oc delete -f "${SCRIPT_DIR}/01-namespace.yaml" --ignore-not-found
+
+echo ""
+echo "✓ Uninstall complete"
+SCRIPT
+
+chmod +x "${INSTALL_DIR}/uninstall.sh"
+
+echo ""
+echo "=========================================="
+echo "✓ Setup Complete"
+echo "=========================================="
+echo ""
+echo "  ✓ ImageDigestMirrorSet created"
+echo "  ✓ ImageTagMirrorSet created"
+echo "  ✓ CatalogSource ready (${CATALOG_NAME})"
+echo "  ✓ Installation manifests: ${INSTALL_DIR}/"
+if [ "$DISABLE_DEFAULT_SOURCES" = "true" ]; then
+    echo "  ✓ Default OperatorHub sources disabled"
+fi
+echo ""

--- a/utils/disconnected-openshift-install/smoke-test.sh
+++ b/utils/disconnected-openshift-install/smoke-test.sh
@@ -1,0 +1,1024 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Smoke test for Kuadrant installation
+# Verifies operators are running and can accept policy resources
+#
+# Usage:
+#   ./utils/disconnected-openshift-install/smoke-test.sh [--cleanup]
+#
+# Options:
+#   --cleanup   Remove test resources after completion
+
+CLEANUP="${1:-}"
+
+echo "=========================================="
+echo "Kuadrant Installation Smoke Test"
+echo "=========================================="
+echo ""
+
+FAILED=false
+FAILED_TESTS=()
+
+# Test 1: Verify all operators are installed and running
+echo "==> Test 1: Operator Installation"
+echo ""
+
+EXPECTED_CSVS=(
+    "kuadrant-operator"
+    "authorino-operator"
+    "limitador-operator"
+    "dns-operator"
+)
+
+# Wait for CSVs to reach Succeeded state (up to 180s)
+echo "  Waiting for CSVs to succeed (up to 180s)..."
+TIMEOUT=180
+ELAPSED=0
+ALL_CSVS_READY=false
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    ALL_READY=true
+    for csv_prefix in "${EXPECTED_CSVS[@]}"; do
+        CSV_NAME=$(oc get csv -n kuadrant-system -o name 2>/dev/null | grep "${csv_prefix}" | head -1 || true)
+        if [ -z "$CSV_NAME" ]; then
+            ALL_READY=false
+            break
+        fi
+        CSV_PHASE=$(oc get ${CSV_NAME} -n kuadrant-system -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+        if [ "$CSV_PHASE" != "Succeeded" ]; then
+            ALL_READY=false
+            break
+        fi
+    done
+
+    if [ "$ALL_READY" = true ]; then
+        ALL_CSVS_READY=true
+        echo "    ✓ All CSVs succeeded (${ELAPSED}s)"
+        break
+    fi
+
+    sleep 10
+    ELAPSED=$((ELAPSED + 10))
+    if [ $((ELAPSED % 30)) -eq 0 ]; then
+        echo "    Still waiting... (${ELAPSED}s)"
+    fi
+done
+
+echo ""
+echo "  Checking CSVs in kuadrant-system namespace..."
+for csv_prefix in "${EXPECTED_CSVS[@]}"; do
+    CSV_NAME=$(oc get csv -n kuadrant-system -o name 2>/dev/null | grep "${csv_prefix}" | head -1 || true)
+
+    if [ -z "$CSV_NAME" ]; then
+        echo "    ✗ ${csv_prefix} - NOT FOUND"
+        FAILED=true
+    else
+        CSV_PHASE=$(oc get ${CSV_NAME} -n kuadrant-system -o jsonpath='{.status.phase}' 2>/dev/null || echo "Unknown")
+        if [ "$CSV_PHASE" = "Succeeded" ]; then
+            echo "    ✓ ${csv_prefix} - ${CSV_PHASE}"
+        else
+            echo "    ✗ ${csv_prefix} - ${CSV_PHASE} (expected: Succeeded)"
+            FAILED=true
+        fi
+    fi
+done
+echo ""
+
+# Wait for pods to be ready (up to 120s)
+echo "  Waiting for operator pods to be ready (up to 120s)..."
+TIMEOUT=120
+ELAPSED=0
+ALL_PODS_READY=false
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    PODS=$(oc get pods -n kuadrant-system --no-headers 2>/dev/null | wc -l || echo "0")
+    if [ "$PODS" -gt 0 ]; then
+        READY=$(oc get pods -n kuadrant-system -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[] | select(.type=="Ready" and .status=="True")) | .metadata.name' | wc -l || echo "0")
+
+        if [ "$READY" -eq "$PODS" ]; then
+            ALL_PODS_READY=true
+            echo "    ✓ All pods ready (${ELAPSED}s)"
+            break
+        fi
+    fi
+
+    sleep 10
+    ELAPSED=$((ELAPSED + 10))
+    if [ $((ELAPSED % 30)) -eq 0 ]; then
+        echo "    Still waiting... (${ELAPSED}s)"
+    fi
+done
+echo ""
+
+echo "  Checking operator pods..."
+PODS=$(oc get pods -n kuadrant-system --no-headers 2>/dev/null | wc -l || echo "0")
+if [ "$PODS" -gt 0 ]; then
+    # Check pod readiness, not just Running phase
+    READY=$(oc get pods -n kuadrant-system -o json 2>/dev/null | jq -r '.items[] | select(.status.conditions[] | select(.type=="Ready" and .status=="True")) | .metadata.name' | wc -l || echo "0")
+    echo "    Pods ready: ${READY}/${PODS}"
+
+    # Show detailed pod status with readiness
+    echo "    Pod status:"
+    oc get pods -n kuadrant-system -o custom-columns=NAME:.metadata.name,READY:.status.conditions[?\(@.type==\"Ready\"\)].status,STATUS:.status.phase,RESTARTS:.status.containerStatuses[0].restartCount 2>/dev/null | sed 's/^/      /'
+
+    # Check for pods not ready
+    if [ "$READY" -lt "$PODS" ]; then
+        echo ""
+        echo "    ✗ FAILED - Not all pods are ready after ${TIMEOUT}s"
+        FAILED=true
+
+        # Show logs from non-ready pods
+        echo "    Checking logs from non-ready pods:"
+        for pod in $(oc get pods -n kuadrant-system -o json | jq -r '.items[] | select(.status.conditions[] | select(.type=="Ready" and .status!="True")) | .metadata.name'); do
+            echo "      Logs from ${pod}:"
+            oc logs -n kuadrant-system "${pod}" --tail=20 2>&1 | sed 's/^/        /'
+        done
+    else
+        echo "    ✓ All pods ready"
+    fi
+
+    # Check for high restart counts (indicates crashlooping)
+    echo ""
+    echo "  Checking for crashlooping pods..."
+    HIGH_RESTARTS=$(oc get pods -n kuadrant-system -o json 2>/dev/null | jq -r '.items[] | select(.status.containerStatuses[0].restartCount > 3) | .metadata.name' || echo "")
+    if [ -n "$HIGH_RESTARTS" ]; then
+        echo "    ✗ FAILED - Pods with high restart counts (>3):"
+        echo "$HIGH_RESTARTS" | sed 's/^/      /'
+        FAILED=true
+    else
+        echo "    ✓ No crashlooping pods detected"
+    fi
+else
+    echo "    ✗ No pods found in kuadrant-system namespace"
+    FAILED=true
+fi
+echo ""
+
+# Test 2: Verify Kuadrant CR and operand CRs
+echo "==> Test 2: Kuadrant Control Plane"
+echo ""
+
+echo "  Checking Kuadrant CR..."
+if oc get kuadrant kuadrant -n kuadrant-system &>/dev/null; then
+    echo "    ✓ Kuadrant CR exists"
+
+    # Check Kuadrant status
+    KUADRANT_READY=$(oc get kuadrant kuadrant -n kuadrant-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+    if [ "$KUADRANT_READY" = "True" ]; then
+        echo "      ✓ Kuadrant is ready"
+    else
+        echo "      ✗ FAILED - Kuadrant not ready (status: ${KUADRANT_READY})"
+        echo "      Kuadrant CR must be ready for operator to function"
+        oc get kuadrant kuadrant -n kuadrant-system -o jsonpath='{.status.conditions}' 2>/dev/null | jq '.' | sed 's/^/        /'
+        FAILED=true
+    fi
+else
+    echo "    ✗ FAILED - Kuadrant CR not found"
+    echo "      Installation incomplete - run: ./test-disconnected/install/install.sh"
+    FAILED=true
+fi
+echo ""
+
+echo "  Checking Authorino CR (created by kuadrant-operator)..."
+if oc get authorino authorino -n kuadrant-system &>/dev/null; then
+    echo "    ✓ Authorino CR exists"
+
+    # Check Authorino status
+    AUTH_READY=$(oc get authorino authorino -n kuadrant-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+    if [ "$AUTH_READY" = "True" ]; then
+        echo "      ✓ Authorino CR is ready"
+    else
+        echo "      ✗ FAILED - Authorino CR not ready (status: ${AUTH_READY})"
+        FAILED=true
+    fi
+else
+    echo "    ✗ FAILED - Authorino CR not found"
+    echo "      kuadrant-operator should create Authorino CR when Kuadrant CR is created"
+    echo "      Check kuadrant-operator logs for errors"
+    FAILED=true
+fi
+echo ""
+
+echo "  Checking Limitador CR (created by kuadrant-operator)..."
+if oc get limitador limitador -n kuadrant-system &>/dev/null; then
+    echo "    ✓ Limitador CR exists"
+
+    # Check Limitador status
+    LIM_READY=$(oc get limitador limitador -n kuadrant-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+    if [ "$LIM_READY" = "True" ]; then
+        echo "      ✓ Limitador CR is ready"
+    else
+        echo "      ✗ FAILED - Limitador CR not ready (status: ${LIM_READY})"
+        FAILED=true
+    fi
+else
+    echo "    ✗ FAILED - Limitador CR not found"
+    echo "      kuadrant-operator should create Limitador CR when Kuadrant CR is created"
+    echo "      Check kuadrant-operator logs for errors"
+    FAILED=true
+fi
+echo ""
+
+# Test 3: Verify CRDs are installed
+echo "==> Test 3: Custom Resource Definitions"
+echo ""
+
+EXPECTED_CRDS=(
+    "authpolicies.kuadrant.io"
+    "ratelimitpolicies.kuadrant.io"
+    "dnspolicies.kuadrant.io"
+    "tlspolicies.kuadrant.io"
+    "authconfigs.authorino.kuadrant.io"
+    "limitadors.limitador.kuadrant.io"
+    "dnsrecords.kuadrant.io"
+)
+
+echo "  Checking CRDs..."
+for crd in "${EXPECTED_CRDS[@]}"; do
+    if oc get crd "${crd}" &>/dev/null; then
+        echo "    ✓ ${crd}"
+    else
+        echo "    ✗ ${crd} - NOT FOUND"
+        FAILED=true
+    fi
+done
+echo ""
+
+# Test 4: Istio Gateway API Provider
+echo "==> Test 4: Istio Gateway API Provider"
+echo ""
+
+echo "  Checking for Istio installation..."
+if ! oc get gatewayclass istio &>/dev/null; then
+    echo "    ✗ FAILED - Istio GatewayClass not found"
+    echo "      Istio must be installed for proper Kuadrant validation"
+    echo "      Run: ./utils/disconnected-openshift-install/install-istio.sh"
+    FAILED=true
+else
+    echo "    ✓ Istio GatewayClass found"
+
+    # Check GatewayClass status
+    GWC_ACCEPTED=$(oc get gatewayclass istio -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null || echo "Unknown")
+    if [ "$GWC_ACCEPTED" = "True" ]; then
+        echo "      ✓ GatewayClass accepted"
+    else
+        echo "      ⚠ GatewayClass status: ${GWC_ACCEPTED}"
+    fi
+fi
+echo ""
+
+echo "  Checking istiod deployment..."
+if oc get deployment istiod -n istio-system &>/dev/null; then
+    ISTIOD_READY=$(oc get deployment istiod -n istio-system -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+    ISTIOD_READY="${ISTIOD_READY:-0}"
+    if [ "$ISTIOD_READY" -gt 0 ]; then
+        echo "    ✓ istiod is ready (${ISTIOD_READY} replicas)"
+    else
+        echo "    ✗ FAILED - istiod not ready"
+        FAILED=true
+    fi
+else
+    echo "    ✗ FAILED - istiod deployment not found"
+    echo "      Istio control plane is not deployed"
+    FAILED=true
+fi
+echo ""
+
+# Test 5: Policy Reconciliation with Real Gateway
+echo "==> Test 5: Policy Reconciliation with Real Gateway"
+echo ""
+
+TEST_NS="kuadrant-smoke-test"
+echo "  Creating test namespace: ${TEST_NS}"
+oc create namespace ${TEST_NS} --dry-run=client -o yaml | oc apply -f - 2>/dev/null
+echo ""
+
+# Create a simple backend service (using Kuadrant httpbin - mirrored by oc-mirror)
+echo "  Creating backend deployment and service..."
+cat <<YAML | oc apply -f - 2>/dev/null
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: smoke-test-backend
+  namespace: ${TEST_NS}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: smoke-test-backend
+  template:
+    metadata:
+      labels:
+        app: smoke-test-backend
+    spec:
+      containers:
+      - name: httpbin
+        image: quay.io/kuadrant/httpbin:latest
+        command:
+        - gunicorn
+        - -b
+        - "0.0.0.0:8080"
+        - "httpbin:app"
+        - -k
+        - gevent
+        ports:
+        - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: smoke-test-backend
+  namespace: ${TEST_NS}
+spec:
+  selector:
+    app: smoke-test-backend
+  ports:
+  - port: 8080
+    targetPort: 8080
+YAML
+
+if oc get deployment smoke-test-backend -n ${TEST_NS} &>/dev/null; then
+    echo "    ✓ Backend deployment created"
+    # Wait for backend to be ready
+    echo "    Waiting for backend pod to be ready..."
+    oc wait --for=condition=available --timeout=90s deployment/smoke-test-backend -n ${TEST_NS} 2>/dev/null || echo "    ⚠ Backend deployment not ready yet (may still be pulling image)"
+else
+    echo "    ✗ Backend deployment creation failed"
+    FAILED=true
+fi
+echo ""
+
+# Create Gateway using Istio GatewayClass
+echo "  Creating Gateway (using istio GatewayClass)..."
+cat <<YAML | oc apply -f - 2>/dev/null
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: smoke-test-gateway
+  namespace: ${TEST_NS}
+  annotations:
+    networking.istio.io/service-type: NodePort
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    hostname: "*.test.example.com"
+YAML
+
+if oc get gateway smoke-test-gateway -n ${TEST_NS} &>/dev/null; then
+    echo "    ✓ Gateway created"
+
+    # Wait for Istio to program the Gateway (NodePort should allow it to reach Programmed)
+    echo "    Waiting for Gateway to be programmed by Istio (60s timeout)..."
+    TIMEOUT=60
+    ELAPSED=0
+    while [ $ELAPSED -lt $TIMEOUT ]; do
+        GW_PROGRAMMED=$(oc get gateway smoke-test-gateway -n ${TEST_NS} -o jsonpath='{.status.conditions[?(@.type=="Programmed")].status}' 2>/dev/null || echo "")
+        GW_ACCEPTED=$(oc get gateway smoke-test-gateway -n ${TEST_NS} -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null || echo "")
+
+        if [ "$GW_PROGRAMMED" = "True" ]; then
+            echo "      ✓ Gateway programmed by Istio (NodePort service ready)"
+            break
+        elif [ "$GW_ACCEPTED" = "True" ] && [ $ELAPSED -gt 30 ]; then
+            # If accepted but not programmed after 30s, show status
+            echo "      ⚠ Gateway accepted but not yet programmed (still waiting...)"
+        fi
+        sleep 3
+        ELAPSED=$((ELAPSED + 3))
+    done
+
+    if [ "$GW_PROGRAMMED" != "True" ]; then
+        echo "      ✗ FAILED - Gateway not programmed by Istio (status: ${GW_PROGRAMMED})"
+        echo "      Gateway status:"
+        oc get gateway smoke-test-gateway -n ${TEST_NS} -o jsonpath='{.status.conditions}' 2>/dev/null | jq '.' | sed 's/^/        /'
+        FAILED=true
+    fi
+else
+    echo "    ✗ Gateway creation failed"
+    FAILED=true
+fi
+echo ""
+
+# Create HTTPRoute
+echo "  Creating HTTPRoute..."
+cat <<YAML | oc apply -f - 2>/dev/null
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: smoke-test-route
+  namespace: ${TEST_NS}
+spec:
+  parentRefs:
+  - name: smoke-test-gateway
+  hostnames:
+  - "api.test.example.com"
+  rules:
+  - backendRefs:
+    - name: smoke-test-backend
+      port: 8080
+YAML
+
+if oc get httproute smoke-test-route -n ${TEST_NS} &>/dev/null; then
+    echo "    ✓ HTTPRoute created"
+else
+    echo "    ✗ HTTPRoute creation failed"
+    FAILED=true
+fi
+echo ""
+
+# Create RateLimitPolicy targeting HTTPRoute
+echo "  Creating RateLimitPolicy..."
+cat <<YAML | oc apply -f - 2>/dev/null
+apiVersion: kuadrant.io/v1
+kind: RateLimitPolicy
+metadata:
+  name: smoke-test-rlp
+  namespace: ${TEST_NS}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: smoke-test-route
+  limits:
+    "smoke-test-limit":
+      rates:
+      - limit: 5
+        window: 10s
+YAML
+
+if oc get ratelimitpolicy smoke-test-rlp -n ${TEST_NS} &>/dev/null; then
+    echo "    ✓ RateLimitPolicy created"
+else
+    echo "    ✗ RateLimitPolicy creation failed"
+    FAILED=true
+fi
+echo ""
+
+# Create AuthPolicy targeting HTTPRoute
+echo "  Creating AuthPolicy..."
+cat <<YAML | oc apply -f - 2>/dev/null
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: smoke-test-authpolicy
+  namespace: ${TEST_NS}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: smoke-test-route
+  rules:
+    authentication:
+      "anonymous":
+        anonymous: {}
+YAML
+
+if oc get authpolicy smoke-test-authpolicy -n ${TEST_NS} &>/dev/null; then
+    echo "    ✓ AuthPolicy created"
+else
+    echo "    ✗ AuthPolicy creation failed"
+    FAILED=true
+fi
+echo ""
+
+# Wait for Authorino to be ready first (required for AuthPolicy reconciliation)
+echo "  Waiting for Authorino to be ready (90s timeout)..."
+TIMEOUT=90
+ELAPSED=0
+AUTHORINO_READY=false
+while [ $ELAPSED -lt $TIMEOUT ]; do
+    AUTHORINO_REPLICAS=$(oc get deployment authorino -n kuadrant-system -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+    AUTHORINO_REPLICAS="${AUTHORINO_REPLICAS:-0}"
+
+    if [ "$AUTHORINO_REPLICAS" -gt 0 ]; then
+        echo "    ✓ Authorino ready (${AUTHORINO_REPLICAS} replicas)"
+        AUTHORINO_READY=true
+        break
+    fi
+
+    sleep 5
+    ELAPSED=$((ELAPSED + 5))
+    if [ $((ELAPSED % 15)) -eq 0 ]; then
+        echo "    Still waiting... (${ELAPSED}s)"
+    fi
+done
+
+if [ "$AUTHORINO_READY" = false ]; then
+    echo "    ⚠ Authorino not ready after ${TIMEOUT}s (continuing anyway)"
+fi
+echo ""
+
+# Wait for policy reconciliation
+echo "  Waiting for policy reconciliation (30 seconds)..."
+sleep 30
+echo ""
+
+# Check policy status conditions
+echo "  Checking policy status conditions..."
+RLP_ACCEPTED=$(oc get ratelimitpolicy smoke-test-rlp -n ${TEST_NS} -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null || echo "Unknown")
+if [ "$RLP_ACCEPTED" = "True" ]; then
+    echo "    ✓ RateLimitPolicy accepted"
+else
+    echo "    ✗ FAILED - RateLimitPolicy not accepted (status: ${RLP_ACCEPTED})"
+    echo "      Policy may not be reconciling correctly"
+    oc get ratelimitpolicy smoke-test-rlp -n ${TEST_NS} -o jsonpath='{.status.conditions}' 2>/dev/null | jq '.' | sed 's/^/      /'
+    FAILED=true
+fi
+
+AUTH_ACCEPTED=$(oc get authpolicy smoke-test-authpolicy -n ${TEST_NS} -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null || echo "Unknown")
+if [ "$AUTH_ACCEPTED" = "True" ]; then
+    echo "    ✓ AuthPolicy accepted"
+else
+    echo "    ✗ FAILED - AuthPolicy not accepted (status: ${AUTH_ACCEPTED})"
+    echo "      Policy may not be reconciling correctly"
+    oc get authpolicy smoke-test-authpolicy -n ${TEST_NS} -o jsonpath='{.status.conditions}' 2>/dev/null | jq '.' | sed 's/^/      /'
+    FAILED=true
+fi
+echo ""
+
+# Test actual traffic through the Gateway
+echo "  Testing traffic through Gateway..."
+# Istio creates a service with pattern {gateway-name}-istio
+GW_SERVICE="smoke-test-gateway-istio"
+if oc get service ${GW_SERVICE} -n ${TEST_NS} &>/dev/null; then
+    echo "    Gateway service: ${GW_SERVICE}"
+
+    # Test using cluster-internal DNS (from a test pod)
+    echo "    Testing via cluster-internal request..."
+
+    # Create a test pod to make internal requests (using mirrored httpbin image with python)
+    if ! oc get pod test-client -n ${TEST_NS} &>/dev/null; then
+        cat <<YAML | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-client
+  namespace: ${TEST_NS}
+spec:
+  containers:
+  - name: client
+    image: quay.io/kuadrant/httpbin:latest
+    command: ["/bin/sh", "-c", "sleep 3600"]
+YAML
+        # Wait for test client pod to be ready
+        oc wait --for=condition=ready --timeout=30s pod/test-client -n ${TEST_NS} 2>/dev/null || echo "    ⚠ Test client pod not ready yet"
+    fi
+
+    # Test 1: Basic routing through Gateway
+    echo "    Testing basic routing..."
+    RESPONSE=$(oc exec -n ${TEST_NS} test-client -- python3 -c "import urllib.request; print(urllib.request.urlopen(urllib.request.Request('http://${GW_SERVICE}.${TEST_NS}.svc.cluster.local:80/', headers={'Host': 'api.test.example.com'})).status)" 2>/dev/null || echo "000")
+
+    if [ "$RESPONSE" = "200" ]; then
+        echo "      ✓ Traffic flows through Gateway (HTTP ${RESPONSE})"
+    elif [ "$RESPONSE" = "000" ]; then
+        echo "      ✗ FAILED - Could not reach Gateway service (connection failed)"
+        echo "        Envoy proxies may not be ready"
+        FAILED=true
+    else
+        echo "      ⚠ Unexpected response: HTTP ${RESPONSE}"
+    fi
+
+    # Test 2: Verify rate limiting enforcement
+    if [ "$RESPONSE" = "200" ]; then
+        echo "    Testing rate limiting (5 requests/10s limit)..."
+        # Make 6 requests rapidly to trigger rate limit
+        SUCCESS_COUNT=0
+        RATE_LIMITED=false
+        for i in {1..6}; do
+            CODE=$(oc exec -n ${TEST_NS} test-client -- python3 -c "
+try:
+    import urllib.request
+    print(urllib.request.urlopen(urllib.request.Request('http://${GW_SERVICE}.${TEST_NS}.svc.cluster.local:80/', headers={'Host': 'api.test.example.com'})).status)
+except urllib.error.HTTPError as e:
+    print(e.code)
+" 2>/dev/null || echo "000")
+            if [ "$CODE" = "200" ]; then
+                SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+            elif [ "$CODE" = "429" ]; then
+                RATE_LIMITED=true
+                break
+            fi
+            sleep 0.2
+        done
+
+        if [ "$RATE_LIMITED" = true ]; then
+            echo "      ✓ Rate limiting enforced (HTTP 429 after ${SUCCESS_COUNT} requests)"
+            # Wait for rate limit window to expire before next test
+            echo "      Waiting 10s for rate limit window to reset..."
+            sleep 10
+        else
+            echo "      ⚠ Rate limiting not triggered (all 6 requests succeeded)"
+            echo "        This may indicate WASM filter is not loading or rate limit policy not enforced"
+            echo "        Check Gateway proxy logs: oc logs -n ${TEST_NS} -l istio.io/gateway-name=smoke-test-gateway"
+        fi
+    fi
+
+    # Test 3: Verify auth is configured (anonymous access allowed)
+    echo "    Testing authentication policy..."
+    # Send request without any auth headers - should succeed with anonymous policy
+    AUTH_RESPONSE=$(oc exec -n ${TEST_NS} test-client -- python3 -c "
+try:
+    import urllib.request
+    print(urllib.request.urlopen(urllib.request.Request('http://${GW_SERVICE}.${TEST_NS}.svc.cluster.local:80/', headers={'Host': 'api.test.example.com'})).status)
+except urllib.error.HTTPError as e:
+    print(e.code)
+" 2>/dev/null || echo "000")
+
+    if [ "$AUTH_RESPONSE" = "200" ]; then
+        echo "      ✓ Anonymous authentication allows access (HTTP ${AUTH_RESPONSE})"
+    elif [ "$AUTH_RESPONSE" = "401" ] || [ "$AUTH_RESPONSE" = "403" ]; then
+        echo "      ✗ FAILED - Authentication blocked request (HTTP ${AUTH_RESPONSE})"
+        echo "        Anonymous policy should allow access"
+        FAILED=true
+    else
+        echo "      ⚠ Unexpected auth response: HTTP ${AUTH_RESPONSE}"
+    fi
+
+    # Test 4: Create stricter auth policy and verify it blocks requests
+    echo "    Testing authentication enforcement (API key required)..."
+    cat <<YAML | oc apply -f - 2>/dev/null
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: smoke-test-authpolicy-strict
+  namespace: ${TEST_NS}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: smoke-test-route
+  rules:
+    authentication:
+      "api-key":
+        apiKey:
+          selector:
+            matchLabels:
+              app: toystore
+        credentials:
+          authorizationHeader:
+            prefix: APIKEY
+YAML
+
+    # Wait for policy to reconcile
+    sleep 5
+
+    # Try to access without API key - should be denied
+    STRICT_AUTH_RESPONSE=$(oc exec -n ${TEST_NS} test-client -- python3 -c "
+try:
+    import urllib.request
+    print(urllib.request.urlopen(urllib.request.Request('http://${GW_SERVICE}.${TEST_NS}.svc.cluster.local:80/', headers={'Host': 'api.test.example.com'})).status)
+except urllib.error.HTTPError as e:
+    print(e.code)
+" 2>/dev/null || echo "000")
+
+    if [ "$STRICT_AUTH_RESPONSE" = "401" ] || [ "$STRICT_AUTH_RESPONSE" = "403" ]; then
+        echo "      ✓ Authentication blocks unauthorized requests (HTTP ${STRICT_AUTH_RESPONSE})"
+    elif [ "$STRICT_AUTH_RESPONSE" = "200" ]; then
+        echo "      ⚠ Authentication did not block request (HTTP ${STRICT_AUTH_RESPONSE})"
+        echo "        This may indicate auth filter is not enforcing policies"
+    else
+        echo "      ⚠ Unexpected response: HTTP ${STRICT_AUTH_RESPONSE}"
+    fi
+
+    # Restore anonymous policy for cleanup
+    oc delete authpolicy smoke-test-authpolicy-strict -n ${TEST_NS} 2>/dev/null || true
+    sleep 2
+else
+    echo "    ⚠ Gateway service not found yet"
+    echo "      Service should be created by Istio - check 'oc get svc -n ${TEST_NS}'"
+fi
+echo ""
+
+# Verify AuthConfig was created by AuthPolicy (proves auth policy reconciliation works)
+# Note: With Istio integration, AuthConfigs are created in kuadrant-system namespace
+echo "  Verifying AuthConfig creation (from AuthPolicy)..."
+AUTH_CONFIG_COUNT=$(oc get authconfig -n kuadrant-system --no-headers 2>/dev/null | wc -l || echo "0")
+if [ "$AUTH_CONFIG_COUNT" -gt 0 ]; then
+    echo "    ✓ AuthConfig created (${AUTH_CONFIG_COUNT} resource(s) in kuadrant-system)"
+    oc get authconfig -n kuadrant-system --no-headers 2>/dev/null | awk '{print "      - " $1}'
+
+    # Check AuthConfig status
+    for authconfig in $(oc get authconfig -n kuadrant-system -o name 2>/dev/null); do
+        AUTH_READY=$(oc get ${authconfig} -n kuadrant-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+        AUTH_NAME=$(echo ${authconfig} | cut -d'/' -f2)
+        if [ "$AUTH_READY" = "True" ]; then
+            echo "      ✓ ${AUTH_NAME} is ready"
+        else
+            echo "      ⚠ ${AUTH_NAME} status: ${AUTH_READY}"
+        fi
+    done
+else
+    echo "    ✗ FAILED - No AuthConfig resources found in kuadrant-system"
+    echo "      This indicates kuadrant-operator is not reconciling AuthPolicy correctly"
+    echo "      Check operator logs: oc logs -n kuadrant-system deployment/kuadrant-operator-controller-manager"
+    FAILED=true
+fi
+echo ""
+
+# Verify EnvoyFilters were created (Istio integration for policies)
+echo "  Verifying EnvoyFilter creation (Istio integration)..."
+ENVOYFILTER_COUNT=$(oc get envoyfilter -n ${TEST_NS} --no-headers 2>/dev/null | wc -l || echo "0")
+if [ "$ENVOYFILTER_COUNT" -gt 0 ]; then
+    echo "    ✓ EnvoyFilters created (${ENVOYFILTER_COUNT} resource(s) in ${TEST_NS})"
+    oc get envoyfilter -n ${TEST_NS} --no-headers 2>/dev/null | awk '{print "      - " $1}'
+
+    # Check for expected EnvoyFilters
+    EXPECTED_FILTERS=("kuadrant-ratelimiting-smoke-test-gateway" "kuadrant-auth-smoke-test-gateway" "kuadrant-smoke-test-gateway")
+    for filter in "${EXPECTED_FILTERS[@]}"; do
+        if oc get envoyfilter "$filter" -n ${TEST_NS} &>/dev/null; then
+            echo "      ✓ ${filter} exists"
+        else
+            echo "      ⚠ ${filter} not found (may indicate policy reconciliation issue)"
+        fi
+    done
+
+    # Validate wasm filter configuration
+    echo "    Checking WASM filter configuration..."
+    WASM_FILTER=$(oc get envoyfilter kuadrant-smoke-test-gateway -n ${TEST_NS} -o jsonpath='{.spec.configPatches[?(@.patch.value.name=="envoy.filters.http.wasm")]}' 2>/dev/null)
+    if [ -n "$WASM_FILTER" ]; then
+        echo "      ✓ WASM filter configured in kuadrant-smoke-test-gateway"
+
+        # Check wasm module source
+        WASM_URI=$(oc get envoyfilter kuadrant-smoke-test-gateway -n ${TEST_NS} -o jsonpath='{.spec.configPatches[?(@.patch.value.name=="envoy.filters.http.wasm")].patch.value.typed_config.value.config.vm_config.code.remote.http_uri.uri}' 2>/dev/null)
+        if [ -n "$WASM_URI" ]; then
+            echo "      WASM module URI: ${WASM_URI}"
+
+            # Check if wasm service endpoint exists
+            if oc get service kuadrant-operator-wasm -n kuadrant-system &>/dev/null; then
+                echo "      ✓ kuadrant-operator-wasm service exists (serves wasm module)"
+            else
+                echo "      ✗ FAILED - kuadrant-operator-wasm service not found"
+                echo "        WASM module cannot be loaded without this service"
+                FAILED=true
+            fi
+        fi
+    else
+        echo "      ✗ FAILED - WASM filter not configured in EnvoyFilter"
+        echo "        Policy enforcement via WASM will not work"
+        FAILED=true
+    fi
+else
+    echo "    ✗ FAILED - No EnvoyFilter resources found in ${TEST_NS}"
+    echo "      EnvoyFilters are required for Istio integration with Kuadrant policies"
+    echo "      Check that Gateway is Programmed and policies are Accepted"
+    FAILED=true
+fi
+echo ""
+
+# Test 6: Check if Authorino is deployed (authorino-operator should deploy it)
+echo "==> Test 6: Authorino Deployment"
+echo ""
+
+if oc get deployment authorino -n kuadrant-system &>/dev/null; then
+    AUTHORINO_REPLICAS=$(oc get deployment authorino -n kuadrant-system -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+    # Handle empty string from jsonpath when field doesn't exist
+    AUTHORINO_REPLICAS="${AUTHORINO_REPLICAS:-0}"
+    if [ "$AUTHORINO_REPLICAS" -gt 0 ]; then
+        echo "  ✓ Authorino is deployed and ready (${AUTHORINO_REPLICAS} replicas)"
+    else
+        echo "  ⚠ Authorino is deployed but not ready yet"
+    fi
+
+    # Show image reference
+    AUTHORINO_IMAGE=$(oc get deployment authorino -n kuadrant-system -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+    if [ -n "$AUTHORINO_IMAGE" ]; then
+        echo "  Image: ${AUTHORINO_IMAGE}"
+        # Check if using digest reference (informational)
+        if echo "$AUTHORINO_IMAGE" | grep -q "@sha256:"; then
+            echo "    Using digest reference (immutable)"
+        else
+            echo "    Using tag reference"
+        fi
+    fi
+else
+    echo "  ✗ FAILED - Authorino deployment not found"
+    echo "      authorino-operator should create Authorino deployment from Authorino CR"
+    echo "      Check authorino-operator logs for errors"
+    FAILED=true
+fi
+echo ""
+
+# Test 7: Check if Limitador is deployed
+echo "==> Test 7: Limitador Deployment"
+echo ""
+
+if oc get deployment limitador-limitador -n kuadrant-system &>/dev/null; then
+    LIMITADOR_REPLICAS=$(oc get deployment limitador-limitador -n kuadrant-system -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+    # Handle empty string from jsonpath when field doesn't exist
+    LIMITADOR_REPLICAS="${LIMITADOR_REPLICAS:-0}"
+    if [ "$LIMITADOR_REPLICAS" -gt 0 ]; then
+        echo "  ✓ Limitador is deployed and ready (${LIMITADOR_REPLICAS} replicas)"
+    else
+        echo "  ⚠ Limitador is deployed but not ready yet"
+    fi
+
+    # Show image reference
+    LIMITADOR_IMAGE=$(oc get deployment limitador-limitador -n kuadrant-system -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+    if [ -n "$LIMITADOR_IMAGE" ]; then
+        echo "  Image: ${LIMITADOR_IMAGE}"
+        # Check if using digest reference (informational)
+        if echo "$LIMITADOR_IMAGE" | grep -q "@sha256:"; then
+            echo "    Using digest reference (immutable)"
+        else
+            echo "    Using tag reference"
+        fi
+    fi
+else
+    echo "  ✗ FAILED - Limitador deployment not found"
+    echo "      limitador-operator should create Limitador deployment from Limitador CR"
+    echo "      Check limitador-operator logs for errors"
+    FAILED=true
+fi
+echo ""
+
+# Test 8: Kuadrant Component Image Information
+echo "==> Test 8: Kuadrant Component Images"
+echo ""
+
+OPERATOR_DEPLOYMENTS=(
+    "kuadrant-operator-controller-manager"
+    "authorino-operator"
+    "limitador-operator-controller-manager"
+    "dns-operator-controller-manager"
+)
+
+echo "  Component images in use:"
+echo ""
+
+# Operators
+echo "  Operators:"
+for deployment in "${OPERATOR_DEPLOYMENTS[@]}"; do
+    if oc get deployment "${deployment}" -n kuadrant-system &>/dev/null; then
+        OPERATOR_IMAGE=$(oc get deployment "${deployment}" -n kuadrant-system -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+        if [ -n "$OPERATOR_IMAGE" ]; then
+            # Check if using digest reference (informational)
+            if echo "$OPERATOR_IMAGE" | grep -q "@sha256:"; then
+                IMAGE_TYPE="digest"
+            else
+                IMAGE_TYPE="tag"
+            fi
+            echo "    ${deployment}"
+            echo "      Image: ${OPERATOR_IMAGE}"
+            echo "      Type:  ${IMAGE_TYPE}"
+            echo ""
+        fi
+    else
+        echo "    ${deployment} - NOT FOUND"
+        FAILED=true
+    fi
+done
+
+# Operands
+echo "  Operands:"
+if oc get deployment authorino -n kuadrant-system &>/dev/null; then
+    AUTH_IMAGE=$(oc get deployment authorino -n kuadrant-system -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+    if [ -n "$AUTH_IMAGE" ]; then
+        if echo "$AUTH_IMAGE" | grep -q "@sha256:"; then
+            AUTH_TYPE="digest"
+        else
+            AUTH_TYPE="tag"
+        fi
+        echo "    Authorino:"
+        echo "      Image: ${AUTH_IMAGE}"
+        echo "      Type:  ${AUTH_TYPE}"
+        echo ""
+    fi
+fi
+
+if oc get deployment limitador-limitador -n kuadrant-system &>/dev/null; then
+    LIM_IMAGE=$(oc get deployment limitador-limitador -n kuadrant-system -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)
+    if [ -n "$LIM_IMAGE" ]; then
+        if echo "$LIM_IMAGE" | grep -q "@sha256:"; then
+            LIM_TYPE="digest"
+        else
+            LIM_TYPE="tag"
+        fi
+        echo "    Limitador:"
+        echo "      Image: ${LIM_IMAGE}"
+        echo "      Type:  ${LIM_TYPE}"
+        echo ""
+    fi
+fi
+
+# WASM Module (check EnvoyFilter for WASM URI)
+if oc get envoyfilter -A &>/dev/null 2>&1; then
+    WASM_URI=$(oc get envoyfilter -A -o jsonpath='{.items[*].spec.configPatches[?(@.patch.value.name=="envoy.filters.http.wasm")].patch.value.typed_config.value.config.vm_config.code.remote.http_uri.uri}' 2>/dev/null | tr ' ' '\n' | head -1)
+    if [ -n "$WASM_URI" ]; then
+        echo "  WASM Module:"
+        echo "    URI: ${WASM_URI}"
+        echo ""
+    fi
+fi
+
+echo "  Note: This is informational output showing what images are currently deployed."
+echo "  Both tag-based and digest-based references can work in disconnected environments"
+echo "  if properly mirrored via ImageContentSourcePolicy or ImageDigestMirrorSet."
+echo ""
+
+# Test 9: Check operator logs for errors
+echo "==> Test 9: Operator Health Check"
+echo ""
+
+echo "  Checking kuadrant-operator logs for errors..."
+OPERATOR_ERRORS=$(oc logs -n kuadrant-system deployment/kuadrant-operator-controller-manager --tail=100 2>/dev/null | grep -i "error\|fatal\|panic" | grep -v "errorSource" | head -10 || echo "")
+if [ -n "$OPERATOR_ERRORS" ]; then
+    echo "    ⚠ WARNING - Errors found in kuadrant-operator logs:"
+    echo "$OPERATOR_ERRORS" | sed 's/^/      /'
+    echo ""
+    echo "    Full recent logs:"
+    oc logs -n kuadrant-system deployment/kuadrant-operator-controller-manager --tail=50 2>/dev/null | sed 's/^/      /'
+    echo ""
+    # Don't fail on log errors as they might be transient, but surface them
+else
+    echo "    ✓ No critical errors in recent logs"
+fi
+echo ""
+
+# Cleanup
+if [ "$CLEANUP" = "--cleanup" ]; then
+    echo "==> Cleaning up test resources"
+    echo ""
+    oc delete namespace ${TEST_NS} 2>/dev/null || true
+    echo "  ✓ Test namespace deleted"
+    echo ""
+fi
+
+# Summary
+echo "=========================================="
+if [ "$FAILED" = false ]; then
+    echo "✓ Smoke Test PASSED"
+    echo "=========================================="
+    echo ""
+    echo "  ✓ All operators installed and running"
+    echo "  ✓ Kuadrant control plane ready"
+    echo "  ✓ Policies reconcile correctly"
+    echo ""
+
+    exit 0
+else
+    echo "✗ Smoke Test FAILED"
+    echo "=========================================="
+    echo ""
+
+    # Show which tests failed
+    echo "Failed checks:"
+    echo ""
+
+    # Parse output to identify which tests had failures
+    # We'll collect the most common failure reasons
+    FAILURE_SUMMARY=""
+
+    # Check for specific failures
+    if ! oc get gatewayclass istio &>/dev/null 2>&1; then
+        echo "  ✗ Istio Gateway API Provider not found"
+        FAILURE_SUMMARY="${FAILURE_SUMMARY}istio,"
+    fi
+
+    if ! oc get deployment istiod -n istio-system &>/dev/null 2>&1; then
+        echo "  ✗ Istio control plane (istiod) not deployed"
+        FAILURE_SUMMARY="${FAILURE_SUMMARY}istio,"
+    fi
+
+    if ! oc get kuadrant kuadrant -n kuadrant-system &>/dev/null 2>&1; then
+        echo "  ✗ Kuadrant CR not created"
+        FAILURE_SUMMARY="${FAILURE_SUMMARY}kuadrant-cr,"
+    fi
+
+    KUADRANT_READY=$(oc get kuadrant kuadrant -n kuadrant-system -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo "Unknown")
+    if [ "$KUADRANT_READY" != "True" ]; then
+        echo "  ✗ Kuadrant control plane not ready (status: ${KUADRANT_READY})"
+        FAILURE_SUMMARY="${FAILURE_SUMMARY}kuadrant-ready,"
+    fi
+
+    AUTHORINO_REPLICAS=$(oc get deployment authorino -n kuadrant-system -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+    AUTHORINO_REPLICAS="${AUTHORINO_REPLICAS:-0}"
+    if [ "$AUTHORINO_REPLICAS" -eq 0 ]; then
+        echo "  ✗ Authorino not ready (may need more time to start)"
+        FAILURE_SUMMARY="${FAILURE_SUMMARY}authorino,"
+    fi
+
+    LIMITADOR_REPLICAS=$(oc get deployment limitador-limitador -n kuadrant-system -o jsonpath='{.status.readyReplicas}' 2>/dev/null || echo "0")
+    LIMITADOR_REPLICAS="${LIMITADOR_REPLICAS:-0}"
+    if [ "$LIMITADOR_REPLICAS" -eq 0 ]; then
+        echo "  ✗ Limitador not ready (may need more time to start)"
+        FAILURE_SUMMARY="${FAILURE_SUMMARY}limitador,"
+    fi
+
+    RLP_ACCEPTED=$(oc get ratelimitpolicy smoke-test-rlp -n kuadrant-smoke-test -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null || echo "Unknown")
+    if [ "$RLP_ACCEPTED" != "True" ] && [ "$RLP_ACCEPTED" != "Unknown" ]; then
+        echo "  ✗ RateLimitPolicy not accepted (status: ${RLP_ACCEPTED})"
+        FAILURE_SUMMARY="${FAILURE_SUMMARY}ratelimitpolicy,"
+    fi
+
+    AUTH_ACCEPTED=$(oc get authpolicy smoke-test-authpolicy -n kuadrant-smoke-test -o jsonpath='{.status.conditions[?(@.type=="Accepted")].status}' 2>/dev/null || echo "Unknown")
+    if [ "$AUTH_ACCEPTED" != "True" ] && [ "$AUTH_ACCEPTED" != "Unknown" ]; then
+        echo "  ✗ AuthPolicy not accepted (status: ${AUTH_ACCEPTED})"
+        FAILURE_SUMMARY="${FAILURE_SUMMARY}authpolicy,"
+    fi
+
+    echo ""
+
+    exit 1
+fi


### PR DESCRIPTION
## Summary

**DRAFT - FOR TESTING PURPOSES ONLY**

Adds comprehensive test scripts for validating Kuadrant installation in disconnected OpenShift environments. These scripts use an **in-cluster mirror** to simulate a disconnected environment and are **not intended for production use**.

## Purpose

These test scripts validate that the digest-based image reference changes in the related PRs work correctly in disconnected OpenShift clusters. They provide an automated way to:
- Build operator and bundle images with digest references
- Create a combined catalog
- Mirror images to an in-cluster registry
- Install and validate Kuadrant in a simulated air-gapped environment

## Test Scripts Included

- **setup.sh**: Creates and configures disconnected OpenShift cluster with image mirrors
- **cleanup.sh**: Removes cluster configuration and test resources
- **smoke-test.sh**: Validates operators, policies, and enforcement
- **build-catalogs.sh**: Builds and pushes all four operator images, bundles, and combined catalog
- **run-e2e-test.sh**: Complete end-to-end validation workflow
- **cluster-disconnect.sh**: Helper for simulating network isolation
- **install-istio.sh**: Istio installation for Gateway API provider

## Dependencies

This PR is for **testing only** and requires the following PRs to be merged first to enable digest-based builds:

- [ ] Kuadrant Operator: https://github.com/Kuadrant/kuadrant-operator/pull/2008
- [ ] DNS Operator: https://github.com/Kuadrant/dns-operator/pull/773
- [ ] Limitador Operator: https://github.com/Kuadrant/limitador-operator/pull/256
- [ ] Authorino Operator: https://github.com/Kuadrant/authorino-operator/pull/313

## Testing with CRC

```bash
# Start CRC with sufficient resources
crc start --cpus 8 --memory 16384 --disk-size 100
eval $(crc oc-env)
oc login -u kubeadmin https://api.crc.testing:6443

# Run end-to-end test (from kuadrant-operator directory)
./utils/disconnected-openshift-install/run-e2e-test.sh --install-istio --image-tag latest --disable-sources
```

## Related

Related to https://github.com/Kuadrant/kuadrant-operator/issues/1894