### PR TITLE
feat: add benchmark and performance tests for data plane policy reconciliation

### DIFF
--- a/internal/controller/reconciliation_bench_test.go
+++ b/internal/controller/reconciliation_bench_test.go
@@ -1,0 +1,483 @@
+//go:build unit
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	kuadrantv1alpha1 "github.com/kuadrant/kuadrant-operator/api/v1alpha1"
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+)
+
+type topologyParams struct {
+	numGateways          int
+	listenersPerGateway  int
+	numRoutes            int
+}
+
+func (p topologyParams) label() string {
+	return fmt.Sprintf("gw=%d_listen=%d_routes=%d", p.numGateways, p.listenersPerGateway, p.numRoutes)
+}
+
+// buildScaleTopology constructs a realistic Kuadrant topology at a given scale:
+//   - 1 Kuadrant CR, 1 GatewayClass
+//   - G Gateways, each with L Listeners
+//   - N HTTPRoutes (each with 1 rule, 1 AuthPolicy attached)
+//
+// Routes are distributed evenly across gateways. Each route references
+// its parent gateway by name (not a specific listener section), which
+// means the Gateway API topology expands the route to all listeners —
+// creating the fan-out that multiplies DFS paths.
+func buildScaleTopology(b testing.TB, params topologyParams) (*machinery.Topology, *kuadrantv1beta1.Kuadrant) {
+	b.Helper()
+
+	const (
+		namespace        = "default"
+		gatewayClassName = "kuadrant-gateway-class"
+	)
+
+	kuadrant := &kuadrantv1beta1.Kuadrant{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kuadrantv1beta1.KuadrantGroupKind.Kind,
+			APIVersion: kuadrantv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuadrant",
+			Namespace: namespace,
+			UID:       types.UID("kuadrant-uid"),
+		},
+	}
+
+	gatewayClass := &gatewayapiv1.GatewayClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       machinery.GatewayClassGroupKind.Kind,
+			APIVersion: gatewayapiv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: gatewayClassName,
+			UID:  types.UID("gwclass-uid"),
+		},
+		Spec: gatewayapiv1.GatewayClassSpec{
+			ControllerName: "kuadrant.io/policy-controller",
+		},
+	}
+
+	store := make(controller.Store)
+	store[string(kuadrant.UID)] = kuadrant
+	store[string(gatewayClass.UID)] = gatewayClass
+
+	gateways := make([]*gatewayapiv1.Gateway, params.numGateways)
+	for g := range params.numGateways {
+		gwName := fmt.Sprintf("gateway-%d", g)
+		gwUID := types.UID(fmt.Sprintf("gw-uid-%d", g))
+
+		listeners := make([]gatewayapiv1.Listener, params.listenersPerGateway)
+		for l := range params.listenersPerGateway {
+			listeners[l] = gatewayapiv1.Listener{
+				Name:     gatewayapiv1.SectionName(fmt.Sprintf("listener-%d", l)),
+				Hostname: ptr.To(gatewayapiv1.Hostname(fmt.Sprintf("*.gw%d-l%d.example.com", g, l))),
+			}
+		}
+
+		gateways[g] = &gatewayapiv1.Gateway{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       machinery.GatewayGroupKind.Kind,
+				APIVersion: gatewayapiv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gwName,
+				Namespace: namespace,
+				UID:       gwUID,
+			},
+			Spec: gatewayapiv1.GatewaySpec{
+				GatewayClassName: gatewayClassName,
+				Listeners:        listeners,
+			},
+		}
+		store[string(gwUID)] = gateways[g]
+	}
+
+	httpRoutes := make([]*gatewayapiv1.HTTPRoute, params.numRoutes)
+	allPolicies := make([]machinery.Policy, 0, params.numRoutes*3)
+
+	for i := range params.numRoutes {
+		gwIndex := i % params.numGateways
+		gwName := fmt.Sprintf("gateway-%d", gwIndex)
+		routeName := fmt.Sprintf("route-%d", i)
+		routeUID := types.UID(fmt.Sprintf("route-uid-%d", i))
+
+		httpRoutes[i] = &gatewayapiv1.HTTPRoute{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       machinery.HTTPRouteGroupKind.Kind,
+				APIVersion: gatewayapiv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      routeName,
+				Namespace: namespace,
+				UID:       routeUID,
+			},
+			Spec: gatewayapiv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+					ParentRefs: []gatewayapiv1.ParentReference{
+						{Name: gatewayapiv1.ObjectName(gwName)},
+					},
+				},
+				Hostnames: []gatewayapiv1.Hostname{
+					gatewayapiv1.Hostname(fmt.Sprintf("app-%d.example.com", i)),
+				},
+				Rules: []gatewayapiv1.HTTPRouteRule{
+					{
+						Name: ptr.To(gatewayapiv1.SectionName("rule-0")),
+						Matches: []gatewayapiv1.HTTPRouteMatch{
+							{Path: &gatewayapiv1.HTTPPathMatch{
+								Type:  ptr.To(gatewayapiv1.PathMatchPathPrefix),
+								Value: ptr.To("/"),
+							}},
+						},
+						BackendRefs: []gatewayapiv1.HTTPBackendRef{
+							{BackendRef: gatewayapiv1.BackendRef{
+								BackendObjectReference: gatewayapiv1.BackendObjectReference{
+									Name: "backend",
+								},
+							}},
+						},
+					},
+				},
+			},
+		}
+		store[string(routeUID)] = httpRoutes[i]
+
+		targetRef := gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+			LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+				Group: gatewayapiv1alpha2.Group(machinery.HTTPRouteGroupKind.Group),
+				Kind:  gatewayapiv1alpha2.Kind(machinery.HTTPRouteGroupKind.Kind),
+				Name:  gatewayapiv1alpha2.ObjectName(routeName),
+			},
+		}
+		acceptedCondition := metav1.Condition{
+			Type:   string(gatewayapiv1alpha2.PolicyConditionAccepted),
+			Status: metav1.ConditionTrue,
+		}
+
+		// AuthPolicy
+		authUID := types.UID(fmt.Sprintf("auth-uid-%d", i))
+		authPolicy := &kuadrantv1.AuthPolicy{
+			TypeMeta:   metav1.TypeMeta{Kind: "AuthPolicy", APIVersion: kuadrantv1.GroupVersion.String()},
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("auth-%d", i), Namespace: namespace, UID: authUID},
+			Spec: kuadrantv1.AuthPolicySpec{
+				TargetRef: targetRef,
+				AuthPolicySpecProper: kuadrantv1.AuthPolicySpecProper{
+					AuthScheme: &kuadrantv1.AuthSchemeSpec{
+						Authentication: map[string]kuadrantv1.MergeableAuthenticationSpec{
+							fmt.Sprintf("apikey-%d", i): {},
+						},
+					},
+				},
+			},
+			Status: kuadrantv1.AuthPolicyStatus{Conditions: []metav1.Condition{acceptedCondition}},
+		}
+		store[string(authUID)] = authPolicy
+		allPolicies = append(allPolicies, authPolicy)
+
+		// RateLimitPolicy
+		rlpUID := types.UID(fmt.Sprintf("rlp-uid-%d", i))
+		rlpPolicy := &kuadrantv1.RateLimitPolicy{
+			TypeMeta:   metav1.TypeMeta{Kind: "RateLimitPolicy", APIVersion: kuadrantv1.GroupVersion.String()},
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("rlp-%d", i), Namespace: namespace, UID: rlpUID},
+			Spec: kuadrantv1.RateLimitPolicySpec{
+				TargetRef:                targetRef,
+				RateLimitPolicySpecProper: kuadrantv1.RateLimitPolicySpecProper{},
+			},
+			Status: kuadrantv1.RateLimitPolicyStatus{Conditions: []metav1.Condition{acceptedCondition}},
+		}
+		store[string(rlpUID)] = rlpPolicy
+		allPolicies = append(allPolicies, rlpPolicy)
+
+		// TokenRateLimitPolicy
+		trlpUID := types.UID(fmt.Sprintf("trlp-uid-%d", i))
+		trlpPolicy := &kuadrantv1alpha1.TokenRateLimitPolicy{
+			TypeMeta:   metav1.TypeMeta{Kind: "TokenRateLimitPolicy", APIVersion: kuadrantv1alpha1.GroupVersion.String()},
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("trlp-%d", i), Namespace: namespace, UID: trlpUID},
+			Spec: kuadrantv1alpha1.TokenRateLimitPolicySpec{
+				TargetRef:                     targetRef,
+				TokenRateLimitPolicySpecProper: kuadrantv1alpha1.TokenRateLimitPolicySpecProper{},
+			},
+			Status: kuadrantv1alpha1.TokenRateLimitPolicyStatus{Conditions: []metav1.Condition{acceptedCondition}},
+		}
+		store[string(trlpUID)] = trlpPolicy
+		allPolicies = append(allPolicies, trlpPolicy)
+	}
+
+	topology, err := machinery.NewGatewayAPITopology(
+		machinery.WithGatewayClasses(gatewayClass),
+		machinery.WithGateways(gateways...),
+		machinery.ExpandGatewayListeners(),
+		machinery.WithHTTPRoutes(httpRoutes...),
+		machinery.ExpandHTTPRouteRules(),
+		machinery.WithGatewayAPITopologyPolicies(allPolicies...),
+		machinery.WithGatewayAPITopologyObjects(kuadrant),
+		machinery.WithGatewayAPITopologyLinks(
+			kuadrantv1beta1.LinkKuadrantToGatewayClasses(store),
+		),
+	)
+	if err != nil {
+		b.Fatalf("failed to create topology: %v", err)
+	}
+
+	return topology, kuadrant
+}
+
+// BenchmarkCalculateEffectiveAuthPolicies measures the full effective policy
+// calculation at varying scale. This is the hot path identified in CONNLINK-895.
+//
+// Run with pprof:
+//
+//	go test -tags=unit -bench=BenchmarkCalculateEffectiveAuthPolicies -cpuprofile=cpu.prof -memprofile=mem.prof ./internal/controller/
+//	go tool pprof -http=:8080 cpu.prof
+func BenchmarkCalculateEffectiveAuthPolicies(b *testing.B) {
+	benchCases := []topologyParams{
+		// Vary routes with fixed 1 gw / 1 listener (CONNLINK-895 scenario)
+		{1, 1, 10},
+		{1, 1, 50},
+		{1, 1, 100},
+		{1, 1, 300},
+		{1, 1, 600},
+		{1, 1, 1000},
+	}
+
+	for _, bc := range benchCases {
+		topology, kuadrant := buildScaleTopology(b, bc)
+
+		b.Run(bc.label(), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				state := &sync.Map{}
+				CalculateEffectiveAuthPolicies(context.Background(), topology, kuadrant, state)
+			}
+		})
+	}
+}
+
+// BenchmarkEffectiveRateLimitPolicies measures the RateLimitPolicy effective
+// policy calculation. Uses Reconcile() since calculateEffectivePolicies is unexported.
+func BenchmarkEffectiveRateLimitPolicies(b *testing.B) {
+	benchCases := []topologyParams{
+		{1, 1, 10},
+		{1, 1, 100},
+		{1, 1, 300},
+		{1, 1, 600},
+		{1, 1, 1000},
+	}
+
+	reconciler := &EffectiveRateLimitPolicyReconciler{}
+
+	for _, bc := range benchCases {
+		topology, _ := buildScaleTopology(b, bc)
+
+		b.Run(bc.label(), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				state := &sync.Map{}
+				_ = reconciler.Reconcile(context.Background(), nil, topology, nil, state)
+			}
+		})
+	}
+}
+
+// BenchmarkEffectiveTokenRateLimitPolicies measures the TokenRateLimitPolicy
+// effective policy calculation.
+func BenchmarkEffectiveTokenRateLimitPolicies(b *testing.B) {
+	benchCases := []topologyParams{
+		{1, 1, 10},
+		{1, 1, 100},
+		{1, 1, 300},
+		{1, 1, 600},
+		{1, 1, 1000},
+	}
+
+	reconciler := &EffectiveTokenRateLimitPolicyReconciler{}
+
+	for _, bc := range benchCases {
+		topology, _ := buildScaleTopology(b, bc)
+
+		b.Run(bc.label(), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				state := &sync.Map{}
+				_ = reconciler.Reconcile(context.Background(), nil, topology, nil, state)
+			}
+		})
+	}
+}
+
+// BenchmarkEffectiveAuthPoliciesListenerFanout measures the impact of
+// increasing listeners per gateway. More listeners = more paths in the
+// DFS traversal. This reproduces the scaling pattern from GH #1085
+// where 63 listeners caused 30-minute reconciliation.
+func BenchmarkEffectiveAuthPoliciesListenerFanout(b *testing.B) {
+	benchCases := []topologyParams{
+		{1, 1, 100},
+		{1, 4, 100},
+		{1, 16, 100},
+		{1, 32, 100},
+		{1, 64, 100},
+	}
+
+	for _, bc := range benchCases {
+		topology, kuadrant := buildScaleTopology(b, bc)
+
+		b.Run(bc.label(), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				state := &sync.Map{}
+				CalculateEffectiveAuthPolicies(context.Background(), topology, kuadrant, state)
+			}
+		})
+	}
+}
+
+// BenchmarkEffectiveAuthPoliciesMultiGateway measures the impact of
+// multiple gateways. Routes are distributed evenly across gateways.
+func BenchmarkEffectiveAuthPoliciesMultiGateway(b *testing.B) {
+	benchCases := []topologyParams{
+		{1, 1, 300},
+		{3, 1, 300},
+		{10, 1, 300},
+		{3, 16, 300},
+	}
+
+	for _, bc := range benchCases {
+		topology, kuadrant := buildScaleTopology(b, bc)
+
+		b.Run(bc.label(), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				state := &sync.Map{}
+				CalculateEffectiveAuthPolicies(context.Background(), topology, kuadrant, state)
+			}
+		})
+	}
+}
+
+// BenchmarkGetKuadrantFromTopology measures the cost of the Kuadrant CR lookup.
+// This is called ~28 times per reconciliation cycle across all reconcilers.
+// PR #1957 adds caching via sync.Map state — this benchmark quantifies the
+// uncached cost to justify that optimisation.
+func BenchmarkGetKuadrantFromTopology(b *testing.B) {
+	benchCases := []topologyParams{
+		{1, 1, 10},
+		{1, 1, 100},
+		{1, 1, 300},
+		{1, 1, 600},
+		{1, 1, 1000},
+	}
+
+	for _, bc := range benchCases {
+		topology, _ := buildScaleTopology(b, bc)
+
+		b.Run(bc.label(), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				GetKuadrantFromTopology(topology)
+			}
+		})
+	}
+}
+
+// BenchmarkTopologyBuild measures the cost of constructing the GatewayAPI
+// topology itself, which happens on every reconciliation cycle.
+func BenchmarkTopologyBuild(b *testing.B) {
+	benchCases := []topologyParams{
+		{1, 1, 10},
+		{1, 1, 100},
+		{1, 1, 300},
+		{1, 1, 1000},
+		{1, 32, 300},
+		{3, 16, 300},
+	}
+
+	for _, bc := range benchCases {
+		b.Run(bc.label(), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				buildScaleTopology(b, bc)
+			}
+		})
+	}
+}
+
+// BenchmarkFullReconciliationCycle simulates what happens in a single
+// reconciliation cycle: build topology, look up Kuadrant CR multiple times
+// (as each reconciler does), then calculate effective policies.
+func BenchmarkFullReconciliationCycle(b *testing.B) {
+	benchCases := []topologyParams{
+		{1, 1, 10},
+		{1, 1, 100},
+		{1, 1, 300},
+		{1, 1, 1000},
+		{1, 32, 100},
+		{3, 16, 300},
+	}
+
+	for _, bc := range benchCases {
+		b.Run(bc.label(), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				topology, kuadrant := buildScaleTopology(b, bc)
+				state := &sync.Map{}
+
+				for range 28 {
+					GetKuadrantFromTopology(topology)
+				}
+
+				CalculateEffectiveAuthPolicies(context.Background(), topology, kuadrant, state)
+			}
+		})
+	}
+}
+
+// BenchmarkMultiReconcilerCycle simulates a realistic reconciliation cycle
+// where all three effective policy reconcilers run against the same topology
+// and shared state. This is the pattern that PR #1957's GetKuadrantFromTopology
+// caching targets — each reconciler calls GetKuadrantFromTopology internally,
+// so caching benefits compound across reconcilers.
+func BenchmarkMultiReconcilerCycle(b *testing.B) {
+	benchCases := []topologyParams{
+		{1, 1, 10},
+		{1, 1, 100},
+		{1, 1, 300},
+		{1, 1, 600},
+		{1, 32, 100},
+	}
+
+	authReconciler := &EffectiveAuthPolicyReconciler{}
+	rlpReconciler := &EffectiveRateLimitPolicyReconciler{}
+	trlpReconciler := &EffectiveTokenRateLimitPolicyReconciler{}
+
+	for _, bc := range benchCases {
+		topology, _ := buildScaleTopology(b, bc)
+
+		b.Run(bc.label(), func(b *testing.B) {
+			b.ReportAllocs()
+			ctx := context.Background()
+			for range b.N {
+				state := &sync.Map{}
+				_ = authReconciler.Reconcile(ctx, nil, topology, nil, state)
+				_ = rlpReconciler.Reconcile(ctx, nil, topology, nil, state)
+				_ = trlpReconciler.Reconcile(ctx, nil, topology, nil, state)
+			}
+		})
+	}
+}

--- a/internal/controller/test_common.go
+++ b/internal/controller/test_common.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || performance
 
 /*
 Copyright 2021.

--- a/internal/wasm/types_bench_test.go
+++ b/internal/wasm/types_bench_test.go
@@ -1,0 +1,256 @@
+//go:build unit
+
+package wasm
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"k8s.io/utils/ptr"
+)
+
+// buildScaleConfig creates a Config with numActionSets ActionSets, each containing
+// actionsPerSet Actions with conditionalData entries. This mirrors the real-world
+// scenario where each HTTPRoute+Policy pair produces an ActionSet.
+func buildScaleConfig(numActionSets, actionsPerSet int) *Config {
+	services := map[string]Service{
+		"ratelimit-service": {
+			Endpoint:    "kuadrant-ratelimit-service",
+			Type:        RateLimitServiceType,
+			FailureMode: FailureModeAllow,
+			Timeout:     ptr.To("100ms"),
+		},
+		"auth-service": {
+			Endpoint:    "kuadrant-auth-service",
+			Type:        AuthServiceType,
+			FailureMode: FailureModeDeny,
+			Timeout:     ptr.To("200ms"),
+		},
+	}
+
+	actionSets := make([]ActionSet, numActionSets)
+	for i := range numActionSets {
+		actions := make([]Action, actionsPerSet)
+		for j := range actionsPerSet {
+			actions[j] = Action{
+				ServiceName: "ratelimit-service",
+				Scope:       fmt.Sprintf("default/route-%d", i),
+				Predicates:  []string{fmt.Sprintf("request.url_path.startsWith('/path-%d')", j)},
+				ConditionalData: []ConditionalData{
+					{
+						Predicates: []string{"source.address != '127.0.0.1'"},
+						Data: []DataType{
+							{
+								Value: &Static{
+									Static: StaticSpec{
+										Key:   fmt.Sprintf("limit.route_%d_action_%d", i, j),
+										Value: "1",
+									},
+								},
+							},
+						},
+					},
+					{
+						Data: []DataType{
+							{
+								Value: &Expression{
+									ExpressionItem: ExpressionItem{
+										Key:   fmt.Sprintf("descriptor.route_%d_action_%d", i, j),
+										Value: "request.host",
+									},
+								},
+							},
+						},
+					},
+				},
+				SourcePolicyLocators: []string{
+					fmt.Sprintf("RateLimitPolicy/default/rlp-%d", i),
+				},
+			}
+		}
+
+		actionSets[i] = ActionSet{
+			Name: fmt.Sprintf("actionset-%d", i),
+			RouteRuleConditions: RouteRuleConditions{
+				Hostnames:  []string{fmt.Sprintf("app-%d.example.com", i)},
+				Predicates: []string{"request.url_path.startsWith('/')"},
+			},
+			Actions: actions,
+		}
+	}
+
+	return &Config{
+		Services:   services,
+		ActionSets: actionSets,
+		RequestData: map[string]string{
+			"metrics.labels.user": "auth.identity.user",
+		},
+	}
+}
+
+// shuffleActionSets returns a copy of the config with ActionSets in a different order.
+// This simulates the non-determinism that occurs when ActionSets are built from Go
+// map iteration, which is the root cause of Issue #1934.
+func shuffleActionSets(cfg *Config, seed int64) *Config {
+	shuffled := make([]ActionSet, len(cfg.ActionSets))
+	copy(shuffled, cfg.ActionSets)
+
+	rng := rand.New(rand.NewSource(seed))
+	rng.Shuffle(len(shuffled), func(i, j int) {
+		shuffled[i], shuffled[j] = shuffled[j], shuffled[i]
+	})
+
+	return &Config{
+		Services:          cfg.Services,
+		ActionSets:        shuffled,
+		RequestData:       cfg.RequestData,
+		DescriptorService: cfg.DescriptorService,
+		Observability:     cfg.Observability,
+	}
+}
+
+// shuffleActions returns a copy of the config with Actions within each ActionSet shuffled.
+func shuffleActions(cfg *Config, seed int64) *Config {
+	rng := rand.New(rand.NewSource(seed))
+
+	newActionSets := make([]ActionSet, len(cfg.ActionSets))
+	for i, as := range cfg.ActionSets {
+		actions := make([]Action, len(as.Actions))
+		copy(actions, as.Actions)
+		rng.Shuffle(len(actions), func(a, b int) {
+			actions[a], actions[b] = actions[b], actions[a]
+		})
+		newActionSets[i] = ActionSet{
+			Name:                as.Name,
+			RouteRuleConditions: as.RouteRuleConditions,
+			Actions:             actions,
+		}
+	}
+
+	return &Config{
+		Services:          cfg.Services,
+		ActionSets:        newActionSets,
+		RequestData:       cfg.RequestData,
+		DescriptorService: cfg.DescriptorService,
+		Observability:     cfg.Observability,
+	}
+}
+
+// TestEqualToNonDeterminism demonstrates the bug from Issue #1934:
+// Two semantically identical configs that differ only in slice ordering
+// are reported as not equal by the current EqualTo() implementation.
+// This causes infinite reconciliation loops because Go map iteration
+// produces different orderings on each run.
+func TestEqualToNonDeterminism(t *testing.T) {
+	testCases := []struct {
+		name         string
+		numActionSets int
+	}{
+		{"1_actionset", 1},
+		{"10_actionsets", 10},
+		{"50_actionsets", 50},
+		{"100_actionsets", 100},
+		{"300_actionsets", 300},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := buildScaleConfig(tc.numActionSets, 2)
+
+			falseNegatives := 0
+			trials := 100
+			for seed := range trials {
+				shuffled := shuffleActionSets(original, int64(seed))
+				if !original.EqualTo(shuffled) {
+					falseNegatives++
+				}
+			}
+
+			if tc.numActionSets > 1 && falseNegatives == 0 {
+				t.Logf("SURPRISING: all %d trials matched for %d action sets — order-sensitive comparison happened to match", trials, tc.numActionSets)
+			}
+
+			if falseNegatives > 0 {
+				t.Logf("BUG CONFIRMED: %d/%d trials reported NOT equal for semantically identical configs with %d action sets (order-sensitive comparison)",
+					falseNegatives, trials, tc.numActionSets)
+				t.Logf("This causes the operator to detect phantom changes and re-reconcile infinitely (Issue #1934)")
+			}
+		})
+	}
+}
+
+// TestEqualToActionOrderNonDeterminism demonstrates the same bug at the
+// Action level within an ActionSet.
+func TestEqualToActionOrderNonDeterminism(t *testing.T) {
+	original := buildScaleConfig(10, 5)
+
+	falseNegatives := 0
+	trials := 100
+	for seed := range trials {
+		shuffled := shuffleActions(original, int64(seed))
+		if !original.EqualTo(shuffled) {
+			falseNegatives++
+		}
+	}
+
+	if falseNegatives > 0 {
+		t.Logf("BUG CONFIRMED: %d/%d trials reported NOT equal when Actions within ActionSets are reordered",
+			falseNegatives, trials)
+	}
+}
+
+// BenchmarkConfigEqualTo measures the cost of comparing two identical configs.
+func BenchmarkConfigEqualTo(b *testing.B) {
+	benchCases := []struct {
+		numActionSets int
+		actionsPerSet int
+	}{
+		{10, 2},
+		{50, 2},
+		{100, 2},
+		{300, 2},
+		{300, 5},
+	}
+
+	for _, bc := range benchCases {
+		name := fmt.Sprintf("actionsets=%d_actions=%d", bc.numActionSets, bc.actionsPerSet)
+		cfg1 := buildScaleConfig(bc.numActionSets, bc.actionsPerSet)
+		cfg2 := buildScaleConfig(bc.numActionSets, bc.actionsPerSet)
+
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				cfg1.EqualTo(cfg2)
+			}
+		})
+	}
+}
+
+// BenchmarkConfigEqualToShuffled measures the cost of comparing two semantically
+// identical configs where the ActionSets are in different order. In the current
+// implementation this always returns false (the bug), but we benchmark it to show
+// the comparison cost that happens on every reconciliation cycle.
+func BenchmarkConfigEqualToShuffled(b *testing.B) {
+	benchCases := []struct {
+		numActionSets int
+	}{
+		{10},
+		{50},
+		{100},
+		{300},
+	}
+
+	for _, bc := range benchCases {
+		name := fmt.Sprintf("actionsets=%d_shuffled", bc.numActionSets)
+		cfg1 := buildScaleConfig(bc.numActionSets, 2)
+		cfg2 := shuffleActionSets(cfg1, 42)
+
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				cfg1.EqualTo(cfg2)
+			}
+		})
+	}
+}

--- a/tests/commons.go
+++ b/tests/commons.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration || performance
 
 package tests
 

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,140 @@
+# Performance Tests
+
+This directory contains tests for measuring and preventing performance regressions in the kuadrant-operator reconciliation paths.
+
+There are two types of tests, each serving a different purpose.
+
+## Unit Benchmarks
+
+Go benchmark tests in `internal/controller/reconciliation_bench_test.go` and `internal/wasm/types_bench_test.go`. These construct topologies in-memory and measure specific code paths without needing a cluster.
+
+### What they test
+
+- `BenchmarkCalculateEffectiveAuthPolicies` — effective policy calculation at varying route/listener/gateway scale
+- `BenchmarkEffectiveRateLimitPolicies` / `BenchmarkEffectiveTokenRateLimitPolicies` — same for other policy types
+- `BenchmarkEffectiveAuthPoliciesListenerFanout` — listener scaling (1–64 listeners)
+- `BenchmarkEffectiveAuthPoliciesMultiGateway` — multi-gateway scaling
+- `BenchmarkGetKuadrantFromTopology` — Kuadrant CR lookup cost
+- `BenchmarkMultiReconcilerCycle` — all three policy reconcilers running together
+- `BenchmarkFullReconciliationCycle` — combined topology build + lookups + effective policies
+- `TestEqualToNonDeterminism` — reproduces the WasmPlugin comparison bug (Issue #1934)
+
+### Running
+
+```bash
+# Run all benchmarks
+go test -tags=unit -bench=. -benchmem -timeout=600s -run='^$' ./internal/controller/
+
+# Run a specific benchmark
+go test -tags=unit -bench='BenchmarkCalculateEffectiveAuthPolicies' -benchmem -run='^$' ./internal/controller/
+
+# Run with multiple iterations for benchstat comparison
+go test -tags=unit -bench=. -benchmem -count=6 -timeout=1800s -run='^$' ./internal/controller/ > results.txt
+```
+
+### Profiling
+
+```bash
+# Capture CPU and memory profiles
+go test -tags=unit -bench='BenchmarkCalculateEffectiveAuthPolicies/gw=1_listen=1_routes=300' \
+  -cpuprofile=cpu.prof -memprofile=mem.prof -run='^$' ./internal/controller/
+
+# View as interactive flame graph
+go tool pprof -http=:8080 cpu.prof
+
+# Terminal-only top functions
+go tool pprof -top -cum cpu.prof
+```
+
+### Comparing before/after
+
+```bash
+# Before your change
+go test -tags=unit -bench=. -benchmem -count=6 -run='^$' ./internal/controller/ > before.txt
+
+# After your change
+go test -tags=unit -bench=. -benchmem -count=6 -run='^$' ./internal/controller/ > after.txt
+
+# Compare with statistical analysis
+benchstat before.txt after.txt
+
+# Compare pprof profiles (red = slower, green = faster)
+go tool pprof -http=:8080 -diff_base=before-cpu.prof after-cpu.prof
+```
+
+### When to use
+
+- Developing and validating performance fixes
+- Identifying which code paths are expensive (via pprof)
+- CI regression detection
+- Fast iteration — runs in seconds, no cluster needed
+
+## Cluster Performance Tests
+
+Ginkgo tests in `tests/performance/` that create real resources on a Kubernetes cluster and measure end-to-end reconciliation time. The operator runs in-process via `SetupKuadrantOperatorForTest`.
+
+### What they test
+
+- Creates a Gateway, then N HTTPRoutes each with an AuthPolicy
+- Measures wall-clock time until all policies reach `Enforced: True`
+- Captures the full operator lifecycle: event handling, topology rebuild, effective policy calculation, AuthConfig creation, Authorino reconciliation, status updates, and API server I/O
+
+### Running
+
+```bash
+# Default scale levels (10, 50, 100, 300)
+GATEWAYAPI_PROVIDER=istio \
+go test -tags=performance -v -timeout=60m ./tests/performance/ -ginkgo.v
+
+# Custom scale levels
+PERF_SCALE_LEVELS=100,300,600,1000 \
+GATEWAYAPI_PROVIDER=istio \
+go test -tags=performance -v -timeout=120m ./tests/performance/ -ginkgo.v
+
+# With error logs visible
+PERF_LOG_ERRORS=true \
+GATEWAYAPI_PROVIDER=istio \
+go test -tags=performance -v -timeout=60m ./tests/performance/ -ginkgo.v
+```
+
+### Profiling
+
+Since the operator runs in-process, Go's built-in profiling captures the reconciliation code:
+
+```bash
+GATEWAYAPI_PROVIDER=istio \
+go test -tags=performance -v -timeout=60m \
+  -cpuprofile=perf-cpu.prof -memprofile=perf-mem.prof \
+  ./tests/performance/ -ginkgo.v
+
+go tool pprof -http=:8080 perf-cpu.prof
+```
+
+### Configuration
+
+| Environment variable | Description | Default |
+|---|---|---|
+| `GATEWAYAPI_PROVIDER` | Gateway provider (required) | — |
+| `PERF_SCALE_LEVELS` | Comma-separated route counts | `10,50,100,300` |
+| `PERF_LOG_ERRORS` | Show operator error logs | `false` |
+
+### When to use
+
+- Validating fixes end-to-end with real API server I/O
+- Measuring impact across multiple reconciliation cycles
+- Finding bottlenecks in downstream components (Authorino, Limitador)
+- Final validation before merging performance-sensitive changes
+
+## Which to use?
+
+| Question | Unit benchmarks | Cluster tests |
+|---|---|---|
+| "Is this code path fast enough?" | ✅ | |
+| "Where is the CPU time going?" | ✅ (pprof) | ✅ (pprof) |
+| "Did my PR regress performance?" | ✅ (benchstat) | |
+| "How long does reconciliation take at 300 routes?" | | ✅ |
+| "Does this fix help in a real cluster?" | | ✅ |
+| "Can I run this without a cluster?" | ✅ | |
+| "Does this capture API server overhead?" | | ✅ |
+
+Start with unit benchmarks for development, use cluster tests for validation.

--- a/tests/performance/reconciliation_scale_test.go
+++ b/tests/performance/reconciliation_scale_test.go
@@ -1,0 +1,150 @@
+//go:build performance
+
+package performance
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	"github.com/kuadrant/kuadrant-operator/tests"
+)
+
+// Reconciliation runs in the test process (via SetupKuadrantOperatorForTest),
+// so Go's built-in profiling captures the operator's hot paths directly:
+//
+//	go test -tags=performance -v -timeout=60m \
+//	  -cpuprofile=perf-cpu.prof -memprofile=perf-mem.prof \
+//	  ./tests/performance/ -ginkgo.v
+//
+//	go tool pprof -http=:8080 perf-cpu.prof
+//
+// TODO: Capture pprof profiles from all cluster components (Authorino,
+// authorino-operator, limitador-operator, dns-operator) via their
+// --pprof-bind-address endpoints during the test. This would give
+// visibility into downstream bottlenecks (e.g., Authorino throughput
+// at high scale) that in-process profiling cannot capture.
+
+var _ = Describe("Reconciliation scale", func() {
+	var testNamespace string
+	var gwName string
+
+	BeforeEach(func(ctx context.Context) {
+		GinkgoWriter.Printf("creating test namespace\n")
+		setupStart := time.Now()
+		testNamespace = tests.CreateNamespace(ctx, testClient())
+
+		gwName = "perf-gateway"
+		gw := tests.BuildBasicGateway(gwName, testNamespace, func(gw *gatewayapiv1.Gateway) {
+			gw.Spec.Listeners = []gatewayapiv1.Listener{
+				{
+					Name:     "http",
+					Hostname: ptr.To[gatewayapiv1.Hostname]("*.perf.example.com"),
+					Port:     80,
+					Protocol: gatewayapiv1.HTTPProtocolType,
+				},
+			}
+		})
+		err := testClient().Create(ctx, gw)
+		Expect(err).ToNot(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			existingGw := &gatewayapiv1.Gateway{}
+			g.Expect(testClient().Get(ctx, client.ObjectKeyFromObject(gw), existingGw)).To(Succeed())
+			g.Expect(existingGw.Status.Conditions).ToNot(BeEmpty())
+		}).WithContext(ctx).WithTimeout(2 * time.Minute).Should(Succeed())
+		GinkgoWriter.Printf("test setup took %s\n", time.Since(setupStart))
+	})
+
+	AfterEach(func(ctx context.Context) {
+		GinkgoWriter.Printf("cleaning up namespace %s\n", testNamespace)
+		cleanupStart := time.Now()
+		tests.DeleteNamespace(ctx, testClient(), testNamespace)
+		GinkgoWriter.Printf("cleanup took %s\n", time.Since(cleanupStart))
+	})
+
+	scaleCases := []int{10, 50, 100, 300}
+
+	for _, n := range scaleCases {
+		numRoutes := n
+
+		It(fmt.Sprintf("reconciles %d AuthPolicies within acceptable time", numRoutes), func(ctx context.Context) {
+			By(fmt.Sprintf("creating %d HTTPRoutes with AuthPolicies", numRoutes))
+
+			createStart := time.Now()
+
+			for i := range numRoutes {
+				routeName := fmt.Sprintf("route-%d", i)
+				route := tests.BuildBasicHttpRoute(routeName, gwName, testNamespace,
+					[]string{fmt.Sprintf("app-%d.perf.example.com", i)})
+				Expect(testClient().Create(ctx, route)).To(Succeed())
+
+				policy := buildAuthPolicy(fmt.Sprintf("auth-%d", i), testNamespace, routeName)
+				Expect(testClient().Create(ctx, policy)).To(Succeed())
+			}
+
+			createDuration := time.Since(createStart)
+			GinkgoWriter.Printf("resource creation took %s\n", createDuration)
+
+			By("waiting for all AuthPolicies to reach Enforced")
+			reconcileStart := time.Now()
+
+			Eventually(func(g Gomega) {
+				policies := &kuadrantv1.AuthPolicyList{}
+				g.Expect(testClient().List(ctx, policies, client.InNamespace(testNamespace))).To(Succeed())
+
+				enforced := 0
+				for _, p := range policies.Items {
+					if meta.IsStatusConditionTrue(p.Status.Conditions, string(gatewayapiv1alpha2.PolicyReasonAccepted)) &&
+						meta.IsStatusConditionTrue(p.Status.Conditions, "Enforced") {
+						enforced++
+					}
+				}
+				GinkgoWriter.Printf("enforced: %d/%d (elapsed: %s)\n", enforced, numRoutes, time.Since(reconcileStart))
+				g.Expect(enforced).To(Equal(numRoutes))
+			}).WithContext(ctx).WithTimeout(30 * time.Minute).WithPolling(5 * time.Second).Should(Succeed())
+
+			reconcileDuration := time.Since(reconcileStart)
+
+			GinkgoWriter.Printf("\n=== RESULTS (routes=%d) ===\n", numRoutes)
+			GinkgoWriter.Printf("resource creation: %s\n", createDuration)
+			GinkgoWriter.Printf("reconciliation:    %s\n", reconcileDuration)
+			GinkgoWriter.Printf("==========================\n\n")
+		})
+	}
+})
+
+func buildAuthPolicy(name, ns, routeName string) *kuadrantv1.AuthPolicy {
+	return &kuadrantv1.AuthPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AuthPolicy",
+			APIVersion: kuadrantv1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: kuadrantv1.AuthPolicySpec{
+			TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+				LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+					Group: "gateway.networking.k8s.io",
+					Kind:  "HTTPRoute",
+					Name:  gatewayapiv1alpha2.ObjectName(routeName),
+				},
+			},
+			AuthPolicySpecProper: kuadrantv1.AuthPolicySpecProper{
+				AuthScheme: tests.BuildBasicAuthScheme(),
+			},
+		},
+	}
+}

--- a/tests/performance/suite_test.go
+++ b/tests/performance/suite_test.go
@@ -1,0 +1,105 @@
+//go:build performance
+
+package performance
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	controllers "github.com/kuadrant/kuadrant-operator/internal/controller"
+	"github.com/kuadrant/kuadrant-operator/internal/log"
+	"github.com/kuadrant/kuadrant-operator/tests"
+)
+
+var k8sClient client.Client
+var testEnv *envtest.Environment
+var testNamespace string
+var perfLogger logr.Logger
+
+func init() {
+	if os.Getenv("PERF_LOG_ERRORS") == "true" {
+		perfLogger = log.NewLogger(
+			log.SetLevel(log.ErrorLevel),
+			log.WriteTo(os.Stderr),
+		)
+	} else {
+		perfLogger = logr.Discard()
+	}
+	log.SetLogger(perfLogger)
+	logf.SetLogger(perfLogger)
+	klog.SetLogger(perfLogger)
+}
+
+func testClient() client.Client { return k8sClient }
+
+func TestPerformance(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	SetDefaultEventuallyPollingInterval(2 * time.Second)
+	SetDefaultEventuallyTimeout(30 * time.Minute)
+
+	RunSpecs(t, "Performance Suite")
+}
+
+var _ = BeforeSuite(func() {
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		UseExistingCluster: &[]bool{true}[0],
+	}
+
+	cfg, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	s := controllers.BootstrapScheme()
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: s})
+	Expect(err).NotTo(HaveOccurred())
+
+	tests.GatewayClassName = os.Getenv("GATEWAYAPI_PROVIDER")
+	Expect(tests.GatewayClassName).NotTo(BeZero(), "GATEWAYAPI_PROVIDER must be set")
+
+	ctx := context.Background()
+	testNamespace = tests.CreateNamespace(ctx, testClient())
+	tests.ApplyKuadrantCR(ctx, testClient(), testNamespace)
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 s,
+		HealthProbeBindAddress: "0",
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		Logger:                 perfLogger,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	dClient, err := dynamic.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	stateOfTheWorld, err := controllers.NewPolicyMachineryController(mgr, dClient, perfLogger)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = stateOfTheWorld.Start(ctrl.SetupSignalHandler())
+		Expect(err).NotTo(HaveOccurred())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	tests.DeleteNamespace(context.Background(), k8sClient, testNamespace)
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})


### PR DESCRIPTION
## Summary

Adds two types of performance tests for measuring and preventing regressions in the kuadrant-operator reconciliation paths. This PR is shared for discussion — not intended to merge as-is.

## What's included

### 1. Unit Benchmarks (`internal/controller/reconciliation_bench_test.go`)

Go benchmark tests that construct realistic topologies in-memory and measure specific reconciliation code paths at varying scale (routes, listeners, gateways). No cluster needed.

Benchmarks cover:
- `CalculateEffectiveAuthPolicies` / `EffectiveRateLimitPolicies` / `EffectiveTokenRateLimitPolicies`
- Listener fanout scaling (1–64 listeners)
- Multi-gateway scaling
- `GetKuadrantFromTopology` lookup cost
- `MultiReconcilerCycle` — all three policy reconcilers together
- `FullReconciliationCycle` — topology build + lookups + effective policies

Also includes `TestEqualToNonDeterminism` in `internal/wasm/types_bench_test.go` which reproduces the WasmPlugin comparison bug (#1934).

Supports pprof profiling via `-cpuprofile`/`-memprofile` and `benchstat` for before/after comparison.

### 2. Cluster Performance Tests (`tests/performance/`)

Ginkgo tests that create real HTTPRoutes and AuthPolicies on a Kubernetes cluster and measure wall-clock reconciliation time. The operator runs in-process, so Go's built-in profiling captures the reconciliation code paths.

- Configurable scale via `PERF_SCALE_LEVELS` env var (default: 10, 50, 100, 300)
- Operator logs silenced by default (`PERF_LOG_ERRORS=true` to enable)
- Supports `-cpuprofile`/`-memprofile` for in-process profiling

## Context

These tests were developed during the investigation of reconciliation performance at scale ([#1919](https://github.com/Kuadrant/kuadrant-operator/issues/1919), [#1085](https://github.com/Kuadrant/kuadrant-operator/issues/1085)). Key findings:

- pprof profiling of the unit benchmarks identified `LocatorFromObject` (47% CPU) and `Children()` (23% CPU) in policy-machinery as the dominant costs in the `Paths()` DFS traversal
- Cluster performance tests showed that single-cycle benchmarks don't capture the compounding effect of repeated reconciliation cycles during bulk resource creation — this is why PR #1957 shows dramatic real-cluster improvement despite minimal unit benchmark impact
- At 3,000 routes, the bottleneck shifts from kuadrant-operator to Authorino throughput (~10 AuthConfigs/second)

See `tests/performance/README.md` for full usage instructions.

## Discussion points

- Should unit benchmarks run in CI? If so, with what thresholds or `benchstat` comparison?
- Should the cluster performance tests be part of the existing integration test infrastructure or remain separate?
- Should we parameterise the cluster tests to also scale listeners and gateways, not just routes?
- Future: capture pprof profiles from all cluster components (Authorino, limitador-operator, etc.) via their `--pprof-bind-address` endpoints during the test