### PR TITLE
Revert "feat(wasm): `allow_on_headers_stop_iteration` on our `PluginConfig`"

### DIFF
--- a/internal/istio/utils.go
+++ b/internal/istio/utils.go
@@ -132,8 +132,7 @@ func buildWasmFilterConfig(wasmURL, imagePullSecret, imageSHA, clusterName strin
 			},
 			"allow_precompiled": true,
 		},
-		"failure_policy":                  "FAIL_RELOAD",
-		"allow_on_headers_stop_iteration": true,
+		"failure_policy": "FAIL_RELOAD",
 	}
 
 	if pluginConfig != nil {


### PR DESCRIPTION
This reverts commit 65068c9ac902b509d86fbd3929453a3f6047f805.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

~~* **Bug Fixes**~~
  ~~* Adjusted the generated wasm filter runtime configuration to remove header-based early termination behaviour.~~
  ~~* Kept the existing reload failure handling in place while simplifying the filter’s runtime settings.~~

<!-- end of auto-generated comment: release notes by coderabbit.ai -->