### PR TITLE
[Release] Kuadrant Operator v1.5.0-rc2

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -224,14 +224,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc1
-    createdAt: "2026-05-29T12:45:48Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc2
+    createdAt: "2026-06-02T08:04:09Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.5.0-rc1
+  name: kuadrant-operator.v1.5.0-rc2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -763,7 +763,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc1
+                image: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -922,4 +922,4 @@ spec:
     name: console-plugin-latest
   - image: quay.io/kuadrant/console-plugin:v0.1.5-2
     name: console-plugin-pf5
-  version: 1.5.0-rc1
+  version: 1.5.0-rc2

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -6,7 +6,7 @@ dependencies:
   - type: olm.package
     value:
       packageName: limitador-operator
-      version: "0.18.1"
+      version: "0.18.2"
   - type: olm.package
     value:
       packageName: dns-operator

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,14 +20,14 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.5.0-rc1"
-appVersion: "1.5.0-rc1"
+version: "1.5.0-rc2"
+appVersion: "1.5.0-rc2"
 dependencies:
   - name: authorino-operator
     version: 0.25.0
     repository: https://kuadrant.io/helm-charts/
   - name: limitador-operator
-    version: 0.18.1
+    version: 0.18.2
     repository: https://kuadrant.io/helm-charts/
   - name: dns-operator
     version: 0.17.0

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14498,7 +14498,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc1
+        image: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/dependencies/limitador/kustomization.yaml
+++ b/config/dependencies/limitador/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-- github.com/Kuadrant/limitador-operator/config/default?ref=v0.18.1
+- github.com/Kuadrant/limitador-operator/config/default?ref=v0.18.2

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.5.0-rc1
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.5.0-rc2
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,4 +12,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.5.0-rc1
+  newTag: v1.5.0-rc2

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc1
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc2
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.5.0-rc1
+  name: kuadrant-operator.v1.5.0-rc2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,4 +88,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.5.0-rc1
+  version: 1.5.0-rc2

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.5.0-rc1"
+  version: "1.5.0-rc2"
 olm:
   channels:
     - "stable"
@@ -9,5 +9,5 @@ dependencies:
   console-plugin: "0.4.0"
   developer-portal-controller: "0.2.0"
   dns-operator: "0.17.0"
-  limitador-operator: "0.18.1"
+  limitador-operator: "0.18.2"
   wasm-shim: "0.13.0"


### PR DESCRIPTION
## Summary

Bumps limitador-operator to v0.18.2 which pins limitador v2.4.1, fixing the Cargo.lock version mismatch from v2.4.0 that caused downstream build failures.

## Changes from rc1

Only limitador-operator version changed:
- `limitador-operator: 0.18.1` → `0.18.2`
- limitador-operator v0.18.2 pins limitador v2.4.1 (Cargo.lock fix)

All other component versions unchanged from rc1.