### PR TITLE
FIX: Prevent operator crash when topology ConfigMap exceeds 1MB limit

### DIFF
--- a/internal/controller/topology_reconciler.go
+++ b/internal/controller/topology_reconciler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kuadrant/policy-machinery/machinery"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,9 +42,7 @@ func NewTopologyReconciler(client dynamic.Interface, namespace string) *Topology
 
 func (r *TopologyReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
 	logger := controller.LoggerFromContext(ctx).WithName("topology file").WithValues("context", ctx)
-	tracer := controller.TracerFromContext(ctx)
-	ctx, span := tracer.Start(ctx, "TopologyReconciler.Reconcile")
-	defer span.End()
+	span := trace.SpanFromContext(ctx)
 
 	span.SetAttributes(
 		attribute.String("configmap.name", TopologyConfigMapName),

--- a/internal/controller/topology_reconciler.go
+++ b/internal/controller/topology_reconciler.go
@@ -2,11 +2,14 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/kuadrant/policy-machinery/controller"
 	"github.com/kuadrant/policy-machinery/machinery"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,14 +20,19 @@ import (
 
 const (
 	TopologyConfigMapName = "topology"
+	// TODO: This size cap is a temporary workaround. The topology can outgrow a single ConfigMap,
+	// and other resources that consume it (e.g. the console-plugin) will need coordinated changes
+	// to support a different storage or serialization strategy.
+	maxTopologyBytes     = 900 * 1024 // ~900KB, safely under the 1MB ConfigMap limit
+	oversizedPlaceholder = `digraph { "error" [label="Topology exceeds ConfigMap 1MB limit"] }`
 )
 
 type TopologyReconciler struct {
-	Client    *dynamic.DynamicClient
+	Client    dynamic.Interface
 	Namespace string
 }
 
-func NewTopologyReconciler(client *dynamic.DynamicClient, namespace string) *TopologyReconciler {
+func NewTopologyReconciler(client dynamic.Interface, namespace string) *TopologyReconciler {
 	if namespace == "" {
 		panic("namespace must be specified and can not be a blank string")
 	}
@@ -33,6 +41,27 @@ func NewTopologyReconciler(client *dynamic.DynamicClient, namespace string) *Top
 
 func (r *TopologyReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
 	logger := controller.LoggerFromContext(ctx).WithName("topology file").WithValues("context", ctx)
+	tracer := controller.TracerFromContext(ctx)
+	ctx, span := tracer.Start(ctx, "TopologyReconciler.Reconcile")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("configmap.name", TopologyConfigMapName),
+		attribute.String("configmap.namespace", r.Namespace),
+	)
+
+	topologyData := topology.ToDot()
+	topologySize := len(topologyData)
+	span.SetAttributes(attribute.Int("topology.size_bytes", topologySize))
+
+	if topologySize > maxTopologyBytes {
+		logger.Info("topology data exceeds ConfigMap size limit, using placeholder",
+			"size_bytes", topologySize, "max_bytes", maxTopologyBytes)
+		span.RecordError(fmt.Errorf("topology data is %d bytes, exceeds %d byte limit", topologySize, maxTopologyBytes))
+		span.SetStatus(codes.Error, "topology exceeds ConfigMap size limit")
+		span.AddEvent("topology data replaced with placeholder")
+		topologyData = oversizedPlaceholder
+	}
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -41,12 +70,14 @@ func (r *TopologyReconciler) Reconcile(ctx context.Context, _ []controller.Resou
 			Labels:    map[string]string{kuadrant.TopologyLabel: "true"},
 		},
 		Data: map[string]string{
-			"topology": topology.ToDot(),
+			"topology": topologyData,
 		},
 	}
 	unstructuredCM, err := controller.Destruct(cm)
 	if err != nil {
 		logger.Error(err, "failed to destruct topology configmap")
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to destruct topology configmap")
 		return err
 	}
 
@@ -57,9 +88,16 @@ func (r *TopologyReconciler) Reconcile(ctx context.Context, _ []controller.Resou
 	if len(existingTopologyConfigMaps) == 0 {
 		_, err := r.Client.Resource(controller.ConfigMapsResource).Namespace(cm.Namespace).Create(ctx, unstructuredCM, metav1.CreateOptions{})
 		if errors.IsAlreadyExists(err) {
-			// This error can happen when the operator is starting, and the create event for the topology has not being processed.
 			logger.Info("already created topology configmap, must not be in topology yet")
+			span.AddEvent("configmap already exists but not in topology yet")
 			return err
+		}
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "failed to create topology configmap")
+		} else {
+			span.AddEvent("topology configmap created")
+			span.SetStatus(codes.Ok, "")
 		}
 		return err
 	}
@@ -74,9 +112,16 @@ func (r *TopologyReconciler) Reconcile(ctx context.Context, _ []controller.Resou
 		_, err := r.Client.Resource(controller.ConfigMapsResource).Namespace(cm.Namespace).Update(ctx, unstructuredCM, metav1.UpdateOptions{})
 		if err != nil {
 			logger.Error(err, "failed to update topology configmap")
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "failed to update topology configmap")
+		} else {
+			span.AddEvent("topology configmap updated")
+			span.SetStatus(codes.Ok, "")
 		}
 		return err
 	}
 
+	span.AddEvent("topology configmap unchanged")
+	span.SetStatus(codes.Ok, "")
 	return nil
 }

--- a/internal/controller/topology_reconciler_test.go
+++ b/internal/controller/topology_reconciler_test.go
@@ -13,6 +13,7 @@ import (
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	dfake "k8s.io/client-go/dynamic/fake"
 
@@ -58,7 +59,7 @@ func TestTopologyReconciler_Create(t *testing.T) {
 	assert.Equal(t, created.GetName(), TopologyConfigMapName)
 	assert.Equal(t, created.GetLabels()[kuadrant.TopologyLabel], "true")
 
-	data, found, err := unstructuredNestedString(created.Object, "data", "topology")
+	data, found, err := metav1unstructured.NestedString(created.Object, "data", "topology")
 	assert.NilError(t, err)
 	assert.Assert(t, found, "topology data key should exist")
 	assert.Assert(t, strings.Contains(data, "digraph"), "topology data should be DOT format")
@@ -102,7 +103,7 @@ func TestTopologyReconciler_Update(t *testing.T) {
 	updated, err := fakeClient.Resource(controller.ConfigMapsResource).Namespace(namespace).Get(context.Background(), TopologyConfigMapName, metav1.GetOptions{})
 	assert.NilError(t, err)
 
-	data, found, err := unstructuredNestedString(updated.Object, "data", "topology")
+	data, found, err := metav1unstructured.NestedString(updated.Object, "data", "topology")
 	assert.NilError(t, err)
 	assert.Assert(t, found, "topology data key should exist")
 	assert.Assert(t, data != "old-data", "topology data should have been updated")
@@ -154,27 +155,4 @@ func TestNewTopologyReconciler_PanicsOnEmptyNamespace(t *testing.T) {
 		assert.Assert(t, r != nil, "expected panic for empty namespace")
 	}()
 	NewTopologyReconciler(nil, "")
-}
-
-func unstructuredNestedString(obj map[string]any, fields ...string) (string, bool, error) {
-	current := obj
-	for i, field := range fields {
-		if i == len(fields)-1 {
-			val, ok := current[field]
-			if !ok {
-				return "", false, nil
-			}
-			s, ok := val.(string)
-			return s, ok, nil
-		}
-		next, ok := current[field]
-		if !ok {
-			return "", false, nil
-		}
-		current, ok = next.(map[string]any)
-		if !ok {
-			return "", false, nil
-		}
-	}
-	return "", false, nil
 }

--- a/internal/controller/topology_reconciler_test.go
+++ b/internal/controller/topology_reconciler_test.go
@@ -1,0 +1,180 @@
+//go:build unit
+
+package controllers
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	dfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
+)
+
+func TestTopologyReconciler_OversizedPlaceholder(t *testing.T) {
+	assert.Assert(t, len(oversizedPlaceholder) < maxTopologyBytes,
+		"placeholder (%d bytes) must be smaller than the limit (%d bytes)", len(oversizedPlaceholder), maxTopologyBytes)
+	assert.Assert(t, strings.Contains(oversizedPlaceholder, "digraph"),
+		"placeholder must be valid DOT syntax")
+}
+
+func TestTopologyReconciler_Create(t *testing.T) {
+	namespace := "test-ns"
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := dfake.NewSimpleDynamicClient(scheme)
+	reconciler := NewTopologyReconciler(fakeClient, namespace)
+
+	topology, err := machinery.NewTopology(
+		machinery.WithObjects(
+			&controller.RuntimeObject{
+				Object: &corev1.ConfigMap{
+					TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some-other-configmap",
+						Namespace: namespace,
+					},
+				},
+			},
+		),
+	)
+	assert.NilError(t, err)
+
+	err = reconciler.Reconcile(context.Background(), nil, topology, nil, &sync.Map{})
+	assert.NilError(t, err)
+
+	created, err := fakeClient.Resource(controller.ConfigMapsResource).Namespace(namespace).Get(context.Background(), TopologyConfigMapName, metav1.GetOptions{})
+	assert.NilError(t, err)
+	assert.Assert(t, created != nil)
+	assert.Equal(t, created.GetName(), TopologyConfigMapName)
+	assert.Equal(t, created.GetLabels()[kuadrant.TopologyLabel], "true")
+
+	data, found, err := unstructuredNestedString(created.Object, "data", "topology")
+	assert.NilError(t, err)
+	assert.Assert(t, found, "topology data key should exist")
+	assert.Assert(t, strings.Contains(data, "digraph"), "topology data should be DOT format")
+}
+
+func TestTopologyReconciler_Update(t *testing.T) {
+	namespace := "test-ns"
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	existingCM := &controller.RuntimeObject{
+		Object: &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      TopologyConfigMapName,
+				Namespace: namespace,
+				Labels:    map[string]string{kuadrant.TopologyLabel: "true"},
+			},
+			Data: map[string]string{
+				"topology": "old-data",
+			},
+		},
+	}
+
+	topology, err := machinery.NewTopology(
+		machinery.WithObjects(existingCM),
+	)
+	assert.NilError(t, err)
+
+	fakeClient := dfake.NewSimpleDynamicClient(scheme)
+	// Pre-create the configmap so the update path is hit
+	unstructuredCM, err := controller.Destruct(existingCM.Object.(*corev1.ConfigMap))
+	assert.NilError(t, err)
+	_, err = fakeClient.Resource(controller.ConfigMapsResource).Namespace(namespace).Create(context.Background(), unstructuredCM, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	reconciler := NewTopologyReconciler(fakeClient, namespace)
+	err = reconciler.Reconcile(context.Background(), nil, topology, nil, &sync.Map{})
+	assert.NilError(t, err)
+
+	updated, err := fakeClient.Resource(controller.ConfigMapsResource).Namespace(namespace).Get(context.Background(), TopologyConfigMapName, metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	data, found, err := unstructuredNestedString(updated.Object, "data", "topology")
+	assert.NilError(t, err)
+	assert.Assert(t, found, "topology data key should exist")
+	assert.Assert(t, data != "old-data", "topology data should have been updated")
+}
+
+func TestTopologyReconciler_NoUpdateWhenUnchanged(t *testing.T) {
+	namespace := "test-ns"
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	// Build a topology first to get the expected DOT output
+	tempTopology, err := machinery.NewTopology()
+	assert.NilError(t, err)
+	expectedDot := tempTopology.ToDot()
+
+	existingCM := &controller.RuntimeObject{
+		Object: &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      TopologyConfigMapName,
+				Namespace: namespace,
+				Labels:    map[string]string{kuadrant.TopologyLabel: "true"},
+			},
+			Data: map[string]string{
+				"topology": expectedDot,
+			},
+		},
+	}
+
+	topology, err := machinery.NewTopology(
+		machinery.WithObjects(existingCM),
+	)
+	assert.NilError(t, err)
+
+	fakeClient := dfake.NewSimpleDynamicClient(scheme)
+	unstructuredCM, err := controller.Destruct(existingCM.Object.(*corev1.ConfigMap))
+	assert.NilError(t, err)
+	_, err = fakeClient.Resource(controller.ConfigMapsResource).Namespace(namespace).Create(context.Background(), unstructuredCM, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	reconciler := NewTopologyReconciler(fakeClient, namespace)
+	err = reconciler.Reconcile(context.Background(), nil, topology, nil, &sync.Map{})
+	assert.NilError(t, err)
+}
+
+func TestNewTopologyReconciler_PanicsOnEmptyNamespace(t *testing.T) {
+	defer func() {
+		r := recover()
+		assert.Assert(t, r != nil, "expected panic for empty namespace")
+	}()
+	NewTopologyReconciler(nil, "")
+}
+
+func unstructuredNestedString(obj map[string]any, fields ...string) (string, bool, error) {
+	current := obj
+	for i, field := range fields {
+		if i == len(fields)-1 {
+			val, ok := current[field]
+			if !ok {
+				return "", false, nil
+			}
+			s, ok := val.(string)
+			return s, ok, nil
+		}
+		next, ok := current[field]
+		if !ok {
+			return "", false, nil
+		}
+		current, ok = next.(map[string]any)
+		if !ok {
+			return "", false, nil
+		}
+	}
+	return "", false, nil
+}


### PR DESCRIPTION
# Problem

The kuadrant-operator crashes when the topology ConfigMap exceeds the Kubernetes 1MB ConfigMap size limit. This happens at scale when approximately 1,500 or more resource sets (HTTPRoute + AuthPolicy + RateLimitPolicy) are present in the cluster. The topology DOT graph grows linearly (~785 bytes per route), and once it exceeds 1MB the API server rejects the write, causing the reconciler to enter a permanent error loop. The operator becomes unable to process any further events, effectively a denial of service.

# Reproduction

1. Deploy kuadrant from the operator repo:
   ```sh
   make local-setup
   ```

2. Increase operator resources (speeds up reproduction, does not affect outcome):
   ```sh
   kubectl set resources deployment/kuadrant-operator-controller-manager -n kuadrant-system \
     --limits=cpu=4,memory=2Gi \
     --requests=cpu=4,memory=2Gi
   kubectl wait --for=condition=Available deployment/kuadrant-operator-controller-manager \
     -n kuadrant-system --timeout=120s
   ```

3. Create the Kuadrant CR and a test namespace:
   ```sh
   kubectl apply -f examples/toystore/kuadrant.yaml -n kuadrant-system
   kubectl create namespace poc-0
   ```

4. Create ~1500 resource sets (HTTPRoute + AuthPolicy + RateLimitPolicy each):
   ```sh
   NAMESPACE="poc-0"
   GATEWAY_NAMESPACE="gateway-system"
   GATEWAY_NAME="kuadrant-ingressgateway"
   NUMBER=1500

   for i in $(seq 0 $((NUMBER - 1))); do
     kubectl apply -f - <<YAML > /dev/null
   apiVersion: gateway.networking.k8s.io/v1
   kind: HTTPRoute
   metadata:
     name: httpbin-route-$i
     namespace: $NAMESPACE
   spec:
     parentRefs:
     - name: $GATEWAY_NAME
       namespace: $GATEWAY_NAMESPACE
     hostnames:
     - "httpbin-$i.local"
     rules:
     - backendRefs:
       - name: httpbin
         port: 80
   YAML

     kubectl apply -f - <<YAML > /dev/null
   apiVersion: kuadrant.io/v1
   kind: AuthPolicy
   metadata:
     name: httpbin-auth-$i
     namespace: $NAMESPACE
   spec:
     targetRef:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: httpbin-route-$i
     rules:
       authentication:
         "api-key":
           apiKey:
             selector:
               matchLabels:
                 app: httpbin
   YAML

     kubectl apply -f - <<YAML > /dev/null
   apiVersion: kuadrant.io/v1
   kind: RateLimitPolicy
   metadata:
     name: httpbin-ratelimit-$i
     namespace: $NAMESPACE
   spec:
     targetRef:
       group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: httpbin-route-$i
     limits:
       "general-user":
         rates:
         - limit: 5
           window: 10s
         counters:
         - expression: auth.identity.userid
         when:
         - predicate: "auth.identity.userid != 'bob'"
       "bob-limit":
         rates:
         - limit: 2
           window: 10s
         when:
         - predicate: "auth.identity.userid == 'bob'"
   YAML
   done
   ```

5. Watch the operator logs:
   ```sh
   kubectl logs -f deployment/kuadrant-operator-controller-manager -n kuadrant-system
   ```

   Without this fix the operator will enter a permanent error loop with:
   ```
   ConfigMap "topology" is invalid: []: Too long: may not be more than 1048576 bytes
   ```

# Solution

This PR adds a size guard to the `TopologyReconciler`. Before writing the topology ConfigMap, the reconciler checks the size of the serialized DOT graph against a 900KB threshold (safely under the 1MB Kubernetes limit). When the topology exceeds this threshold, a small placeholder DOT graph is written instead, preventing the API server rejection and allowing the operator to continue reconciling other resources.

## Changes

- Add a `maxTopologyBytes` constant (900KB) and an `oversizedPlaceholder` DOT string
- Check topology size before writing and substitute the placeholder when oversized
- Add OpenTelemetry tracing spans, attributes, and events for observability
- Change `Client` field type from `*dynamic.DynamicClient` to `dynamic.Interface` to support test fakes
- Add span instrumentation for all error and success paths
- Add unit tests covering create, update, no-op, oversized placeholder validation, and panic on empty namespace

## Limitations

This is a temporary workaround. The placeholder means the console-plugin will not display the full topology graph at scale. A proper solution will require a different storage or serialization strategy, coordinated with the console-plugin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Automatically caps oversized topology DOT payloads and replaces them with a valid placeholder to prevent reconciliation failures.

* **New Features**
  * Improved observability for topology reconciliation using OpenTelemetry tracing, including span attributes and events covering the ConfigMap create/update lifecycle.

* **Tests**
  * Added unit tests for placeholder sizing, topology ConfigMap creation, updates, and handling of unchanged content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->