### PR TITLE
fix: retry transient owner-reference errors for Authorino and Limitador

### DIFF
--- a/internal/controller/authorino_reconciler.go
+++ b/internal/controller/authorino_reconciler.go
@@ -13,11 +13,14 @@ import (
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/ptr"
 
 	"github.com/kuadrant/kuadrant-operator/api/v1beta1"
 )
+
+const AuthorinoReconcilerName = "AuthorinoReconciler"
 
 type AuthorinoReconciler struct {
 	Client *dynamic.DynamicClient
@@ -199,7 +202,15 @@ func (r *AuthorinoReconciler) Reconcile(ctx context.Context, _ []controller.Reso
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "failed to create authorino")
 			logger.Error(err, "failed to create authorino resource", "status", "error")
-			return err
+
+			// Record error for deferred retry
+			GetOrCreateErrorRegistry(state).Record(
+				AuthorinoReconcilerName,
+				OperationCreate,
+				k8stypes.NamespacedName{Name: authorino.GetName(), Namespace: authorino.GetNamespace()},
+				v1beta1.AuthorinoGroupKind,
+				err,
+			)
 		}
 	} else {
 		span.AddEvent("Authorino resource created successfully")

--- a/internal/controller/limitador_reconciler.go
+++ b/internal/controller/limitador_reconciler.go
@@ -14,12 +14,15 @@ import (
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/utils/ptr"
 
 	"github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	"github.com/kuadrant/kuadrant-operator/internal/kuadrant"
 )
+
+const LimitadorReconcilerName = "LimitadorResourceReconciler"
 
 type LimitadorReconciler struct {
 	Client *dynamic.DynamicClient
@@ -141,7 +144,16 @@ func (r *LimitadorReconciler) Reconcile(ctx context.Context, _ []controller.Reso
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to apply limitador")
 		logger.Error(err, "failed to apply limitador", "status", "error")
-		return err
+
+		// Record error for deferred retry
+		GetOrCreateErrorRegistry(state).Record(
+			LimitadorReconcilerName,
+			OperationCreate,
+			k8stypes.NamespacedName{Name: desiredLimitador.GetName(), Namespace: desiredLimitador.GetNamespace()},
+			v1beta1.LimitadorGroupKind,
+			err,
+		)
+		return nil
 	}
 
 	span.SetAttributes(


### PR DESCRIPTION
## Description
On a fresh OLM install, the apiserver's gc-admission RESTMapper may not yet know the `Kuadrant` kind, so creating Authorino/Limitador with a blocking owner reference is briefly rejected (`cannot find RESTMapping ... no matches for kind "Kuadrant"`). Previously this returned an error, aborting the reconciliation workflow and requiring an operator restart.

Instead of returning the error, the Authorino and Limitador reconcilers now record it via the `ErrorRegistry` introduced in #2043, so the reconciliation completes and is retried with backoff rather than aborting.

Fixes #1578 

## Testing

- **No new test**: This change only wires into #2043's retry framework, whose mechanics are covered by `reconciliation_errors_test.go`.
- `make verify-all` and `make test-bare-k8s-integration` pass (10/10) on the branch, confirming no regression in Authorino/Limitador creation.
- Verified the retry path by injecting a transient create failure (removing the operator's `create` permission on `authorinos`): the error is recorded and a backoff retry is scheduled instead of aborting the workflow. Log excerpt:
```
{"level":"error","logger":"kuadrant-operator.AuthorinoReconciler","msg":"failed to create authorino resource","error":"authorinos.operator.authorino.kuadrant.io is forbidden: ... cannot create resource \"authorinos\" ..."}
{"level":"info","logger":"kuadrant-operator.PersistentErrorTracker","msg":"new non-blocking error recorded","source":"AuthorinoReconciler","operation":"create","resource":"kuadrant-system/authorino","kind":"Authorino.operator.authorino.kuadrant.io"}
{"level":"info","logger":"kuadrant-operator.ReconciliationErrorHandler","msg":"scheduling retry for non-blocking errors","errorCount":1,"requeueAfter":2}
```

## Note

Supersedes #2061- the retry-based approach here was discussed and agreed on that PR which also has the full root-cause analysis of the admission-time RESTMapper race.
 Full unattended self-heal depends on #2043's retry loop; while validating I saw an error marked `resolved` while its create
 was still failing (a workflow triggered by an unrelated event clears errors recorded by reconcilers that didn't run that cycle).  
 Flagging in case it's worth hardening in #2043.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of resource creation and update failures so issues are recorded more reliably.
  * Reduced the chance of reconciliation stopping immediately on transient failures, helping retries happen more smoothly.
  * Added clearer tracking for failed operations to support more consistent recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->