### PR TITLE
developer portal cluster roles

### DIFF
--- a/bundle/manifests/kuadrant-operator-api-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kuadrant-operator-api-admin_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,85 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+  name: kuadrant-operator-api-admin
+rules:
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apiproducts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeyapprovals
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeyrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeys
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - extensions.kuadrant.io
+  resources:
+  - planpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - authpolicies
+  - ratelimitpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/kuadrant-operator-api-catalog-browser_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kuadrant-operator-api-catalog-browser_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+  name: kuadrant-operator-api-catalog-browser
+rules:
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apiproducts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.kuadrant.io
+  resources:
+  - planpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - authpolicies
+  - ratelimitpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch

--- a/bundle/manifests/kuadrant-operator-api-consumer_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kuadrant-operator-api-consumer_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+  name: kuadrant-operator-api-consumer
+rules:
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeys
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete

--- a/bundle/manifests/kuadrant-operator-api-owner_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kuadrant-operator-api-owner_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,73 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: kuadrant
+  name: kuadrant-operator-api-owner
+rules:
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apiproducts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeyapprovals
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeyrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.kuadrant.io
+  resources:
+  - planpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - authpolicies
+  - ratelimitpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14001,6 +14001,241 @@ metadata:
   labels:
     app: kuadrant
     app.kubernetes.io/managed-by: helm
+  name: kuadrant-operator-api-admin
+rules:
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apiproducts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeyapprovals
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeyrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeys
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - extensions.kuadrant.io
+  resources:
+  - planpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - authpolicies
+  - ratelimitpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kuadrant
+    app.kubernetes.io/managed-by: helm
+  name: kuadrant-operator-api-catalog-browser
+rules:
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apiproducts
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.kuadrant.io
+  resources:
+  - planpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - authpolicies
+  - ratelimitpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kuadrant
+    app.kubernetes.io/managed-by: helm
+  name: kuadrant-operator-api-consumer
+rules:
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeys
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kuadrant
+    app.kubernetes.io/managed-by: helm
+  name: kuadrant-operator-api-owner
+rules:
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apiproducts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeyapprovals
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - devportal.kuadrant.io
+  resources:
+  - apikeyrequests
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.kuadrant.io
+  resources:
+  - planpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - authpolicies
+  - ratelimitpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - httproutes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: kuadrant
+    app.kubernetes.io/managed-by: helm
   name: kuadrant-operator-manager-role
 rules:
 - apiGroups:

--- a/config/rbac/api_admin_clusterrole.yaml
+++ b/config/rbac/api_admin_clusterrole.yaml
@@ -1,0 +1,76 @@
+# API Admin ClusterRole
+# Provides platform operators cluster-wide access for management and troubleshooting
+#
+# Usage:
+#   kubectl apply -f api-admin-clusterrole.yaml
+#
+#   Bind to admin users (ClusterRoleBinding grants cluster-wide access):
+#   kubectl create clusterrolebinding api-admin-alice \
+#     --clusterrole=api-admin \
+#     --user=alice
+#
+#   Bind to admin group:
+#   kubectl create clusterrolebinding api-admin-platform-team \
+#     --clusterrole=api-admin \
+#     --group=platform-team
+#
+# Binding strategy: ClusterRoleBinding for platform administrators (cluster-wide scope)
+#
+# Key characteristics:
+#   - Same core permissions as "api-owner" but bound cluster-wide
+#   - Additional APIKey write access for troubleshooting
+#   - Intentional limitation: No secret read permissions in consumer namespaces (consumer secrets remain isolated)
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: api-admin
+rules:
+  # Manage API products cluster-wide (same as api-owner, but cluster-wide via ClusterRoleBinding)
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: ["apiproducts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Manage API key approvals cluster-wide (same as api-owner, but cluster-wide via ClusterRoleBinding)
+  # Allows admins to approve/reject on behalf of owners in any namespace
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: ["apikeyapprovals"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # View API key requests cluster-wide (same as api-owner, but cluster-wide via ClusterRoleBinding)
+  # Allows admins to see all APIKeyRequest shadow resources across all namespaces
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: ["apikeyrequests"]
+    verbs: ["get", "list", "watch"]
+
+  # Additional troubleshooting permission: Full access to API keys cluster-wide
+  # Unlike api-owner (no apikeys access), admins can create/update/delete APIKeys for troubleshooting
+  # Admins are trusted platform operators who may need to troubleshoot consumer API key issues
+  # NOTE: Admins still do NOT have secret read permissions in consumer namespaces (consumer secrets remain isolated)
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: ["apikeys"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # NOTE: Secrets are managed by consumers in their own namespace and by controller in kuadrant namespace
+  # Admins do NOT have secret read permissions in consumer namespaces (consumer secrets remain isolated)
+  # Admins can view APIKey resources but cannot access consumer secrets containing API key values
+
+  # View rate limiting plans cluster-wide (same as api-owner)
+  - apiGroups: ["extensions.kuadrant.io"]
+    resources: ["planpolicies"]
+    verbs: ["get", "list", "watch"]
+
+  # View policies cluster-wide (same as api-owner)
+  - apiGroups: ["kuadrant.io"]
+    resources: ["authpolicies", "ratelimitpolicies"]
+    verbs: ["get", "list", "watch"]
+
+  # View HTTPRoutes cluster-wide (same as api-owner)
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch"]
+
+  # View Gateways cluster-wide (same as api-owner)
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]
+    verbs: ["get", "list", "watch"]

--- a/config/rbac/api_catalog_browser_clusterrole.yaml
+++ b/config/rbac/api_catalog_browser_clusterrole.yaml
@@ -1,0 +1,37 @@
+# API Catalog Browser ClusterRole
+# Provides cluster-wide read access to API catalog resources for discovery
+#
+# Usage:
+#   kubectl apply -f api-catalog-browser-clusterrole.yaml
+#
+#   Bind to users or groups cluster-wide using ClusterRoleBinding:
+#   kubectl create clusterrolebinding api-catalog-browser-consumers \
+#     --clusterrole=api-catalog-browser \
+#     --group=mobile-developers
+#
+# Binding strategy: ClusterRoleBinding for API Consumers and Admins (cluster-wide catalog discovery)
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: api-catalog-browser
+rules:
+  # Browse all API products for discovery (cluster-wide read-only)
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: ["apiproducts"]
+    verbs: ["get", "list", "watch"]
+
+  # View rate limiting plans cluster-wide (to understand available tiers)
+  - apiGroups: ["extensions.kuadrant.io"]
+    resources: ["planpolicies"]
+    verbs: ["get", "list", "watch"]
+
+  # View policies cluster-wide (read-only, to understand API requirements)
+  - apiGroups: ["kuadrant.io"]
+    resources: ["authpolicies", "ratelimitpolicies"]
+    verbs: ["get", "list", "watch"]
+
+  # View HTTPRoutes and Gateways cluster-wide (to understand API endpoints)
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes", "gateways"]
+    verbs: ["get", "list", "watch"]

--- a/config/rbac/api_consumer_clusterrole.yaml
+++ b/config/rbac/api_consumer_clusterrole.yaml
@@ -1,0 +1,45 @@
+# API Consumer ClusterRole
+# Enables developers to create and manage API access requests in their own namespace
+#
+# Usage:
+#   kubectl apply -f api-consumer-clusterrole.yaml
+#
+#   Bind to users or groups in their namespace using RoleBinding:
+#   kubectl create rolebinding api-consumer-binding \
+#     --clusterrole=api-consumer \
+#     --user=<username> \
+#     -n <consumer-namespace>
+#
+#   For catalog browsing, also create a ClusterRoleBinding for api-catalog-browser:
+#   kubectl create clusterrolebinding api-catalog-browser-consumers \
+#     --clusterrole=api-catalog-browser \
+#     --group=<consumer-group>
+#
+# Binding strategy: RoleBinding per consumer namespace (namespace-scoped APIKey and Secret management)
+#
+# Key characteristics:
+#   - Consumers create secrets containing API keys before creating APIKey resources
+#   - Cross-namespace APIProduct references allowed via spec.apiProductRef.namespace
+#   - Strict RBAC enforcement: consumers can only access their own namespace's resources
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: api-consumer
+rules:
+  # Create and manage API keys in consumer's own namespace (namespace-scoped via RoleBinding)
+  # Consumers can create, update, patch, and delete their own APIKeys
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: ["apikeys"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Manage secrets in consumer's own namespace (namespace-scoped via RoleBinding)
+  # Consumer creates secret with API key before creating APIKey (spec.secretRef references this secret)
+  # On approval, controller creates enforcement secret in kuadrant namespace (consumer cannot access)
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+
+  # NOTE: Catalog browsing permissions are in the separate api-catalog-browser ClusterRole
+  # NOTE: Consumers do NOT have apikeyapprovals permissions (architectural principle)
+  # Only API owners can approve/reject requests

--- a/config/rbac/api_owner_clusterrole.yaml
+++ b/config/rbac/api_owner_clusterrole.yaml
@@ -1,0 +1,69 @@
+# API Owner ClusterRole
+# Allows teams to publish APIs and manage consumer access requests
+#
+# Usage:
+#   kubectl apply -f api-owner-clusterrole.yaml
+#
+#   Bind to team users or groups in their namespace using RoleBinding:
+#   kubectl create rolebinding api-owner-binding \
+#     --clusterrole=api-owner \
+#     --group=team-payment-services \
+#     -n payment-services
+#
+# Binding strategy: RoleBinding per owner namespace (namespace-scoped API management)
+#
+# Key architectural features:
+#   - Owners discover requests via "APIKeyRequest" shadow resources (not direct APIKey access)
+#   - No secret read permissions in consumer namespaces (API key values protected)
+#   - Approval enforcement via "APIKeyApproval" CRD in owner's namespace
+#   - Namespace-scoped catalog browsing (only see resources in assigned namespace)
+#
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: api-owner
+rules:
+  # Manage API products (namespace-scoped via RoleBinding)
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: ["apiproducts"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Approve/reject API key requests via APIKeyApproval resource (namespace-scoped via RoleBinding)
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: ["apikeyapprovals"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  # Discover API key requests via APIKeyRequest shadow resources (namespace-scoped via RoleBinding)
+  # Controller automatically creates APIKeyRequest in owner's namespace when consumer creates APIKey
+  # APIKeyRequest does NOT contain apiKeyValue (security isolation)
+  # Namespace boundaries ensure owners only see requests for their API products
+  - apiGroups: ["devportal.kuadrant.io"]
+    resources: ["apikeyrequests"]
+    verbs: ["get", "list", "watch"]
+
+  # NOTE: Owners do NOT have access to apikeys resources (consumers own these)
+  # Owners discover requests via apikeyrequests in their own namespace only
+
+  # View rate limiting plans cluster-wide (reference when creating products)
+  - apiGroups: ["extensions.kuadrant.io"]
+    resources: ["planpolicies"]
+    verbs: ["get", "list", "watch"]
+
+  # View policies cluster-wide (read-only, to understand API requirements)
+  - apiGroups: ["kuadrant.io"]
+    resources: ["authpolicies", "ratelimitpolicies"]
+    verbs: ["get", "list", "watch"]
+
+  # View HTTPRoutes cluster-wide (for discovery and referencing in APIProducts)
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list", "watch"]
+
+  # View Gateways cluster-wide (for context)
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways"]
+    verbs: ["get", "list", "watch"]
+
+  # NOTE: Secrets are managed by consumers in their own namespace and by controller in kuadrant namespace
+  # Owners do NOT have secret read permissions in consumer namespaces (consumer secrets remain isolated)
+  # Owners do not have access to consumer APIKey resources or consumer secrets

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,11 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+# DevPortal ClusterRoles for API management
+- api_admin_clusterrole.yaml
+- api_owner_clusterrole.yaml
+- api_consumer_clusterrole.yaml
+- api_catalog_browser_clusterrole.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.


### PR DESCRIPTION
Closes https://github.com/Kuadrant/kuadrant-operator/issues/1870

> In the future, the source of truth for these roles could live in the developer portal controller repo

### Verification steps:
- Create bundle image from this branch [guide](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/overviews/development.md#build-kuadrant-operator-bundle-image)
- Create custom catalog image from this branch [guide](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/overviews/development.md#build-custom-olm-catalog)
- Deploy kuadrant operator using OLM from the custom catalog [guide](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/overviews/development.md#deploy-kuadrant-operator-using-olm)
- Verify ClusterRoles Exist in the Cluster
```
kubectl get clusterrole | grep kuadrant-operator-api-
```
Expected output

```
kuadrant-operator-api-admin
kuadrant-operator-api-catalog-browser
kuadrant-operator-api-consumer
kuadrant-operator-api-owner
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced four new role-based access control roles for API management: API Admin (full management permissions), API Catalog Browser (read-only catalogue access), API Consumer (personal API key management), and API Owner (product management with approval controls).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->