### PR TITLE
fix: Return error from PipelineCommit when change notification fails

### DIFF
--- a/cmd/extensions/threat-policy/main.go
+++ b/cmd/extensions/threat-policy/main.go
@@ -6,6 +6,7 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kuadrant/kuadrant-operator/cmd/extensions/threat-policy/api/v1alpha1"
 	"github.com/kuadrant/kuadrant-operator/cmd/extensions/threat-policy/internal/controller"
@@ -17,6 +18,7 @@ var (
 )
 
 func init() {
+	utilruntime.Must(gatewayapiv1.Install(scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 }
 

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -773,7 +773,7 @@ func (s *extensionService) PipelineCommit(_ context.Context, request *extpb.Pipe
 		reason := fmt.Sprintf("pipeline committed for policy %s/%s (%d actions)",
 			policyID.Namespace, policyID.Name, len(entries))
 		if err := s.changeNotifier(reason); err != nil {
-			s.logger.Error(err, "failed to trigger change notification", "reason", reason)
+			return nil, fmt.Errorf("pipeline committed but failed to trigger reconciliation: %w", err)
 		}
 	}
 

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -1307,3 +1307,24 @@ func TestPipelineCommit_ChangeNotifier(t *testing.T) {
 		t.Fatal("Expected change notifier to have been called")
 	}
 }
+
+func TestPipelineCommit_ChangeNotifierError(t *testing.T) {
+	svc := newTestExtensionService()
+
+	svc.changeNotifier = func(reason string) error {
+		return fmt.Errorf("no Kuadrant resources found in cluster")
+	}
+
+	_, err := svc.PipelineCommit(context.Background(), &extpb.PipelineCommitRequest{
+		Policy: testPipelinePolicy(),
+		Actions: []*extpb.ActionEntry{
+			{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Phase: "request", WithStatus: 403},
+		},
+	})
+	if err == nil {
+		t.Fatal("Expected error when change notifier fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to trigger reconciliation") {
+		t.Errorf("Expected error about failed reconciliation, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- **PipelineCommit** now returns an error when the change notification fails instead of swallowing it. This prevents extension policies from falsely reporting `Enforced: True` when the operator couldn't trigger reconciliation (e.g. no Kuadrant CR exists).
- **threat-policy scheme fix**: registers Gateway API types so `validateTarget` can resolve HTTPRoute/Gateway references.

Fixes #2010

## Test plan
- [x] Unit test added: `TestPipelineCommit_ChangeNotifierError`
- [x] `make test-unit` passes
- [x] Manual verification: ThreatPolicy without Kuadrant CR shows `Accepted: False` with reconciliation error
- [x] Manual verification: ThreatPolicy recovers to `Enforced: True` after Kuadrant CR is created
- [x] Manual verification: EnvoyFilter cleanup works correctly on ThreatPolicy deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added Gateway API v1 integration to the extension runtime.

**Bug Fixes**
* Enhanced error handling to ensure reconciliation failures are properly reported instead of being silently logged, providing better visibility into system state changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-operator/pull/2013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->