### PR TITLE
refactor: optimize limitadorLimitsContain to accept pointer parameter

### DIFF
--- a/tests/common/ratelimitpolicy/ratelimitpolicy_grpcroute_test.go
+++ b/tests/common/ratelimitpolicy/ratelimitpolicy_grpcroute_test.go
@@ -148,7 +148,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				}
 				limitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				limitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(policy), "l1")
-				return limitadorLimitsContain(*limitador, limitsNamespace, limitKey)
+				return limitadorLimitsContain(limitador, limitsNamespace, limitKey)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -177,7 +177,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				}
 				limitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				limitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(policy), "l1")
-				return limitadorLimitsContain(*limitador, limitsNamespace, limitKey)
+				return limitadorLimitsContain(limitador, limitsNamespace, limitKey)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 
@@ -233,12 +233,12 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				// Route policy limit for grpcRoute
 				routeLimitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				routeLimitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(routePolicy), "l1")
-				hasRouteLimit := limitadorLimitsContain(*limitador, routeLimitsNamespace, routeLimitKey)
+				hasRouteLimit := limitadorLimitsContain(limitador, routeLimitsNamespace, routeLimitKey)
 
 				// Gateway policy limit for policyless route
 				gwLimitsNamespace := limitsNamespaceForGRPCRoute(otherRoute)
 				gwLimitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(gwPolicy), "gw-limit")
-				hasGWLimit := limitadorLimitsContain(*limitador, gwLimitsNamespace, gwLimitKey)
+				hasGWLimit := limitadorLimitsContain(limitador, gwLimitsNamespace, gwLimitKey)
 
 				return hasRouteLimit && hasGWLimit
 			}).WithContext(ctx).Should(BeTrue())
@@ -266,7 +266,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				}
 				limitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				limitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(policy), "l1")
-				return limitadorLimitsContain(*limitador, limitsNamespace, limitKey)
+				return limitadorLimitsContain(limitador, limitsNamespace, limitKey)
 			}).WithContext(ctx).Should(BeTrue())
 
 			// delete policy
@@ -281,7 +281,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 				}
 				limitsNamespace := limitsNamespaceForGRPCRoute(grpcRoute)
 				limitKey := limitKeyForGRPCPath(client.ObjectKeyFromObject(policy), "l1")
-				return !limitadorLimitsContain(*limitador, limitsNamespace, limitKey)
+				return !limitadorLimitsContain(limitador, limitsNamespace, limitKey)
 			}).WithContext(ctx).Should(BeTrue())
 		}, testTimeOut)
 	})
@@ -289,7 +289,7 @@ var _ = Describe("RateLimitPolicy controller (GRPCRoute)", func() {
 })
 
 // limitadorLimitsContain checks if limitador contains a limit with the given namespace and identifier
-func limitadorLimitsContain(limitador limitadorv1alpha1.Limitador, namespace, identifier string) bool {
+func limitadorLimitsContain(limitador *limitadorv1alpha1.Limitador, namespace, identifier string) bool {
 	expected := fmt.Sprintf(`descriptors[0]["%s"] == "1"`, identifier)
 	for _, limit := range limitador.Spec.Limits {
 		if limit.Namespace != namespace {


### PR DESCRIPTION
Fixes #1891 and #2034. Changes the signature of limitadorLimitsContain to accept a pointer instead of copying the struct, optimizing performance and following Go best practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated rate-limit policy test assertions to use pointer-based limit data consistently.
  * Improved validation of limit presence and removal scenarios without changing end-user behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->