### PR TITLE
fix: correct spelling mistakes in type and variable names

### DIFF
--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -375,7 +375,7 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 	// unique paths by key
 	paths := lo.UniqBy(allPaths, func(e lo.Entry[string, []machinery.Targetable]) string { return e.Key })
 
-	wasmActionSets := kuadrantgatewayapi.GrouppedHTTPRouteMatchConfigs{}
+	wasmActionSets := kuadrantgatewayapi.GroupedHTTPRouteMatchConfigs{}
 	celValidationIssues := celvalidator.NewIssueCollection()
 
 	tracer := controller.TracerFromContext(ctx)

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -397,7 +397,7 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 	authPathIDs := lo.Keys(effectiveAuthPoliciesMap)
 	logger.V(1).Info("effective auth policy pathIDs", "count", len(authPathIDs), "pathIDs", authPathIDs)
 
-	wasmActionSets := kuadrantgatewayapi.GrouppedHTTPRouteMatchConfigs{}
+	wasmActionSets := kuadrantgatewayapi.GroupedHTTPRouteMatchConfigs{}
 	celValidationIssues := celvalidator.NewIssueCollection()
 
 	tracer := controller.TracerFromContext(ctx)

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -795,7 +795,7 @@ func certManagerControllerOpts() []controller.ControllerOption {
 		),
 		controller.WithRunnable("clusterissuers watcher", controller.Watch(
 			&certmanagerv1.ClusterIssuer{},
-			CertMangerClusterIssuersResource,
+			CertManagerClusterIssuersResource,
 			metav1.NamespaceAll,
 			controller.WithPredicates(ctrlruntimepredicate.TypedFuncs[*certmanagerv1.ClusterIssuer]{
 				UpdateFunc: func(e event.TypedUpdateEvent[*certmanagerv1.ClusterIssuer]) bool {

--- a/internal/controller/tls_workflow.go
+++ b/internal/controller/tls_workflow.go
@@ -26,7 +26,7 @@ const (
 var (
 	CertManagerCertificatesResource  = certmanagerv1.SchemeGroupVersion.WithResource("certificates")
 	CertManagerIssuersResource       = certmanagerv1.SchemeGroupVersion.WithResource("issuers")
-	CertMangerClusterIssuersResource = certmanagerv1.SchemeGroupVersion.WithResource("clusterissuers")
+	CertManagerClusterIssuersResource = certmanagerv1.SchemeGroupVersion.WithResource("clusterissuers")
 
 	CertManagerCertificateKind   = schema.GroupKind{Group: certmanager.GroupName, Kind: certmanagerv1.CertificateKind}
 	CertManagerIssuerKind        = schema.GroupKind{Group: certmanager.GroupName, Kind: certmanagerv1.IssuerKind}

--- a/internal/controller/tls_workflow.go
+++ b/internal/controller/tls_workflow.go
@@ -24,8 +24,8 @@ const (
 )
 
 var (
-	CertManagerCertificatesResource  = certmanagerv1.SchemeGroupVersion.WithResource("certificates")
-	CertManagerIssuersResource       = certmanagerv1.SchemeGroupVersion.WithResource("issuers")
+	CertManagerCertificatesResource   = certmanagerv1.SchemeGroupVersion.WithResource("certificates")
+	CertManagerIssuersResource        = certmanagerv1.SchemeGroupVersion.WithResource("issuers")
 	CertManagerClusterIssuersResource = certmanagerv1.SchemeGroupVersion.WithResource("clusterissuers")
 
 	CertManagerCertificateKind   = schema.GroupKind{Group: certmanager.GroupName, Kind: certmanagerv1.CertificateKind}

--- a/internal/gatewayapi/types.go
+++ b/internal/gatewayapi/types.go
@@ -120,15 +120,15 @@ func pathMatchCount(pathMatch *gatewayapiv1.HTTPPathMatch) int {
 	return 0
 }
 
-type GrouppedHTTPRouteMatchConfigs map[string]SortableHTTPRouteMatchConfigs
+type GroupedHTTPRouteMatchConfigs map[string]SortableHTTPRouteMatchConfigs
 
-func (g *GrouppedHTTPRouteMatchConfigs) Add(key string, configs ...HTTPRouteMatchConfig) {
+func (g *GroupedHTTPRouteMatchConfigs) Add(key string, configs ...HTTPRouteMatchConfig) {
 	for _, config := range configs {
 		(*g)[key] = append((*g)[key], config)
 	}
 }
 
-func (g *GrouppedHTTPRouteMatchConfigs) Sorted() GrouppedHTTPRouteMatchConfigs {
+func (g *GroupedHTTPRouteMatchConfigs) Sorted() GroupedHTTPRouteMatchConfigs {
 	if g == nil {
 		return nil
 	}


### PR DESCRIPTION
## Description
This PR corrects two spelling mistakes found across the codebase in variable and type definitions. It is a minor code quality and readability enhancement.

**Changes made:**
- Renamed `CertMangerClusterIssuersResource` to `CertManagerClusterIssuersResource` (fixes "Manger" typo) in `tls_workflow.go` and `state_of_the_world.go`.
- Renamed `GrouppedHTTPRouteMatchConfigs` to `GroupedHTTPRouteMatchConfigs` (fixes double-P typo) in `types.go`, `envoy_gateway_extension_reconciler.go`, and `istio_extension_reconciler.go`.

**Related Issue:**
Fixes #2099 

## Verification
- Code successfully builds and passes all tests (`make test`).
- These are purely renaming operations; there is no change in behavior or logic.

## Checklist
- [x] Commits are signed off (`git commit -s`)
- [x] Code builds locally (`make build`)
- [x] Relevant tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected how route match settings are grouped, helping WASM configuration build more reliably.
  * Fixed the resource reference used for cert-manager cluster issuers, so the correct resources are watched and handled.
  * Renamed a misspelt cluster-issuer resource label to its correct form for consistency and clearer behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->