### PR TITLE
fix: Scope extension pipeline actions to their target refs

### DIFF
--- a/cmd/extensions/threat-policy/main.go
+++ b/cmd/extensions/threat-policy/main.go
@@ -6,6 +6,7 @@ import (
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kuadrant/kuadrant-operator/cmd/extensions/threat-policy/api/v1alpha1"
 	"github.com/kuadrant/kuadrant-operator/cmd/extensions/threat-policy/internal/controller"
@@ -17,6 +18,7 @@ var (
 )
 
 func init() {
+	utilruntime.Must(gatewayapiv1.Install(scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 }
 

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -765,6 +765,23 @@ func (s *extensionService) PipelineCommit(_ context.Context, request *extpb.Pipe
 		return nil, err
 	}
 
+	if len(request.Policy.TargetRefs) == 0 {
+		return nil, fmt.Errorf("pipeline commit for policy %s/%s: policy must have target references", policyID.Namespace, policyID.Name)
+	}
+	targetRefs := make([]TargetRef, 0, len(request.Policy.TargetRefs))
+	for _, ref := range request.Policy.TargetRefs {
+		if ref == nil {
+			return nil, fmt.Errorf("pipeline commit for policy %s/%s: target reference cannot be nil", policyID.Namespace, policyID.Name)
+		}
+		targetRefs = append(targetRefs, TargetRef{
+			Group:     ref.Group,
+			Kind:      ref.Kind,
+			Name:      ref.Name,
+			Namespace: ref.Namespace,
+		})
+	}
+	s.registeredData.SetPipelineTargetRefs(policyID, targetRefs)
+
 	s.logger.Info("pipeline committed",
 		"policy", fmt.Sprintf("%s/%s", policyID.Namespace, policyID.Name),
 		"actions", len(entries))

--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -128,11 +129,27 @@ func (r *MutatorRegistry) ApplyWasmConfigMutators(wasmConfig *wasm.Config, gatew
 		targetRefs = append(targetRefs, collectRouteTargetRefs(gateway, topology)...)
 	}
 
-	// When no actionsets exist but extension policies have pipeline actions,
-	// create skeleton actionsets from the topology so the mutator's append logic works.
-	if len(wasmConfig.ActionSets) == 0 && topology != nil {
-		if r.hasRelevantPipelineActions(targetRefs) {
-			wasmConfig.ActionSets = buildActionSetsFromTopology(gateway, topology)
+	// When extension policies have pipeline actions, ensure skeleton action sets
+	// exist for their targeted routes so the mutator's append logic works.
+	if topology != nil && r.hasRelevantPipelineActions(targetRefs) {
+		skeletons := buildActionSetsFromTopology(gateway, topology)
+		if len(wasmConfig.ActionSets) == 0 {
+			wasmConfig.ActionSets = skeletons
+		} else {
+			neededRoutes := r.routesNeedingSkeletons(targetRefs)
+			if len(neededRoutes) > 0 {
+				existingRoutes := make(map[string]bool)
+				for _, as := range wasmConfig.ActionSets {
+					if as.SourceRoute != "" {
+						existingRoutes[as.SourceRoute] = true
+					}
+				}
+				for _, sk := range skeletons {
+					if neededRoutes[sk.SourceRoute] && !existingRoutes[sk.SourceRoute] {
+						wasmConfig.ActionSets = append(wasmConfig.ActionSets, sk)
+					}
+				}
+			}
 		}
 	}
 
@@ -179,8 +196,8 @@ func (r *MutatorRegistry) hasRelevantPipelineActions(targetRefs []machinery.Poli
 		// Check policies with registered upstreams
 		relevantUpstreamKeys := m.store.GetRelevantUpstreamKeys(targetRefs)
 		policyIDs := lo.Uniq(lo.Map(lo.Keys(relevantUpstreamKeys), func(k RegisteredUpstreamKey, _ int) ResourceID { return k.Policy }))
-		// Also include policies that have pipeline actions but no upstreams
-		policyIDs = append(policyIDs, m.store.GetPoliciesWithPipelineActions()...)
+		// Also include pipeline-only policies whose target refs match this gateway
+		policyIDs = append(policyIDs, m.store.GetPoliciesWithPipelineActionsForTargetRefs(targetRefs)...)
 		policyIDs = lo.Uniq(policyIDs)
 		for _, policyID := range policyIDs {
 			for _, phase := range []PipelinePhase{PipelinePhaseRequest, PipelinePhaseResponse} {
@@ -191,6 +208,27 @@ func (r *MutatorRegistry) hasRelevantPipelineActions(targetRefs []machinery.Poli
 		}
 	}
 	return false
+}
+
+// routesNeedingSkeletons returns the set of route locators (Kind/Namespace/Name)
+// for routes targeted by extension pipeline policies that don't have action sets
+// from core policies. These routes need skeleton action sets.
+func (r *MutatorRegistry) routesNeedingSkeletons(targetRefs []machinery.PolicyTargetReference) map[string]bool {
+	routes := make(map[string]bool)
+	for _, mutator := range r.wasmConfigMutators {
+		m, ok := mutator.(*RegisteredDataMutator[*wasm.Config])
+		if !ok {
+			continue
+		}
+		for _, policyID := range m.store.GetPoliciesWithPipelineActionsForTargetRefs(targetRefs) {
+			for _, tr := range m.store.GetPipelineTargetRefs(policyID) {
+				if tr.Kind == "HTTPRoute" || tr.Kind == "GRPCRoute" {
+					routes[fmt.Sprintf("%s/%s/%s", tr.Kind, tr.Namespace, tr.Name)] = true
+				}
+			}
+		}
+	}
+	return routes
 }
 
 // collectRouteTargetRefs traverses the topology from a gateway through listeners to
@@ -357,9 +395,10 @@ type RegisteredDataStore struct {
 	protoCache          *ProtoCache
 	upstreamsMutex      sync.RWMutex
 
-	pipelineActions  map[pipelineKey][]PipelineActionEntry
-	pipelineCounters map[pipelineKey]int
-	pipelineMutex    sync.RWMutex
+	pipelineActions    map[pipelineKey][]PipelineActionEntry
+	pipelineCounters   map[pipelineKey]int
+	pipelineTargetRefs map[ResourceID][]TargetRef
+	pipelineMutex      sync.RWMutex
 }
 
 func NewRegisteredDataStore() *RegisteredDataStore {
@@ -370,6 +409,7 @@ func NewRegisteredDataStore() *RegisteredDataStore {
 		protoCache:          NewProtoCache(),
 		pipelineActions:     make(map[pipelineKey][]PipelineActionEntry),
 		pipelineCounters:    make(map[pipelineKey]int),
+		pipelineTargetRefs:  make(map[ResourceID][]TargetRef),
 	}
 }
 
@@ -782,7 +822,34 @@ func (r *RegisteredDataStore) ClearPipelineActions(policy ResourceID) int {
 		delete(r.pipelineActions, key)
 		delete(r.pipelineCounters, key)
 	}
+	delete(r.pipelineTargetRefs, policy)
 	return cleared
+}
+
+func (r *RegisteredDataStore) SetPipelineTargetRefs(policy ResourceID, refs []TargetRef) {
+	r.pipelineMutex.Lock()
+	defer r.pipelineMutex.Unlock()
+
+	if len(refs) == 0 {
+		delete(r.pipelineTargetRefs, policy)
+		return
+	}
+	dst := make([]TargetRef, len(refs))
+	copy(dst, refs)
+	r.pipelineTargetRefs[policy] = dst
+}
+
+func (r *RegisteredDataStore) GetPipelineTargetRefs(policy ResourceID) []TargetRef {
+	r.pipelineMutex.RLock()
+	defer r.pipelineMutex.RUnlock()
+
+	refs := r.pipelineTargetRefs[policy]
+	if refs == nil {
+		return nil
+	}
+	dst := make([]TargetRef, len(refs))
+	copy(dst, refs)
+	return dst
 }
 
 // GetPoliciesWithPipelineActions returns the set of policy IDs that have any
@@ -802,6 +869,43 @@ func (r *RegisteredDataStore) GetPoliciesWithPipelineActions() []ResourceID {
 		result = append(result, id)
 	}
 	return result
+}
+
+// GetPoliciesWithPipelineActionsForTargetRefs returns the set of policy IDs
+// that have pipeline actions AND whose stored target refs overlap with the
+// given target references.
+func (r *RegisteredDataStore) GetPoliciesWithPipelineActionsForTargetRefs(targetRefs []machinery.PolicyTargetReference) []ResourceID {
+	r.pipelineMutex.RLock()
+	defer r.pipelineMutex.RUnlock()
+
+	seen := make(map[ResourceID]bool)
+	for key, actions := range r.pipelineActions {
+		if len(actions) == 0 || seen[key.Policy] {
+			continue
+		}
+		storedRefs := r.pipelineTargetRefs[key.Policy]
+		if pipelineTargetRefsMatch(storedRefs, targetRefs) {
+			seen[key.Policy] = true
+		}
+	}
+	result := make([]ResourceID, 0, len(seen))
+	for id := range seen {
+		result = append(result, id)
+	}
+	return result
+}
+
+func pipelineTargetRefsMatch(storedRefs []TargetRef, targetRefs []machinery.PolicyTargetReference) bool {
+	for _, stored := range storedRefs {
+		for _, tr := range targetRefs {
+			if stored.Kind == tr.GroupVersionKind().Kind &&
+				stored.Name == tr.GetName() &&
+				stored.Namespace == tr.GetNamespace() {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (r *RegisteredDataStore) ClearPolicyData(policy ResourceID) (clearedMutators int, clearedSubscriptions int, clearedUpstreams int) {
@@ -865,12 +969,13 @@ func (r *RegisteredDataStore) ClearPolicyData(policy ResourceID) (clearedMutator
 		}
 	}
 
-	// clear pipeline actions (lock already held)
+	// clear pipeline actions and target refs (lock already held)
 	for _, phase := range []PipelinePhase{PipelinePhaseRequest, PipelinePhaseResponse} {
 		key := pipelineKey{Policy: policy, Phase: phase}
 		delete(r.pipelineActions, key)
 		delete(r.pipelineCounters, key)
 	}
+	delete(r.pipelineTargetRefs, policy)
 
 	return clearedMutators, clearedSubscriptions, clearedUpstreams
 }
@@ -1001,8 +1106,9 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 		wasmConfig.DescriptorService = "kuadrant-operator-grpc"
 	}
 
-	// Translate pipeline actions into TypedAction entries (deterministic order across policies)
-	policyIDs := lo.Uniq(append(lo.Keys(methodServiceKeys), m.store.GetPoliciesWithPipelineActions()...))
+	// Translate pipeline actions into TypedAction entries (deterministic order across policies).
+	// Only include pipeline policies whose stored target refs match this gateway's routes.
+	policyIDs := lo.Uniq(append(lo.Keys(methodServiceKeys), m.store.GetPoliciesWithPipelineActionsForTargetRefs(targetRefs)...))
 	sort.Slice(policyIDs, func(i, j int) bool {
 		if policyIDs[i].Kind != policyIDs[j].Kind {
 			return policyIDs[i].Kind < policyIDs[j].Kind
@@ -1016,14 +1122,29 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 	// Build upstream lookup: policy+method → RegisteredUpstreamEntry (for MessageTemplate)
 	// Also build policy → route locator mapping for action set filtering.
 	upstreamByMethod := make(map[ResourceID]map[string]RegisteredUpstreamEntry)
-	policyRouteLocator := make(map[ResourceID]string)
+	policyRouteLocators := make(map[ResourceID][]string)
 	for key, entry := range relevantUpstreamKeys {
 		if upstreamByMethod[key.Policy] == nil {
 			upstreamByMethod[key.Policy] = make(map[string]RegisteredUpstreamEntry)
 		}
 		upstreamByMethod[key.Policy][key.Name] = entry
 		if entry.TargetRef.Kind == "HTTPRoute" || entry.TargetRef.Kind == "GRPCRoute" {
-			policyRouteLocator[key.Policy] = fmt.Sprintf("%s/%s/%s", entry.TargetRef.Kind, entry.TargetRef.Namespace, entry.TargetRef.Name)
+			locator := fmt.Sprintf("%s/%s/%s", entry.TargetRef.Kind, entry.TargetRef.Namespace, entry.TargetRef.Name)
+			policyRouteLocators[key.Policy] = append(policyRouteLocators[key.Policy], locator)
+		}
+	}
+
+	// For pipeline-only policies (no upstreams), populate policyRouteLocators
+	// from stored pipeline target refs so they get the same route scoping.
+	for _, policyID := range policyIDs {
+		if _, hasUpstream := policyRouteLocators[policyID]; hasUpstream {
+			continue
+		}
+		for _, tr := range m.store.GetPipelineTargetRefs(policyID) {
+			if tr.Kind == "HTTPRoute" || tr.Kind == "GRPCRoute" {
+				locator := fmt.Sprintf("%s/%s/%s", tr.Kind, tr.Namespace, tr.Name)
+				policyRouteLocators[policyID] = append(policyRouteLocators[policyID], locator)
+			}
 		}
 	}
 
@@ -1043,10 +1164,10 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 			continue
 		}
 
-		routeLocator := policyRouteLocator[policyID]
+		routeLocators := policyRouteLocators[policyID]
 		for i := range wasmConfig.ActionSets {
 			asRoute := wasmConfig.ActionSets[i].SourceRoute
-			if routeLocator != "" && asRoute != "" && asRoute != routeLocator {
+			if len(routeLocators) > 0 && asRoute != "" && !slices.Contains(routeLocators, asRoute) {
 				continue
 			}
 			wasmConfig.ActionSets[i].TypedActions = append(wasmConfig.ActionSets[i].TypedActions, typedActions...)

--- a/internal/extension/registry_test.go
+++ b/internal/extension/registry_test.go
@@ -2757,10 +2757,12 @@ func TestApplyWasmConfigMutators_RouteTargetedExtensionWithBuiltinActionSets(t *
 func TestMutateWasmConfig_DenyOnlyPipelineProducesRootAction(t *testing.T) {
 	store := NewRegisteredDataStore()
 	policyID := testResourceID("DenyPolicy", "default", "deny-only")
+	routeRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "HTTPRoute", Name: "test-route", Namespace: "test-namespace"}
 
 	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
 		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: `request.url_path == "/admin"`, WithStatus: 403},
 	})
+	store.SetPipelineTargetRefs(policyID, []TargetRef{routeRef})
 
 	wasmConfig := wasm.Config{
 		ActionSets: []wasm.ActionSet{{
@@ -2771,8 +2773,9 @@ func TestMutateWasmConfig_DenyOnlyPipelineProducesRootAction(t *testing.T) {
 		}},
 	}
 
+	mockTargetRef := createMockHTTPRouteTargetRef()
 	mutator := NewRegisteredDataMutator[*wasm.Config](store)
-	err := mutator.Mutate(&wasmConfig, nil)
+	err := mutator.Mutate(&wasmConfig, []machinery.PolicyTargetReference{mockTargetRef})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -2792,5 +2795,217 @@ func TestMutateWasmConfig_DenyOnlyPipelineProducesRootAction(t *testing.T) {
 	}
 	if !ta.Terminal {
 		t.Error("Expected deny action to be terminal")
+	}
+}
+
+func TestMutateWasmConfig_CrossGatewayIsolation(t *testing.T) {
+	store := NewRegisteredDataStore()
+	policyID := testResourceID("ThreatPolicy", "test-ns", "my-threat")
+	routeRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "HTTPRoute", Name: "route-a", Namespace: "test-ns"}
+
+	store.SetUpstream(
+		RegisteredUpstreamKey{Policy: policyID, Name: "assess", URL: "grpc://svc:8081", Service: "threat.Service", Method: "Check"},
+		RegisteredUpstreamEntry{ClusterName: "ext-svc-8081", Host: "svc", Port: 8081, TargetRef: routeRef, FailureMode: "deny", Timeout: "100ms", Service: "threat.Service", Method: "Check"},
+		testFileDescriptorSet(),
+	)
+	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
+		{ActionType: extpb.ActionType_ACTION_TYPE_GRPC_METHOD, Method: "assess"},
+	})
+	store.SetPipelineTargetRefs(policyID, []TargetRef{routeRef})
+
+	savedRegistry := *GlobalMutatorRegistry
+	defer func() { *GlobalMutatorRegistry = savedRegistry }()
+	*GlobalMutatorRegistry = MutatorRegistry{}
+	GlobalMutatorRegistry.RegisterWasmConfigMutator(NewRegisteredDataMutator[*wasm.Config](store))
+
+	gwA := BuildGateway(func(g *gwapiv1.Gateway) { g.Name = "gw-a"; g.Namespace = "test-ns" })
+	routeA := BuildHTTPRoute(func(r *gwapiv1.HTTPRoute) {
+		r.Name = "route-a"
+		r.Namespace = "test-ns"
+		r.Spec.ParentRefs = []gwapiv1.ParentReference{{Name: "gw-a"}}
+		r.Spec.Hostnames = []gwapiv1.Hostname{"a.example.com"}
+		r.Spec.Rules = []gwapiv1.HTTPRouteRule{{Matches: []gwapiv1.HTTPRouteMatch{{
+			Path: &gwapiv1.HTTPPathMatch{Type: ptr.To(gwapiv1.PathMatchPathPrefix), Value: ptr.To("/")},
+		}}}}
+	})
+
+	gwB := BuildGateway(func(g *gwapiv1.Gateway) { g.Name = "gw-b"; g.Namespace = "test-ns" })
+	routeB := BuildHTTPRoute(func(r *gwapiv1.HTTPRoute) {
+		r.Name = "route-b"
+		r.Namespace = "test-ns"
+		r.Spec.ParentRefs = []gwapiv1.ParentReference{{Name: "gw-b"}}
+		r.Spec.Hostnames = []gwapiv1.Hostname{"b.example.com"}
+		r.Spec.Rules = []gwapiv1.HTTPRouteRule{{Matches: []gwapiv1.HTTPRouteMatch{{
+			Path: &gwapiv1.HTTPPathMatch{Type: ptr.To(gwapiv1.PathMatchPathPrefix), Value: ptr.To("/")},
+		}}}}
+	})
+
+	topology := testTopology(t, []*gwapiv1.Gateway{gwA, gwB}, []*gwapiv1.HTTPRoute{routeA, routeB}, nil)
+	gatewayA := findGatewayInTopology(t, topology, "gw-a")
+	gatewayB := findGatewayInTopology(t, topology, "gw-b")
+
+	configA := wasm.Config{}
+	if err := ApplyWasmConfigMutators(&configA, gatewayA, topology); err != nil {
+		t.Fatalf("Unexpected error for gw-a: %v", err)
+	}
+	if len(configA.ActionSets) != 1 {
+		t.Fatalf("gw-a: expected 1 actionset, got %d", len(configA.ActionSets))
+	}
+	if len(configA.ActionSets[0].TypedActions) == 0 {
+		t.Fatal("gw-a: expected typed actions on route-a's action set")
+	}
+
+	configB := wasm.Config{}
+	if err := ApplyWasmConfigMutators(&configB, gatewayB, topology); err != nil {
+		t.Fatalf("Unexpected error for gw-b: %v", err)
+	}
+	if len(configB.ActionSets) != 0 {
+		t.Fatalf("gw-b: expected 0 actionsets (no policies target this gateway), got %d", len(configB.ActionSets))
+	}
+}
+
+func TestMutateWasmConfig_PipelineOnlyRouteIsolation(t *testing.T) {
+	store := NewRegisteredDataStore()
+	policyID := testResourceID("DenyPolicy", "test-ns", "deny-route-a")
+	routeRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "HTTPRoute", Name: "route-a", Namespace: "test-ns"}
+
+	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "true", WithStatus: 403},
+	})
+	store.SetPipelineTargetRefs(policyID, []TargetRef{routeRef})
+
+	mutator := NewRegisteredDataMutator[*wasm.Config](store)
+	routeTargetRef := policyTargetRef("HTTPRoute", "route-a", "test-ns")
+	otherRouteRef := policyTargetRef("HTTPRoute", "route-b", "test-ns")
+	targetRefs := []machinery.PolicyTargetReference{routeTargetRef, otherRouteRef}
+
+	wasmConfig := &wasm.Config{
+		ActionSets: []wasm.ActionSet{
+			{Name: "set-a", SourceRoute: "HTTPRoute/test-ns/route-a"},
+			{Name: "set-b", SourceRoute: "HTTPRoute/test-ns/route-b"},
+		},
+	}
+
+	if err := mutator.Mutate(wasmConfig, targetRefs); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(wasmConfig.ActionSets[0].TypedActions) != 1 {
+		t.Fatalf("route-a: expected 1 typed action, got %d", len(wasmConfig.ActionSets[0].TypedActions))
+	}
+	if wasmConfig.ActionSets[0].TypedActions[0].Type != "deny" {
+		t.Errorf("route-a: expected deny action, got %s", wasmConfig.ActionSets[0].TypedActions[0].Type)
+	}
+
+	if len(wasmConfig.ActionSets[1].TypedActions) != 0 {
+		t.Fatalf("route-b: expected 0 typed actions (policy doesn't target this route), got %d", len(wasmConfig.ActionSets[1].TypedActions))
+	}
+}
+
+func TestApplyWasmConfigMutators_SkeletonCreatedForExtensionOnlyRoute(t *testing.T) {
+	store := NewRegisteredDataStore()
+	policyID := testResourceID("DenyPolicy", "test-ns", "deny-route-b")
+	routeRef := TargetRef{Group: "gateway.networking.k8s.io", Kind: "HTTPRoute", Name: "route-b", Namespace: "test-ns"}
+
+	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "true", WithStatus: 403},
+	})
+	store.SetPipelineTargetRefs(policyID, []TargetRef{routeRef})
+
+	savedRegistry := *GlobalMutatorRegistry
+	defer func() { *GlobalMutatorRegistry = savedRegistry }()
+	*GlobalMutatorRegistry = MutatorRegistry{}
+	GlobalMutatorRegistry.RegisterWasmConfigMutator(NewRegisteredDataMutator[*wasm.Config](store))
+
+	gw := BuildGateway(func(g *gwapiv1.Gateway) { g.Name = "test-gw"; g.Namespace = "test-ns" })
+	routeA := BuildHTTPRoute(func(r *gwapiv1.HTTPRoute) {
+		r.Name = "route-a"
+		r.Namespace = "test-ns"
+		r.Spec.ParentRefs = []gwapiv1.ParentReference{{Name: "test-gw"}}
+		r.Spec.Hostnames = []gwapiv1.Hostname{"a.example.com"}
+		r.Spec.Rules = []gwapiv1.HTTPRouteRule{{Matches: []gwapiv1.HTTPRouteMatch{{
+			Path: &gwapiv1.HTTPPathMatch{Type: ptr.To(gwapiv1.PathMatchPathPrefix), Value: ptr.To("/")},
+		}}}}
+	})
+	routeB := BuildHTTPRoute(func(r *gwapiv1.HTTPRoute) {
+		r.Name = "route-b"
+		r.Namespace = "test-ns"
+		r.Spec.ParentRefs = []gwapiv1.ParentReference{{Name: "test-gw"}}
+		r.Spec.Hostnames = []gwapiv1.Hostname{"b.example.com"}
+		r.Spec.Rules = []gwapiv1.HTTPRouteRule{{Matches: []gwapiv1.HTTPRouteMatch{{
+			Path: &gwapiv1.HTTPPathMatch{Type: ptr.To(gwapiv1.PathMatchPathPrefix), Value: ptr.To("/")},
+		}}}}
+	})
+
+	topology := testTopology(t, []*gwapiv1.Gateway{gw}, []*gwapiv1.HTTPRoute{routeA, routeB}, nil)
+	gateway := findGatewayInTopology(t, topology, "test-gw")
+
+	// Simulate route-a having a built-in policy action set, route-b has none
+	wasmConfig := wasm.Config{
+		ActionSets: []wasm.ActionSet{
+			{
+				Name:                "builtin-a",
+				SourceRoute:         "HTTPRoute/test-ns/route-a",
+				RouteRuleConditions: wasm.RouteRuleConditions{Hostnames: []string{"a.example.com"}},
+				Actions:             []wasm.Action{{ServiceName: "ratelimit-service"}},
+			},
+		},
+	}
+
+	if err := ApplyWasmConfigMutators(&wasmConfig, gateway, topology); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(wasmConfig.ActionSets) != 2 {
+		t.Fatalf("Expected 2 actionsets (builtin for route-a + skeleton for route-b), got %d", len(wasmConfig.ActionSets))
+	}
+
+	// route-a's action set should be untouched
+	if wasmConfig.ActionSets[0].SourceRoute != "HTTPRoute/test-ns/route-a" {
+		t.Errorf("Expected route-a action set first, got %s", wasmConfig.ActionSets[0].SourceRoute)
+	}
+	if len(wasmConfig.ActionSets[0].TypedActions) != 0 {
+		t.Errorf("route-a: expected 0 typed actions (deny targets route-b only), got %d", len(wasmConfig.ActionSets[0].TypedActions))
+	}
+
+	// route-b should have a skeleton with the deny action
+	if wasmConfig.ActionSets[1].SourceRoute != "HTTPRoute/test-ns/route-b" {
+		t.Errorf("Expected route-b action set second, got %s", wasmConfig.ActionSets[1].SourceRoute)
+	}
+	if len(wasmConfig.ActionSets[1].TypedActions) != 1 {
+		t.Fatalf("route-b: expected 1 typed action (deny), got %d", len(wasmConfig.ActionSets[1].TypedActions))
+	}
+	if wasmConfig.ActionSets[1].TypedActions[0].Type != "deny" {
+		t.Errorf("route-b: expected deny action, got %s", wasmConfig.ActionSets[1].TypedActions[0].Type)
+	}
+}
+
+func TestPipelineTargetRefCleanup(t *testing.T) {
+	store := NewRegisteredDataStore()
+	policyID := testResourceID("ThreatPolicy", "default", "my-policy")
+	refs := []TargetRef{{Kind: "HTTPRoute", Name: "route-a", Namespace: "default"}}
+
+	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "true", WithStatus: 403},
+	})
+	store.SetPipelineTargetRefs(policyID, refs)
+
+	if got := store.GetPipelineTargetRefs(policyID); len(got) != 1 {
+		t.Fatalf("Expected 1 target ref, got %d", len(got))
+	}
+
+	store.ClearPipelineActions(policyID)
+	if got := store.GetPipelineTargetRefs(policyID); got != nil {
+		t.Fatalf("Expected nil target refs after ClearPipelineActions, got %v", got)
+	}
+
+	// Verify ClearPolicyData also cleans up
+	store.AppendPipelineActions(policyID, PipelinePhaseRequest, []PipelineActionEntry{
+		{ActionType: extpb.ActionType_ACTION_TYPE_DENY, Predicate: "true", WithStatus: 403},
+	})
+	store.SetPipelineTargetRefs(policyID, refs)
+	store.ClearPolicyData(policyID)
+	if got := store.GetPipelineTargetRefs(policyID); got != nil {
+		t.Fatalf("Expected nil target refs after ClearPolicyData, got %v", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Extension pipeline actions were leaking across gateways and routes because target ref information was discarded during storage. This caused 503 errors when leaked gRPC actions referenced services not configured on unrelated gateways, and caused actions to disappear from routes that only had extension policies.
- Stores pipeline target refs alongside pipeline actions and uses them for filtering during wasm config generation. Pipeline-only policies now get proper route scoping, skeleton action sets are created for extension-only routes, and cross-gateway filtering prevents actions from leaking.

Closes #2023

## Changes

- **`internal/extension/registry.go`**: Added `pipelineTargetRefs` storage with `SetPipelineTargetRefs`/`GetPipelineTargetRefs` methods; added `GetPoliciesWithPipelineActionsForTargetRefs` for gateway-scoped filtering; fixed `mutateWasmConfig` to populate `policyRouteLocator` from stored target refs for pipeline-only policies and filter by gateway; fixed `hasRelevantPipelineActions` to use scoped filtering; added `routesNeedingSkeletons` for targeted skeleton action set creation
- **`internal/extension/manager.go`**: Captures target refs from `PipelineCommitRequest` at commit time
- **`internal/extension/registry_test.go`**: Added tests for cross-gateway isolation, same-gateway route isolation, skeleton creation for extension-only routes, and target ref cleanup
- **`cmd/extensions/threat-policy/main.go`**: Added Gateway API scheme registration

## Test plan

- [x] Unit tests for cross-gateway isolation (policy on gw-a's route produces 0 action sets for gw-b)
- [x] Unit tests for same-gateway route isolation (pipeline-only policy on route-a produces no typed actions on route-b)
- [x] Unit tests for skeleton creation with mixed policies (core policy on route-a, extension-only on route-b)
- [x] Unit tests for target ref cleanup in ClearPipelineActions and ClearPolicyData
- [x] All 168 existing unit tests pass
- [ ] Manual verification: route-a gets ThreatPolicy headers, route-b does not (same-gateway)
- [ ] Manual verification: second gateway's route returns 200 with no threat headers (cross-gateway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline policies now validate and persist target references, erroring on missing or nil targets.
  * Improved isolation so pipeline policies apply only to intended gateways/routes.
  * Tightened pipeline targeting to avoid unintended policy application.
  * Skeleton action sets are created only where needed, leaving existing routes untouched.
  * Pipeline target refs are cleaned up when policies or actions are removed.

* **Tests**
  * Added tests for cross‑gateway isolation, route‑specific pipeline behaviour, skeleton creation and cleanup.

* **Chores**
  * Updated platform type registrations for runtime compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->