### PR TITLE
Change docs to use the OPA Rego v1 syntax

### DIFF
--- a/doc/overviews/token-rate-limiting.md
+++ b/doc/overviews/token-rate-limiting.md
@@ -217,8 +217,9 @@ spec:
         opa:
           rego: |
             groups := split(object.get(input.auth.identity.metadata.annotations, "kuadrant.io/groups", ""), ",")
-            allow { groups[_] == "free" }
-            allow { groups[_] == "gold" }
+            allow if groups[_] == "free"
+            allow if groups[_] == "gold"
+          version: v1
 ```
 
 This configuration makes `auth.identity.groups` and `auth.identity.userid` available to TokenRateLimitPolicy for use in predicates and counters.

--- a/doc/user-guides/auth/anonymous-access.md
+++ b/doc/user-guides/auth/anonymous-access.md
@@ -116,7 +116,8 @@ spec:
       authorization:
         deny-all:
           opa:
-            rego: "allow = false"
+            rego: "allow := false"
+            version: v1
 EOF
 ```
 

--- a/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
+++ b/doc/user-guides/auth/auth-for-app-devs-and-platform-engineers.md
@@ -220,7 +220,8 @@ spec:
         opa:
           rego: |
             groups := split(object.get(input.auth.identity.metadata.annotations, "kuadrant.io/groups", ""), ",")
-            allow { groups[_] == "admins" }
+            allow if groups[_] == "admins"
+          version: v1
 EOF
 ```
 
@@ -301,7 +302,8 @@ spec:
       authorization:
         deny-all:
           opa:
-            rego: "allow = false"
+            rego: "allow := false"
+            version: v1
       response:
         unauthorized:
           headers:

--- a/doc/user-guides/full-walkthrough/secure-protect-connect.md
+++ b/doc/user-guides/full-walkthrough/secure-protect-connect.md
@@ -223,7 +223,8 @@ spec:
     authorization:
       deny-all:
         opa:
-          rego: "allow = false"
+          rego: "allow := false"
+          version: v1
     response:
       unauthorized:
         headers:

--- a/doc/user-guides/observability/token-metrics.md
+++ b/doc/user-guides/observability/token-metrics.md
@@ -248,8 +248,9 @@ spec:
         opa:
           rego: |
             groups := split(object.get(input.auth.identity.metadata.annotations, "kuadrant.io/groups", ""), ",")
-            allow { groups[_] == "free" }
-            allow { groups[_] == "gold" }
+            allow if groups[_] == "free"
+            allow if groups[_] == "gold"
+          version: v1
 EOF
 ```
 

--- a/doc/user-guides/tokenratelimitpolicy/authenticated-token-ratelimiting-tutorial.md
+++ b/doc/user-guides/tokenratelimitpolicy/authenticated-token-ratelimiting-tutorial.md
@@ -255,8 +255,9 @@ spec:
         opa:
           rego: |
             groups := split(object.get(input.auth.identity.metadata.annotations, "kuadrant.io/groups", ""), ",")
-            allow { groups[_] == "free" }
-            allow { groups[_] == "gold" }
+            allow if groups[_] == "free"
+            allow if groups[_] == "gold"
+          version: v1
 EOF
 ```
 


### PR DESCRIPTION
The addition to the authorino docs change https://github.com/Kuadrant/authorino/pull/648, updating the docs residing in the kuadrant-operator to also use the new OPA Rego v1 syntax. 

I verified the new syntax with the OPA CLI, and also simplified some of the conditions where it was possible.