### PR TITLE
Optimize test helper to accept pointer parameter

### DIFF
--- a/tests/common/ratelimitpolicy/ratelimitpolicy_grpcroute_test.go
+++ b/tests/common/ratelimitpolicy/ratelimitpolicy_grpcroute_test.go
@@ -148,7 +148,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				}
 				limitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				limitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(policy), "l1")
-				return limitadorLimitsContain(*limitador, limitsNamespace, limitKey)
+				return limitadorLimitsContain(limitador, limitsNamespace, limitKey)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -177,7 +177,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				}
 				limitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				limitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(policy), "l1")
-				return limitadorLimitsContain(*limitador, limitsNamespace, limitKey)
+				return limitadorLimitsContain(limitador, limitsNamespace, limitKey)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -233,12 +233,12 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				// Route policy limit for grpcRoute
 				routeLimitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				routeLimitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(routePolicy), "l1")
-				hasRouteLimit := limitadorLimitsContain(*limitador, routeLimitsNamespace, routeLimitKey)
+				hasRouteLimit := limitadorLimitsContain(limitador, routeLimitsNamespace, routeLimitKey)
 
 				// Gateway policy limit for policyless route
 				gwLimitsNamespace := limitsNamespaceForGRPCRoute(otherRoute)
 				gwLimitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(gwPolicy), "gw-limit")
-				hasGWLimit := limitadorLimitsContain(*limitador, gwLimitsNamespace, gwLimitKey)
+				hasGWLimit := limitadorLimitsContain(limitador, gwLimitsNamespace, gwLimitKey)
 
 				return hasRouteLimit && hasGWLimit
 			}).WithContext(ctx).Should(BeTrue())
@@ -266,7 +266,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				}
 				limitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				limitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(policy), "l1")
-				return limitadorLimitsContain(*limitador, limitsNamespace, limitKey)
+				return limitadorLimitsContain(limitador, limitsNamespace, limitKey)
 			}).WithContext(ctx).Should(BeTrue())
 
 			// delete policy
@@ -281,7 +281,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				}
 				limitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				limitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(policy), "l1")
-				return !limitadorLimitsContain(*limitador, limitsNamespace, limitKey)
+				return !limitadorLimitsContain(limitador, limitsNamespace, limitKey)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 	})
@@ -289,7 +289,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 })
 
 // limitadorLimitsContain checks if limitador contains a limit with the given namespace and identifier
-func limitadorLimitsContain(limitador limitadorv1alpha1.Limitador, namespace, identifier string) bool {
+func limitadorLimitsContain(limitador *limitadorv1alpha1.Limitador, namespace, identifier string) bool {
 	expected := fmt.Sprintf(`descriptors[0]["%s"] == "1"`, identifier)
 	for _, limit := range limitador.Spec.Limits {
 		if limit.Namespace != namespace {


### PR DESCRIPTION
## What problem does this PR solve?

Closes #1891

The `limitadorLimitsContain()` helper accepted a `limitadorv1alpha1.Limitador` value, causing the entire struct to be copied on each call.

## What's changed and how does it work?

* Updated `limitadorLimitsContain()` to accept `*limitadorv1alpha1.Limitador`.
* Updated all call sites to pass the existing pointer directly.
* Preserved existing behavior while avoiding unnecessary struct copies.

## Testing

* [x] Existing tests pass
* [x] No functional behavior changes introduced





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated GRPCRoute rate limit integration test implementation for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->