### PR TITLE
fix: reject top-level fail actions in pipeline validation

### DIFF
--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -386,9 +386,14 @@ func (p *PipelineImpl) validateAndAppend(phase string, actions []exttypes.Action
 		}
 	}
 
-	varPatterns := make(map[string]*regexp.Regexp, len(batchVars))
-	for varName := range batchVars {
+	varPatterns := make(map[string]*regexp.Regexp, len(batchVars)+len(p.populatedVars))
+	for varName := range p.populatedVars {
 		varPatterns[varName] = regexp.MustCompile(`\b` + regexp.QuoteMeta(varName) + `\b`)
+	}
+	for varName := range batchVars {
+		if _, exists := varPatterns[varName]; !exists {
+			varPatterns[varName] = regexp.MustCompile(`\b` + regexp.QuoteMeta(varName) + `\b`)
+		}
 	}
 
 	localPopulated := make(map[string]bool, len(p.populatedVars))

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -397,6 +397,20 @@ func (p *PipelineImpl) validateAndAppend(phase string, actions []exttypes.Action
 	}
 
 	for _, action := range actions {
+		if _, ok := action.(exttypes.FailAction); ok {
+			refsVar := false
+			for _, expr := range action.CelExpressions() {
+				for _, pattern := range varPatterns {
+					if pattern.MatchString(expr) {
+						refsVar = true
+					}
+				}
+			}
+			if !refsVar {
+				return fmt.Errorf("fail action must reference a gRPC response variable")
+			}
+		}
+
 		exprs := action.CelExpressions()
 		for _, expr := range exprs {
 			for varName, pattern := range varPatterns {

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -408,7 +408,11 @@ func (p *PipelineImpl) validateAndAppend(phase string, actions []exttypes.Action
 				for _, pattern := range varPatterns {
 					if pattern.MatchString(expr) {
 						refsVar = true
+						break
 					}
+				}
+				if refsVar {
+					break
 				}
 			}
 			if !refsVar {

--- a/pkg/extension/controller/controller_test.go
+++ b/pkg/extension/controller/controller_test.go
@@ -544,10 +544,6 @@ func TestPipeline_NoVarReference_NoError(t *testing.T) {
 			Predicate:  `request.url_path == "/blocked"`,
 			WithStatus: 403,
 		},
-		exttypes.FailAction{
-			Predicate:  `request.headers["x-debug"] == "true"`,
-			LogMessage: "debug failure",
-		},
 	)
 	assert.NilError(t, err)
 
@@ -660,7 +656,7 @@ func TestPipeline_TopLevelFailAction(t *testing.T) {
 			Predicate:  `threatResponse.threat_level >= 5`,
 			LogMessage: "threat detected",
 		})
-		assert.Assert(t, cmp.Contains(err.Error(), "fail action must reference a gRPC response variable"))
+		assert.NilError(t, err)
 	})
 
 	t.Run("fail action with no predicate rejected", func(t *testing.T) {
@@ -698,7 +694,7 @@ func TestPipelineCommit_SendsAllActions(t *testing.T) {
 			Var:       "threatResponse",
 		},
 		exttypes.FailAction{
-			Predicate:  `request.headers["x-debug"] == "true"`,
+			Predicate:  `threatResponse.threat_level >= 10`,
 			LogMessage: "Request blocked",
 		},
 	)

--- a/pkg/extension/controller/controller_test.go
+++ b/pkg/extension/controller/controller_test.go
@@ -600,6 +600,81 @@ func TestPipeline_VarInHeadersToAdd_ForwardReference(t *testing.T) {
 	assert.Assert(t, cmp.Contains(err.Error(), "references variable \"threatResponse\" before it is populated"))
 }
 
+func TestPipeline_TopLevelFailAction(t *testing.T) {
+	t.Run("standalone fail action rejected", func(t *testing.T) {
+		p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+		err := p.OnHTTPRequest(exttypes.FailAction{
+			Predicate:  `request.url_path == "/blocked"`,
+			LogMessage: "Request blocked",
+		})
+		assert.Assert(t, err != nil)
+		assert.Assert(t, cmp.Contains(err.Error(), "fail action must reference a gRPC response variable"))
+	})
+
+	t.Run("standalone fail action rejected in response phase", func(t *testing.T) {
+		p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+		err := p.OnHTTPResponse(exttypes.FailAction{
+			Predicate:  `request.url_path == "/blocked"`,
+			LogMessage: "Request blocked",
+		})
+		assert.Assert(t, err != nil)
+		assert.Assert(t, cmp.Contains(err.Error(), "fail action must reference a gRPC response variable"))
+	})
+
+	t.Run("fail action with grpc var but not referencing it", func(t *testing.T) {
+		p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+		err := p.OnHTTPRequest(
+			exttypes.GRPCMethodAction{Method: "assess-threat", Var: "threatResponse"},
+			exttypes.FailAction{
+				Predicate:  `request.url_path == "/blocked"`,
+				LogMessage: "blocked",
+			},
+		)
+		assert.Assert(t, err != nil)
+		assert.Assert(t, cmp.Contains(err.Error(), "fail action must reference a gRPC response variable"))
+	})
+
+	t.Run("fail action referencing grpc var accepted", func(t *testing.T) {
+		p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+		err := p.OnHTTPRequest(
+			exttypes.GRPCMethodAction{Method: "assess-threat", Var: "threatResponse"},
+			exttypes.FailAction{
+				Predicate:  `threatResponse.threat_level >= 5`,
+				LogMessage: "threat detected",
+			},
+		)
+		assert.NilError(t, err)
+	})
+
+	t.Run("fail action referencing grpc var from previous call", func(t *testing.T) {
+		p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+		err := p.OnHTTPRequest(exttypes.GRPCMethodAction{Method: "assess-threat", Var: "threatResponse"})
+		assert.NilError(t, err)
+
+		err = p.OnHTTPResponse(exttypes.FailAction{
+			Predicate:  `threatResponse.threat_level >= 5`,
+			LogMessage: "threat detected",
+		})
+		assert.Assert(t, cmp.Contains(err.Error(), "fail action must reference a gRPC response variable"))
+	})
+
+	t.Run("fail action with no predicate rejected", func(t *testing.T) {
+		p := &PipelineImpl{populatedVars: make(map[string]bool)}
+
+		err := p.OnHTTPRequest(
+			exttypes.GRPCMethodAction{Method: "assess-threat", Var: "threatResponse"},
+			exttypes.FailAction{LogMessage: "always fail"},
+		)
+		assert.Assert(t, err != nil)
+		assert.Assert(t, cmp.Contains(err.Error(), "fail action must reference a gRPC response variable"))
+	})
+}
+
 func TestPipelineCommit_SendsAllActions(t *testing.T) {
 	var capturedReq *extpb.PipelineCommitRequest
 	mock := &mockExtensionServiceClient{


### PR DESCRIPTION
## Summary
- Reject `FailAction`s that don't reference any gRPC response variable in `validateAndAppend()`, since they remain top-level and are silently ignored by the wasm-shim at runtime
- Include previously populated vars (`p.populatedVars`) in `varPatterns` so fail actions referencing gRPC vars from earlier pipeline calls are correctly accepted
- Add comprehensive test cases covering standalone fail, fail with/without gRPC var reference, cross-call references, and no-predicate fail

Closes #2021

## Test plan
- [x] All existing pipeline tests pass
- [x] New `TestPipeline_TopLevelFailAction` subtests cover all edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for fail actions: must reference required gRPC response variables and cannot be configured as standalone, top-level, or response-phase actions.
  * Improved error messages clarifying invalid fail-action configurations.
  * Expanded variable-tracking to include variables introduced in the same batch for more accurate validation.

* **Tests**
  * Added and updated tests covering fail-action validation rules and predicate behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->