### PR TITLE
Upgrade Go to 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG WASM_SHIM_IMAGE=quay.io/kuadrant/wasm-shim:latest
 FROM ${WASM_SHIM_IMAGE} AS wasm-shim
 
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/kuadrant-operator
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kuadrant/kuadrant-operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Upgrade Go from 1.25.9 to 1.26.3.

**Changes:**
- `go.mod`: updated `go` directive from 1.25.9 to 1.26.3
- `Dockerfile`: updated builder image from `golang:1.25` to `golang:1.26`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to 1.26.3.
  * Upgraded the local `golangci-lint` tool version to v2.12.2.

* **Refactor**
  * Improved CEL string assembly internals without changing the resulting output.

* **Tests**
  * Streamlined test environment setup for CEL extensions with equivalent behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->