### PR TITLE
fix: sanitize CEL string interpolation to prevent quote injection

### DIFF
--- a/cmd/extensions/oidc-policy/internal/controller/oidcpolicy_reconciler.go
+++ b/cmd/extensions/oidc-policy/internal/controller/oidcpolicy_reconciler.go
@@ -26,6 +26,7 @@ import (
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	"github.com/kuadrant/kuadrant-operator/cmd/extensions/oidc-policy/api/v1alpha1"
+	pkgcel "github.com/kuadrant/kuadrant-operator/pkg/cel"
 	extcontroller "github.com/kuadrant/kuadrant-operator/pkg/extension/controller"
 	"github.com/kuadrant/kuadrant-operator/pkg/extension/types"
 )
@@ -303,7 +304,7 @@ func buildMainAuthPolicy(pol *v1alpha1.OIDCPolicy, igw *ingressGatewayInfo) (*ku
 		for k, v := range claims {
 			authPatterns = append(authPatterns, authorinov1beta3.PatternExpressionOrRef{
 				CelPredicate: authorinov1beta3.CelPredicate{
-					Predicate: fmt.Sprintf(`"%s" in auth.identity.%s`, v, k),
+					Predicate: fmt.Sprintf(`auth.identity[%s] == %s`, pkgcel.StringLiteral(k), pkgcel.StringLiteral(v)),
 				},
 			})
 		}
@@ -326,7 +327,7 @@ func buildMainAuthPolicy(pol *v1alpha1.OIDCPolicy, igw *ingressGatewayInfo) (*ku
 			},
 		}
 		if pol.Spec.Provider.IssuerURL != "" {
-			authorization["oidc"].Conditions[0].Predicate = fmt.Sprintf(`auth.identity.iss == "%s"`, pol.Spec.Provider.IssuerURL)
+			authorization["oidc"].Conditions[0].Predicate = fmt.Sprintf(`auth.identity.iss == %s`, pkgcel.StringLiteral(pol.Spec.Provider.IssuerURL))
 		}
 	}
 
@@ -641,7 +642,7 @@ func credentialsHeader(tokenSource *authorinov1beta3.Credentials, igw *ingressGa
 	headers["location"] = authorinov1beta3.ValueOrSelector{Expression: "auth.authorization.location.location"}
 	switch tokenSource.GetType() {
 	case authorinov1beta3.AuthorizationHeaderCredentials:
-		headers["Authorization"] = authorinov1beta3.ValueOrSelector{Expression: authorinov1beta3.CelExpression(fmt.Sprintf(`"%s " + auth.metadata.token.id_token`, tokenSource.AuthorizationHeader.Prefix))}
+		headers["Authorization"] = authorinov1beta3.ValueOrSelector{Expression: authorinov1beta3.CelExpression(fmt.Sprintf(`%s + " " + auth.metadata.token.id_token`, pkgcel.StringLiteral(tokenSource.AuthorizationHeader.Prefix)))}
 	case authorinov1beta3.CustomHeaderCredentials:
 		headers[tokenSource.CustomHeader.Name] = authorinov1beta3.ValueOrSelector{Expression: "auth.metadata.token.id_token"}
 	case authorinov1beta3.CookieCredentials:
@@ -653,11 +654,11 @@ func credentialsHeader(tokenSource *authorinov1beta3.Credentials, igw *ingressGa
 }
 
 func cookieHeader(cookieName string, igw *ingressGatewayInfo) authorinov1beta3.ValueOrSelector {
-	return authorinov1beta3.ValueOrSelector{Expression: authorinov1beta3.CelExpression(fmt.Sprintf(`
-"%s=" + auth.metadata.token.id_token + "; domain=%s; HttpOnly; %s SameSite=Lax; Path=/; Max-Age=3600"
-`, cookieName, igw.Hostname, getSecureFlag(igw.Protocol)))}
+	cookiePrefix := pkgcel.StringLiteral(cookieName + "=")
+	domainSuffix := pkgcel.StringLiteral("; domain=" + igw.Hostname + "; HttpOnly; " + getSecureFlag(igw.Protocol) + " SameSite=Lax; Path=/; Max-Age=3600")
+	expr := fmt.Sprintf("%s + auth.metadata.token.id_token + %s", cookiePrefix, domainSuffix)
+	return authorinov1beta3.ValueOrSelector{Expression: authorinov1beta3.CelExpression(expr)}
 }
-
 func getSecureFlag(protocol gatewayapiv1.ProtocolType) string {
 	flag := ""
 	if protocol == gatewayapiv1.HTTPSProtocolType {

--- a/cmd/extensions/plan-policy/api/v1alpha1/planpolicy_types.go
+++ b/cmd/extensions/plan-policy/api/v1alpha1/planpolicy_types.go
@@ -29,6 +29,7 @@ import (
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	"github.com/kuadrant/kuadrant-operator/internal/utils"
+	pkgcel "github.com/kuadrant/kuadrant-operator/pkg/cel"
 )
 
 var (
@@ -65,7 +66,7 @@ func (p *PlanPolicy) GetTargetRefs() []gatewayapiv1alpha2.LocalPolicyTargetRefer
 func (p *PlanPolicy) ToRateLimits() map[string]kuadrantv1.Limit {
 	return utils.Associate(p.Spec.Plans, func(plan Plan) (string, kuadrantv1.Limit) {
 		return plan.Tier, kuadrantv1.Limit{
-			When:  kuadrantv1.NewWhenPredicates(fmt.Sprintf(`auth.kuadrant.plan == "%s"`, plan.Tier)),
+			When:  kuadrantv1.NewWhenPredicates(fmt.Sprintf(`auth.kuadrant.plan == %s`, pkgcel.StringLiteral(plan.Tier))),
 			Rates: plan.Limits.ToRates(),
 		}
 	})
@@ -77,8 +78,8 @@ func (p *PlanPolicy) BuildCelExpression() string {
 
 	for i, plan := range p.Spec.Plans {
 		predicate := strings.ReplaceAll(plan.Predicate, "\n", "")
-		tierList.WriteString(fmt.Sprintf(`"%s"`, plan.Tier))
-		tierPredicates.WriteString(fmt.Sprintf(`    "%s": %s,`, plan.Tier, predicate))
+		tierList.WriteString(pkgcel.StringLiteral(plan.Tier))
+		tierPredicates.WriteString(fmt.Sprintf(`    %s: %s,`, pkgcel.StringLiteral(plan.Tier), predicate))
 
 		if i < len(p.Spec.Plans)-1 {
 			tierList.WriteString(", ")

--- a/pkg/cel/strings.go
+++ b/pkg/cel/strings.go
@@ -1,0 +1,12 @@
+package cel
+
+import "encoding/json"
+
+// StringLiteral returns a properly escaped CEL string literal for the given value.
+// It JSON-encodes the value, producing a double-quoted, escape-safe string that
+// is also a valid CEL string literal. This prevents quote injection when
+// interpolating user-supplied values into CEL expressions or predicates.
+func StringLiteral(value string) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}

--- a/pkg/cel/strings_test.go
+++ b/pkg/cel/strings_test.go
@@ -1,0 +1,26 @@
+package cel
+
+import "testing"
+
+func TestStringLiteral(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "normal value", input: "hello", want: `"hello"`},
+		{name: "double quote injection", input: `admin"||true`, want: `"admin\"||true"`},
+		{name: "claim key with special characters", input: "custom:role", want: `"custom:role"`},
+		{name: "backslash", input: `foo\bar`, want: `"foo\\bar"`},
+		{name: "empty string", input: "", want: `""`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StringLiteral(tt.input)
+			if got != tt.want {
+				t.Errorf("StringLiteral(%q) = %s; want %s", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2036

## What's the problem?

While going through the codebase I noticed that user-supplied values were being 
dropped directly into CEL expressions using fmt.Sprintf without any escaping. 

This caused two issues:
- Claim keys with special characters like `custom:role` broke dot-notation and 
  made the CEL expression fail to compile entirely
- Unescaped string values could allow quote injection to alter CEL logic 
  (e.g. a value like `admin"||true` could make an expression always evaluate to true)

## What I changed

Added a small `StringLiteral` helper in `pkg/cel` that uses `json.Marshal` to 
safely escape values before they go into CEL expressions. JSON-encoded strings 
are also valid CEL string literals, so this works cleanly without any extra 
dependencies.

Also switched claim key lookups from dot-notation to bracket notation so any 
valid JWT claim name works correctly.

## Files changed

- `pkg/cel/strings.go` — new helper + tests
- `cmd/extensions/oidc-policy/internal/controller/oidcpolicy_reconciler.go` — 4 sites fixed
- `cmd/extensions/plan-policy/api/v1alpha1/planpolicy_types.go` — 2 sites fixed

## Testing

Added unit tests in `pkg/cel/strings_test.go` covering:
- Normal values
- Quote injection attempt (`admin"||true`)
- Claim key with special characters (`custom:role`)
- Backslash handling
- Empty string

Happy to make any changes if I've missed something or the approach needs adjusting!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactoring**
  * Updated CEL expression generation in OIDC policy and plan policy modules to employ consistent, standardised string literal handling across configurations, enhancing code consistency and maintainability.

* **Tests**
  * Added comprehensive test coverage validating CEL string literal generation across various input scenarios, including edge cases with special characters and escape sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->