### PR TITLE
fix: return created object instead of nil in ReconcileResource

### DIFF
--- a/internal/reconcilers/base_reconciler.go
+++ b/internal/reconcilers/base_reconciler.go
@@ -125,7 +125,10 @@ func (b *BaseReconciler) ReconcileResource(ctx context.Context, obj, desired cli
 
 		// Not found
 		if !utils.IsObjectTaggedToDelete(desired) {
-			return nil, b.CreateResource(ctx, desired)
+			if err := b.CreateResource(ctx, desired); err != nil {
+				return nil, err
+			}
+			return desired, nil
 		}
 
 		// Marked for deletion and not found. Nothing to do.


### PR DESCRIPTION
## Motivation
This PR addresses **Bug 2** described in issue #2046: *Nil pointer panic in plan-policy-extension-controller*.

During a `PlanPolicy` creation (or an `OIDCPolicy` creation), the controller delegates to `BaseReconciler.ReconcileResource` to apply the newly generated underlying policies to the cluster. Previously, upon successfully creating a new object via the Kubernetes client, `ReconcileResource` returned a `nil` object instead of returning the newly created object.

This resulted in a nil pointer panic in downstream reconcilers when they attempted to inspect the `Status.Conditions` of the returned `nil` interface to determine if the object was enforced.

## Changes
- **Core Update**: Modified `internal/reconcilers/base_reconciler.go`'s `ReconcileResource` to return the `desired` object upon successful creation instead of `nil`.
- **Impact**: Instead of panicking, the calling reconcilers now safely receive the newly created object. They correctly identify that it lacks an `Enforced` status, return an error, and gracefully requeue the reconciliation until the policy is enforced.

Fixes #2046
