### PR TITLE
Cleanup orphaned WasmPlugin objects

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2026-05-25T14:07:27Z"
+    createdAt: "2026-06-22T15:16:38Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -502,6 +502,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - extensions.istio.io
+          resources:
+          - wasmplugins
+          verbs:
+          - delete
         - apiGroups:
           - extensions.kuadrant.io
           resources:

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14347,6 +14347,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - extensions.istio.io
+  resources:
+  - wasmplugins
+  verbs:
+  - delete
+- apiGroups:
   - extensions.kuadrant.io
   resources:
   - oidcpolicies

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -113,6 +113,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - extensions.istio.io
+  resources:
+  - wasmplugins
+  verbs:
+  - delete
+- apiGroups:
   - extensions.kuadrant.io
   resources:
   - oidcpolicies

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -97,6 +97,7 @@ func (r *IstioExtensionReconciler) Reconcile(ctx context.Context, _ []controller
 	}
 
 	modifiedGateways := make([]string, 0, len(gateways))
+	var reconcileErr error
 
 	for _, gateway := range gateways {
 		gatewayKey := k8stypes.NamespacedName{Name: gateway.GetName(), Namespace: gateway.GetNamespace()}
@@ -124,11 +125,12 @@ func (r *IstioExtensionReconciler) Reconcile(ctx context.Context, _ []controller
 			desiredEnvoyFilterUnstructured, err := controller.Destruct(desiredEnvoyFilter)
 			if err != nil {
 				logger.Error(err, "failed to destruct envoyfilter object", "gateway", gatewayKey.String(), "envoyfilter", desiredEnvoyFilter)
+				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("failed to destruct envoyfilter %s/%s: %w", gateway.GetNamespace(), desiredEnvoyFilter.GetName(), err))
 				continue
 			}
 			if _, err = resource.Create(ctx, desiredEnvoyFilterUnstructured, metav1.CreateOptions{}); err != nil {
 				logger.Error(err, "failed to create envoyfilter object", "gateway", gatewayKey.String(), "envoyfilter", desiredEnvoyFilterUnstructured.Object)
-				// TODO: handle error
+				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("failed to create envoyfilter %s/%s: %w", gateway.GetNamespace(), desiredEnvoyFilter.GetName(), err))
 			}
 			continue
 		}
@@ -136,7 +138,8 @@ func (r *IstioExtensionReconciler) Reconcile(ctx context.Context, _ []controller
 		// Clean up old WasmPlugin for this specific gateway - temporary to be removed
 		wasmPluginName := wasm.ExtensionName(gateway.GetName())
 		if err := r.client.Resource(kuadrantistio.WasmPluginsResource).Namespace(gateway.GetNamespace()).Delete(ctx, wasmPluginName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			logger.Error(err, "failed to delete old wasmplugin", "gateway", gatewayKey.String(), "wasmplugin", wasmPluginName)
+			logger.Error(err, "failed to delete wasmplugin", "gateway", gatewayKey.String(), "wasmplugin", wasmPluginName)
+			reconcileErr = errors.Join(reconcileErr, fmt.Errorf("failed to delete wasmplugin %s/%s: %w", gateway.GetNamespace(), wasmPluginName, err))
 		}
 
 		existingEnvoyFilter := existingEnvoyFilterObj.(*controller.RuntimeObject).Object.(*istioclientgonetworkingv1alpha3.EnvoyFilter)
@@ -145,7 +148,7 @@ func (r *IstioExtensionReconciler) Reconcile(ctx context.Context, _ []controller
 		if utils.IsObjectTaggedToDelete(desiredEnvoyFilter) && !utils.IsObjectTaggedToDelete(existingEnvoyFilter) {
 			if err := resource.Delete(ctx, existingEnvoyFilter.GetName(), metav1.DeleteOptions{}); err != nil {
 				logger.Error(err, "failed to delete envoyfilter object", "gateway", gatewayKey.String(), "envoyfilter", fmt.Sprintf("%s/%s", existingEnvoyFilter.GetNamespace(), existingEnvoyFilter.GetName()))
-				// TODO: handle error
+				reconcileErr = errors.Join(reconcileErr, fmt.Errorf("failed to delete envoyfilter %s/%s: %w", existingEnvoyFilter.GetNamespace(), existingEnvoyFilter.GetName(), err))
 			}
 			continue
 		}
@@ -167,13 +170,13 @@ func (r *IstioExtensionReconciler) Reconcile(ctx context.Context, _ []controller
 		}
 		if _, err = resource.Update(ctx, existingEnvoyFilterUnstructured, metav1.UpdateOptions{}); err != nil {
 			logger.Error(err, "failed to update envoyfilter object", "gateway", gatewayKey.String(), "envoyfilter", existingEnvoyFilterUnstructured.Object)
-			// TODO: handle error
+			reconcileErr = errors.Join(reconcileErr, fmt.Errorf("failed to update envoyfilter %s/%s: %w", existingEnvoyFilter.GetNamespace(), existingEnvoyFilter.GetName(), err))
 		}
 	}
 
 	state.Store(StateIstioExtensionsModified, modifiedGateways)
 
-	return nil
+	return reconcileErr
 }
 
 func (r *IstioExtensionReconciler) reconcileUpstreamClusters(ctx context.Context, topology *machinery.Topology, gateways []*machinery.Gateway) {

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -16,6 +16,7 @@ import (
 	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	istiov1beta1 "istio.io/api/type/v1beta1"
 	istioclientgonetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -35,6 +36,7 @@ import (
 	"github.com/kuadrant/kuadrant-operator/internal/wasm"
 )
 
+//+kubebuilder:rbac:groups=extensions.istio.io,resources=wasmplugins,verbs=delete
 //+kubebuilder:rbac:groups=networking.istio.io,resources=envoyfilters,verbs=get;list;watch;create;update;patch;delete
 
 // IstioExtensionReconciler reconciles Istio EnvoyFilter custom resources for wasm plugin injection
@@ -129,6 +131,12 @@ func (r *IstioExtensionReconciler) Reconcile(ctx context.Context, _ []controller
 				// TODO: handle error
 			}
 			continue
+		}
+
+		// Clean up old WasmPlugin for this specific gateway - temporary to be removed
+		wasmPluginName := wasm.ExtensionName(gateway.GetName())
+		if err := r.client.Resource(kuadrantistio.WasmPluginsResource).Namespace(gateway.GetNamespace()).Delete(ctx, wasmPluginName, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete old wasmplugin", "gateway", gatewayKey.String(), "wasmplugin", wasmPluginName)
 		}
 
 		existingEnvoyFilter := existingEnvoyFilterObj.(*controller.RuntimeObject).Object.(*istioclientgonetworkingv1alpha3.EnvoyFilter)


### PR DESCRIPTION
We recently migrated away from `WasmPlugin` to `EnvoyFilter` for our wasm configuration to configure `allow_on_headers_stop_iteration`, to move toward supporting request body processing. 

As part of this work we missed the cleanup of existing `WasmPlugin` objects. This would result in the envoy configuration having two merged copies of the wasm config. The protection policy configuration for one of these would be snapshotted at the state at the time of upgrade, and the other would reflect current state. This would result in overly restrictive policies where double auth/double rate limiting is happening on each request.

A workaround to mitigate, the existing `WasmPlugin` objects in gateway namespaces, with the kuadrant ownership label should be removed, once it’s been confirmed that the new `EnvoyFilter` is in place - guide outlines this here https://gist.github.com/adam-cattermole/5dd1fa53aa36af57254170776ad53601.

### Questions

This PR implements a naive solution to remove the orphaned `WasmPlugin` objects as part of the regular reconcile logic. This comes with a major racey caveat that there is no guarantee the `EnvoyFilter` has been applied correctly before the `WasmPlugin` is removed (there's no status on these and it requires extracting the envoy config from the gateway) - leaving the upstream unprotected.

- What's our stance on upgrades, and uptime - do we have guides on expected behaviour for an istio version upgrade for example?
- Is it acceptable to have this behaviour documented with a warning indicating that for workloads where service protection is critical you cut off access to your cluster/gateways prior to upgrade?

Curious on thoughts and how to proceed here, perhaps @maleck13, @guicassolato

### Alternatives

- I've considered using an initContainer as part of the upgrade process instead of the reconciler. I see one major drawback which is that there's no guarantee the `EnvoyFilter` would ever be ready for a gateway - does the initContainer have timeout conditions, could this make our upgrade process flakey and error prone?
- We have discussed having proper communication between the wasm-shim and the kuadrant-operator. We now have a channel where these communicate, and so there's the option of having the wasm-shim _confirm_ it has loaded the config for a specific identifier - this would mean we can update policy status' much more reliably and say at what time they are `Enforced`, and in this scenario, we would know when it's safe to remove the `WasmPlugin`. This however is not a small amount of work and I'm concerned about rushing this for the fix here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configuration updates so failed changes are reported properly instead of being silently ignored.
  * Added safer cleanup for related Istio resources during reconciliation, helping prevent stale resources from lingering.
* **Chores**
  * Updated generated deployment metadata and permissions to match the latest resource access requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->