### PR TITLE
fix: separate error handling in IsCertManagerInstalled

### DIFF
--- a/internal/gatewayapi/utils.go
+++ b/internal/gatewayapi/utils.go
@@ -209,19 +209,34 @@ func IsGatewayAPIInstalled(restMapper meta.RESTMapper) (bool, error) {
 }
 
 func IsCertManagerInstalled(restMapper meta.RESTMapper, logger logr.Logger) (bool, error) {
-	if ok, err := utils.IsCRDInstalled(restMapper, certmanager.GroupName, certmanv1.CertificateKind, certmanv1.SchemeGroupVersion.Version); !ok || err != nil {
-		logger.V(1).Error(err, "CertManager CRD was not installed", "group", certmanager.GroupName, "kind", certmanv1.CertificateKind, "version", certmanv1.SchemeGroupVersion.Version)
+	ok, err := utils.IsCRDInstalled(restMapper, certmanager.GroupName, certmanv1.CertificateKind, certmanv1.SchemeGroupVersion.Version)
+	if err != nil {
+		logger.Error(err, "failed to check if CertManager CRD is installed", "group", certmanager.GroupName, "kind", certmanv1.CertificateKind, "version", certmanv1.SchemeGroupVersion.Version)
 		return false, err
 	}
-
-	if ok, err := utils.IsCRDInstalled(restMapper, certmanager.GroupName, certmanv1.IssuerKind, certmanv1.SchemeGroupVersion.Version); !ok || err != nil {
-		logger.V(1).Error(err, "CertManager CRD was not installed", "group", certmanager.GroupName, "kind", certmanv1.IssuerKind, "version", certmanv1.SchemeGroupVersion.Version)
-		return false, err
+	if !ok {
+		logger.V(1).Info("CertManager CRD was not installed", "group", certmanager.GroupName, "kind", certmanv1.CertificateKind, "version", certmanv1.SchemeGroupVersion.Version)
+		return false, nil
 	}
 
-	if ok, err := utils.IsCRDInstalled(restMapper, certmanager.GroupName, certmanv1.ClusterIssuerKind, certmanv1.SchemeGroupVersion.Version); !ok || err != nil {
-		logger.V(1).Error(err, "CertManager CRD was not installed", "group", certmanager.GroupName, "kind", certmanv1.ClusterIssuerKind, "version", certmanv1.SchemeGroupVersion.Version)
+	ok, err = utils.IsCRDInstalled(restMapper, certmanager.GroupName, certmanv1.IssuerKind, certmanv1.SchemeGroupVersion.Version)
+	if err != nil {
+		logger.Error(err, "failed to check if CertManager CRD is installed", "group", certmanager.GroupName, "kind", certmanv1.IssuerKind, "version", certmanv1.SchemeGroupVersion.Version)
 		return false, err
+	}
+	if !ok {
+		logger.V(1).Info("CertManager CRD was not installed", "group", certmanager.GroupName, "kind", certmanv1.IssuerKind, "version", certmanv1.SchemeGroupVersion.Version)
+		return false, nil
+	}
+
+	ok, err = utils.IsCRDInstalled(restMapper, certmanager.GroupName, certmanv1.ClusterIssuerKind, certmanv1.SchemeGroupVersion.Version)
+	if err != nil {
+		logger.Error(err, "failed to check if CertManager CRD is installed", "group", certmanager.GroupName, "kind", certmanv1.ClusterIssuerKind, "version", certmanv1.SchemeGroupVersion.Version)
+		return false, err
+	}
+	if !ok {
+		logger.V(1).Info("CertManager CRD was not installed", "group", certmanager.GroupName, "kind", certmanv1.ClusterIssuerKind, "version", certmanv1.SchemeGroupVersion.Version)
+		return false, nil
 	}
 
 	return true, nil


### PR DESCRIPTION
## Description
This PR fixes a bug in `internal/gatewayapi/utils.go` where `IsCertManagerInstalled` was logging an error with a `nil` error object if the CertManager CRD was simply not installed in the cluster.

Previously, the function combined the CRD presence check (`!ok`) and the error check (`err != nil`) into a single condition, logging a generic error in both scenarios. This led to confusing log output for users who intentionally did not install cert-manager (a valid configuration for some policies).

**Changes made:**
- Split the combined condition into two explicit checks.
- If an actual error occurs when communicating with the API server (`err != nil`), it logs an `Error` and returns `false, err`.
- If the CRD is just missing (`!ok`), it gracefully logs an `Info` message at verbosity level 1 and returns `false, nil`.

**Related Issue:**
Fixes #2097


## Verification
- Run the operator locally (`make run`) against a cluster without cert-manager installed.
- Ensure that the operator logs an informational message (`CertManager CRD was not installed`) instead of a nil error trace.

## Checklist
- [x] Commits are signed off (`git commit -s`)
- [x] Code builds locally (`make build`)
- [x] Relevant tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cert-Manager detection so the app more reliably recognises whether required components are available.
  * Added clearer handling when a required component is missing or cannot be checked, helping avoid incorrect installation status results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->