### PR TITLE
fix: use non-blocking owner refs for Authorino and Limitador

### DIFF
--- a/internal/controller/authorino_reconciler.go
+++ b/internal/controller/authorino_reconciler.go
@@ -149,11 +149,13 @@ func (r *AuthorinoReconciler) Reconcile(ctx context.Context, _ []controller.Reso
 			Namespace: kobj.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         kobj.GroupVersionKind().GroupVersion().String(),
-					Kind:               kobj.GroupVersionKind().Kind,
-					Name:               kobj.Name,
-					UID:                kobj.UID,
-					BlockOwnerDeletion: ptr.To(true),
+					APIVersion: kobj.GroupVersionKind().GroupVersion().String(),
+					Kind:       kobj.GroupVersionKind().Kind,
+					Name:       kobj.Name,
+					UID:        kobj.UID,
+					// Intentionally false: a blocking owner ref to the Kuadrant CR
+					// races OLM startup and fails the Create.
+					BlockOwnerDeletion: ptr.To(false),
 					Controller:         ptr.To(true),
 				},
 			},

--- a/internal/controller/limitador_reconciler.go
+++ b/internal/controller/limitador_reconciler.go
@@ -71,11 +71,13 @@ func (r *LimitadorReconciler) Reconcile(ctx context.Context, _ []controller.Reso
 			Namespace: kobj.Namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         kobj.GroupVersionKind().GroupVersion().String(),
-					Kind:               kobj.GroupVersionKind().Kind,
-					Name:               kobj.Name,
-					UID:                kobj.UID,
-					BlockOwnerDeletion: ptr.To(true),
+					APIVersion: kobj.GroupVersionKind().GroupVersion().String(),
+					Kind:       kobj.GroupVersionKind().Kind,
+					Name:       kobj.Name,
+					UID:        kobj.UID,
+					// Intentionally false: a blocking owner ref to the Kuadrant CR
+					// races OLM startup and fails the Create.
+					BlockOwnerDeletion: ptr.To(false),
 					Controller:         ptr.To(true),
 				},
 			},

--- a/tests/bare_k8s/kuadrant_controller_test.go
+++ b/tests/bare_k8s/kuadrant_controller_test.go
@@ -93,6 +93,27 @@ var _ = Describe("Kuadrant controller when Gateway API is missing", func() {
 			}).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
 
+		It("Kuadrant-owned resources use non-blocking owner references", func(ctx SpecContext) {
+			assertNonBlockingKuadrantOwnerRef := func(g Gomega, owner []metav1.OwnerReference) {
+				g.Expect(owner).To(ContainElement(SatisfyAll(
+					HaveField("Kind", "Kuadrant"),
+					HaveField("Name", kuadrantCR.Name),
+					HaveField("Controller", ptr.To(true)),
+					HaveField("BlockOwnerDeletion", ptr.To(false)),
+				)))
+			}
+
+			Eventually(func(g Gomega) {
+				limitador := &limitadorv1alpha1.Limitador{}
+				g.Expect(testClient().Get(ctx, client.ObjectKey{Name: kuadrant.LimitadorName, Namespace: testNamespace}, limitador)).To(Succeed())
+				assertNonBlockingKuadrantOwnerRef(g, limitador.GetOwnerReferences())
+
+				authorino := &authorinoopapi.Authorino{}
+				g.Expect(testClient().Get(ctx, client.ObjectKey{Name: "authorino", Namespace: testNamespace}, authorino)).To(Succeed())
+				assertNonBlockingKuadrantOwnerRef(g, authorino.GetOwnerReferences())
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+
 		It("Limitador CR should retain user fields and restore default", func(ctx SpecContext) {
 			By("Patching Limitador CR with user fields")
 			limitador := &limitadorv1alpha1.Limitador{


### PR DESCRIPTION
### Changes
- Set `BlockOwnerDeletion: false` on the owner references pointing at the Kuadrant CR in the Authorino and Limitador reconcilers. The GC-admission RESTMapping check only runs for blocking refs, so this avoids the startup race entirely.
- The owner reference is retained (`Controller: true`), so garbage collection of the children is unchanged, only foreground-deletion ordering (unused by the operator) is dropped.
- Added a regression test asserting both resources carry a non-blocking owner ref.

### Note
`PeerAuthentication` also sets a blocking owner ref to the Kuadrant CR (via `SetControllerReference`, default `true`), so it carries the same latent risk. Left unchanged here as it's created after startup (outside the race window).

Fixes #1578 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed resource creation failures that could occur during Operator Lifecycle Manager (OLM) startup by adjusting resource ownership configurations.

## Tests

* Added integration test validating resource ownership behaviour in Gateway API scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->