### PR TITLE
release 1.5.0

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -224,14 +224,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc3
-    createdAt: "2026-06-26T08:32:19Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.0
+    createdAt: "2026-06-26T14:14:32Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.5.0-rc3
+  name: kuadrant-operator.v1.5.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -769,7 +769,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc3
+                image: quay.io/kuadrant/kuadrant-operator:v1.5.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -928,4 +928,4 @@ spec:
     name: console-plugin-latest
   - image: quay.io/kuadrant/console-plugin:v0.1.5-2
     name: console-plugin-pf5
-  version: 1.5.0-rc3
+  version: 1.5.0

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.5.0-rc3"
-appVersion: "1.5.0-rc3"
+version: "1.5.0"
+appVersion: "1.5.0"
 dependencies:
   - name: authorino-operator
     version: 0.25.1

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14504,7 +14504,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc3
+        image: quay.io/kuadrant/kuadrant-operator:v1.5.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.5.0-rc3
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.5.0
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,4 +12,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.5.0-rc3
+  newTag: v1.5.0

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.0-rc3
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.0
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.5.0-rc3
+  name: kuadrant-operator.v1.5.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,4 +88,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.5.0-rc3
+  version: 1.5.0

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.5.0-rc3"
+  version: "1.5.0"
 olm:
   channels:
     - "stable"


### PR DESCRIPTION
The following PR for the release release Kuadrant Operator version 1.5.0 includes:
- Authorino Operator version 0.25.1
- DNS Operator version 0.17.0
- Limitador Operator version 0.18.2
- Console Plugin version 0.4.0
- WASM Shim version 0.14.1
- Developer Portal Controller version 0.2.0