### PR TITLE
feat: add Prometheus metrics for reconciliation performance

### DIFF
--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	authorinov1beta3 "github.com/kuadrant/authorino/api/v1beta3"
 	"github.com/kuadrant/policy-machinery/controller"
@@ -24,6 +25,7 @@ import (
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	kuadrantauthorino "github.com/kuadrant/kuadrant-operator/internal/authorino"
 	extensionmanager "github.com/kuadrant/kuadrant-operator/internal/extension"
+	kuadrantmetrics "github.com/kuadrant/kuadrant-operator/internal/metrics"
 	kuadrantpolicymachinery "github.com/kuadrant/kuadrant-operator/internal/policymachinery"
 	"github.com/kuadrant/kuadrant-operator/internal/utils"
 )
@@ -51,6 +53,9 @@ func (r *AuthConfigsReconciler) Subscription() controller.Subscription {
 }
 
 func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
+	startTime := time.Now()
+	defer kuadrantmetrics.ObserveAuthconfigGenerationDuration(startTime)
+
 	logger := controller.LoggerFromContext(ctx).WithName("AuthConfigsReconciler").WithValues("context", ctx)
 
 	authorino := GetAuthorinoFromTopology(topology, state)
@@ -83,6 +88,8 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 			modifiedAuthConfigs = append(modifiedAuthConfigs, authConfigName)
 		}
 	}
+
+	kuadrantmetrics.SetAuthconfigsGeneratedTotal(len(desiredAuthConfigs))
 
 	if len(modifiedAuthConfigs) > 0 {
 		state.Store(StateModifiedAuthConfigs, modifiedAuthConfigs)

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -89,7 +89,7 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 		}
 	}
 
-	kuadrantmetrics.SetAuthconfigsGeneratedTotal(len(desiredAuthConfigs))
+	kuadrantmetrics.SetAuthconfigsGenerated(len(desiredAuthConfigs))
 
 	if len(modifiedAuthConfigs) > 0 {
 		state.Store(StateModifiedAuthConfigs, modifiedAuthConfigs)

--- a/internal/controller/effective_auth_policies_reconciler.go
+++ b/internal/controller/effective_auth_policies_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"time"
 
 	"github.com/kuadrant/policy-machinery/controller"
 	"github.com/kuadrant/policy-machinery/machinery"
@@ -11,6 +12,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	kuadrantmetrics "github.com/kuadrant/kuadrant-operator/internal/metrics"
 )
 
 type EffectiveAuthPolicy struct {
@@ -34,6 +36,9 @@ func (r *EffectiveAuthPolicyReconciler) Subscription() controller.Subscription {
 }
 
 func (r *EffectiveAuthPolicyReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
+	startTime := time.Now()
+	defer kuadrantmetrics.ObserveEffectivePolicyDuration("auth", startTime)
+
 	logger := controller.LoggerFromContext(ctx).WithName("EffectiveAuthPolicyReconciler").WithValues("context", ctx)
 	logger.V(1).Info("generate effective auth policy", "status", "started")
 	defer logger.V(1).Info("generate effective auth policy", "status", "completed")

--- a/internal/controller/effective_ratelimit_policies_reconciler.go
+++ b/internal/controller/effective_ratelimit_policies_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"time"
 
 	"github.com/kuadrant/policy-machinery/controller"
 	"github.com/kuadrant/policy-machinery/machinery"
@@ -11,6 +12,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	kuadrantmetrics "github.com/kuadrant/kuadrant-operator/internal/metrics"
 )
 
 type EffectiveRateLimitPolicy struct {
@@ -34,6 +36,9 @@ func (r *EffectiveRateLimitPolicyReconciler) Subscription() controller.Subscript
 }
 
 func (r *EffectiveRateLimitPolicyReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
+	startTime := time.Now()
+	defer kuadrantmetrics.ObserveEffectivePolicyDuration("ratelimit", startTime)
+
 	logger := controller.LoggerFromContext(ctx).WithName("EffectiveRateLimitPolicyReconciler").WithValues("context", ctx)
 	logger.V(1).Info("generating effective rate limit policy", "status", "started")
 	defer logger.V(1).Info("generating effective rate limit policy", "status", "completed")

--- a/internal/controller/effective_tokenratelimit_policies_reconciler.go
+++ b/internal/controller/effective_tokenratelimit_policies_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"time"
 
 	"github.com/kuadrant/policy-machinery/controller"
 	"github.com/kuadrant/policy-machinery/machinery"
@@ -12,6 +13,7 @@ import (
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1alpha1 "github.com/kuadrant/kuadrant-operator/api/v1alpha1"
+	kuadrantmetrics "github.com/kuadrant/kuadrant-operator/internal/metrics"
 )
 
 type EffectiveTokenRateLimitPolicy struct {
@@ -35,6 +37,9 @@ func (r *EffectiveTokenRateLimitPolicyReconciler) Subscription() controller.Subs
 }
 
 func (r *EffectiveTokenRateLimitPolicyReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
+	startTime := time.Now()
+	defer kuadrantmetrics.ObserveEffectivePolicyDuration("tokenratelimit", startTime)
+
 	logger := controller.LoggerFromContext(ctx).WithName("EffectiveTokenRateLimitPolicyReconciler").WithValues("context", ctx)
 	logger.V(1).Info("generating effective token rate limit policy", "status", "started")
 	defer logger.V(1).Info("generating effective token rate limit policy", "status", "completed")

--- a/internal/controller/limitador_limits_reconciler.go
+++ b/internal/controller/limitador_limits_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	"github.com/kuadrant/policy-machinery/controller"
@@ -20,6 +21,7 @@ import (
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1alpha1 "github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	kuadrantmetrics "github.com/kuadrant/kuadrant-operator/internal/metrics"
 	kuadrantpolicymachinery "github.com/kuadrant/kuadrant-operator/internal/policymachinery"
 	"github.com/kuadrant/kuadrant-operator/internal/ratelimit"
 	"github.com/kuadrant/kuadrant-operator/internal/utils"
@@ -47,6 +49,9 @@ func (r *LimitadorLimitsReconciler) Subscription() controller.Subscription {
 }
 
 func (r *LimitadorLimitsReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, state *sync.Map) error {
+	startTime := time.Now()
+	defer kuadrantmetrics.ObserveLimitadorLimitsGenerationDuration(startTime)
+
 	logger := controller.LoggerFromContext(ctx).WithName("LimitadorLimitsReconciler").WithValues("context", ctx)
 	logger.Info("Limitador limits reconciler", "status", "started")
 	defer logger.Info("Limitador limits reconciler", "status", "completed")

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -726,15 +726,15 @@ func additionalMainTraceAttributes(resourceEvents []controller.ResourceEvent, _ 
 
 func (b *BootOptionsBuilder) Reconciler() controller.ReconcileFunc {
 	mainWorkflow := &controller.Workflow{
-		Precondition: metricsReconcileFunc("init", traceReconcileFunc("workflow.init", initWorkflow(b.client).Run)),
+		Precondition: metricsReconcileFunc("workflow.init", traceReconcileFunc("workflow.init", initWorkflow(b.client).Run)),
 		Tasks: []controller.ReconcileFunc{
-			metricsReconcileFunc("dns", traceReconcileFunc("workflow.dns", NewDNSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isDNSOperatorInstalled).Run)),
-			metricsReconcileFunc("tls", traceReconcileFunc("workflow.tls", NewTLSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isCertManagerInstalled).Run)),
-			metricsReconcileFunc("data_plane", traceReconcileFunc("workflow.data_plane_policies", NewDataPlanePoliciesWorkflow(b.manager, b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled, b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Run)),
-			metricsReconcileFunc("observability", traceReconcileFunc("workflow.observability", NewObservabilityReconciler(b.client, b.manager, operatorNamespace).Subscription().Reconcile)),
-			traceReconcileFunc("workflow.developer_portal", NewDeveloperPortalReconciler(b.manager).Subscription().Reconcile),
+			metricsReconcileFunc("workflow.dns", traceReconcileFunc("workflow.dns", NewDNSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isDNSOperatorInstalled).Run)),
+			metricsReconcileFunc("workflow.tls", traceReconcileFunc("workflow.tls", NewTLSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isCertManagerInstalled).Run)),
+			metricsReconcileFunc("workflow.data_plane_policies", traceReconcileFunc("workflow.data_plane_policies", NewDataPlanePoliciesWorkflow(b.manager, b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled, b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Run)),
+			metricsReconcileFunc("workflow.observability", traceReconcileFunc("workflow.observability", NewObservabilityReconciler(b.client, b.manager, operatorNamespace).Subscription().Reconcile)),
+			metricsReconcileFunc("workflow.developer_portal", traceReconcileFunc("workflow.developer_portal", NewDeveloperPortalReconciler(b.manager).Subscription().Reconcile)),
 		},
-		Postcondition: metricsReconcileFunc("finalize", traceReconcileFunc("workflow.finalize", b.finalStepsWorkflow().Run)),
+		Postcondition: metricsReconcileFunc("workflow.finalize", traceReconcileFunc("workflow.finalize", b.finalStepsWorkflow().Run)),
 	}
 
 	if b.isConsolePluginInstalled && b.isClusterVersionInstalled {

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"time"
 
 	istiosecurity "istio.io/client-go/pkg/apis/security/v1"
 
@@ -698,6 +699,14 @@ func traceReconcileFunc(name string, reconcileFunc controller.ReconcileFunc, add
 	}
 }
 
+func metricsReconcileFunc(workflow string, reconcileFunc controller.ReconcileFunc) controller.ReconcileFunc {
+	return func(ctx context.Context, resourceEvents []controller.ResourceEvent, topology *machinery.Topology, err error, state *sync.Map) error {
+		startTime := time.Now()
+		defer operatormetrics.ObserveReconciliationDuration(workflow, startTime)
+		return reconcileFunc(ctx, resourceEvents, topology, err, state)
+	}
+}
+
 func additionalMainTraceAttributes(resourceEvents []controller.ResourceEvent, _ *machinery.Topology, _ error, _ *sync.Map) []attribute.KeyValue {
 	attrs := []attribute.KeyValue{
 		attribute.Int("event_count", len(resourceEvents)),
@@ -717,15 +726,15 @@ func additionalMainTraceAttributes(resourceEvents []controller.ResourceEvent, _ 
 
 func (b *BootOptionsBuilder) Reconciler() controller.ReconcileFunc {
 	mainWorkflow := &controller.Workflow{
-		Precondition: traceReconcileFunc("workflow.init", initWorkflow(b.client).Run),
+		Precondition: metricsReconcileFunc("init", traceReconcileFunc("workflow.init", initWorkflow(b.client).Run)),
 		Tasks: []controller.ReconcileFunc{
-			traceReconcileFunc("workflow.dns", NewDNSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isDNSOperatorInstalled).Run),
-			traceReconcileFunc("workflow.tls", NewTLSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isCertManagerInstalled).Run),
-			traceReconcileFunc("workflow.data_plane_policies", NewDataPlanePoliciesWorkflow(b.manager, b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled, b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Run),
-			traceReconcileFunc("workflow.observability", NewObservabilityReconciler(b.client, b.manager, operatorNamespace).Subscription().Reconcile),
+			metricsReconcileFunc("dns", traceReconcileFunc("workflow.dns", NewDNSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isDNSOperatorInstalled).Run)),
+			metricsReconcileFunc("tls", traceReconcileFunc("workflow.tls", NewTLSWorkflow(b.client, b.manager.GetScheme(), b.isGatewayAPIInstalled, b.isCertManagerInstalled).Run)),
+			metricsReconcileFunc("data_plane", traceReconcileFunc("workflow.data_plane_policies", NewDataPlanePoliciesWorkflow(b.manager, b.client, b.isGatewayAPIInstalled, b.isIstioInstalled, b.isEnvoyGatewayInstalled, b.isLimitadorOperatorInstalled, b.isAuthorinoOperatorInstalled).Run)),
+			metricsReconcileFunc("observability", traceReconcileFunc("workflow.observability", NewObservabilityReconciler(b.client, b.manager, operatorNamespace).Subscription().Reconcile)),
 			traceReconcileFunc("workflow.developer_portal", NewDeveloperPortalReconciler(b.manager).Subscription().Reconcile),
 		},
-		Postcondition: traceReconcileFunc("workflow.finalize", b.finalStepsWorkflow().Run),
+		Postcondition: metricsReconcileFunc("finalize", traceReconcileFunc("workflow.finalize", b.finalStepsWorkflow().Run)),
 	}
 
 	if b.isConsolePluginInstalled && b.isClusterVersionInstalled {

--- a/internal/controller/topology_reconciler.go
+++ b/internal/controller/topology_reconciler.go
@@ -39,12 +39,13 @@ func (r *TopologyReconciler) Reconcile(ctx context.Context, _ []controller.Resou
 
 	logger := controller.LoggerFromContext(ctx).WithName("topology file").WithValues("context", ctx)
 
+	kuadrantmetrics.ResetTopologyObjects()
 	objectsByKind := make(map[string]int)
 	for _, obj := range topology.All().Items() {
 		objectsByKind[obj.GroupVersionKind().Kind]++
 	}
 	for kind, count := range objectsByKind {
-		kuadrantmetrics.SetTopologyObjectsTotal(kind, count)
+		kuadrantmetrics.SetTopologyObjects(kind, count)
 	}
 
 	cm := &corev1.ConfigMap{

--- a/internal/controller/topology_reconciler.go
+++ b/internal/controller/topology_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/kuadrant/policy-machinery/controller"
 	"github.com/kuadrant/policy-machinery/machinery"
@@ -13,6 +14,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
+	kuadrantmetrics "github.com/kuadrant/kuadrant-operator/internal/metrics"
 )
 
 const (
@@ -32,7 +34,18 @@ func NewTopologyReconciler(client *dynamic.DynamicClient, namespace string) *Top
 }
 
 func (r *TopologyReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
+	startTime := time.Now()
+	defer kuadrantmetrics.ObserveTopologyRebuildDuration(startTime)
+
 	logger := controller.LoggerFromContext(ctx).WithName("topology file").WithValues("context", ctx)
+
+	objectsByKind := make(map[string]int)
+	for _, obj := range topology.All().Items() {
+		objectsByKind[obj.GroupVersionKind().Kind]++
+	}
+	for kind, count := range objectsByKind {
+		kuadrantmetrics.SetTopologyObjectsTotal(kind, count)
+	}
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/metrics/reconciliation.go
+++ b/internal/metrics/reconciliation.go
@@ -8,11 +8,13 @@ import (
 )
 
 var (
+	reconciliationBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60}
+
 	reconciliationDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "kuadrant_reconciliation_duration_seconds",
 			Help:    "Duration of each top-level workflow phase in seconds",
-			Buckets: prometheus.DefBuckets,
+			Buckets: reconciliationBuckets,
 		},
 		[]string{"workflow"})
 
@@ -20,7 +22,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "kuadrant_effective_policy_duration_seconds",
 			Help:    "Duration of effective policy calculation in seconds",
-			Buckets: prometheus.DefBuckets,
+			Buckets: reconciliationBuckets,
 		},
 		[]string{"policy_type"})
 
@@ -28,21 +30,21 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "kuadrant_topology_rebuild_duration_seconds",
 			Help:    "Duration of topology reconciliation including ToDot serialization and ConfigMap write in seconds",
-			Buckets: prometheus.DefBuckets,
+			Buckets: reconciliationBuckets,
 		})
 
 	authconfigGenerationDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "kuadrant_authconfig_generation_duration_seconds",
 			Help:    "Duration of AuthConfig reconciliation in seconds",
-			Buckets: prometheus.DefBuckets,
+			Buckets: reconciliationBuckets,
 		})
 
 	limitadorLimitsGenerationDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "kuadrant_limitador_limits_generation_duration_seconds",
 			Help:    "Duration of Limitador limits reconciliation in seconds",
-			Buckets: prometheus.DefBuckets,
+			Buckets: reconciliationBuckets,
 		})
 
 	topologyObjects = prometheus.NewGaugeVec(

--- a/internal/metrics/reconciliation.go
+++ b/internal/metrics/reconciliation.go
@@ -1,0 +1,100 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	reconciliationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kuadrant_reconciliation_duration_seconds",
+			Help:    "Duration of each top-level workflow phase in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"workflow"})
+
+	effectivePolicyDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kuadrant_effective_policy_duration_seconds",
+			Help:    "Duration of effective policy calculation in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"policy_type"})
+
+	topologyRebuildDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "kuadrant_topology_rebuild_duration_seconds",
+			Help:    "Duration of topology reconciliation including ToDot serialization and ConfigMap write in seconds",
+			Buckets: prometheus.DefBuckets,
+		})
+
+	authconfigGenerationDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "kuadrant_authconfig_generation_duration_seconds",
+			Help:    "Duration of AuthConfig reconciliation in seconds",
+			Buckets: prometheus.DefBuckets,
+		})
+
+	limitadorLimitsGenerationDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "kuadrant_limitador_limits_generation_duration_seconds",
+			Help:    "Duration of Limitador limits reconciliation in seconds",
+			Buckets: prometheus.DefBuckets,
+		})
+
+	topologyObjectsTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kuadrant_topology_objects_total",
+			Help: "Number of objects in the topology DAG by kind",
+		},
+		[]string{"kind"})
+
+	authconfigsGeneratedTotal = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "kuadrant_authconfigs_generated_total",
+			Help: "Number of AuthConfigs generated in the last reconciliation cycle",
+		})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		reconciliationDuration,
+		effectivePolicyDuration,
+		topologyRebuildDuration,
+		authconfigGenerationDuration,
+		limitadorLimitsGenerationDuration,
+		topologyObjectsTotal,
+		authconfigsGeneratedTotal,
+	)
+}
+
+func ObserveReconciliationDuration(workflow string, start time.Time) {
+	reconciliationDuration.WithLabelValues(workflow).Observe(time.Since(start).Seconds())
+}
+
+func ObserveEffectivePolicyDuration(policyType string, start time.Time) {
+	effectivePolicyDuration.WithLabelValues(policyType).Observe(time.Since(start).Seconds())
+}
+
+func ObserveTopologyRebuildDuration(start time.Time) {
+	topologyRebuildDuration.Observe(time.Since(start).Seconds())
+}
+
+func ObserveAuthconfigGenerationDuration(start time.Time) {
+	authconfigGenerationDuration.Observe(time.Since(start).Seconds())
+}
+
+func ObserveLimitadorLimitsGenerationDuration(start time.Time) {
+	limitadorLimitsGenerationDuration.Observe(time.Since(start).Seconds())
+}
+
+func SetTopologyObjectsTotal(kind string, count int) {
+	topologyObjectsTotal.WithLabelValues(kind).Set(float64(count))
+}
+
+func SetAuthconfigsGeneratedTotal(count int) {
+	authconfigsGeneratedTotal.Set(float64(count))
+}

--- a/internal/metrics/reconciliation.go
+++ b/internal/metrics/reconciliation.go
@@ -45,16 +45,16 @@ var (
 			Buckets: prometheus.DefBuckets,
 		})
 
-	topologyObjectsTotal = prometheus.NewGaugeVec(
+	topologyObjects = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "kuadrant_topology_objects_total",
+			Name: "kuadrant_topology_objects",
 			Help: "Number of objects in the topology DAG by kind",
 		},
 		[]string{"kind"})
 
-	authconfigsGeneratedTotal = prometheus.NewGauge(
+	authconfigsGenerated = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "kuadrant_authconfigs_generated_total",
+			Name: "kuadrant_authconfigs_generated",
 			Help: "Number of AuthConfigs generated in the last reconciliation cycle",
 		})
 )
@@ -66,8 +66,8 @@ func init() {
 		topologyRebuildDuration,
 		authconfigGenerationDuration,
 		limitadorLimitsGenerationDuration,
-		topologyObjectsTotal,
-		authconfigsGeneratedTotal,
+		topologyObjects,
+		authconfigsGenerated,
 	)
 }
 
@@ -91,10 +91,14 @@ func ObserveLimitadorLimitsGenerationDuration(start time.Time) {
 	limitadorLimitsGenerationDuration.Observe(time.Since(start).Seconds())
 }
 
-func SetTopologyObjectsTotal(kind string, count int) {
-	topologyObjectsTotal.WithLabelValues(kind).Set(float64(count))
+func ResetTopologyObjects() {
+	topologyObjects.Reset()
 }
 
-func SetAuthconfigsGeneratedTotal(count int) {
-	authconfigsGeneratedTotal.Set(float64(count))
+func SetTopologyObjects(kind string, count int) {
+	topologyObjects.WithLabelValues(kind).Set(float64(count))
+}
+
+func SetAuthconfigsGenerated(count int) {
+	authconfigsGenerated.Set(float64(count))
 }

--- a/internal/metrics/reconciliation_test.go
+++ b/internal/metrics/reconciliation_test.go
@@ -1,0 +1,151 @@
+//go:build unit
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func collectHistogramVec(h *prometheus.HistogramVec, label string) (*dto.Metric, error) {
+	metric := &dto.Metric{}
+	observer := h.WithLabelValues(label)
+	err := observer.(prometheus.Metric).Write(metric)
+	return metric, err
+}
+
+func TestObserveReconciliationDuration(t *testing.T) {
+	reconciliationDuration.Reset()
+
+	start := time.Now().Add(-100 * time.Millisecond)
+	ObserveReconciliationDuration("data_plane", start)
+
+	metric, err := collectHistogramVec(reconciliationDuration, "data_plane")
+	if err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if metric.Histogram == nil {
+		t.Fatal("expected histogram metric, got nil")
+	}
+	if *metric.Histogram.SampleCount != 1 {
+		t.Errorf("expected 1 sample, got %d", *metric.Histogram.SampleCount)
+	}
+	if *metric.Histogram.SampleSum <= 0 {
+		t.Errorf("expected positive sum, got %v", *metric.Histogram.SampleSum)
+	}
+}
+
+func TestObserveEffectivePolicyDuration(t *testing.T) {
+	effectivePolicyDuration.Reset()
+
+	start := time.Now().Add(-50 * time.Millisecond)
+	ObserveEffectivePolicyDuration("auth", start)
+
+	metric, err := collectHistogramVec(effectivePolicyDuration, "auth")
+	if err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if *metric.Histogram.SampleCount != 1 {
+		t.Errorf("expected 1 sample, got %d", *metric.Histogram.SampleCount)
+	}
+}
+
+func TestObserveTopologyRebuildDuration(t *testing.T) {
+	metric := &dto.Metric{}
+	ObserveTopologyRebuildDuration(time.Now().Add(-10 * time.Millisecond))
+
+	if err := topologyRebuildDuration.(prometheus.Metric).Write(metric); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if metric.Histogram == nil || *metric.Histogram.SampleCount < 1 {
+		t.Error("expected at least 1 sample")
+	}
+}
+
+func TestObserveAuthconfigGenerationDuration(t *testing.T) {
+	metric := &dto.Metric{}
+	ObserveAuthconfigGenerationDuration(time.Now().Add(-5 * time.Millisecond))
+
+	if err := authconfigGenerationDuration.(prometheus.Metric).Write(metric); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if metric.Histogram == nil || *metric.Histogram.SampleCount < 1 {
+		t.Error("expected at least 1 sample")
+	}
+}
+
+func TestObserveLimitadorLimitsGenerationDuration(t *testing.T) {
+	metric := &dto.Metric{}
+	ObserveLimitadorLimitsGenerationDuration(time.Now().Add(-5 * time.Millisecond))
+
+	if err := limitadorLimitsGenerationDuration.(prometheus.Metric).Write(metric); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if metric.Histogram == nil || *metric.Histogram.SampleCount < 1 {
+		t.Error("expected at least 1 sample")
+	}
+}
+
+func TestSetTopologyObjects(t *testing.T) {
+	topologyObjects.Reset()
+
+	SetTopologyObjects("Gateway", 3)
+	SetTopologyObjects("HTTPRoute", 10)
+
+	metric := &dto.Metric{}
+	if err := topologyObjects.WithLabelValues("Gateway").Write(metric); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if *metric.Gauge.Value != 3 {
+		t.Errorf("expected 3, got %v", *metric.Gauge.Value)
+	}
+
+	if err := topologyObjects.WithLabelValues("HTTPRoute").Write(metric); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if *metric.Gauge.Value != 10 {
+		t.Errorf("expected 10, got %v", *metric.Gauge.Value)
+	}
+}
+
+func TestResetTopologyObjects(t *testing.T) {
+	topologyObjects.Reset()
+
+	SetTopologyObjects("Gateway", 5)
+	ResetTopologyObjects()
+
+	metric := &dto.Metric{}
+	if err := topologyObjects.WithLabelValues("Gateway").Write(metric); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if *metric.Gauge.Value != 0 {
+		t.Errorf("expected 0 after reset, got %v", *metric.Gauge.Value)
+	}
+}
+
+func TestSetAuthconfigsGenerated(t *testing.T) {
+	SetAuthconfigsGenerated(42)
+
+	metric := &dto.Metric{}
+	if err := authconfigsGenerated.Write(metric); err != nil {
+		t.Fatalf("failed to write metric: %v", err)
+	}
+	if *metric.Gauge.Value != 42 {
+		t.Errorf("expected 42, got %v", *metric.Gauge.Value)
+	}
+}
+
+func TestReconciliationBuckets(t *testing.T) {
+	expected := []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30, 60}
+	if len(reconciliationBuckets) != len(expected) {
+		t.Fatalf("expected %d buckets, got %d", len(expected), len(reconciliationBuckets))
+	}
+	for i, v := range expected {
+		if reconciliationBuckets[i] != v {
+			t.Errorf("bucket[%d]: expected %v, got %v", i, v, reconciliationBuckets[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Prometheus histograms and gauges for reconciliation performance observability. These metrics are the interface for QE scale tests — QE scrapes them via kube-burner and displays in Grafana dashboards.

## Metrics

### Histograms

| Metric | Labels | What it measures |
|--------|--------|-----------------|
| `kuadrant_reconciliation_duration_seconds` | `workflow` (init, dns, tls, data_plane, observability, finalize) | End-to-end duration of each workflow phase |
| `kuadrant_effective_policy_duration_seconds` | `policy_type` (auth, ratelimit, tokenratelimit) | Time to calculate effective policies |
| `kuadrant_topology_rebuild_duration_seconds` | — | Time for topology reconciliation (ToDot + ConfigMap) |
| `kuadrant_authconfig_generation_duration_seconds` | — | Time for AuthConfig reconciliation |
| `kuadrant_limitador_limits_generation_duration_seconds` | — | Time for Limitador limits reconciliation |

### Gauges

| Metric | Labels | What it measures |
|--------|--------|-----------------|
| `kuadrant_topology_objects` | `kind` | Number of objects in the topology DAG by kind |
| `kuadrant_authconfigs_generated` | — | Number of AuthConfigs generated per cycle |

## Verification

```bash
make local-env-setup && make run
curl localhost:8080/metrics | grep kuadrant_reconciliation
curl localhost:8080/metrics | grep kuadrant_effective_policy
curl localhost:8080/metrics | grep kuadrant_topology
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for reconciliation phase durations and effective policy processing.
  * Added visibility into topology rebuilds, generated AuthConfigs, topology object counts, and limit generation times.
  * Added workflow-level timing for key reconciliation stages.

* **Tests**
  * Added coverage validating metric observations, gauges, resets, and duration buckets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->