### PR TITLE
feat: implement non-blocking error handling with automatic retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/kuadrant/authorino-operator v0.21.0
 	github.com/kuadrant/dns-operator v0.0.0-20251125201831-f74008dc171c
 	github.com/kuadrant/limitador-operator v0.15.0
-	github.com/kuadrant/policy-machinery v0.8.0
+	github.com/kuadrant/policy-machinery v0.8.1-0.20260611112329-244a3ec8172a
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/kuadrant/authorino-operator v0.21.0
 	github.com/kuadrant/dns-operator v0.0.0-20251125201831-f74008dc171c
 	github.com/kuadrant/limitador-operator v0.15.0
-	github.com/kuadrant/policy-machinery v0.8.1-0.20260611112329-244a3ec8172a
+	github.com/kuadrant/policy-machinery v0.9.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/kuadrant/policy-machinery v0.8.0 h1:WktikruCgNcNdITDOI80yfRnr4uivCh6b
 github.com/kuadrant/policy-machinery v0.8.0/go.mod h1:gAnVskiC8jXk13k56QHUhHvMUkYiDA6IqMpYv2UqOng=
 github.com/kuadrant/policy-machinery v0.8.1-0.20260611112329-244a3ec8172a h1:OUU62tFD1WxVvpTCIzStb/laBKAvHfY3rbQBm57LgqA=
 github.com/kuadrant/policy-machinery v0.8.1-0.20260611112329-244a3ec8172a/go.mod h1:cMPwXsMTamG2y3QmLKR3Vs4atZQ7wMIDNST6NXRlJ/4=
+github.com/kuadrant/policy-machinery v0.9.0 h1:qsNqfzikW9a3HYZjV9fEHdcO3wQ3kmbFt9XpcsECl0o=
+github.com/kuadrant/policy-machinery v0.9.0/go.mod h1:r7V8wn8UwL80p1FHgJJR5R2daPz1NX3FBHsj80xMC/o=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
@@ -220,6 +222,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
+golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
@@ -233,12 +237,18 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=
+golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
+golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
@@ -247,6 +257,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
+golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
 golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/kuadrant/limitador-operator v0.15.0 h1:BWgYKV0iasFY3+zKQhLpTdfIlI2pD4
 github.com/kuadrant/limitador-operator v0.15.0/go.mod h1:58b5gdSemjXUijd2TBPKBwaQskU7rynHGHD7rTqk2OE=
 github.com/kuadrant/policy-machinery v0.8.0 h1:WktikruCgNcNdITDOI80yfRnr4uivCh6bxxfrsf0ibc=
 github.com/kuadrant/policy-machinery v0.8.0/go.mod h1:gAnVskiC8jXk13k56QHUhHvMUkYiDA6IqMpYv2UqOng=
+github.com/kuadrant/policy-machinery v0.8.1-0.20260611112329-244a3ec8172a h1:OUU62tFD1WxVvpTCIzStb/laBKAvHfY3rbQBm57LgqA=
+github.com/kuadrant/policy-machinery v0.8.1-0.20260611112329-244a3ec8172a/go.mod h1:cMPwXsMTamG2y3QmLKR3Vs4atZQ7wMIDNST6NXRlJ/4=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -102,7 +103,7 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 			Namespace: authConfig.GetNamespace(),
 		}
 
-		if err := r.client.Resource(kuadrantauthorino.AuthConfigsResource).Namespace(authConfig.GetNamespace()).Delete(ctx, authConfig.GetName(), metav1.DeleteOptions{}); err != nil {
+		if err := r.client.Resource(kuadrantauthorino.AuthConfigsResource).Namespace(authConfig.GetNamespace()).Delete(ctx, authConfig.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			logger.Error(err, "failed to delete authconfig object", "authconfig", fmt.Sprintf("%s/%s", authConfig.GetNamespace(), authConfig.GetName()))
 
 			// Record the error for deferred retry instead of returning it
@@ -199,7 +200,7 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 
 	// delete
 	if utils.IsObjectTaggedToDelete(desiredAuthConfig) && !utils.IsObjectTaggedToDelete(existingAuthConfig) {
-		if err := resource.Delete(ctx, existingAuthConfig.GetName(), metav1.DeleteOptions{}); err != nil {
+		if err := resource.Delete(ctx, existingAuthConfig.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 			msg := "failed to delete authconfig object"
 			logger.Error(err, msg, "route", routeKey.String(), "routeRule", routeRuleKey, "authconfig", fmt.Sprintf("%s/%s", existingAuthConfig.GetNamespace(), existingAuthConfig.GetName()))
 			span.RecordError(err)

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -70,11 +70,13 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 	logger.V(1).Info("reconciling authconfig objects", "effectivePolicies", len(effectivePoliciesMap))
 	defer logger.V(1).Info("finished reconciling authconfig objects")
 
+	errorRegistry := GetOrCreateErrorRegistry(state)
+
 	desiredAuthConfigs := make(map[k8stypes.NamespacedName]struct{})
 	modifiedAuthConfigs := []string{}
 
 	for pathID, effectivePolicy := range effectivePoliciesMap {
-		authConfigName, modified := r.reconcileAuthConfigForPath(ctx, pathID, effectivePolicy, authConfigsNamespace, topology)
+		authConfigName, modified := r.reconcileAuthConfigForPath(ctx, pathID, effectivePolicy, authConfigsNamespace, topology, errorRegistry)
 		if authConfigName == "" {
 			continue
 		}
@@ -93,10 +95,24 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 		_, desired := desiredAuthConfigs[k8stypes.NamespacedName{Name: o.GetName(), Namespace: o.GetNamespace()}]
 		return o.GroupVersionKind().GroupKind() == kuadrantauthorino.AuthConfigGroupKind && labels.Set(o.(*controller.RuntimeObject).GetLabels()).AsSelector().Matches(AuthObjectLabels()) && !desired
 	})
+
 	for _, authConfig := range staleAuthConfigs {
+		resourceName := k8stypes.NamespacedName{
+			Name:      authConfig.GetName(),
+			Namespace: authConfig.GetNamespace(),
+		}
+
 		if err := r.client.Resource(kuadrantauthorino.AuthConfigsResource).Namespace(authConfig.GetNamespace()).Delete(ctx, authConfig.GetName(), metav1.DeleteOptions{}); err != nil {
 			logger.Error(err, "failed to delete authconfig object", "authconfig", fmt.Sprintf("%s/%s", authConfig.GetNamespace(), authConfig.GetName()))
-			// TODO: handle error
+
+			// Record the error for deferred retry instead of returning it
+			errorRegistry.Record(
+				"AuthConfigsReconciler",
+				"delete",
+				resourceName,
+				kuadrantauthorino.AuthConfigGroupKind,
+				err,
+			)
 		}
 	}
 
@@ -105,7 +121,7 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 
 // reconcileAuthConfigForPath reconciles the AuthConfig for a single effective policy path.
 // It returns the authConfigName (empty if the path is invalid) and whether the object was modified.
-func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, pathID string, effectivePolicy EffectiveAuthPolicy, authConfigsNamespace string, topology *machinery.Topology) (string, bool) {
+func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, pathID string, effectivePolicy EffectiveAuthPolicy, authConfigsNamespace string, topology *machinery.Topology, errorRegistry *ErrorRegistry) (string, bool) {
 	logger := controller.LoggerFromContext(ctx).WithName("AuthConfigsReconciler")
 
 	parsed, err := kuadrantpolicymachinery.ParseTopologyPath(effectivePolicy.Path)
@@ -161,7 +177,15 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 			logger.Error(err, msg, "route", routeKey.String(), "routeRule", routeRuleKey, "authconfig", desiredAuthConfigUnstructured.Object)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, msg)
-			// TODO: handle error
+
+			// Record error for deferred retry
+			errorRegistry.Record(
+				"AuthConfigsReconciler",
+				"create",
+				k8stypes.NamespacedName{Name: authConfigName, Namespace: authConfigsNamespace},
+				kuadrantauthorino.AuthConfigGroupKind,
+				err,
+			)
 		}
 		return authConfigName, true
 	}
@@ -180,7 +204,15 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 			logger.Error(err, msg, "route", routeKey.String(), "routeRule", routeRuleKey, "authconfig", fmt.Sprintf("%s/%s", existingAuthConfig.GetNamespace(), existingAuthConfig.GetName()))
 			span.RecordError(err)
 			span.SetStatus(codes.Error, msg)
-			// TODO: handle error
+
+			// Record error for deferred retry
+			errorRegistry.Record(
+				"AuthConfigsReconciler",
+				"delete",
+				k8stypes.NamespacedName{Name: authConfigName, Namespace: authConfigsNamespace},
+				kuadrantauthorino.AuthConfigGroupKind,
+				err,
+			)
 		}
 		return authConfigName, true
 	}
@@ -200,7 +232,15 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 		logger.Error(err, msg, "route", routeKey.String(), "routeRule", routeRuleKey, "authconfig", existingAuthConfigUnstructured.Object)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, msg)
-		// TODO: handle error
+
+		// Record error for deferred retry
+		errorRegistry.Record(
+			"AuthConfigsReconciler",
+			"update",
+			k8stypes.NamespacedName{Name: authConfigName, Namespace: authConfigsNamespace},
+			kuadrantauthorino.AuthConfigGroupKind,
+			err,
+		)
 	}
 	return authConfigName, true
 }

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -31,6 +31,8 @@ import (
 
 //+kubebuilder:rbac:groups=authorino.kuadrant.io,resources=authconfigs,verbs=get;list;watch;create;update;patch;delete
 
+const AuthConfigsReconcilerName = "AuthConfigsReconciler"
+
 type AuthConfigsReconciler struct {
 	client *dynamic.DynamicClient
 }
@@ -108,8 +110,8 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 
 			// Record the error for deferred retry instead of returning it
 			errorRegistry.Record(
-				"AuthConfigsReconciler",
-				"delete",
+				AuthConfigsReconcilerName,
+				OperationDelete,
 				resourceName,
 				kuadrantauthorino.AuthConfigGroupKind,
 				err,
@@ -181,8 +183,8 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 
 			// Record error for deferred retry
 			errorRegistry.Record(
-				"AuthConfigsReconciler",
-				"create",
+				AuthConfigsReconcilerName,
+				OperationCreate,
 				k8stypes.NamespacedName{Name: authConfigName, Namespace: authConfigsNamespace},
 				kuadrantauthorino.AuthConfigGroupKind,
 				err,
@@ -208,8 +210,8 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 
 			// Record error for deferred retry
 			errorRegistry.Record(
-				"AuthConfigsReconciler",
-				"delete",
+				AuthConfigsReconcilerName,
+				OperationDelete,
 				k8stypes.NamespacedName{Name: authConfigName, Namespace: authConfigsNamespace},
 				kuadrantauthorino.AuthConfigGroupKind,
 				err,
@@ -236,8 +238,8 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 
 		// Record error for deferred retry
 		errorRegistry.Record(
-			"AuthConfigsReconciler",
-			"update",
+			AuthConfigsReconcilerName,
+			OperationUpdate,
 			k8stypes.NamespacedName{Name: authConfigName, Namespace: authConfigsNamespace},
 			kuadrantauthorino.AuthConfigGroupKind,
 			err,

--- a/internal/controller/kuadrant_controller.go
+++ b/internal/controller/kuadrant_controller.go
@@ -55,6 +55,9 @@ func (c *KuadrantController) ScheduleRetry(delay time.Duration, events []control
 		"errorCount", c.errorTracker.GetErrorCount(),
 	)
 
+	// Defensive copy of events slice to avoid reference issues if caller reuses the backing array
+	eventsCopy := append([]controller.ResourceEvent(nil), events...)
+
 	// Create a new timer that will trigger propagation
 	c.retryTimer = time.AfterFunc(delay, func() {
 		c.logger.Info("triggering reconciliation retry for non-blocking errors",
@@ -65,7 +68,7 @@ func (c *KuadrantController) ScheduleRetry(delay time.Duration, events []control
 		if c.errorTracker.ShouldRequeue() > 0 {
 			// Trigger reconciliation by calling Propagate with the original events
 			// This forces the reconciliation workflow to run with the same context
-			c.Propagate(events)
+			c.Propagate(eventsCopy)
 		}
 	})
 }

--- a/internal/controller/kuadrant_controller.go
+++ b/internal/controller/kuadrant_controller.go
@@ -84,3 +84,28 @@ func (c *KuadrantController) cancelPendingRetry() {
 		c.logger.V(1).Info("cancelled pending retry (new reconciliation started)")
 	}
 }
+
+// Start wraps the embedded controller's Start method and ensures cleanup on context cancellation
+func (c *KuadrantController) Start(ctx context.Context) error {
+	// Start a goroutine to call Stop() when context is cancelled
+	go func() {
+		<-ctx.Done()
+		c.Stop()
+	}()
+
+	// Delegate to the embedded controller's Start method
+	return c.Controller.Start(ctx)
+}
+
+// Stop cancels any pending retry timer and cleans up resources
+// Called automatically when the context passed to Start() is cancelled
+func (c *KuadrantController) Stop() {
+	c.retryTimerMu.Lock()
+	defer c.retryTimerMu.Unlock()
+
+	if c.retryTimer != nil {
+		c.retryTimer.Stop()
+		c.retryTimer = nil
+		c.logger.V(1).Info("stopped retry timer on controller shutdown")
+	}
+}

--- a/internal/controller/kuadrant_controller.go
+++ b/internal/controller/kuadrant_controller.go
@@ -63,9 +63,9 @@ func (c *KuadrantController) ScheduleRetry(delay time.Duration, events []control
 
 		// Check if we should still retry (in case errors were resolved by external events)
 		if c.errorTracker.ShouldRequeue() > 0 {
-			// Trigger reconciliation by calling Propagate with empty events
-			// This forces the reconciliation workflow to run even though no objects changed
-			c.Controller.Propagate(events)
+			// Trigger reconciliation by calling Propagate with the original events
+			// This forces the reconciliation workflow to run with the same context
+			c.Propagate(events)
 		}
 	})
 }

--- a/internal/controller/kuadrant_controller.go
+++ b/internal/controller/kuadrant_controller.go
@@ -20,15 +20,6 @@ type KuadrantController struct {
 	retryTimerMu sync.Mutex
 }
 
-// NewKuadrantController wraps a policy-machinery controller with error tracking
-func NewKuadrantController(policyMachineryController *controller.Controller, errorTracker *PersistentErrorTracker, logger logr.Logger) *KuadrantController {
-	return &KuadrantController{
-		Controller:   policyMachineryController,
-		errorTracker: errorTracker,
-		logger:       logger.WithName("KuadrantController"),
-	}
-}
-
 // Reconcile implements the controller-runtime Reconciler interface
 // It delegates to the wrapped policy-machinery controller and handles error tracking
 func (c *KuadrantController) Reconcile(ctx context.Context, req ctrlruntimereconcile.Request) (ctrlruntimereconcile.Result, error) {

--- a/internal/controller/kuadrant_controller.go
+++ b/internal/controller/kuadrant_controller.go
@@ -1,0 +1,83 @@
+package controllers
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/policy-machinery/controller"
+	ctrlruntimereconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// KuadrantController wraps the policy-machinery controller with error tracking
+// and retry capabilities for non-blocking errors
+type KuadrantController struct {
+	*controller.Controller
+	errorTracker *PersistentErrorTracker
+	logger       logr.Logger
+	retryTimer   *time.Timer
+	retryTimerMu sync.Mutex
+}
+
+// NewKuadrantController wraps a policy-machinery controller with error tracking
+func NewKuadrantController(policyMachineryController *controller.Controller, errorTracker *PersistentErrorTracker, logger logr.Logger) *KuadrantController {
+	return &KuadrantController{
+		Controller:   policyMachineryController,
+		errorTracker: errorTracker,
+		logger:       logger.WithName("KuadrantController"),
+	}
+}
+
+// Reconcile implements the controller-runtime Reconciler interface
+// It delegates to the wrapped policy-machinery controller and handles error tracking
+func (c *KuadrantController) Reconcile(ctx context.Context, req ctrlruntimereconcile.Request) (ctrlruntimereconcile.Result, error) {
+	// Cancel any pending retry timer since we're reconciling now
+	c.cancelPendingRetry()
+
+	// Delegate to the policy-machinery controller's Reconcile method
+	return c.Controller.Reconcile(ctx, req)
+}
+
+// ScheduleRetry schedules a retry after the specified delay
+// This is called by ReconciliationErrorHandler from within the workflow
+func (c *KuadrantController) ScheduleRetry(delay time.Duration, events []controller.ResourceEvent) {
+	c.retryTimerMu.Lock()
+	defer c.retryTimerMu.Unlock()
+
+	// Cancel any existing timer
+	if c.retryTimer != nil {
+		c.retryTimer.Stop()
+	}
+
+	c.logger.V(1).Info("scheduling reconciliation retry for non-blocking errors",
+		"delay", delay,
+		"errorCount", c.errorTracker.GetErrorCount(),
+	)
+
+	// Create a new timer that will trigger propagation
+	c.retryTimer = time.AfterFunc(delay, func() {
+		c.logger.Info("triggering reconciliation retry for non-blocking errors",
+			"errorCount", c.errorTracker.GetErrorCount(),
+		)
+
+		// Check if we should still retry (in case errors were resolved by external events)
+		if c.errorTracker.ShouldRequeue() > 0 {
+			// Trigger reconciliation by calling Propagate with empty events
+			// This forces the reconciliation workflow to run even though no objects changed
+			c.Controller.Propagate(events)
+		}
+	})
+}
+
+// cancelPendingRetry cancels any scheduled retry timer
+func (c *KuadrantController) cancelPendingRetry() {
+	c.retryTimerMu.Lock()
+	defer c.retryTimerMu.Unlock()
+
+	if c.retryTimer != nil {
+		c.retryTimer.Stop()
+		c.retryTimer = nil
+		c.logger.V(1).Info("cancelled pending retry (new reconciliation started)")
+	}
+}

--- a/internal/controller/kuadrant_controller_test.go
+++ b/internal/controller/kuadrant_controller_test.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -24,11 +23,6 @@ func TestKuadrantController_ScheduleRetry(t *testing.T) {
 		{EventType: controller.UpdateEvent},
 	}
 
-	var timerFired bool
-	var timerMu sync.Mutex
-
-	// Mock time.AfterFunc to capture the timer behavior
-	// We can't easily mock time.AfterFunc, so we'll just verify the timer is set
 	kuadrantController.ScheduleRetry(100*time.Millisecond, events)
 
 	// Verify timer was created
@@ -59,10 +53,6 @@ func TestKuadrantController_ScheduleRetry(t *testing.T) {
 		t.Error("Expected timer to be cleared by Stop()")
 	}
 	kuadrantController.retryTimerMu.Unlock()
-
-	timerMu.Lock()
-	_ = timerFired // Prevent unused variable error
-	timerMu.Unlock()
 }
 
 func TestKuadrantController_CancelPendingRetry(t *testing.T) {
@@ -131,34 +121,5 @@ func TestKuadrantController_Stop(t *testing.T) {
 	kuadrantController.retryTimerMu.Unlock()
 
 	// Stopping again should be a no-op
-	kuadrantController.Stop()
-}
-
-func TestKuadrantController_EventsCopy(t *testing.T) {
-	logger := logr.Discard()
-	errorTracker := NewPersistentErrorTracker(logger)
-
-	kuadrantController := &KuadrantController{
-		errorTracker: errorTracker,
-		logger:       logger,
-	}
-
-	// Create events slice
-	events := []controller.ResourceEvent{
-		{EventType: controller.UpdateEvent},
-	}
-
-	// Schedule retry
-	kuadrantController.ScheduleRetry(100*time.Millisecond, events)
-
-	// Modify the original events slice (simulate backing array reuse)
-	events[0].EventType = controller.DeleteEvent
-	events = append(events, controller.ResourceEvent{EventType: controller.CreateEvent})
-
-	// The timer callback should have a copy, not the modified slice
-	// We can't easily verify this without triggering the timer, but at least
-	// we've verified the code creates a copy in the implementation
-
-	// Clean up
 	kuadrantController.Stop()
 }

--- a/internal/controller/kuadrant_controller_test.go
+++ b/internal/controller/kuadrant_controller_test.go
@@ -1,85 +1,164 @@
 package controllers
 
 import (
-	"context"
-	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
-	ctrlruntimereconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"github.com/kuadrant/policy-machinery/controller"
 )
 
-// mockController implements the Reconcile method for testing
-type mockController struct {
-	reconcileResult ctrlruntimereconcile.Result
-	reconcileError  error
-}
-
-func (m *mockController) Reconcile(_ context.Context, _ ctrlruntimereconcile.Request) (ctrlruntimereconcile.Result, error) {
-	return m.reconcileResult, m.reconcileError
-}
-
-func TestKuadrantController_Reconcile_BlockingError(t *testing.T) {
+func TestKuadrantController_ScheduleRetry(t *testing.T) {
 	logger := logr.Discard()
 	errorTracker := NewPersistentErrorTracker(logger)
 
-	// Create a mock controller that returns a blocking error
-	blockingErr := errors.New("topology build failed")
-	mock := &mockController{
-		reconcileResult: ctrlruntimereconcile.Result{},
-		reconcileError:  blockingErr,
+	// Create a minimal KuadrantController (Controller field can be nil for this test)
+	kuadrantController := &KuadrantController{
+		errorTracker: errorTracker,
+		logger:       logger,
 	}
 
-	// We can't directly create a controller.Controller, so we'll just test the logic
-	// In a real scenario, the KuadrantController wraps a real controller
-
-	// Simulate the logic from KuadrantController.Reconcile
-	result, err := mock.Reconcile(context.Background(), ctrlruntimereconcile.Request{})
-
-	// Blocking error should be returned immediately
-	if err == nil {
-		t.Error("Expected blocking error to be returned")
-	}
-	if !errors.Is(err, blockingErr) {
-		t.Errorf("Expected error %v, got %v", blockingErr, err)
+	// Test scheduling a retry
+	events := []controller.ResourceEvent{
+		{EventType: controller.UpdateEvent},
 	}
 
-	// Error tracker should not affect the result when there's a blocking error
-	if result.RequeueAfter != 0 {
-		t.Errorf("Expected no requeue with blocking error, got %v", result.RequeueAfter)
-	}
+	var timerFired bool
+	var timerMu sync.Mutex
 
-	// Verify error tracker state didn't interfere
-	if errorTracker.ShouldRequeue() != 0 {
-		t.Error("Error tracker should not have errors")
+	// Mock time.AfterFunc to capture the timer behavior
+	// We can't easily mock time.AfterFunc, so we'll just verify the timer is set
+	kuadrantController.ScheduleRetry(100*time.Millisecond, events)
+
+	// Verify timer was created
+	kuadrantController.retryTimerMu.Lock()
+	if kuadrantController.retryTimer == nil {
+		t.Error("Expected retry timer to be set")
 	}
+	initialTimer := kuadrantController.retryTimer
+	kuadrantController.retryTimerMu.Unlock()
+
+	// Schedule another retry - should cancel the first timer
+	kuadrantController.ScheduleRetry(200*time.Millisecond, events)
+
+	kuadrantController.retryTimerMu.Lock()
+	if kuadrantController.retryTimer == initialTimer {
+		t.Error("Expected new timer to replace the old one")
+	}
+	if kuadrantController.retryTimer == nil {
+		t.Error("Expected new retry timer to be set")
+	}
+	kuadrantController.retryTimerMu.Unlock()
+
+	// Clean up
+	kuadrantController.Stop()
+
+	kuadrantController.retryTimerMu.Lock()
+	if kuadrantController.retryTimer != nil {
+		t.Error("Expected timer to be cleared by Stop()")
+	}
+	kuadrantController.retryTimerMu.Unlock()
+
+	timerMu.Lock()
+	_ = timerFired // Prevent unused variable error
+	timerMu.Unlock()
 }
 
-func TestKuadrantController_Reconcile_NoErrors(t *testing.T) {
-	// Create a mock controller that succeeds
-	mock := &mockController{
-		reconcileResult: ctrlruntimereconcile.Result{},
-		reconcileError:  nil,
-	}
-
+func TestKuadrantController_CancelPendingRetry(t *testing.T) {
 	logger := logr.Discard()
 	errorTracker := NewPersistentErrorTracker(logger)
 
-	// Simulate the logic
-	result, err := mock.Reconcile(context.Background(), ctrlruntimereconcile.Request{})
-
-	// Should succeed with no error
-	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
+	kuadrantController := &KuadrantController{
+		errorTracker: errorTracker,
+		logger:       logger,
 	}
 
-	// No requeue should be set (no non-blocking errors)
-	requeueAfter := errorTracker.ShouldRequeue()
-	if requeueAfter != 0 {
-		t.Errorf("Expected no requeue, got %v", requeueAfter)
+	// Schedule a retry
+	events := []controller.ResourceEvent{
+		{EventType: controller.UpdateEvent},
+	}
+	kuadrantController.ScheduleRetry(1*time.Second, events)
+
+	// Verify timer is set
+	kuadrantController.retryTimerMu.Lock()
+	if kuadrantController.retryTimer == nil {
+		t.Fatal("Expected retry timer to be set")
+	}
+	kuadrantController.retryTimerMu.Unlock()
+
+	// Cancel the pending retry
+	kuadrantController.cancelPendingRetry()
+
+	// Verify timer is cleared
+	kuadrantController.retryTimerMu.Lock()
+	if kuadrantController.retryTimer != nil {
+		t.Error("Expected timer to be cancelled")
+	}
+	kuadrantController.retryTimerMu.Unlock()
+}
+
+func TestKuadrantController_Stop(t *testing.T) {
+	logger := logr.Discard()
+	errorTracker := NewPersistentErrorTracker(logger)
+
+	kuadrantController := &KuadrantController{
+		errorTracker: errorTracker,
+		logger:       logger,
 	}
 
-	if result.RequeueAfter != 0 {
-		t.Errorf("Expected no requeue in result, got %v", result.RequeueAfter)
+	// Schedule a retry
+	events := []controller.ResourceEvent{
+		{EventType: controller.UpdateEvent},
 	}
+	kuadrantController.ScheduleRetry(1*time.Second, events)
+
+	// Verify timer is set
+	kuadrantController.retryTimerMu.Lock()
+	if kuadrantController.retryTimer == nil {
+		t.Fatal("Expected retry timer to be set")
+	}
+	kuadrantController.retryTimerMu.Unlock()
+
+	// Stop the controller
+	kuadrantController.Stop()
+
+	// Verify timer is cleaned up
+	kuadrantController.retryTimerMu.Lock()
+	if kuadrantController.retryTimer != nil {
+		t.Error("Expected timer to be stopped and cleared")
+	}
+	kuadrantController.retryTimerMu.Unlock()
+
+	// Stopping again should be a no-op
+	kuadrantController.Stop()
+}
+
+func TestKuadrantController_EventsCopy(t *testing.T) {
+	logger := logr.Discard()
+	errorTracker := NewPersistentErrorTracker(logger)
+
+	kuadrantController := &KuadrantController{
+		errorTracker: errorTracker,
+		logger:       logger,
+	}
+
+	// Create events slice
+	events := []controller.ResourceEvent{
+		{EventType: controller.UpdateEvent},
+	}
+
+	// Schedule retry
+	kuadrantController.ScheduleRetry(100*time.Millisecond, events)
+
+	// Modify the original events slice (simulate backing array reuse)
+	events[0].EventType = controller.DeleteEvent
+	events = append(events, controller.ResourceEvent{EventType: controller.CreateEvent})
+
+	// The timer callback should have a copy, not the modified slice
+	// We can't easily verify this without triggering the timer, but at least
+	// we've verified the code creates a copy in the implementation
+
+	// Clean up
+	kuadrantController.Stop()
 }

--- a/internal/controller/kuadrant_controller_test.go
+++ b/internal/controller/kuadrant_controller_test.go
@@ -15,7 +15,7 @@ type mockController struct {
 	reconcileError  error
 }
 
-func (m *mockController) Reconcile(ctx context.Context, req ctrlruntimereconcile.Request) (ctrlruntimereconcile.Result, error) {
+func (m *mockController) Reconcile(_ context.Context, _ ctrlruntimereconcile.Request) (ctrlruntimereconcile.Result, error) {
 	return m.reconcileResult, m.reconcileError
 }
 
@@ -40,7 +40,7 @@ func TestKuadrantController_Reconcile_BlockingError(t *testing.T) {
 	if err == nil {
 		t.Error("Expected blocking error to be returned")
 	}
-	if err != blockingErr {
+	if !errors.Is(err, blockingErr) {
 		t.Errorf("Expected error %v, got %v", blockingErr, err)
 	}
 

--- a/internal/controller/kuadrant_controller_test.go
+++ b/internal/controller/kuadrant_controller_test.go
@@ -1,0 +1,85 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	ctrlruntimereconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// mockController implements the Reconcile method for testing
+type mockController struct {
+	reconcileResult ctrlruntimereconcile.Result
+	reconcileError  error
+}
+
+func (m *mockController) Reconcile(ctx context.Context, req ctrlruntimereconcile.Request) (ctrlruntimereconcile.Result, error) {
+	return m.reconcileResult, m.reconcileError
+}
+
+func TestKuadrantController_Reconcile_BlockingError(t *testing.T) {
+	logger := logr.Discard()
+	errorTracker := NewPersistentErrorTracker(logger)
+
+	// Create a mock controller that returns a blocking error
+	blockingErr := errors.New("topology build failed")
+	mock := &mockController{
+		reconcileResult: ctrlruntimereconcile.Result{},
+		reconcileError:  blockingErr,
+	}
+
+	// We can't directly create a controller.Controller, so we'll just test the logic
+	// In a real scenario, the KuadrantController wraps a real controller
+
+	// Simulate the logic from KuadrantController.Reconcile
+	result, err := mock.Reconcile(context.Background(), ctrlruntimereconcile.Request{})
+
+	// Blocking error should be returned immediately
+	if err == nil {
+		t.Error("Expected blocking error to be returned")
+	}
+	if err != blockingErr {
+		t.Errorf("Expected error %v, got %v", blockingErr, err)
+	}
+
+	// Error tracker should not affect the result when there's a blocking error
+	if result.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue with blocking error, got %v", result.RequeueAfter)
+	}
+
+	// Verify error tracker state didn't interfere
+	if errorTracker.ShouldRequeue() != 0 {
+		t.Error("Error tracker should not have errors")
+	}
+}
+
+func TestKuadrantController_Reconcile_NoErrors(t *testing.T) {
+	// Create a mock controller that succeeds
+	mock := &mockController{
+		reconcileResult: ctrlruntimereconcile.Result{},
+		reconcileError:  nil,
+	}
+
+	logger := logr.Discard()
+	errorTracker := NewPersistentErrorTracker(logger)
+
+	// Simulate the logic
+	result, err := mock.Reconcile(context.Background(), ctrlruntimereconcile.Request{})
+
+	// Should succeed with no error
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// No requeue should be set (no non-blocking errors)
+	requeueAfter := errorTracker.ShouldRequeue()
+	if requeueAfter != 0 {
+		t.Errorf("Expected no requeue, got %v", requeueAfter)
+	}
+
+	if result.RequeueAfter != 0 {
+		t.Errorf("Expected no requeue in result, got %v", result.RequeueAfter)
+	}
+}

--- a/internal/controller/limitador_limits_reconciler.go
+++ b/internal/controller/limitador_limits_reconciler.go
@@ -25,6 +25,8 @@ import (
 	"github.com/kuadrant/kuadrant-operator/internal/utils"
 )
 
+const LimitadorLimitsReconcilerName = "LimitadorLimitsReconciler"
+
 type LimitadorLimitsReconciler struct {
 	client *dynamic.DynamicClient
 }
@@ -98,8 +100,8 @@ func (r *LimitadorLimitsReconciler) Reconcile(ctx context.Context, _ []controlle
 		// Record error for deferred retry
 		errorRegistry := GetOrCreateErrorRegistry(state)
 		errorRegistry.Record(
-			"LimitadorLimitsReconciler",
-			"update",
+			LimitadorLimitsReconcilerName,
+			OperationUpdate,
 			k8stypes.NamespacedName{Name: limitador.GetName(), Namespace: limitador.GetNamespace()},
 			kuadrantv1beta1.LimitadorGroupKind,
 			err,

--- a/internal/controller/limitador_limits_reconciler.go
+++ b/internal/controller/limitador_limits_reconciler.go
@@ -94,7 +94,16 @@ func (r *LimitadorLimitsReconciler) Reconcile(ctx context.Context, _ []controlle
 
 	if _, err := r.client.Resource(kuadrantv1beta1.LimitadorsResource).Namespace(limitador.GetNamespace()).Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
 		logger.Error(err, "failed to update limitador object")
-		// TODO: handle error
+
+		// Record error for deferred retry
+		errorRegistry := GetOrCreateErrorRegistry(state)
+		errorRegistry.Record(
+			"LimitadorLimitsReconciler",
+			"update",
+			k8stypes.NamespacedName{Name: limitador.GetName(), Namespace: limitador.GetNamespace()},
+			kuadrantv1beta1.LimitadorGroupKind,
+			err,
+		)
 	}
 
 	logger.V(1).Info("finished updating limitador object", "limitador", (k8stypes.NamespacedName{Name: limitador.GetName(), Namespace: limitador.GetNamespace()}).String())

--- a/internal/controller/reconciliation_errors.go
+++ b/internal/controller/reconciliation_errors.go
@@ -24,6 +24,11 @@ const (
 	initialRetryDelay = 2 * time.Second
 	maxRetryDelay     = 1 * time.Minute
 	maxRetryAttempts  = 5
+
+	// Operation types for error recording
+	OperationCreate = "create"
+	OperationUpdate = "update"
+	OperationDelete = "delete"
 )
 
 // ReconciliationError represents a single non-blocking error

--- a/internal/controller/reconciliation_errors.go
+++ b/internal/controller/reconciliation_errors.go
@@ -174,6 +174,21 @@ func (t *PersistentErrorTracker) UpdateFromRegistry(registry *ErrorRegistry) {
 			existing.LastSeen = time.Now()
 			existing.Err = newErr.Err // Update error message in case it changed
 
+			// Check if we've exceeded max retries - if so, give up and remove from tracker
+			if !existing.ShouldRetry() {
+				t.logger.Error(existing.Err, "max retry attempts reached, giving up",
+					"source", existing.Source,
+					"operation", existing.Operation,
+					"resource", existing.Resource.String(),
+					"kind", existing.ResourceKind.String(),
+					"attempts", existing.RetryCount,
+					"duration", time.Since(existing.FirstSeen),
+				)
+				delete(t.errors, key)
+				delete(currentKeys, key) // Don't count as "still active"
+				continue
+			}
+
 			t.logger.V(1).Info("error persists",
 				"key", key,
 				"retryCount", existing.RetryCount,
@@ -220,33 +235,14 @@ func (t *PersistentErrorTracker) ShouldRequeue() time.Duration {
 		return 0
 	}
 
-	// Find the minimum retry delay among all retryable errors
+	// Find the minimum retry delay among all errors
+	// (errors that exceed max retries are already removed from the tracker)
 	var minDelay time.Duration
-	hasRetryableError := false
-
 	for _, err := range t.errors {
-		if !err.ShouldRetry() {
-			// Max attempts reached - log and skip
-			t.logger.Error(err.Err, "max retry attempts reached, giving up",
-				"source", err.Source,
-				"operation", err.Operation,
-				"resource", err.Resource.String(),
-				"kind", err.ResourceKind.String(),
-				"attempts", err.RetryCount,
-				"duration", time.Since(err.FirstSeen),
-			)
-			continue
-		}
-
 		delay := err.NextRetryDelay()
-		if !hasRetryableError || delay < minDelay {
+		if minDelay == 0 || delay < minDelay {
 			minDelay = delay
-			hasRetryableError = true
 		}
-	}
-
-	if !hasRetryableError {
-		return 0
 	}
 
 	return minDelay

--- a/internal/controller/reconciliation_errors.go
+++ b/internal/controller/reconciliation_errors.go
@@ -50,7 +50,20 @@ func (e *ReconciliationError) Key() string {
 
 // NextRetryDelay calculates exponential backoff delay
 func (e *ReconciliationError) NextRetryDelay() time.Duration {
-	delay := time.Duration(float64(initialRetryDelay) * float64(uint(1)<<uint(e.RetryCount)))
+	// Calculate 2^retryCount with safe conversion
+	// Cap the shift at 30 to avoid overflow (2^30 seconds = ~34 years, well over maxRetryDelay)
+	retryCount := e.RetryCount
+	if retryCount < 0 {
+		retryCount = 0
+	}
+	if retryCount > 30 {
+		retryCount = 30
+	}
+
+	// Safe conversion: retryCount is now guaranteed to be in [0, 30]
+	// #nosec G115 -- retryCount is bounded to [0, 30]
+	shift := uint(retryCount)
+	delay := time.Duration(float64(initialRetryDelay) * float64(uint(1)<<shift))
 	if delay > maxRetryDelay {
 		delay = maxRetryDelay
 	}

--- a/internal/controller/reconciliation_errors.go
+++ b/internal/controller/reconciliation_errors.go
@@ -1,0 +1,317 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// StateReconciliationErrors is the key for storing errors in the workflow state
+	StateReconciliationErrors = "ReconciliationErrors"
+
+	// StateRequeueAfter is the key for storing the requeue delay in workflow state
+	StateRequeueAfter = "RequeueAfter"
+
+	// Retry configuration
+	initialRetryDelay = 2 * time.Second
+	maxRetryDelay     = 1 * time.Minute
+	maxRetryAttempts  = 5
+)
+
+// ReconciliationError represents a single non-blocking error
+type ReconciliationError struct {
+	Source       string                  // Reconciler name
+	Operation    string                  // create, update, delete
+	Resource     k8stypes.NamespacedName // Resource that failed
+	ResourceKind schema.GroupKind        // Resource type
+	Err          error                   // Underlying error
+	FirstSeen    time.Time               // When first recorded
+	LastSeen     time.Time               // When last attempted
+	RetryCount   int                     // Number of retry attempts
+}
+
+// Key returns a unique identifier for this error
+func (e *ReconciliationError) Key() string {
+	return fmt.Sprintf("%s/%s/%s/%s",
+		e.ResourceKind.String(),
+		e.Resource.Namespace,
+		e.Resource.Name,
+		e.Operation,
+	)
+}
+
+// NextRetryDelay calculates exponential backoff delay
+func (e *ReconciliationError) NextRetryDelay() time.Duration {
+	delay := time.Duration(float64(initialRetryDelay) * float64(uint(1)<<uint(e.RetryCount)))
+	if delay > maxRetryDelay {
+		delay = maxRetryDelay
+	}
+	return delay
+}
+
+// ShouldRetry determines if this error should be retried
+func (e *ReconciliationError) ShouldRetry() bool {
+	return e.RetryCount < maxRetryAttempts
+}
+
+// ErrorRegistry collects non-blocking errors during a single reconciliation
+// It's stored in the workflow state map and only lives for one reconciliation cycle
+type ErrorRegistry struct {
+	mu     sync.Mutex
+	errors map[string]*ReconciliationError
+}
+
+// NewErrorRegistry creates a new error registry
+func NewErrorRegistry() *ErrorRegistry {
+	return &ErrorRegistry{
+		errors: make(map[string]*ReconciliationError),
+	}
+}
+
+// Record adds a non-blocking error to the registry
+func (r *ErrorRegistry) Record(source, operation string, resource k8stypes.NamespacedName, kind schema.GroupKind, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	rec := &ReconciliationError{
+		Source:       source,
+		Operation:    operation,
+		Resource:     resource,
+		ResourceKind: kind,
+		Err:          err,
+		FirstSeen:    time.Now(),
+		LastSeen:     time.Now(),
+		RetryCount:   0,
+	}
+
+	r.errors[rec.Key()] = rec
+}
+
+// GetErrors returns all recorded errors
+func (r *ErrorRegistry) GetErrors() []*ReconciliationError {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	errors := make([]*ReconciliationError, 0, len(r.errors))
+	for _, err := range r.errors {
+		errors = append(errors, err)
+	}
+	return errors
+}
+
+// HasErrors returns true if any errors were recorded
+func (r *ErrorRegistry) HasErrors() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.errors) > 0
+}
+
+// GetOrCreateErrorRegistry retrieves or creates an error registry from workflow state
+func GetOrCreateErrorRegistry(state *sync.Map) *ErrorRegistry {
+	if state == nil {
+		return NewErrorRegistry()
+	}
+
+	reg, _ := state.LoadOrStore(StateReconciliationErrors, NewErrorRegistry())
+	return reg.(*ErrorRegistry)
+}
+
+// PersistentErrorTracker tracks errors across reconciliation cycles
+// It's stored in the Controller and persists beyond individual reconciliations
+type PersistentErrorTracker struct {
+	mu     sync.RWMutex
+	errors map[string]*ReconciliationError
+	logger logr.Logger
+}
+
+// NewPersistentErrorTracker creates a new persistent error tracker
+func NewPersistentErrorTracker(logger logr.Logger) *PersistentErrorTracker {
+	return &PersistentErrorTracker{
+		errors: make(map[string]*ReconciliationError),
+		logger: logger.WithName("PersistentErrorTracker"),
+	}
+}
+
+// UpdateFromRegistry merges errors from a workflow's error registry
+// This is called at the end of each reconciliation to persist errors
+func (t *PersistentErrorTracker) UpdateFromRegistry(registry *ErrorRegistry) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	newErrors := registry.GetErrors()
+
+	// Track which errors are still active in this reconciliation
+	currentKeys := make(map[string]bool)
+
+	for _, newErr := range newErrors {
+		key := newErr.Key()
+		currentKeys[key] = true
+
+		if existing, found := t.errors[key]; found {
+			// Error persists - increment retry count
+			existing.RetryCount++
+			existing.LastSeen = time.Now()
+			existing.Err = newErr.Err // Update error message in case it changed
+
+			t.logger.V(1).Info("error persists",
+				"key", key,
+				"retryCount", existing.RetryCount,
+				"nextDelay", existing.NextRetryDelay(),
+			)
+		} else {
+			// New error
+			newErr.FirstSeen = time.Now()
+			newErr.LastSeen = time.Now()
+			newErr.RetryCount = 0
+			t.errors[key] = newErr
+
+			t.logger.Info("new non-blocking error recorded",
+				"source", newErr.Source,
+				"operation", newErr.Operation,
+				"resource", newErr.Resource.String(),
+				"kind", newErr.ResourceKind.String(),
+				"error", newErr.Err.Error(),
+			)
+		}
+	}
+
+	// Remove errors that were not seen in this reconciliation
+	// (they were successfully resolved)
+	for key, err := range t.errors {
+		if !currentKeys[key] {
+			t.logger.Info("non-blocking error resolved",
+				"key", key,
+				"attempts", err.RetryCount+1,
+				"duration", time.Since(err.FirstSeen),
+			)
+			delete(t.errors, key)
+		}
+	}
+}
+
+// ShouldRequeue determines if we need to schedule a retry reconciliation
+// Returns the delay until the next retry, or zero if no retry needed
+func (t *PersistentErrorTracker) ShouldRequeue() time.Duration {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	if len(t.errors) == 0 {
+		return 0
+	}
+
+	// Find the minimum retry delay among all retryable errors
+	var minDelay time.Duration
+	hasRetryableError := false
+
+	for _, err := range t.errors {
+		if !err.ShouldRetry() {
+			// Max attempts reached - log and skip
+			t.logger.Error(err.Err, "max retry attempts reached, giving up",
+				"source", err.Source,
+				"operation", err.Operation,
+				"resource", err.Resource.String(),
+				"kind", err.ResourceKind.String(),
+				"attempts", err.RetryCount,
+				"duration", time.Since(err.FirstSeen),
+			)
+			continue
+		}
+
+		delay := err.NextRetryDelay()
+		if !hasRetryableError || delay < minDelay {
+			minDelay = delay
+			hasRetryableError = true
+		}
+	}
+
+	if !hasRetryableError {
+		return 0
+	}
+
+	return minDelay
+}
+
+// GetErrorCount returns the number of tracked errors
+func (t *PersistentErrorTracker) GetErrorCount() int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return len(t.errors)
+}
+
+// Clear removes all tracked errors (used for testing or manual intervention)
+func (t *PersistentErrorTracker) Clear() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.logger.Info("clearing all tracked errors", "count", len(t.errors))
+	t.errors = make(map[string]*ReconciliationError)
+}
+
+// RetryScheduler is a callback to schedule a retry after a delay
+type RetryScheduler func(delay time.Duration, events []controller.ResourceEvent)
+
+// ReconciliationErrorHandler is a workflow postcondition that:
+// 1. Collects errors from the ErrorRegistry in workflow state
+// 2. Merges them into the PersistentErrorTracker
+// 3. Schedules a retry if needed (via callback)
+type ReconciliationErrorHandler struct {
+	tracker       *PersistentErrorTracker
+	scheduleRetry RetryScheduler
+}
+
+func NewReconciliationErrorHandler(tracker *PersistentErrorTracker, scheduleRetry RetryScheduler) *ReconciliationErrorHandler {
+	return &ReconciliationErrorHandler{
+		tracker:       tracker,
+		scheduleRetry: scheduleRetry,
+	}
+}
+
+// Reconcile processes errors from the registry and determines requeue strategy
+// This is meant to be called as a workflow postcondition, not via the Subscription pattern
+func (h *ReconciliationErrorHandler) Reconcile(ctx context.Context, events []controller.ResourceEvent, _ *machinery.Topology, _ error, state *sync.Map) error {
+	logger := controller.LoggerFromContext(ctx).WithName("ReconciliationErrorHandler")
+
+	registry := GetOrCreateErrorRegistry(state)
+
+	if !registry.HasErrors() {
+		logger.V(1).Info("no non-blocking errors in this reconciliation")
+		// No errors in this cycle - tracker will clean up resolved errors
+		h.tracker.UpdateFromRegistry(registry)
+		return nil
+	}
+
+	errors := registry.GetErrors()
+	logger.V(1).Info("processing non-blocking errors", "count", len(errors))
+
+	// Merge errors into persistent tracker
+	h.tracker.UpdateFromRegistry(registry)
+
+	// Determine if we should requeue
+	requeueAfter := h.tracker.ShouldRequeue()
+
+	if requeueAfter > 0 {
+		logger.Info("scheduling retry for non-blocking errors",
+			"errorCount", h.tracker.GetErrorCount(),
+			"requeueAfter", requeueAfter,
+		)
+
+		// Schedule the retry via callback (runs in the workflow's goroutine)
+		if h.scheduleRetry != nil {
+			h.scheduleRetry(requeueAfter, events)
+		}
+	} else {
+		logger.Info("all non-blocking errors have exceeded max retry attempts",
+			"errorCount", h.tracker.GetErrorCount(),
+		)
+	}
+
+	return nil
+}

--- a/internal/controller/reconciliation_errors_test.go
+++ b/internal/controller/reconciliation_errors_test.go
@@ -1,0 +1,295 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/policy-machinery/controller"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+func TestErrorRegistry_Record(t *testing.T) {
+	registry := NewErrorRegistry()
+
+	resource := k8stypes.NamespacedName{Namespace: "test-ns", Name: "test-resource"}
+	kind := schema.GroupKind{Group: "test.io", Kind: "TestKind"}
+	err := errors.New("test error")
+
+	registry.Record("TestReconciler", "delete", resource, kind, err)
+
+	if !registry.HasErrors() {
+		t.Error("Expected registry to have errors")
+	}
+
+	errors := registry.GetErrors()
+	if len(errors) != 1 {
+		t.Errorf("Expected 1 error, got %d", len(errors))
+	}
+
+	recErr := errors[0]
+	if recErr.Source != "TestReconciler" {
+		t.Errorf("Expected source 'TestReconciler', got '%s'", recErr.Source)
+	}
+	if recErr.Operation != "delete" {
+		t.Errorf("Expected operation 'delete', got '%s'", recErr.Operation)
+	}
+	if recErr.Resource != resource {
+		t.Errorf("Expected resource %v, got %v", resource, recErr.Resource)
+	}
+	if recErr.ResourceKind != kind {
+		t.Errorf("Expected kind %v, got %v", kind, recErr.ResourceKind)
+	}
+}
+
+func TestReconciliationError_Key(t *testing.T) {
+	err := &ReconciliationError{
+		Resource:     k8stypes.NamespacedName{Namespace: "ns", Name: "name"},
+		ResourceKind: schema.GroupKind{Group: "test.io", Kind: "TestKind"},
+		Operation:    "delete",
+	}
+
+	expected := "TestKind.test.io/ns/name/delete"
+	if err.Key() != expected {
+		t.Errorf("Expected key '%s', got '%s'", expected, err.Key())
+	}
+}
+
+func TestReconciliationError_NextRetryDelay(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryCount int
+		expected   time.Duration
+	}{
+		{"first retry", 0, 2 * time.Second},
+		{"second retry", 1, 4 * time.Second},
+		{"third retry", 2, 8 * time.Second},
+		{"fourth retry", 3, 16 * time.Second},
+		{"fifth retry", 4, 32 * time.Second},
+		{"capped at max", 5, 1 * time.Minute}, // Should be capped at maxRetryDelay
+		{"capped at max", 10, 1 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &ReconciliationError{RetryCount: tt.retryCount}
+			delay := err.NextRetryDelay()
+			if delay != tt.expected {
+				t.Errorf("Expected delay %v, got %v", tt.expected, delay)
+			}
+		})
+	}
+}
+
+func TestReconciliationError_ShouldRetry(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryCount int
+		expected   bool
+	}{
+		{"under limit", 0, true},
+		{"under limit", 4, true},
+		{"at limit", 5, false},
+		{"over limit", 6, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := &ReconciliationError{RetryCount: tt.retryCount}
+			if err.ShouldRetry() != tt.expected {
+				t.Errorf("Expected ShouldRetry() = %v, got %v", tt.expected, err.ShouldRetry())
+			}
+		})
+	}
+}
+
+func TestPersistentErrorTracker_UpdateFromRegistry(t *testing.T) {
+	logger := logr.Discard()
+	tracker := NewPersistentErrorTracker(logger)
+
+	resource1 := k8stypes.NamespacedName{Namespace: "ns", Name: "resource1"}
+	resource2 := k8stypes.NamespacedName{Namespace: "ns", Name: "resource2"}
+	kind := schema.GroupKind{Group: "test.io", Kind: "TestKind"}
+
+	// First reconciliation - record two errors
+	registry1 := NewErrorRegistry()
+	registry1.Record("TestReconciler", "delete", resource1, kind, errors.New("error1"))
+	registry1.Record("TestReconciler", "delete", resource2, kind, errors.New("error2"))
+
+	tracker.UpdateFromRegistry(registry1)
+
+	if tracker.GetErrorCount() != 2 {
+		t.Errorf("Expected 2 errors, got %d", tracker.GetErrorCount())
+	}
+
+	// Second reconciliation - resource1 still fails, resource2 succeeds
+	registry2 := NewErrorRegistry()
+	registry2.Record("TestReconciler", "delete", resource1, kind, errors.New("error1 still failing"))
+
+	tracker.UpdateFromRegistry(registry2)
+
+	// Should have 1 error (resource2 was resolved)
+	if tracker.GetErrorCount() != 1 {
+		t.Errorf("Expected 1 error after resolution, got %d", tracker.GetErrorCount())
+	}
+
+	// Check that retry count was incremented for resource1
+	tracker.mu.RLock()
+	key1 := "TestKind.test.io/ns/resource1/delete"
+	if err, found := tracker.errors[key1]; !found {
+		t.Error("Expected resource1 error to still be tracked")
+	} else if err.RetryCount != 1 {
+		t.Errorf("Expected retry count 1, got %d", err.RetryCount)
+	}
+	tracker.mu.RUnlock()
+}
+
+func TestPersistentErrorTracker_ShouldRequeue(t *testing.T) {
+	logger := logr.Discard()
+	tracker := NewPersistentErrorTracker(logger)
+
+	// No errors - should not requeue
+	if delay := tracker.ShouldRequeue(); delay != 0 {
+		t.Errorf("Expected no requeue with no errors, got %v", delay)
+	}
+
+	// Add error with retry count 0 - should requeue after 2s
+	registry := NewErrorRegistry()
+	resource := k8stypes.NamespacedName{Namespace: "ns", Name: "resource"}
+	kind := schema.GroupKind{Group: "test.io", Kind: "TestKind"}
+	registry.Record("TestReconciler", "delete", resource, kind, errors.New("error"))
+
+	tracker.UpdateFromRegistry(registry)
+
+	delay := tracker.ShouldRequeue()
+	if delay != 2*time.Second {
+		t.Errorf("Expected 2s requeue delay, got %v", delay)
+	}
+
+	// Simulate another failure - retry count should be 1, delay 4s
+	registry2 := NewErrorRegistry()
+	registry2.Record("TestReconciler", "delete", resource, kind, errors.New("error"))
+	tracker.UpdateFromRegistry(registry2)
+
+	delay = tracker.ShouldRequeue()
+	if delay != 4*time.Second {
+		t.Errorf("Expected 4s requeue delay, got %v", delay)
+	}
+
+	// Exceed max retries - should not requeue
+	for i := 0; i < 5; i++ {
+		reg := NewErrorRegistry()
+		reg.Record("TestReconciler", "delete", resource, kind, errors.New("error"))
+		tracker.UpdateFromRegistry(reg)
+	}
+
+	delay = tracker.ShouldRequeue()
+	if delay != 0 {
+		t.Errorf("Expected no requeue after max retries, got %v", delay)
+	}
+}
+
+func TestReconciliationErrorHandler_Reconcile(t *testing.T) {
+	logger := logr.Discard()
+	tracker := NewPersistentErrorTracker(logger)
+
+	// Track if retry was scheduled
+	var scheduledDelay time.Duration
+	scheduleRetry := func(delay time.Duration, events []controller.ResourceEvent) {
+		scheduledDelay = delay
+		// events are captured but not asserted in this test
+	}
+
+	handler := NewReconciliationErrorHandler(tracker, scheduleRetry)
+
+	ctx := context.Background()
+	ctx = controller.LoggerIntoContext(ctx, logger)
+	state := &sync.Map{}
+
+	// No errors - should not set requeue
+	err := handler.Reconcile(ctx, nil, nil, nil, state)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if _, ok := state.Load(StateRequeueAfter); ok {
+		t.Error("Expected no requeue decision with no errors")
+	}
+
+	// Add error to registry
+	registry := GetOrCreateErrorRegistry(state)
+	resource := k8stypes.NamespacedName{Namespace: "ns", Name: "resource"}
+	kind := schema.GroupKind{Group: "test.io", Kind: "TestKind"}
+	registry.Record("TestReconciler", "delete", resource, kind, errors.New("error"))
+
+	// Run handler
+	err = handler.Reconcile(ctx, nil, nil, nil, state)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Should have scheduled retry via callback
+	if scheduledDelay != 2*time.Second {
+		t.Errorf("Expected retry scheduled with 2s delay, got %v", scheduledDelay)
+	}
+}
+
+func TestGetOrCreateErrorRegistry(t *testing.T) {
+	state := &sync.Map{}
+
+	// First call should create registry
+	registry1 := GetOrCreateErrorRegistry(state)
+	if registry1 == nil {
+		t.Error("Expected registry to be created")
+	}
+
+	// Second call should return same registry
+	registry2 := GetOrCreateErrorRegistry(state)
+	if registry1 != registry2 {
+		t.Error("Expected same registry instance")
+	}
+
+	// Should work with nil state
+	registry3 := GetOrCreateErrorRegistry(nil)
+	if registry3 == nil {
+		t.Error("Expected registry to be created even with nil state")
+	}
+}
+
+func TestPersistentErrorTracker_MinimumDelay(t *testing.T) {
+	logger := logr.Discard()
+	tracker := NewPersistentErrorTracker(logger)
+
+	// Add two errors with different retry counts
+	resource1 := k8stypes.NamespacedName{Namespace: "ns", Name: "resource1"}
+	resource2 := k8stypes.NamespacedName{Namespace: "ns", Name: "resource2"}
+	kind := schema.GroupKind{Group: "test.io", Kind: "TestKind"}
+
+	// Add both errors initially
+	registry1 := NewErrorRegistry()
+	registry1.Record("TestReconciler", "delete", resource1, kind, errors.New("error1"))
+	registry1.Record("TestReconciler", "delete", resource2, kind, errors.New("error2"))
+	tracker.UpdateFromRegistry(registry1)
+
+	// Manually set different retry counts
+	tracker.mu.Lock()
+	key1 := "TestKind.test.io/ns/resource1/delete"
+	key2 := "TestKind.test.io/ns/resource2/delete"
+	if err, found := tracker.errors[key1]; found {
+		err.RetryCount = 0 // 2s delay
+	}
+	if err, found := tracker.errors[key2]; found {
+		err.RetryCount = 2 // 8s delay
+	}
+	tracker.mu.Unlock()
+
+	// Should requeue after minimum delay (2s from resource1)
+	delay := tracker.ShouldRequeue()
+	if delay != 2*time.Second {
+		t.Errorf("Expected minimum delay of 2s, got %v", delay)
+	}
+}

--- a/internal/controller/reconciliation_errors_test.go
+++ b/internal/controller/reconciliation_errors_test.go
@@ -180,11 +180,18 @@ func TestPersistentErrorTracker_ShouldRequeue(t *testing.T) {
 		t.Errorf("Expected 4s requeue delay, got %v", delay)
 	}
 
-	// Exceed max retries - should not requeue
-	for i := 0; i < 5; i++ {
+	// Exceed max retries - error should be removed from tracker
+	// We've already done 2 updates above (RetryCount is now 1)
+	// Need 4 more to reach RetryCount = 5, which triggers deletion
+	for i := 0; i < 4; i++ {
 		reg := NewErrorRegistry()
 		reg.Record("TestReconciler", "delete", resource, kind, errors.New("error"))
 		tracker.UpdateFromRegistry(reg)
+	}
+
+	// After exceeding max retries, the error should be removed
+	if tracker.GetErrorCount() != 0 {
+		t.Errorf("Expected error to be removed after max retries, got %d errors", tracker.GetErrorCount())
 	}
 
 	delay = tracker.ShouldRequeue()
@@ -256,6 +263,38 @@ func TestGetOrCreateErrorRegistry(t *testing.T) {
 	registry3 := GetOrCreateErrorRegistry(nil)
 	if registry3 == nil {
 		t.Error("Expected registry to be created even with nil state")
+	}
+}
+
+func TestPersistentErrorTracker_MaxRetriesCleanup(t *testing.T) {
+	logger := logr.Discard()
+	tracker := NewPersistentErrorTracker(logger)
+
+	resource := k8stypes.NamespacedName{Namespace: "ns", Name: "resource"}
+	kind := schema.GroupKind{Group: "test.io", Kind: "TestKind"}
+
+	// Record error and fail it maxRetryAttempts times
+	for i := 0; i <= maxRetryAttempts; i++ {
+		registry := NewErrorRegistry()
+		registry.Record("TestReconciler", "delete", resource, kind, errors.New("persistent error"))
+		tracker.UpdateFromRegistry(registry)
+
+		if i < maxRetryAttempts {
+			// Should still be tracked
+			if tracker.GetErrorCount() != 1 {
+				t.Errorf("Iteration %d: Expected 1 error in tracker, got %d", i, tracker.GetErrorCount())
+			}
+		} else {
+			// After max retries, should be removed
+			if tracker.GetErrorCount() != 0 {
+				t.Errorf("After max retries: Expected error to be removed, got %d errors", tracker.GetErrorCount())
+			}
+		}
+	}
+
+	// Verify no requeue is scheduled
+	if delay := tracker.ShouldRequeue(); delay != 0 {
+		t.Errorf("Expected no requeue after cleanup, got %v", delay)
 	}
 }
 

--- a/internal/controller/reconciliation_errors_test.go
+++ b/internal/controller/reconciliation_errors_test.go
@@ -199,9 +199,8 @@ func TestReconciliationErrorHandler_Reconcile(t *testing.T) {
 
 	// Track if retry was scheduled
 	var scheduledDelay time.Duration
-	scheduleRetry := func(delay time.Duration, events []controller.ResourceEvent) {
+	scheduleRetry := func(delay time.Duration, _ []controller.ResourceEvent) {
 		scheduledDelay = delay
-		// events are captured but not asserted in this test
 	}
 
 	handler := NewReconciliationErrorHandler(tracker, scheduleRetry)

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -84,7 +84,10 @@ var (
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=leases,verbs=get;list;watch;create;update;patch;delete
 
-func NewPolicyMachineryController(manager ctrlruntime.Manager, client *dynamic.DynamicClient, logger logr.Logger, opts ...controller.ControllerOption) (*controller.Controller, error) {
+func NewPolicyMachineryController(manager ctrlruntime.Manager, client *dynamic.DynamicClient, logger logr.Logger, opts ...controller.ControllerOption) (*KuadrantController, error) {
+	// Create error tracker for non-blocking error handling
+	errorTracker := NewPersistentErrorTracker(logger)
+
 	// Base options
 	controllerOpts := []controller.ControllerOption{
 		controller.ManagedBy(manager),
@@ -172,6 +175,18 @@ func NewPolicyMachineryController(manager ctrlruntime.Manager, client *dynamic.D
 
 	// Boot options and reconciler based on detected dependencies
 	bootOptions := NewBootOptionsBuilder(manager, client, logger)
+	bootOptions.errorTracker = errorTracker
+
+	// Create KuadrantController wrapper first so we can pass its ScheduleRetry method to the error handler
+	// We'll set the actual policy-machinery controller later
+	kuadrantController := &KuadrantController{
+		errorTracker: errorTracker,
+		logger:       logger.WithName("KuadrantController"),
+	}
+
+	// Now create the error handler with the retry scheduler callback
+	bootOptions.retryScheduler = kuadrantController.ScheduleRetry
+
 	options, err := bootOptions.getOptions()
 	if err != nil {
 		return nil, err
@@ -179,7 +194,12 @@ func NewPolicyMachineryController(manager ctrlruntime.Manager, client *dynamic.D
 	controllerOpts = append(controllerOpts, options...)
 	controllerOpts = append(controllerOpts, controller.WithReconcile(bootOptions.Reconciler()))
 
-	return controller.NewController(controllerOpts...), nil
+	policyMachineryController := controller.NewController(controllerOpts...)
+
+	// Set the controller in the wrapper
+	kuadrantController.Controller = policyMachineryController
+
+	return kuadrantController, nil
 }
 
 // NewBootOptionsBuilder is used to return a list of controller.ControllerOption and a controller.ReconcileFunc that depend
@@ -209,6 +229,10 @@ type BootOptionsBuilder struct {
 	isAuthorinoOperatorInstalled  bool
 	isPrometheusOperatorInstalled bool
 	isUsingExtensions             bool
+
+	// Error tracking for non-blocking errors
+	errorTracker   *PersistentErrorTracker
+	retryScheduler RetryScheduler
 }
 
 func (b *BootOptionsBuilder) getOptions() ([]controller.ControllerOption, error) {
@@ -821,6 +845,11 @@ func (b *BootOptionsBuilder) finalStepsWorkflow() *controller.Workflow {
 	if b.isUsingExtensions {
 		workflow.Tasks = append(workflow.Tasks, traceReconcileFunc("finalize.extensions", extension.Reconcile))
 	}
+
+	// Add error handler as the final postcondition to collect and process non-blocking errors
+	// The scheduleRetry callback is provided by the KuadrantController wrapper
+	errorHandler := NewReconciliationErrorHandler(b.errorTracker, b.retryScheduler)
+	workflow.Postcondition = traceReconcileFunc("finalize.error_handler", errorHandler.Reconcile)
 
 	return workflow
 }


### PR DESCRIPTION
## Summary

Implements a holistic solution for handling API server errors that should not block the reconciliation workflow but require automatic retry.

Previously, errors during resource cleanup (e.g., AuthConfig deletion) were logged but not handled, leading to resource leaks when operations failed due to transient issues like rate limiting, network errors, or permission issues. Returning errors would abort the entire workflow, preventing other reconcilers from running.

## Solution Architecture

Implements a **two-layer error tracking system** with automatic retry:

### 1. ErrorRegistry (Per-Reconciliation)
- Lives in workflow state (`*sync.Map`) for a single reconciliation cycle
- Reconcilers record non-blocking errors instead of returning them
- Workflow continues - all reconcilers run despite individual failures

### 2. PersistentErrorTracker (Cross-Reconciliation)
- Persists errors across reconciliation cycles
- Deduplicates by unique key: `{GroupKind}/{Namespace}/{Name}/{Operation}`
- Tracks retry count per error
- Detects resolution: errors absent from new registry are removed
- Implements exponential backoff: 2s → 4s → 8s → 16s → 32s → 60s (max)

### 3. ReconciliationErrorHandler (Workflow Postcondition)
- Runs at workflow end to merge errors from registry to tracker
- Calculates retry delay
- Schedules retry via callback with original events

### 4. KuadrantController (Retry Trigger)
- Wraps policy-machinery controller
- Provides ScheduleRetry callback
- Creates timer that calls `Propagate(events)` after delay
- Replays original events to ensure proper context

## Key Features

- ✅ **Non-blocking**: Errors recorded, not returned; workflow completes
- ✅ **Automatic retry**: Programmatic retry via timer + Propagate()
- ✅ **Event replay**: Original events captured and replayed on retry
- ✅ **Exponential backoff**: 2s, 4s, 8s, 16s, 32s, 60s (capped)
- ✅ **Max attempts**: 5 retries then give up (prevents infinite loops)
- ✅ **Auto-resolution**: Successful operations remove errors from tracker
- ✅ **Deduplication**: Same error key increments count, not duplicated
- ✅ **Observability**: Detailed logging at each stage

## Implementation Details

### Modified Reconcilers

`AuthConfigsReconciler` and `LimitadorLimitsReconciler` now:
1. Get `ErrorRegistry` from workflow state
2. Record failures via `registry.Record()` instead of returning errors
3. Continue with `nil` return (workflow proceeds)

### Error Handler Flow

Error handler runs as final postcondition:
1. Reads errors from ephemeral `ErrorRegistry`
2. Merges into `PersistentErrorTracker`
3. Calls `scheduleRetry(delay, events)` callback

### Retry Mechanism

`KuadrantController.ScheduleRetry()`:
1. Creates `time.AfterFunc(delay, ...)`
2. Timer fires → calls `c.Controller.Propagate(events)`
3. Workflow re-runs with original events
4. Failed operations retry; successful ones don't error

## Testing

### Manual Testing

Setup an environment with a policy to test a non-blocking error retry:

```sh
make local-setup

GATEWAY_IP=$(kubectl get gateway kuadrant-ingressgateway -n gateway-system -o jsonpath='{.status.addresses[0].value}') && echo "Gateway IP: $GATEWAY_IP"

kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
  namespace: kuadrant-system
spec: {}
---
apiVersion: kuadrant.io/v1
kind: AuthPolicy
metadata:
  name: test-auth-policy
  namespace: gateway-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: kuadrant-ingressgateway
  rules:
    authentication:
      "anonymous":
        anonymous: {}
---
# create an HTTPRoute only so the policy is enforced
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: authorino-metrics-route
  namespace: kuadrant-system
spec:
  parentRefs:
  - kind: Gateway
    name: kuadrant-ingressgateway
    namespace: gateway-system
  hostnames:
  - authorino.$GATEWAY_IP.nip.io
  rules:
  - backendRefs:
    - kind: Service
      name: authorino-controller-metrics
      port: 8080
EOF
```

Inject an RBAC failure (remove the controller's permission to delete AuthConfig resources):

```sh
kubectl get clusterrole kuadrant-operator-manager-role -o json | \
jq --arg idx "$(kubectl get clusterrole kuadrant-operator-manager-role -o json | jq '.rules | map(.resources // [] | contains(["authconfigs"])) | index(true)')" \
  '.rules[$idx | tonumber].verbs |= map(select(. != "delete"))' | kubectl apply -f -
```

Delete the policy:

```sh
kubectl delete authpolicy test-auth-policy -n gateway-system
```

Watch the controller handles the retries:

```sh
kubectl logs -n kuadrant-system deployment/kuadrant-operator-controller-manager -f | grep -E "(non-blocking|error persist|retry|AuthConfig)"
```

Tested both critical scenarios:
- ✅ **Max retries exceeded**: Operator stops after 5 attempts (~2 min total)
- ✅ **Error recovery**: RBAC restored mid-retry, cleanup succeeds

### Unit Tests
Comprehensive test coverage (295 lines):
- Error recording and registry behavior
- Persistent tracker deduplication and retry counting
- Exponential backoff calculation
- Error resolution detection
- Retry scheduling callback

## Example Logs

### Initial Error
```
"new non-blocking error recorded" source="AuthConfigsReconciler" operation="delete" resource="istio-system/auth-config-xyz" kind="AuthConfig.authorino.kuadrant.io"
"scheduling retry for non-blocking errors" errorCount=1 requeueAfter=2s
```

### Retry Attempts
```
"triggering reconciliation retry for non-blocking errors" errorCount=1
"error persists" retryCount=1 nextDelay=4s
"scheduling retry for non-blocking errors" errorCount=1 requeueAfter=4s
```

### Resolution
```
"triggering reconciliation retry for non-blocking errors" errorCount=1
"non-blocking error resolved" attempts=3 duration="14s"
```

### Max Attempts
```
"max retry attempts reached, giving up" source="AuthConfigsReconciler" operation="delete" attempts=5 duration="2m2s"
```

## Dependencies

Requires policy-machinery with exported `Propagate()` method:
- Updated to `v0.8.1-0.20260611112329-244a3ec8172a`

## Files Changed

**New files (4):**
- `internal/controller/kuadrant_controller.go` - Controller wrapper with retry logic
- `internal/controller/kuadrant_controller_test.go` - Tests for blocking error handling
- `internal/controller/reconciliation_errors.go` - Error tracking infrastructure (317 lines)
- `internal/controller/reconciliation_errors_test.go` - Comprehensive test suite (295 lines)

**Modified files (5):**
- `go.mod`, `go.sum` - Updated policy-machinery dependency
- `internal/controller/authconfigs_reconciler.go` - Uses error registry for create/update/delete
- `internal/controller/limitador_limits_reconciler.go` - Uses error registry for updates
- `internal/controller/state_of_the_world.go` - Integrates error tracker and handler

**Total**: 9 files changed, 870 insertions(+), 10 deletions(-)

Closes #946
Closes #1867
Supersedes #1913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent, non-blocking reconciliation error tracking with automatic delayed requeues using exponential backoff.
  * Introduced a controller wrapper that manages scheduled retries safely across reconcile cycles.
* **Bug Fixes**
  * Improved authentication config and limit reconciliation by recording create/update/delete/update failures for deferred retry, while ignoring “not found” delete errors.
* **Tests**
  * Expanded coverage for retry scheduling, cancellation, stop behaviour, and error backoff/eligibility logic.
* **Chores**
  * Updated the Go module dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->