### PR TITLE
feat: treat DenyAction WithBody as a CEL expression

### DIFF
--- a/cmd/extensions/threat-policy/internal/controller/threatpolicy_reconciler.go
+++ b/cmd/extensions/threat-policy/internal/controller/threatpolicy_reconciler.go
@@ -131,7 +131,7 @@ func (r *ThreatPolicyReconciler) reconcileSpec(ctx context.Context, pol *v1alpha
 			Predicate:   fmt.Sprintf("threatResponse.threat_level >= %d", pol.Spec.Threshold),
 			WithStatus:  403,
 			WithHeaders: `[["x-threat-blocked", "true"], ["x-threat-level", string(threatResponse.threat_level)]]`,
-			WithBody:    "Request blocked: threat level exceeds threshold",
+			WithBody:    "'Request blocked: threat level exceeds threshold'",
 		},
 	); err != nil {
 		return calculateErrorStatus(pol, err), err

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -1187,8 +1187,7 @@ func buildDenyResponseExpr(status int, headers, body string) string {
 		parts = append(parts, fmt.Sprintf("headers: %s", headers))
 	}
 	if body != "" {
-		escaped := strings.NewReplacer(`\`, `\\`, `'`, `\'`, "\n", `\n`, "\r", `\r`).Replace(body)
-		parts = append(parts, fmt.Sprintf("body: '%s'", escaped))
+		parts = append(parts, fmt.Sprintf("body: %s", body))
 	}
 	if len(parts) == 0 {
 		return "DenyResponse{}"

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -1151,6 +1151,9 @@ func entryMatchesVar(entry PipelineActionEntry, pattern *regexp.Regexp) bool {
 	if entry.LogMessage != "" && pattern.MatchString(entry.LogMessage) {
 		return true
 	}
+	if entry.WithBody != "" && pattern.MatchString(entry.WithBody) {
+		return true
+	}
 	return false
 }
 

--- a/pkg/extension/types/actions.go
+++ b/pkg/extension/types/actions.go
@@ -60,7 +60,7 @@ type DenyAction struct {
 	Predicate   string // CEL — if true, deny
 	WithStatus  int    // HTTP status code (e.g. 403); optional
 	WithHeaders string // CEL expression — array of [name, value] pairs; optional
-	WithBody    string // Response body string; optional
+	WithBody    string // CEL expression; optional
 }
 
 func (a DenyAction) actionType() ActionType { return ActionTypeDeny }
@@ -72,6 +72,9 @@ func (a DenyAction) CelExpressions() []string {
 	}
 	if a.WithHeaders != "" {
 		exprs = append(exprs, a.WithHeaders)
+	}
+	if a.WithBody != "" {
+		exprs = append(exprs, a.WithBody)
 	}
 	return exprs
 }


### PR DESCRIPTION
## Summary
- Treat `DenyAction.WithBody` as a CEL expression instead of a plain string, consistent with `WithHeaders` and `Predicate`
- Add `WithBody` to `CelExpressions()` so it participates in pipeline variable reference validation
- Update `buildDenyResponseExpr()` to embed the body directly as a CEL expression instead of escaping and quoting it
- Update threat-policy call site to use a CEL string literal

Closes #2018

## Test plan
- [ ] Run `make test-unit` to verify existing tests pass
- [ ] Verify threat-policy deny response body still works with the CEL string literal
- [ ] Test a dynamic body expression referencing a gRPC response variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent deny response body formatting so configured response bodies are handled consistently.

* **Documentation**
  * Clarified that deny response body fields are treated as CEL expressions rather than raw strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->