### PR TITLE
Fix non-deterministic EnvoyFilter generation

### DIFF
--- a/internal/controller/data_plane_policies_workflow.go
+++ b/internal/controller/data_plane_policies_workflow.go
@@ -219,6 +219,14 @@ func mergeAndVerify(ctx context.Context, actions []wasm.Action) ([]wasm.Action, 
 			// Merge source policy locators - deduplicate them
 			lastAction.SourcePolicyLocators = lo.Uniq(append(lastAction.SourcePolicyLocators, currentAction.SourcePolicyLocators...))
 			slices.Sort(lastAction.SourcePolicyLocators)
+
+			// Sort by the first predicate (if any), then by the concatenation of all predicates
+			slices.SortFunc(lastAction.ConditionalData, func(a, b wasm.ConditionalData) int {
+				// Compare by predicates (join them into a single string for comparison)
+				aKey := strings.Join(a.Predicates, "|")
+				bKey := strings.Join(b.Predicates, "|")
+				return strings.Compare(aKey, bKey)
+			})
 		} else {
 			result = append(result, currentAction)
 		}

--- a/internal/controller/istio_extension_reconciler_test.go
+++ b/internal/controller/istio_extension_reconciler_test.go
@@ -636,4 +636,86 @@ func TestMergeAndVerifyEdgeCases(t *testing.T) {
 		_, err := mergeAndVerify(context.TODO(), actions)
 		assert.ErrorContains(t, err, "duplicate key '' with different values")
 	})
+
+	t.Run("deterministic conditional data ordering after merge", func(t *testing.T) {
+		// Create two sets of actions in different orders
+		actionsOrder1 := []wasm.Action{
+			{
+				ServiceName: wasm.RateLimitCheckServiceName,
+				Scope:       "route-0",
+				ConditionalData: []wasm.ConditionalData{
+					{
+						Predicates: []string{"auth.identity.bob"},
+						Data: []wasm.DataType{
+							{Value: &wasm.Static{Static: wasm.StaticSpec{Key: "limit.bob", Value: "1"}}},
+						},
+					},
+				},
+			},
+			{
+				ServiceName: wasm.RateLimitCheckServiceName,
+				Scope:       "route-0",
+				ConditionalData: []wasm.ConditionalData{
+					{
+						Predicates: []string{"auth.identity.alice"},
+						Data: []wasm.DataType{
+							{Value: &wasm.Static{Static: wasm.StaticSpec{Key: "limit.alice", Value: "1"}}},
+						},
+					},
+				},
+			},
+		}
+
+		actionsOrder2 := []wasm.Action{
+			{
+				ServiceName: wasm.RateLimitCheckServiceName,
+				Scope:       "route-0",
+				ConditionalData: []wasm.ConditionalData{
+					{
+						Predicates: []string{"auth.identity.alice"},
+						Data: []wasm.DataType{
+							{Value: &wasm.Static{Static: wasm.StaticSpec{Key: "limit.alice", Value: "1"}}},
+						},
+					},
+				},
+			},
+			{
+				ServiceName: wasm.RateLimitCheckServiceName,
+				Scope:       "route-0",
+				ConditionalData: []wasm.ConditionalData{
+					{
+						Predicates: []string{"auth.identity.bob"},
+						Data: []wasm.DataType{
+							{Value: &wasm.Static{Static: wasm.StaticSpec{Key: "limit.bob", Value: "1"}}},
+						},
+					},
+				},
+			},
+		}
+
+		result1, err := mergeAndVerify(context.TODO(), actionsOrder1)
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(result1))
+
+		result2, err := mergeAndVerify(context.TODO(), actionsOrder2)
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(result2))
+
+		// Both results should have exactly the same ConditionalData in the same order
+		assert.Equal(t, len(result1[0].ConditionalData), len(result2[0].ConditionalData))
+		for i := range result1[0].ConditionalData {
+			cd1 := result1[0].ConditionalData[i]
+			cd2 := result2[0].ConditionalData[i]
+
+			// Predicates should be in the same order
+			assert.DeepEqual(t, cd1.Predicates, cd2.Predicates)
+
+			// Data should be in the same order
+			assert.Equal(t, len(cd1.Data), len(cd2.Data))
+		}
+
+		// The ConditionalData should be sorted by predicates (alice before bob)
+		assert.Equal(t, "auth.identity.alice", result1[0].ConditionalData[0].Predicates[0])
+		assert.Equal(t, "auth.identity.bob", result1[0].ConditionalData[1].Predicates[0])
+	})
 }

--- a/internal/controller/ratelimit_workflow_helpers.go
+++ b/internal/controller/ratelimit_workflow_helpers.go
@@ -5,6 +5,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 	"sync"
 	"unicode"
 
@@ -331,7 +333,12 @@ func buildWasmActionsForTokenRateLimit(effectivePolicy EffectiveTokenRateLimitPo
 	}
 	limitsNamespace := LimitsNamespaceFromRoute(parsed.GetRoute())
 
-	topLevelRules, limitRules := lo.FilterReject(lo.Entries(rules),
+	rulesEntries := lo.Entries(rules)
+	slices.SortFunc(rulesEntries, func(a, b lo.Entry[string, kuadrantv1.MergeableRule]) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+
+	topLevelRules, limitRules := lo.FilterReject(rulesEntries,
 		func(r lo.Entry[string, kuadrantv1.MergeableRule], _ int) bool {
 			return r.Key == kuadrantv1.RulesKeyTopLevelPredicates
 		},
@@ -386,7 +393,12 @@ func buildWasmActionsForAnyRateLimit(
 	}
 	limitsNamespace := LimitsNamespaceFromRoute(parsed.GetRoute())
 
-	topLevelRules, limitRules := lo.FilterReject(lo.Entries(rules),
+	rulesEntries := lo.Entries(rules)
+	slices.SortFunc(rulesEntries, func(a, b lo.Entry[string, kuadrantv1.MergeableRule]) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+
+	topLevelRules, limitRules := lo.FilterReject(rulesEntries,
 		func(r lo.Entry[string, kuadrantv1.MergeableRule], _ int) bool {
 			return r.Key == topLevelPredicatesKey
 		},

--- a/internal/istio/utils.go
+++ b/internal/istio/utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kuadrant/policy-machinery/controller"
 	"github.com/kuadrant/policy-machinery/machinery"
 	"github.com/samber/lo"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	istioapimetav1alpha1 "istio.io/api/meta/v1alpha1"
 	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
@@ -194,12 +195,9 @@ func EqualEnvoyFilters(a, b *istioclientgonetworkingv1alpha3.EnvoyFilter) bool {
 				if (aListener == nil) != (bListener == nil) {
 					return false
 				}
-				// For HTTP_FILTER patches, we compare the listener match structure if present
-				// Since the structure is complex, we'll compare the JSON representation
+				// For HTTP_FILTER patches, compare the match structure using protobuf equality
 				if aListener != nil && bListener != nil {
-					aMatchJSON, aErr := json.Marshal(aConfigPatch.Match)
-					bMatchJSON, _ := json.Marshal(bConfigPatch.Match)
-					if string(aMatchJSON) != string(bMatchJSON) || aErr != nil {
+					if !proto.Equal(aConfigPatch.Match, bConfigPatch.Match) {
 						return false
 					}
 				}
@@ -214,10 +212,8 @@ func EqualEnvoyFilters(a, b *istioclientgonetworkingv1alpha3.EnvoyFilter) bool {
 					return false
 				}
 			default:
-				// For other patch types, compare the match structure via JSON
-				aMatchJSON, aErr := json.Marshal(aConfigPatch.Match)
-				bMatchJSON, _ := json.Marshal(bConfigPatch.Match)
-				if string(aMatchJSON) != string(bMatchJSON) || aErr != nil {
+				// For other patch types, compare the match structure using protobuf equality
+				if !proto.Equal(aConfigPatch.Match, bConfigPatch.Match) {
 					return false
 				}
 			}
@@ -229,9 +225,9 @@ func EqualEnvoyFilters(a, b *istioclientgonetworkingv1alpha3.EnvoyFilter) bool {
 			if aPatch.Operation != bPatch.Operation || aPatch.FilterClass != bPatch.FilterClass {
 				return false
 			}
-			aPatchJSON, _ := aPatch.Value.MarshalJSON()
-			bPatchJSON, _ := bPatch.Value.MarshalJSON()
-			return string(aPatchJSON) == string(bPatchJSON)
+
+			// Use protobuf equality for patch values to handle non-deterministic map ordering.
+			return proto.Equal(aPatch.Value, bPatch.Value)
 		})
 	})
 }

--- a/internal/istio/utils_test.go
+++ b/internal/istio/utils_test.go
@@ -209,6 +209,100 @@ func TestEqualEnvoyFilters(t *testing.T) {
 
 		assert.Assert(subT, !EqualEnvoyFilters(a, b))
 	})
+
+	t.Run("equal patch values with maps in different order", func(subT *testing.T) {
+		a := testBasicEnvoyFilter(subT)
+		b := testBasicEnvoyFilter(subT)
+
+		// Create identical data but from separate map instances (which could marshal differently)
+		mapData := map[string]any{
+			"actionSets": []any{
+				map[string]any{
+					"name": "route-0",
+					"routeRuleConditions": map[string]any{
+						"hostnames": []any{"*.example.com"},
+					},
+					"actions": []any{
+						map[string]any{
+							"service": "ratelimit",
+							"scope":   "route-0-rlp",
+							"conditionalData": []any{
+								map[string]any{
+									"predicates": []string{"auth.identity.bob"},
+									"data": []any{
+										map[string]any{
+											"static": map[string]any{
+												"key":   "limit.route-0__1234",
+												"value": "1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// Marshal to JSON and unmarshal into structpb.Struct for both a and b
+		aJSON, _ := json.Marshal(mapData)
+		aPatchValue := &_struct.Struct{}
+		assert.NilError(subT, aPatchValue.UnmarshalJSON(aJSON))
+		a.Spec.ConfigPatches[0].Patch.Value = aPatchValue
+
+		bJSON, _ := json.Marshal(mapData)
+		bPatchValue := &_struct.Struct{}
+		assert.NilError(subT, bPatchValue.UnmarshalJSON(bJSON))
+		b.Spec.ConfigPatches[0].Patch.Value = bPatchValue
+
+		// With proto.Equal, these should be equal even if JSON string representations differ
+		assert.Assert(subT, EqualEnvoyFilters(a, b),
+			"EnvoyFilters with semantically identical patch values should be equal")
+	})
+
+	t.Run("equal HTTP_FILTER match with complex listener structure", func(subT *testing.T) {
+		// This test validates proto.Equal is used for Match comparison (another fix for #2033)
+		a := testBasicEnvoyFilter(subT)
+		a.Spec.ConfigPatches[0].ApplyTo = istioapinetworkingv1alpha3.EnvoyFilter_HTTP_FILTER
+		a.Spec.ConfigPatches[0].Match = &istioapinetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch{
+			Context: istioapinetworkingv1alpha3.EnvoyFilter_GATEWAY,
+			ObjectTypes: &istioapinetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+				Listener: &istioapinetworkingv1alpha3.EnvoyFilter_ListenerMatch{
+					FilterChain: &istioapinetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterChainMatch{
+						Filter: &istioapinetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterMatch{
+							Name: "envoy.filters.network.http_connection_manager",
+							SubFilter: &istioapinetworkingv1alpha3.EnvoyFilter_ListenerMatch_SubFilterMatch{
+								Name: "envoy.filters.http.router",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		b := testBasicEnvoyFilter(subT)
+		b.Spec.ConfigPatches[0].ApplyTo = istioapinetworkingv1alpha3.EnvoyFilter_HTTP_FILTER
+		b.Spec.ConfigPatches[0].Match = &istioapinetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch{
+			Context: istioapinetworkingv1alpha3.EnvoyFilter_GATEWAY,
+			ObjectTypes: &istioapinetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+				Listener: &istioapinetworkingv1alpha3.EnvoyFilter_ListenerMatch{
+					FilterChain: &istioapinetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterChainMatch{
+						Filter: &istioapinetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterMatch{
+							Name: "envoy.filters.network.http_connection_manager",
+							SubFilter: &istioapinetworkingv1alpha3.EnvoyFilter_ListenerMatch_SubFilterMatch{
+								Name: "envoy.filters.http.router",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// With proto.Equal, these identical Match structures should be equal
+		assert.Assert(subT, EqualEnvoyFilters(a, b),
+			"EnvoyFilters with identical HTTP_FILTER Match structures should be equal")
+	})
 }
 
 func TestEqualTargetRefs(t *testing.T) {


### PR DESCRIPTION
## Verification

Follow the steps outlined in #2033  before and after this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved consistency in data-plane policy merging for WASM actions sharing scope and service configuration
* Enhanced deterministic processing order for rate-limit policy rule handling in token-rate and generic rate-limit scenarios
* Refined Envoy filter comparison methodology for more reliable configuration validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->