### PR TITLE
Add cosigning and provenance attestation to image builds

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -147,7 +147,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: true
-          provenance: false
+          provenance: true
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
@@ -158,6 +158,11 @@ jobs:
         run: |
           echo "Image(s) pushed:"
           echo "${{ steps.meta.outputs.tags }}"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}@${{ steps.build-image.outputs.digest }}
 
   build-bundle:
     needs: build
@@ -209,13 +214,18 @@ jobs:
           file: ./bundle.Dockerfile
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: true
-          provenance: false
+          provenance: true
           tags: ${{ steps.bundle-meta.outputs.tags }}
           build-args: QUAY_IMAGE_EXPIRY=${{ inputs.quayImageExpiry }}
       - name: Print Image URL
         run: |
           echo "Image(s) pushed:"
           echo "${{ steps.bundle-meta.outputs.tags }}"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle@${{ steps.build-bundle-image.outputs.digest }}
 
   build-catalog:
     name: Build Catalog
@@ -260,10 +270,15 @@ jobs:
           file: ./catalog/kuadrant-operator-catalog.Dockerfile
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
           push: true
-          provenance: false
+          provenance: true
           tags: ${{ steps.catalog-meta.outputs.tags }}
           # The Quay image expiry label for the generated catalog Dockerfile is set via opm, using the value set in the QUAY_IMAGE_EXPIRY environment variable
       - name: Print Image URL
         run: |
           echo "Image(s) pushed:"
           echo "${{ steps.catalog-meta.outputs.tags }}"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog@${{ steps.build-catalog-image.outputs.digest }}

--- a/.github/workflows/build-images-branches.yaml
+++ b/.github/workflows/build-images-branches.yaml
@@ -10,6 +10,9 @@ on:
 jobs:
   workflow-build:
     name: Calls build-images-base workflow
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build-images-base.yaml
     secrets: inherit
     with:

--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -14,6 +14,10 @@ jobs:
   build:
     name: Build and Push image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
       image: ${{ steps.push-to-quay.outputs.registry-path }}
@@ -66,10 +70,36 @@ jobs:
       - name: Print Image URL
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
 
+      - name: Login to registry for cosign
+        if: github.repository_owner == 'kuadrant'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
+        with:
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Install cosign
+        if: github.repository_owner == 'kuadrant'
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        if: github.repository_owner == 'kuadrant'
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}@${{ steps.push-to-quay.outputs.digest }}
+      - name: Attest build provenance
+        if: github.repository_owner == 'kuadrant'
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # ratchet:actions/attest@v4
+        with:
+          subject-name: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}
+          subject-digest: ${{ steps.push-to-quay.outputs.digest }}
+          push-to-registry: true
+
   build-bundle:
     name: Build and Push bundle image
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
       image: ${{ steps.push-to-quay.outputs.registry-path }}
@@ -123,10 +153,36 @@ jobs:
       - name: Print Image URL
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
 
+      - name: Login to registry for cosign
+        if: github.repository_owner == 'kuadrant'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
+        with:
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Install cosign
+        if: github.repository_owner == 'kuadrant'
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        if: github.repository_owner == 'kuadrant'
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle@${{ steps.push-to-quay.outputs.digest }}
+      - name: Attest build provenance
+        if: github.repository_owner == 'kuadrant'
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # ratchet:actions/attest@v4
+        with:
+          subject-name: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-bundle
+          subject-digest: ${{ steps.push-to-quay.outputs.digest }}
+          push-to-registry: true
+
   build-catalog:
     name: Build and Push catalog image
     needs: [build, build-bundle]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     outputs:
       build-tags: ${{ steps.build-image.outputs.tags }}
       image: ${{ steps.push-to-quay.outputs.registry-path }}
@@ -204,6 +260,28 @@ jobs:
 
       - name: Print Image URL
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+
+      - name: Login to registry for cosign
+        if: github.repository_owner == 'kuadrant'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # ratchet:docker/login-action@v3
+        with:
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Install cosign
+        if: github.repository_owner == 'kuadrant'
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # ratchet:sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        if: github.repository_owner == 'kuadrant'
+        run: |
+          cosign sign --yes ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog@${{ steps.push-to-quay.outputs.digest }}
+      - name: Attest build provenance
+        if: github.repository_owner == 'kuadrant'
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # ratchet:actions/attest@v4
+        with:
+          subject-name: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}-catalog
+          subject-digest: ${{ steps.push-to-quay.outputs.digest }}
+          push-to-registry: true
 
   verify-builds:
     name: Ensure all image references are equal (operator, bundle, catalog)

--- a/.github/workflows/build-images-main.yaml
+++ b/.github/workflows/build-images-main.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   workflow-build:
     name: Calls build-images-base workflow
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build-images-base.yaml
     secrets: inherit
     with:

--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -85,6 +85,9 @@ jobs:
       - console-plugin-latest-digest
       - console-plugin-pf5-digest
     name: Calls build-images-base workflow
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build-images-base.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary
  - Sign all container images (operator, bundle, catalog) with cosign (https://github.com/sigstore/cosign) keyless
  signing using the GitHub OIDC identity
  - Enable SLSA build provenance for Docker Buildx workflows (`provenance: true`) and add `actions/attest@v4` provenance attestation for buildah-based tag release workflow
  - New actions are pinned by commit SHA using ratchet (https://github.com/sethvargo/ratchet) format comments, consistent with action pinning being added in #2057.

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2038

## Context

This improves the Signed-Releases (https://github.com/ossf/scorecard/blob/main/docs/checks.md#signed-releases) check from the OpenSSF Scorecard (https://scorecard.dev/). Merging this should bring this section score from current 0 to 10.

## Verification

Building workflows with the new changes were executed on my fork of the kuadrant-operator, and the successful run can be found [here](https://github.com/averevki/kuadrant-operator/actions/runs/28458948292), with the images pushed [here](https://quay.io/repository/averevki/kuadrant-operator-catalog?tab=tags)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container images now include provenance details and are signed before release, improving trust in published builds.
  * Release workflows now support signing and attestation for operator, bundle, and catalog images.
* **Security**
  * Added stronger identity and permission settings for image publishing jobs to support secure signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->