### PR TITLE
feat: nightly benchmark workflow (alternative to per-PR)

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,78 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'internal/**'
+      - 'pkg/**'
+      - 'api/**'
+      - 'go.mod'
+      - 'go.sum'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Check out PR branch
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      # Run benchmarks on PR branch
+      - name: Run benchmarks (PR)
+        run: make test-bench
+      - name: Save PR results
+        run: mv benchmark-results.txt pr-bench.txt
+
+      # Run benchmarks on base branch
+      - name: Check out base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.base_ref }}
+          clean: false
+          path: base
+      - name: Run benchmarks (base)
+        run: cd base && make test-bench
+      - name: Save base results
+        run: mv base/benchmark-results.txt base-bench.txt
+
+      # Compare with benchstat
+      - name: Compare results
+        id: benchstat
+        run: |
+          {
+            echo '## Benchmark Results'
+            echo '```'
+            benchstat base-bench.txt pr-bench.txt 2>&1 || true
+            echo '```'
+          } > benchmark-report.md
+
+      - name: Post PR comment
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          path: benchmark-report.md
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: |
+            pr-bench.txt
+            base-bench.txt
+            benchmark-report.md

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -54,12 +54,17 @@ jobs:
       - name: Compare results
         id: benchstat
         run: |
+          BENCHSTAT_OUTPUT=$(benchstat base-bench.txt pr-bench.txt 2>&1 || true)
           {
             echo '## Benchmark Results'
             echo '```'
-            benchstat base-bench.txt pr-bench.txt 2>&1 || true
+            echo "$BENCHSTAT_OUTPUT"
             echo '```'
           } > benchmark-report.md
+
+          if echo "$BENCHSTAT_OUTPUT" | grep -qE '\+[0-9]+\.[0-9]+% \(p=' ; then
+            echo 'regression=true' >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Post PR comment
         if: github.event.pull_request.head.repo.full_name == github.repository
@@ -75,3 +80,9 @@ jobs:
             pr-bench.txt
             base-bench.txt
             benchmark-report.md
+
+      - name: Check for regressions
+        if: steps.benchstat.outputs.regression == 'true'
+        run: |
+          echo "::warning::Benchmark regression detected. Check the PR comment for details."
+          exit 1

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -55,15 +55,24 @@ jobs:
         id: benchstat
         run: |
           BENCHSTAT_OUTPUT=$(benchstat base-bench.txt pr-bench.txt 2>&1 || true)
-          {
-            echo '## Benchmark Results'
-            echo '```'
-            echo "$BENCHSTAT_OUTPUT"
-            echo '```'
-          } > benchmark-report.md
 
-          if echo "$BENCHSTAT_OUTPUT" | grep -qE '\+[0-9]+\.[0-9]+% \(p=' ; then
+          REGRESSIONS=$(echo "$BENCHSTAT_OUTPUT" | grep -E '\+[0-9]+\.[0-9]+% \(p=' || true)
+          if [ -n "$REGRESSIONS" ]; then
+            {
+              echo '## Benchmark: regression detected'
+              echo '```'
+              echo "$REGRESSIONS"
+              echo '```'
+              echo '<details><summary>Full benchstat output</summary>'
+              echo ''
+              echo '```'
+              echo "$BENCHSTAT_OUTPUT"
+              echo '```'
+              echo '</details>'
+            } > benchmark-report.md
             echo 'regression=true' >> "$GITHUB_OUTPUT"
+          else
+            echo '## Benchmark: no regression' > benchmark-report.md
           fi
 
       - name: Post PR comment
@@ -79,7 +88,6 @@ jobs:
           path: |
             pr-bench.txt
             base-bench.txt
-            benchmark-report.md
 
       - name: Check for regressions
         if: steps.benchstat.outputs.regression == 'true'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -47,13 +47,8 @@ jobs:
           clean: false
           path: base
       - name: Run benchmarks (base)
-        run: |
-          cd base
-          if make test-bench 2>/dev/null; then
-            mv benchmark-results.txt ../base-bench.txt
-          else
-            go test ./pkg/... ./api/... ./internal/... -bench=. -benchmem -run='^$' -count=6 -timeout 30m -tags bench | tee ../base-bench.txt
-          fi
+        run: cd base && make test-bench && mv benchmark-results.txt ../base-bench.txt
+        continue-on-error: true
 
       # Compare with benchstat
       - name: Compare results

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -52,7 +52,7 @@ jobs:
           if make test-bench 2>/dev/null; then
             mv benchmark-results.txt ../base-bench.txt
           else
-            go test ./pkg/... ./api/... ./internal/... -bench=. -benchmem -run='^$' -count=6 -timeout 30m -tags unit | tee ../base-bench.txt
+            go test ./pkg/... ./api/... ./internal/... -bench=. -benchmem -run='^$' -count=6 -timeout 30m -tags bench | tee ../base-bench.txt
           fi
 
       # Compare with benchstat

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           BENCHSTAT_OUTPUT=$(benchstat base-bench.txt pr-bench.txt 2>&1 || true)
 
-          REGRESSIONS=$(echo "$BENCHSTAT_OUTPUT" | grep -E '\+[0-9]+\.[0-9]+% \(p=' || true)
+          REGRESSIONS=$(echo "$BENCHSTAT_OUTPUT" | sed '/B\/op/,$d' | grep -E '\+[0-9]+\.[0-9]+% \(p=' | awk -F'+' '{split($2,a,"%"); if (a[1]+0 >= 5) print $0}' || true)
           if [ -n "$REGRESSIONS" ]; then
             {
               echo '## Benchmark: regression detected'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -71,12 +71,10 @@ jobs:
               echo '</details>'
             } > benchmark-report.md
             echo 'regression=true' >> "$GITHUB_OUTPUT"
-          else
-            echo '## Benchmark: no regression' > benchmark-report.md
           fi
 
       - name: Post PR comment
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.benchstat.outputs.regression == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           path: benchmark-report.md

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,18 +1,14 @@
-name: Benchmark
+name: Benchmark (Nightly)
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'internal/**'
-      - 'pkg/**'
-      - 'api/**'
-      - 'go.mod'
-      - 'go.sum'
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: write
+  issues: write
+  actions: read
 
 jobs:
   benchmark:
@@ -22,7 +18,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Check out PR branch
+      - name: Check out code
         uses: actions/checkout@v4
 
       - name: Set up Go
@@ -33,62 +29,89 @@ jobs:
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest
 
-      # Run benchmarks on PR branch
-      - name: Run benchmarks (PR)
+      - name: Run benchmarks
         run: make test-bench
-      - name: Save PR results
-        run: mv benchmark-results.txt pr-bench.txt
 
-      # Run benchmarks on base branch
-      - name: Check out base branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.base_ref }}
-          clean: false
-          path: base
-      - name: Run benchmarks (base)
-        run: cd base && make test-bench && mv benchmark-results.txt ../base-bench.txt
-        continue-on-error: true
-
-      # Compare with benchstat
-      - name: Compare results
-        id: benchstat
+      # Download previous baseline from the last successful nightly run
+      - name: Download previous baseline
+        id: baseline
         run: |
-          BENCHSTAT_OUTPUT=$(benchstat base-bench.txt pr-bench.txt 2>&1 || true)
+          # Find the most recent successful run of this workflow (excluding current)
+          RUN_ID=$(gh run list \
+            --workflow=benchmark.yaml \
+            --status=success \
+            --limit=1 \
+            --json databaseId \
+            --jq '.[0].databaseId' 2>/dev/null || true)
+
+          if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+            gh run download "$RUN_ID" -n benchmark-baseline -D previous/ 2>/dev/null && \
+              echo 'found=true' >> "$GITHUB_OUTPUT" || \
+              echo 'found=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'found=false' >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      # Compare with previous baseline if available
+      - name: Compare with previous baseline
+        id: benchstat
+        if: steps.baseline.outputs.found == 'true'
+        run: |
+          BENCHSTAT_OUTPUT=$(benchstat previous/benchmark-results.txt benchmark-results.txt 2>&1 || true)
 
           REGRESSIONS=$(echo "$BENCHSTAT_OUTPUT" | sed '/B\/op/,$d' | grep -E '\+[0-9]+\.[0-9]+% \(p=' | awk -F'+' '{split($2,a,"%"); if (a[1]+0 >= 5) print $0}' || true)
           if [ -n "$REGRESSIONS" ]; then
+            echo 'regression=true' >> "$GITHUB_OUTPUT"
             {
-              echo '## Benchmark: regression detected'
+              echo "## Nightly Benchmark: regression detected"
+              echo ""
+              echo "Compared to previous nightly run."
               echo '```'
               echo "$REGRESSIONS"
               echo '```'
+              echo ""
+              echo "**Note:** This regression was introduced by one or more PRs merged since the last nightly run. Manual bisection is required to identify the cause."
+              echo ""
               echo '<details><summary>Full benchstat output</summary>'
-              echo ''
+              echo ""
               echo '```'
               echo "$BENCHSTAT_OUTPUT"
               echo '```'
               echo '</details>'
             } > benchmark-report.md
-            echo 'regression=true' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Post PR comment
-        if: steps.benchstat.outputs.regression == 'true' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          path: benchmark-report.md
-
-      - name: Upload artifacts
+      # Save current results as baseline for next run
+      - name: Upload baseline for next run
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-results
-          path: |
-            pr-bench.txt
-            base-bench.txt
+          name: benchmark-baseline
+          path: benchmark-results.txt
+          overwrite: true
+
+      - name: Upload comparison report
+        if: steps.benchstat.outputs.regression == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-report
+          path: benchmark-report.md
+
+      # Create an issue if regression detected
+      - name: Create regression issue
+        if: steps.benchstat.outputs.regression == 'true'
+        run: |
+          BODY=$(cat benchmark-report.md)
+          gh issue create \
+            --title "Nightly benchmark regression detected ($(date +%Y-%m-%d))" \
+            --body "$BODY" \
+            --label "performance"
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: Check for regressions
         if: steps.benchstat.outputs.regression == 'true'
         run: |
-          echo "::warning::Benchmark regression detected. Check the PR comment for details."
+          echo "::warning::Benchmark regression detected compared to previous nightly. See workflow artifacts."
           exit 1

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -47,9 +47,13 @@ jobs:
           clean: false
           path: base
       - name: Run benchmarks (base)
-        run: cd base && make test-bench
-      - name: Save base results
-        run: mv base/benchmark-results.txt base-bench.txt
+        run: |
+          cd base
+          if make test-bench 2>/dev/null; then
+            mv benchmark-results.txt ../base-bench.txt
+          else
+            go test ./pkg/... ./api/... ./internal/... -bench=. -benchmem -run='^$' -count=6 -timeout 30m -tags unit | tee ../base-bench.txt
+          fi
 
       # Compare with benchstat
       - name: Compare results

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ vendor
 
 # Helm chart packages
 *operator*.tgz*
+
+# Benchmark results
+benchmark-results.txt

--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ test-unit: clean-cov generate fmt vet ## Run Unit tests.
 
 .PHONY: test-bench
 test-bench: ## Run benchmarks.
-	go test ./internal/controller/... -bench=. -benchmem -run='^$$' -count=10 -timeout 30m -tags bench | tee benchmark-results.txt
+	go test ./internal/controller/... -bench=. -benchmem -benchtime=200ms -run='^$$' -count=10 -timeout 30m -tags bench | tee benchmark-results.txt
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ test-unit: clean-cov generate fmt vet ## Run Unit tests.
 
 .PHONY: test-bench
 test-bench: ## Run benchmarks.
-	go test $(UNIT_DIRS) -bench=. -benchmem -run='^$$' -count=6 -timeout 30m -tags unit | tee benchmark-results.txt
+	go test $(UNIT_DIRS) -bench=. -benchmem -run='^$$' -count=10 -timeout 30m -tags bench | tee benchmark-results.txt
 
 ##@ Build
 

--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,10 @@ test-unit: clean-cov generate fmt vet ## Run Unit tests.
 	mkdir -p $(PROJECT_PATH)/coverage/unit
 	go test $(UNIT_DIRS) -coverprofile $(PROJECT_PATH)/coverage/unit/cover.out -race -tags unit $(VERBOSE_FLAG) -timeout 0 $(TEST_PATTERN)
 
+.PHONY: test-bench
+test-bench: ## Run benchmarks.
+	go test $(UNIT_DIRS) -bench=. -benchmem -run='^$$' -count=6 -timeout 30m -tags unit | tee benchmark-results.txt
+
 ##@ Build
 
 build: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")

--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ test-unit: clean-cov generate fmt vet ## Run Unit tests.
 
 .PHONY: test-bench
 test-bench: ## Run benchmarks.
-	go test $(UNIT_DIRS) -bench=. -benchmem -run='^$$' -count=10 -timeout 30m -tags bench | tee benchmark-results.txt
+	go test ./internal/controller/... -bench=. -benchmem -run='^$$' -count=10 -timeout 30m -tags bench | tee benchmark-results.txt
 
 ##@ Build
 

--- a/internal/controller/bench_test.go
+++ b/internal/controller/bench_test.go
@@ -18,20 +18,41 @@ import (
 	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	kuadrantv1alpha1 "github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	kuadrantauthorino "github.com/kuadrant/kuadrant-operator/internal/authorino"
 )
 
+// benchTopologyParams controls the shape of the synthetic topology.
+// Policies can target gateways (policyTarget="gateway") or routes (policyTarget="route").
 type benchTopologyParams struct {
 	numGatewayClasses  int
 	numRoutesPerGW     int
 	numRulesPerRoute   int
+	listenersPerGW     int
 	attachAuthPolicies bool
 	attachRLPolicies   bool
+	attachTRLPolicies  bool
+	policyTarget       string // "gateway" (default) or "route"
 }
 
-func buildBenchTopology(b *testing.B, params benchTopologyParams) (*machinery.Topology, *kuadrantv1beta1.Kuadrant, *sync.Map) {
+func (p benchTopologyParams) label() string {
+	listeners := p.listenersPerGW
+	if listeners == 0 {
+		listeners = 1
+	}
+	return fmt.Sprintf("gw=%d_listen=%d_routes=%d", p.numGatewayClasses, listeners, p.numRoutesPerGW)
+}
+
+func buildBenchTopology(b testing.TB, params benchTopologyParams) (*machinery.Topology, *kuadrantv1beta1.Kuadrant, *sync.Map) {
 	b.Helper()
+
+	if params.listenersPerGW == 0 {
+		params.listenersPerGW = 1
+	}
+	if params.policyTarget == "" {
+		params.policyTarget = "gateway"
+	}
 
 	kuadrant := &kuadrantv1beta1.Kuadrant{
 		TypeMeta: metav1.TypeMeta{
@@ -47,6 +68,11 @@ func buildBenchTopology(b *testing.B, params benchTopologyParams) (*machinery.To
 
 	store := make(controller.Store)
 	store[string(kuadrant.UID)] = kuadrant
+
+	acceptedCondition := metav1.Condition{
+		Type:   string(gatewayapiv1alpha2.PolicyConditionAccepted),
+		Status: metav1.ConditionTrue,
+	}
 
 	var gatewayClasses []*gatewayapiv1.GatewayClass
 	var gateways []*gatewayapiv1.Gateway
@@ -72,6 +98,15 @@ func buildBenchTopology(b *testing.B, params benchTopologyParams) (*machinery.To
 		store[string(gatewayClass.UID)] = gatewayClass
 
 		gwName := fmt.Sprintf("gw-%d", gc)
+
+		listeners := make([]gatewayapiv1.Listener, params.listenersPerGW)
+		for l := 0; l < params.listenersPerGW; l++ {
+			listeners[l] = gatewayapiv1.Listener{
+				Name:     gatewayapiv1.SectionName(fmt.Sprintf("listener-%d", l)),
+				Hostname: ptr.To(gatewayapiv1.Hostname(fmt.Sprintf("*.gw%d-l%d.example.com", gc, l))),
+			}
+		}
+
 		gateway := &gatewayapiv1.Gateway{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       machinery.GatewayGroupKind.Kind,
@@ -84,105 +119,66 @@ func buildBenchTopology(b *testing.B, params benchTopologyParams) (*machinery.To
 			},
 			Spec: gatewayapiv1.GatewaySpec{
 				GatewayClassName: gatewayapiv1.ObjectName(gcName),
-				Listeners: []gatewayapiv1.Listener{
-					{
-						Name:     "http",
-						Hostname: ptr.To(gatewayapiv1.Hostname(fmt.Sprintf("*.gw-%d.example.com", gc))),
-					},
-				},
+				Listeners:        listeners,
 			},
 		}
 		gateways = append(gateways, gateway)
 		store[string(gateway.UID)] = gateway
 
-		if params.attachAuthPolicies {
-			policy := &kuadrantv1.AuthPolicy{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "AuthPolicy",
-					APIVersion: kuadrantv1.GroupVersion.String(),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("auth-%d", gc),
-					Namespace: "default",
-					UID:       types.UID(fmt.Sprintf("uid-auth-%d", gc)),
-				},
-				Spec: kuadrantv1.AuthPolicySpec{
-					TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
-						LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
-							Group: gatewayapiv1alpha2.Group(machinery.GatewayGroupKind.Group),
-							Kind:  gatewayapiv1.Kind(machinery.GatewayGroupKind.Kind),
-							Name:  gatewayapiv1.ObjectName(gwName),
-						},
-					},
-					AuthPolicySpecProper: kuadrantv1.AuthPolicySpecProper{
-						AuthScheme: &kuadrantv1.AuthSchemeSpec{
-							Authentication: map[string]kuadrantv1.MergeableAuthenticationSpec{
-								"jwt": {
-									AuthenticationSpec: authorinov1beta3.AuthenticationSpec{
-										AuthenticationMethodSpec: authorinov1beta3.AuthenticationMethodSpec{
-											Jwt: &authorinov1beta3.JwtAuthenticationSpec{
-												IssuerUrl: "http://auth.example.com",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				Status: kuadrantv1.AuthPolicyStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(gatewayapiv1alpha2.PolicyConditionAccepted),
-							Status: metav1.ConditionTrue,
-						},
-					},
-				},
-			}
-			policies = append(policies, policy)
-			store[string(policy.UID)] = policy
+		gwTargetRef := gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+			LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+				Group: gatewayapiv1alpha2.Group(machinery.GatewayGroupKind.Group),
+				Kind:  gatewayapiv1.Kind(machinery.GatewayGroupKind.Kind),
+				Name:  gatewayapiv1.ObjectName(gwName),
+			},
 		}
 
-		if params.attachRLPolicies {
-			policy := &kuadrantv1.RateLimitPolicy{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "RateLimitPolicy",
-					APIVersion: kuadrantv1.GroupVersion.String(),
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("rlp-%d", gc),
-					Namespace: "default",
-					UID:       types.UID(fmt.Sprintf("uid-rlp-%d", gc)),
-				},
-				Spec: kuadrantv1.RateLimitPolicySpec{
-					TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
-						LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
-							Group: gatewayapiv1alpha2.Group(machinery.GatewayGroupKind.Group),
-							Kind:  gatewayapiv1.Kind(machinery.GatewayGroupKind.Kind),
-							Name:  gatewayapiv1.ObjectName(gwName),
-						},
-					},
-					RateLimitPolicySpecProper: kuadrantv1.RateLimitPolicySpecProper{
-						Limits: map[string]kuadrantv1.Limit{
-							"requests": {
-								Rates: []kuadrantv1.Rate{
-									{Limit: 10, Window: "10s"},
+		if params.policyTarget == "gateway" {
+			if params.attachAuthPolicies {
+				p := &kuadrantv1.AuthPolicy{
+					TypeMeta:   metav1.TypeMeta{Kind: "AuthPolicy", APIVersion: kuadrantv1.GroupVersion.String()},
+					ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("auth-gw-%d", gc), Namespace: "default", UID: types.UID(fmt.Sprintf("uid-auth-gw-%d", gc))},
+					Spec: kuadrantv1.AuthPolicySpec{
+						TargetRef: gwTargetRef,
+						AuthPolicySpecProper: kuadrantv1.AuthPolicySpecProper{
+							AuthScheme: &kuadrantv1.AuthSchemeSpec{
+								Authentication: map[string]kuadrantv1.MergeableAuthenticationSpec{
+									"jwt": {AuthenticationSpec: authorinov1beta3.AuthenticationSpec{AuthenticationMethodSpec: authorinov1beta3.AuthenticationMethodSpec{Jwt: &authorinov1beta3.JwtAuthenticationSpec{IssuerUrl: "http://auth.example.com"}}}},
 								},
 							},
 						},
 					},
-				},
-				Status: kuadrantv1.RateLimitPolicyStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   string(gatewayapiv1alpha2.PolicyConditionAccepted),
-							Status: metav1.ConditionTrue,
-						},
-					},
-				},
+					Status: kuadrantv1.AuthPolicyStatus{Conditions: []metav1.Condition{acceptedCondition}},
+				}
+				policies = append(policies, p)
+				store[string(p.UID)] = p
 			}
-			policies = append(policies, policy)
-			store[string(policy.UID)] = policy
+			if params.attachRLPolicies {
+				p := &kuadrantv1.RateLimitPolicy{
+					TypeMeta:   metav1.TypeMeta{Kind: "RateLimitPolicy", APIVersion: kuadrantv1.GroupVersion.String()},
+					ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("rlp-gw-%d", gc), Namespace: "default", UID: types.UID(fmt.Sprintf("uid-rlp-gw-%d", gc))},
+					Spec: kuadrantv1.RateLimitPolicySpec{
+						TargetRef:                 gwTargetRef,
+						RateLimitPolicySpecProper: kuadrantv1.RateLimitPolicySpecProper{Limits: map[string]kuadrantv1.Limit{"requests": {Rates: []kuadrantv1.Rate{{Limit: 10, Window: "10s"}}}}},
+					},
+					Status: kuadrantv1.RateLimitPolicyStatus{Conditions: []metav1.Condition{acceptedCondition}},
+				}
+				policies = append(policies, p)
+				store[string(p.UID)] = p
+			}
+			if params.attachTRLPolicies {
+				p := &kuadrantv1alpha1.TokenRateLimitPolicy{
+					TypeMeta:   metav1.TypeMeta{Kind: "TokenRateLimitPolicy", APIVersion: kuadrantv1alpha1.GroupVersion.String()},
+					ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("trlp-gw-%d", gc), Namespace: "default", UID: types.UID(fmt.Sprintf("uid-trlp-gw-%d", gc))},
+					Spec: kuadrantv1alpha1.TokenRateLimitPolicySpec{
+						TargetRef:                      gwTargetRef,
+						TokenRateLimitPolicySpecProper: kuadrantv1alpha1.TokenRateLimitPolicySpecProper{},
+					},
+					Status: kuadrantv1alpha1.TokenRateLimitPolicyStatus{Conditions: []metav1.Condition{acceptedCondition}},
+				}
+				policies = append(policies, p)
+				store[string(p.UID)] = p
+			}
 		}
 
 		for r := 0; r < params.numRoutesPerGW; r++ {
@@ -192,20 +188,10 @@ func buildBenchTopology(b *testing.B, params benchTopologyParams) (*machinery.To
 				rules[k] = gatewayapiv1.HTTPRouteRule{
 					Name: ptr.To(gatewayapiv1.SectionName(fmt.Sprintf("rule-%d", k))),
 					Matches: []gatewayapiv1.HTTPRouteMatch{
-						{
-							Path: &gatewayapiv1.HTTPPathMatch{
-								Value: ptr.To(fmt.Sprintf("/%s/rule-%d", routeName, k)),
-							},
-						},
+						{Path: &gatewayapiv1.HTTPPathMatch{Value: ptr.To(fmt.Sprintf("/%s/rule-%d", routeName, k))}},
 					},
 					BackendRefs: []gatewayapiv1.HTTPBackendRef{
-						{
-							BackendRef: gatewayapiv1.BackendRef{
-								BackendObjectReference: gatewayapiv1.BackendObjectReference{
-									Name: gatewayapiv1.ObjectName(fmt.Sprintf("svc-%s", routeName)),
-								},
-							},
-						},
+						{BackendRef: gatewayapiv1.BackendRef{BackendObjectReference: gatewayapiv1.BackendObjectReference{Name: "backend"}}},
 					},
 				}
 			}
@@ -226,11 +212,69 @@ func buildBenchTopology(b *testing.B, params benchTopologyParams) (*machinery.To
 							{Name: gatewayapiv1.ObjectName(gwName)},
 						},
 					},
-					Rules: rules,
+					Hostnames: []gatewayapiv1.Hostname{gatewayapiv1.Hostname(fmt.Sprintf("app-%d-%d.example.com", gc, r))},
+					Rules:     rules,
 				},
 			}
 			httpRoutes = append(httpRoutes, route)
 			store[string(route.UID)] = route
+
+			if params.policyTarget == "route" {
+				routeTargetRef := gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+					LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+						Group: gatewayapiv1alpha2.Group(machinery.HTTPRouteGroupKind.Group),
+						Kind:  gatewayapiv1alpha2.Kind(machinery.HTTPRouteGroupKind.Kind),
+						Name:  gatewayapiv1alpha2.ObjectName(routeName),
+					},
+				}
+				globalRouteIdx := gc*params.numRoutesPerGW + r
+
+				if params.attachAuthPolicies {
+					p := &kuadrantv1.AuthPolicy{
+						TypeMeta:   metav1.TypeMeta{Kind: "AuthPolicy", APIVersion: kuadrantv1.GroupVersion.String()},
+						ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("auth-%d", globalRouteIdx), Namespace: "default", UID: types.UID(fmt.Sprintf("uid-auth-%d", globalRouteIdx))},
+						Spec: kuadrantv1.AuthPolicySpec{
+							TargetRef: routeTargetRef,
+							AuthPolicySpecProper: kuadrantv1.AuthPolicySpecProper{
+								AuthScheme: &kuadrantv1.AuthSchemeSpec{
+									Authentication: map[string]kuadrantv1.MergeableAuthenticationSpec{
+										fmt.Sprintf("apikey-%d", globalRouteIdx): {},
+									},
+								},
+							},
+						},
+						Status: kuadrantv1.AuthPolicyStatus{Conditions: []metav1.Condition{acceptedCondition}},
+					}
+					policies = append(policies, p)
+					store[string(p.UID)] = p
+				}
+				if params.attachRLPolicies {
+					p := &kuadrantv1.RateLimitPolicy{
+						TypeMeta:   metav1.TypeMeta{Kind: "RateLimitPolicy", APIVersion: kuadrantv1.GroupVersion.String()},
+						ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("rlp-%d", globalRouteIdx), Namespace: "default", UID: types.UID(fmt.Sprintf("uid-rlp-%d", globalRouteIdx))},
+						Spec: kuadrantv1.RateLimitPolicySpec{
+							TargetRef:                 routeTargetRef,
+							RateLimitPolicySpecProper: kuadrantv1.RateLimitPolicySpecProper{},
+						},
+						Status: kuadrantv1.RateLimitPolicyStatus{Conditions: []metav1.Condition{acceptedCondition}},
+					}
+					policies = append(policies, p)
+					store[string(p.UID)] = p
+				}
+				if params.attachTRLPolicies {
+					p := &kuadrantv1alpha1.TokenRateLimitPolicy{
+						TypeMeta:   metav1.TypeMeta{Kind: "TokenRateLimitPolicy", APIVersion: kuadrantv1alpha1.GroupVersion.String()},
+						ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("trlp-%d", globalRouteIdx), Namespace: "default", UID: types.UID(fmt.Sprintf("uid-trlp-%d", globalRouteIdx))},
+						Spec: kuadrantv1alpha1.TokenRateLimitPolicySpec{
+							TargetRef:                      routeTargetRef,
+							TokenRateLimitPolicySpecProper: kuadrantv1alpha1.TokenRateLimitPolicySpecProper{},
+						},
+						Status: kuadrantv1alpha1.TokenRateLimitPolicyStatus{Conditions: []metav1.Condition{acceptedCondition}},
+					}
+					policies = append(policies, p)
+					store[string(p.UID)] = p
+				}
+			}
 		}
 	}
 
@@ -251,9 +295,12 @@ func buildBenchTopology(b *testing.B, params benchTopologyParams) (*machinery.To
 	}
 
 	state := &sync.Map{}
-
 	return topology, kuadrant, state
 }
+
+// ---------------------------------------------------------------------------
+// Original benchmarks: individual reconciler hot paths
+// ---------------------------------------------------------------------------
 
 // BenchmarkCalculateEffectiveAuthPolicies measures the O(GatewayClasses × RouteRules) loop
 // that calls Paths() for each pair — the most expensive reconciliation path.
@@ -262,10 +309,10 @@ func BenchmarkCalculateEffectiveAuthPolicies(b *testing.B) {
 		name string
 		p    benchTopologyParams
 	}{
-		{"1gc-10routes", benchTopologyParams{1, 10, 2, true, false}},
-		{"1gc-100routes", benchTopologyParams{1, 100, 2, true, false}},
-		{"1gc-300routes", benchTopologyParams{1, 300, 2, true, false}},
-		{"3gc-100routes", benchTopologyParams{3, 100, 2, true, false}},
+		{"1gc-10routes", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 2, attachAuthPolicies: true}},
+		{"1gc-100routes", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 2, attachAuthPolicies: true}},
+		{"1gc-300routes", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 2, attachAuthPolicies: true}},
+		{"3gc-100routes", benchTopologyParams{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 2, attachAuthPolicies: true}},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
@@ -293,7 +340,7 @@ func BenchmarkTopologyToDot(b *testing.B) {
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
-			topology, _, _ := buildBenchTopology(b, benchTopologyParams{1, tc.routes, tc.rules, false, false})
+			topology, _, _ := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: tc.routes, numRulesPerRoute: tc.rules})
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				topology.ToDot()
@@ -315,26 +362,22 @@ func BenchmarkBuildDesiredAuthConfig(b *testing.B) {
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
-			topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{1, 1, tc.rules, true, false})
+			topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 1, numRulesPerRoute: tc.rules, attachAuthPolicies: true})
 			ctx := context.Background()
 
 			effectivePolicies := CalculateEffectiveAuthPolicies(ctx, topology, kuadrant, state)
 
 			type authConfigInput struct {
-				pathID           string
 				effectivePolicy  EffectiveAuthPolicy
 				name             string
-				namespace        string
 				annotationKey    string
 				routeRuleLocator string
 			}
 			var inputs []authConfigInput
 			for pathID, ep := range effectivePolicies {
 				inputs = append(inputs, authConfigInput{
-					pathID:           pathID,
 					effectivePolicy:  ep,
 					name:             AuthConfigNameForPath(pathID),
-					namespace:        "kuadrant-system",
 					annotationKey:    kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation,
 					routeRuleLocator: ep.Path[len(ep.Path)-1].GetLocator(),
 				})
@@ -344,7 +387,7 @@ func BenchmarkBuildDesiredAuthConfig(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				for _, in := range inputs {
-					r.buildDesiredAuthConfig(ctx, in.effectivePolicy, in.name, in.namespace, in.annotationKey, in.routeRuleLocator)
+					r.buildDesiredAuthConfig(ctx, in.effectivePolicy, in.name, "kuadrant-system", in.annotationKey, in.routeRuleLocator)
 				}
 			}
 		})
@@ -363,7 +406,7 @@ func BenchmarkBuildLimitadorLimits(b *testing.B) {
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
-			topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{1, tc.routes, 2, false, true})
+			topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: tc.routes, numRulesPerRoute: 2, attachRLPolicies: true})
 			ctx := context.Background()
 
 			targetables := topology.Targetables()
@@ -416,10 +459,10 @@ func BenchmarkTopologyPaths(b *testing.B) {
 		name string
 		p    benchTopologyParams
 	}{
-		{"shallow-narrow", benchTopologyParams{1, 5, 2, false, false}},
-		{"shallow-wide", benchTopologyParams{1, 100, 2, false, false}},
-		{"deep-wide", benchTopologyParams{3, 100, 5, false, false}},
-		{"stress", benchTopologyParams{1, 300, 2, false, false}},
+		{"shallow-narrow", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 5, numRulesPerRoute: 2}},
+		{"shallow-wide", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 2}},
+		{"deep-wide", benchTopologyParams{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 5}},
+		{"stress", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 2}},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
@@ -440,6 +483,201 @@ func BenchmarkTopologyPaths(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				targetables.Paths(from, to)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks from Mike Nairn's PR #2031: scaling dimensions and composite cycles
+// ---------------------------------------------------------------------------
+
+// BenchmarkEffectiveRateLimitPolicies measures the RateLimitPolicy effective
+// policy calculation via Reconcile() (calculateEffectivePolicies is unexported).
+func BenchmarkEffectiveRateLimitPolicies(b *testing.B) {
+	cases := []benchTopologyParams{
+		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 1000, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
+	}
+	reconciler := &EffectiveRateLimitPolicyReconciler{}
+	for _, tc := range cases {
+		b.Run(tc.label(), func(b *testing.B) {
+			topology, _, _ := buildBenchTopology(b, tc)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				state := &sync.Map{}
+				reconciler.Reconcile(context.Background(), nil, topology, nil, state)
+			}
+		})
+	}
+}
+
+// BenchmarkEffectiveTokenRateLimitPolicies measures the TokenRateLimitPolicy
+// effective policy calculation.
+func BenchmarkEffectiveTokenRateLimitPolicies(b *testing.B) {
+	cases := []benchTopologyParams{
+		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachTRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachTRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachTRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 1000, numRulesPerRoute: 1, attachTRLPolicies: true, policyTarget: "route"},
+	}
+	reconciler := &EffectiveTokenRateLimitPolicyReconciler{}
+	for _, tc := range cases {
+		b.Run(tc.label(), func(b *testing.B) {
+			topology, _, _ := buildBenchTopology(b, tc)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				state := &sync.Map{}
+				reconciler.Reconcile(context.Background(), nil, topology, nil, state)
+			}
+		})
+	}
+}
+
+// BenchmarkEffectiveAuthPoliciesListenerFanout measures the impact of increasing
+// listeners per gateway. More listeners = more paths in the DFS traversal.
+// Reproduces the scaling pattern from #1085 where 63 listeners caused 30-minute reconciliation.
+func BenchmarkEffectiveAuthPoliciesListenerFanout(b *testing.B) {
+	cases := []benchTopologyParams{
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 1, attachAuthPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 4, attachAuthPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 16, attachAuthPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 32, attachAuthPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 64, attachAuthPolicies: true, policyTarget: "route"},
+	}
+	for _, tc := range cases {
+		topology, kuadrant, _ := buildBenchTopology(b, tc)
+		b.Run(tc.label(), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				state := &sync.Map{}
+				CalculateEffectiveAuthPolicies(context.Background(), topology, kuadrant, state)
+			}
+		})
+	}
+}
+
+// BenchmarkEffectiveAuthPoliciesMultiGateway measures the impact of
+// multiple gateways with routes distributed evenly across them.
+func BenchmarkEffectiveAuthPoliciesMultiGateway(b *testing.B) {
+	cases := []benchTopologyParams{
+		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachAuthPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 1, attachAuthPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 10, numRoutesPerGW: 30, numRulesPerRoute: 1, attachAuthPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 16, attachAuthPolicies: true, policyTarget: "route"},
+	}
+	for _, tc := range cases {
+		topology, kuadrant, _ := buildBenchTopology(b, tc)
+		b.Run(tc.label(), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				state := &sync.Map{}
+				CalculateEffectiveAuthPolicies(context.Background(), topology, kuadrant, state)
+			}
+		})
+	}
+}
+
+// BenchmarkGetKuadrantFromTopology measures the cost of the Kuadrant CR lookup.
+// Called ~28 times per reconciliation cycle across all reconcilers.
+func BenchmarkGetKuadrantFromTopology(b *testing.B) {
+	cases := []benchTopologyParams{
+		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1},
+		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1},
+		{numGatewayClasses: 1, numRoutesPerGW: 1000, numRulesPerRoute: 1},
+	}
+	for _, tc := range cases {
+		topology, _, _ := buildBenchTopology(b, tc)
+		b.Run(tc.label(), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				GetKuadrantFromTopology(topology, &sync.Map{})
+			}
+		})
+	}
+}
+
+// BenchmarkTopologyBuild measures the cost of constructing the GatewayAPI
+// topology itself, which happens on every reconciliation cycle.
+func BenchmarkTopologyBuild(b *testing.B) {
+	cases := []benchTopologyParams{
+		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1},
+		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1},
+		{numGatewayClasses: 1, numRoutesPerGW: 1000, numRulesPerRoute: 1},
+		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, listenersPerGW: 32},
+		{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 16},
+	}
+	for _, tc := range cases {
+		b.Run(tc.label(), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				buildBenchTopology(b, tc)
+			}
+		})
+	}
+}
+
+// BenchmarkMultiReconcilerCycle simulates a realistic reconciliation cycle
+// where all three effective policy reconcilers run against the same topology
+// and shared state.
+func BenchmarkMultiReconcilerCycle(b *testing.B) {
+	cases := []benchTopologyParams{
+		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 32, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
+	}
+	authReconciler := &EffectiveAuthPolicyReconciler{}
+	rlpReconciler := &EffectiveRateLimitPolicyReconciler{}
+	trlpReconciler := &EffectiveTokenRateLimitPolicyReconciler{}
+
+	for _, tc := range cases {
+		topology, _, _ := buildBenchTopology(b, tc)
+		b.Run(tc.label(), func(b *testing.B) {
+			ctx := context.Background()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				state := &sync.Map{}
+				authReconciler.Reconcile(ctx, nil, topology, nil, state)
+				rlpReconciler.Reconcile(ctx, nil, topology, nil, state)
+				trlpReconciler.Reconcile(ctx, nil, topology, nil, state)
+			}
+		})
+	}
+}
+
+// BenchmarkFullReconciliationCycle simulates a full reconciliation cycle:
+// build topology, look up Kuadrant CR (as each reconciler does), then
+// calculate effective policies for all three policy types.
+func BenchmarkFullReconciliationCycle(b *testing.B) {
+	cases := []benchTopologyParams{
+		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
+		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 32, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
+	}
+
+	authReconciler := &EffectiveAuthPolicyReconciler{}
+	rlpReconciler := &EffectiveRateLimitPolicyReconciler{}
+	trlpReconciler := &EffectiveTokenRateLimitPolicyReconciler{}
+
+	for _, tc := range cases {
+		b.Run(tc.label(), func(b *testing.B) {
+			ctx := context.Background()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				topology, _, _ := buildBenchTopology(b, tc)
+				state := &sync.Map{}
+				for j := 0; j < 28; j++ {
+					GetKuadrantFromTopology(topology, state)
+				}
+				authReconciler.Reconcile(ctx, nil, topology, nil, state)
+				rlpReconciler.Reconcile(ctx, nil, topology, nil, state)
+				trlpReconciler.Reconcile(ctx, nil, topology, nil, state)
 			}
 		})
 	}

--- a/internal/controller/bench_test.go
+++ b/internal/controller/bench_test.go
@@ -1,4 +1,4 @@
-//go:build unit
+//go:build bench
 
 package controllers
 
@@ -499,31 +499,8 @@ func BenchmarkEffectiveRateLimitPolicies(b *testing.B) {
 		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
 		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
 		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 1000, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
 	}
 	reconciler := &EffectiveRateLimitPolicyReconciler{}
-	for _, tc := range cases {
-		b.Run(tc.label(), func(b *testing.B) {
-			topology, _, _ := buildBenchTopology(b, tc)
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				state := &sync.Map{}
-				reconciler.Reconcile(context.Background(), nil, topology, nil, state)
-			}
-		})
-	}
-}
-
-// BenchmarkEffectiveTokenRateLimitPolicies measures the TokenRateLimitPolicy
-// effective policy calculation.
-func BenchmarkEffectiveTokenRateLimitPolicies(b *testing.B) {
-	cases := []benchTopologyParams{
-		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachTRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachTRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachTRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 1000, numRulesPerRoute: 1, attachTRLPolicies: true, policyTarget: "route"},
-	}
-	reconciler := &EffectiveTokenRateLimitPolicyReconciler{}
 	for _, tc := range cases {
 		b.Run(tc.label(), func(b *testing.B) {
 			topology, _, _ := buildBenchTopology(b, tc)
@@ -545,7 +522,6 @@ func BenchmarkEffectiveAuthPoliciesListenerFanout(b *testing.B) {
 		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 4, attachAuthPolicies: true, policyTarget: "route"},
 		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 16, attachAuthPolicies: true, policyTarget: "route"},
 		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 32, attachAuthPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 64, attachAuthPolicies: true, policyTarget: "route"},
 	}
 	for _, tc := range cases {
 		topology, kuadrant, _ := buildBenchTopology(b, tc)
@@ -563,10 +539,8 @@ func BenchmarkEffectiveAuthPoliciesListenerFanout(b *testing.B) {
 // multiple gateways with routes distributed evenly across them.
 func BenchmarkEffectiveAuthPoliciesMultiGateway(b *testing.B) {
 	cases := []benchTopologyParams{
-		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachAuthPolicies: true, policyTarget: "route"},
 		{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 1, attachAuthPolicies: true, policyTarget: "route"},
 		{numGatewayClasses: 10, numRoutesPerGW: 30, numRulesPerRoute: 1, attachAuthPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 16, attachAuthPolicies: true, policyTarget: "route"},
 	}
 	for _, tc := range cases {
 		topology, kuadrant, _ := buildBenchTopology(b, tc)
@@ -587,7 +561,6 @@ func BenchmarkGetKuadrantFromTopology(b *testing.B) {
 		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1},
 		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1},
 		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1},
-		{numGatewayClasses: 1, numRoutesPerGW: 1000, numRulesPerRoute: 1},
 	}
 	for _, tc := range cases {
 		topology, _, _ := buildBenchTopology(b, tc)
@@ -607,7 +580,6 @@ func BenchmarkTopologyBuild(b *testing.B) {
 		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1},
 		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1},
 		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1},
-		{numGatewayClasses: 1, numRoutesPerGW: 1000, numRulesPerRoute: 1},
 		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, listenersPerGW: 32},
 		{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 16},
 	}
@@ -621,35 +593,6 @@ func BenchmarkTopologyBuild(b *testing.B) {
 	}
 }
 
-// BenchmarkMultiReconcilerCycle simulates a realistic reconciliation cycle
-// where all three effective policy reconcilers run against the same topology
-// and shared state.
-func BenchmarkMultiReconcilerCycle(b *testing.B) {
-	cases := []benchTopologyParams{
-		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 32, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
-	}
-	authReconciler := &EffectiveAuthPolicyReconciler{}
-	rlpReconciler := &EffectiveRateLimitPolicyReconciler{}
-	trlpReconciler := &EffectiveTokenRateLimitPolicyReconciler{}
-
-	for _, tc := range cases {
-		topology, _, _ := buildBenchTopology(b, tc)
-		b.Run(tc.label(), func(b *testing.B) {
-			ctx := context.Background()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				state := &sync.Map{}
-				authReconciler.Reconcile(ctx, nil, topology, nil, state)
-				rlpReconciler.Reconcile(ctx, nil, topology, nil, state)
-				trlpReconciler.Reconcile(ctx, nil, topology, nil, state)
-			}
-		})
-	}
-}
-
 // BenchmarkFullReconciliationCycle simulates a full reconciliation cycle:
 // build topology, look up Kuadrant CR (as each reconciler does), then
 // calculate effective policies for all three policy types.
@@ -658,7 +601,6 @@ func BenchmarkFullReconciliationCycle(b *testing.B) {
 		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
 		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
 		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 32, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
 	}
 
 	authReconciler := &EffectiveAuthPolicyReconciler{}

--- a/internal/controller/bench_test.go
+++ b/internal/controller/bench_test.go
@@ -298,10 +298,6 @@ func buildBenchTopology(b testing.TB, params benchTopologyParams) (*machinery.To
 	return topology, kuadrant, state
 }
 
-// ---------------------------------------------------------------------------
-// Original benchmarks: individual reconciler hot paths
-// ---------------------------------------------------------------------------
-
 // BenchmarkCalculateEffectiveAuthPolicies measures the O(GatewayClasses × RouteRules) loop
 // that calls Paths() for each pair — the most expensive reconciliation path.
 func BenchmarkCalculateEffectiveAuthPolicies(b *testing.B) {
@@ -309,8 +305,6 @@ func BenchmarkCalculateEffectiveAuthPolicies(b *testing.B) {
 		name string
 		p    benchTopologyParams
 	}{
-		{"1gc-10routes", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 2, attachAuthPolicies: true}},
-		{"1gc-100routes", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 2, attachAuthPolicies: true}},
 		{"1gc-300routes", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 2, attachAuthPolicies: true}},
 		{"3gc-100routes", benchTopologyParams{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 2, attachAuthPolicies: true}},
 	}
@@ -328,299 +322,164 @@ func BenchmarkCalculateEffectiveAuthPolicies(b *testing.B) {
 
 // BenchmarkTopologyToDot measures the DAG-to-DOT serialization called every reconciliation cycle.
 func BenchmarkTopologyToDot(b *testing.B) {
-	cases := []struct {
-		name   string
-		routes int
-		rules  int
-	}{
-		{"10obj", 2, 1},
-		{"100obj", 20, 2},
-		{"300obj", 60, 2},
-		{"1000obj", 200, 2},
-	}
-	for _, tc := range cases {
-		b.Run(tc.name, func(b *testing.B) {
-			topology, _, _ := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: tc.routes, numRulesPerRoute: tc.rules})
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				topology.ToDot()
-			}
-		})
+	topology, _, _ := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 200, numRulesPerRoute: 2})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		topology.ToDot()
 	}
 }
 
 // BenchmarkBuildDesiredAuthConfig measures AuthConfig generation for N route rules.
 func BenchmarkBuildDesiredAuthConfig(b *testing.B) {
-	cases := []struct {
-		name  string
-		rules int
-	}{
-		{"1-rule", 1},
-		{"10-rules", 10},
-		{"100-rules", 100},
-		{"300-rules", 300},
+	topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 1, numRulesPerRoute: 300, attachAuthPolicies: true})
+	ctx := context.Background()
+
+	effectivePolicies := CalculateEffectiveAuthPolicies(ctx, topology, kuadrant, state)
+
+	type authConfigInput struct {
+		effectivePolicy  EffectiveAuthPolicy
+		name             string
+		annotationKey    string
+		routeRuleLocator string
 	}
-	for _, tc := range cases {
-		b.Run(tc.name, func(b *testing.B) {
-			topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 1, numRulesPerRoute: tc.rules, attachAuthPolicies: true})
-			ctx := context.Background()
-
-			effectivePolicies := CalculateEffectiveAuthPolicies(ctx, topology, kuadrant, state)
-
-			type authConfigInput struct {
-				effectivePolicy  EffectiveAuthPolicy
-				name             string
-				annotationKey    string
-				routeRuleLocator string
-			}
-			var inputs []authConfigInput
-			for pathID, ep := range effectivePolicies {
-				inputs = append(inputs, authConfigInput{
-					effectivePolicy:  ep,
-					name:             AuthConfigNameForPath(pathID),
-					annotationKey:    kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation,
-					routeRuleLocator: ep.Path[len(ep.Path)-1].GetLocator(),
-				})
-			}
-
-			r := &AuthConfigsReconciler{client: nil}
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				for _, in := range inputs {
-					r.buildDesiredAuthConfig(ctx, in.effectivePolicy, in.name, "kuadrant-system", in.annotationKey, in.routeRuleLocator)
-				}
-			}
+	var inputs []authConfigInput
+	for pathID, ep := range effectivePolicies {
+		inputs = append(inputs, authConfigInput{
+			effectivePolicy:  ep,
+			name:             AuthConfigNameForPath(pathID),
+			annotationKey:    kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation,
+			routeRuleLocator: ep.Path[len(ep.Path)-1].GetLocator(),
 		})
+	}
+
+	r := &AuthConfigsReconciler{client: nil}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, in := range inputs {
+			r.buildDesiredAuthConfig(ctx, in.effectivePolicy, in.name, "kuadrant-system", in.annotationKey, in.routeRuleLocator)
+		}
 	}
 }
 
 // BenchmarkBuildLimitadorLimits measures merging effective rate limit policies into Limitador limits.
 func BenchmarkBuildLimitadorLimits(b *testing.B) {
-	cases := []struct {
-		name   string
-		routes int
-	}{
-		{"10-policies", 5},
-		{"100-policies", 50},
-		{"300-policies", 150},
+	topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 150, numRulesPerRoute: 2, attachRLPolicies: true})
+	ctx := context.Background()
+
+	targetables := topology.Targetables()
+	gatewayClasses := targetables.Children(kuadrant)
+	httpRouteRules := targetables.Items(func(o machinery.Object) bool {
+		_, ok := o.(*machinery.HTTPRouteRule)
+		return ok
+	})
+
+	allPolicies := topology.Policies().Items()
+	var rlPolicies []machinery.Policy
+	for _, p := range allPolicies {
+		if _, ok := p.(*kuadrantv1.RateLimitPolicy); ok {
+			rlPolicies = append(rlPolicies, p)
+		}
 	}
-	for _, tc := range cases {
-		b.Run(tc.name, func(b *testing.B) {
-			topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: tc.routes, numRulesPerRoute: 2, attachRLPolicies: true})
-			ctx := context.Background()
+	if len(rlPolicies) == 0 {
+		b.Fatal("no rate limit policies in topology")
+	}
 
-			targetables := topology.Targetables()
-			gatewayClasses := targetables.Children(kuadrant)
-			httpRouteRules := targetables.Items(func(o machinery.Object) bool {
-				_, ok := o.(*machinery.HTTPRouteRule)
-				return ok
-			})
-
-			allPolicies := topology.Policies().Items()
-			var rlPolicies []machinery.Policy
-			for _, p := range allPolicies {
-				if _, ok := p.(*kuadrantv1.RateLimitPolicy); ok {
-					rlPolicies = append(rlPolicies, p)
+	effectivePolicies := EffectiveRateLimitPolicies{}
+	for _, gc := range gatewayClasses {
+		for _, rule := range httpRouteRules {
+			paths := targetables.Paths(gc, rule)
+			for _, path := range paths {
+				pathID := kuadrantv1.PathID(path)
+				rlp := rlPolicies[0].(*kuadrantv1.RateLimitPolicy)
+				effectivePolicies[pathID] = EffectiveRateLimitPolicy{
+					Path:           path,
+					Spec:           *rlp,
+					SourcePolicies: []string{rlp.GetLocator()},
 				}
 			}
-			if len(rlPolicies) == 0 {
-				b.Fatal("no rate limit policies in topology")
-			}
+		}
+	}
+	state.Store(StateEffectiveRateLimitPolicies, effectivePolicies)
 
-			effectivePolicies := EffectiveRateLimitPolicies{}
-			for _, gc := range gatewayClasses {
-				for _, rule := range httpRouteRules {
-					paths := targetables.Paths(gc, rule)
-					for _, path := range paths {
-						pathID := kuadrantv1.PathID(path)
-						rlp := rlPolicies[0].(*kuadrantv1.RateLimitPolicy)
-						effectivePolicies[pathID] = EffectiveRateLimitPolicy{
-							Path:           path,
-							Spec:           *rlp,
-							SourcePolicies: []string{rlp.GetLocator()},
-						}
-					}
-				}
-			}
-			state.Store(StateEffectiveRateLimitPolicies, effectivePolicies)
-
-			r := &LimitadorLimitsReconciler{client: nil}
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				r.buildLimitadorLimits(ctx, state)
-			}
-		})
+	r := &LimitadorLimitsReconciler{client: nil}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r.buildLimitadorLimits(ctx, state)
 	}
 }
 
-// BenchmarkTopologyPaths measures the Paths() DFS traversal — the single most expensive operation.
+// BenchmarkTopologyPaths measures the Paths() DFS traversal in isolation.
 func BenchmarkTopologyPaths(b *testing.B) {
+	topology, kuadrant, _ := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 2})
+
+	targetables := topology.Targetables()
+	gatewayClasses := targetables.Children(kuadrant)
+	httpRouteRules := targetables.Items(func(o machinery.Object) bool {
+		_, ok := o.(*machinery.HTTPRouteRule)
+		return ok
+	})
+	if len(gatewayClasses) == 0 || len(httpRouteRules) == 0 {
+		b.Fatal("topology has no gateway classes or route rules")
+	}
+	from := gatewayClasses[0]
+	to := httpRouteRules[len(httpRouteRules)-1]
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		targetables.Paths(from, to)
+	}
+}
+
+// BenchmarkListenerFanout measures the impact of listener count on Paths() DFS traversal.
+// Reproduces the scaling pattern from #1085 where 63 listeners caused 30-minute reconciliation.
+func BenchmarkListenerFanout(b *testing.B) {
+	topology, kuadrant, _ := buildBenchTopology(b, benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 32, attachAuthPolicies: true, policyTarget: "route"})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		state := &sync.Map{}
+		CalculateEffectiveAuthPolicies(context.Background(), topology, kuadrant, state)
+	}
+}
+
+// BenchmarkTopologyBuild measures the cost of constructing the GatewayAPI topology.
+func BenchmarkTopologyBuild(b *testing.B) {
 	cases := []struct {
 		name string
 		p    benchTopologyParams
 	}{
-		{"shallow-narrow", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 5, numRulesPerRoute: 2}},
-		{"shallow-wide", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 2}},
-		{"deep-wide", benchTopologyParams{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 5}},
-		{"stress", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 2}},
+		{"300routes", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1}},
+		{"300routes-32listeners", benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, listenersPerGW: 32}},
 	}
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
-			topology, kuadrant, _ := buildBenchTopology(b, tc.p)
-
-			targetables := topology.Targetables()
-			gatewayClasses := targetables.Children(kuadrant)
-			httpRouteRules := targetables.Items(func(o machinery.Object) bool {
-				_, ok := o.(*machinery.HTTPRouteRule)
-				return ok
-			})
-			if len(gatewayClasses) == 0 || len(httpRouteRules) == 0 {
-				b.Fatal("topology has no gateway classes or route rules")
-			}
-			from := gatewayClasses[0]
-			to := httpRouteRules[len(httpRouteRules)-1]
-
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				targetables.Paths(from, to)
-			}
-		})
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Benchmarks from Mike Nairn's PR #2031: scaling dimensions and composite cycles
-// ---------------------------------------------------------------------------
-
-// BenchmarkEffectiveRateLimitPolicies measures the RateLimitPolicy effective
-// policy calculation via Reconcile() (calculateEffectivePolicies is unexported).
-func BenchmarkEffectiveRateLimitPolicies(b *testing.B) {
-	cases := []benchTopologyParams{
-		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachRLPolicies: true, policyTarget: "route"},
-	}
-	reconciler := &EffectiveRateLimitPolicyReconciler{}
-	for _, tc := range cases {
-		b.Run(tc.label(), func(b *testing.B) {
-			topology, _, _ := buildBenchTopology(b, tc)
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				state := &sync.Map{}
-				reconciler.Reconcile(context.Background(), nil, topology, nil, state)
-			}
-		})
-	}
-}
-
-// BenchmarkEffectiveAuthPoliciesListenerFanout measures the impact of increasing
-// listeners per gateway. More listeners = more paths in the DFS traversal.
-// Reproduces the scaling pattern from #1085 where 63 listeners caused 30-minute reconciliation.
-func BenchmarkEffectiveAuthPoliciesListenerFanout(b *testing.B) {
-	cases := []benchTopologyParams{
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 1, attachAuthPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 4, attachAuthPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 16, attachAuthPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 32, attachAuthPolicies: true, policyTarget: "route"},
-	}
-	for _, tc := range cases {
-		topology, kuadrant, _ := buildBenchTopology(b, tc)
-		b.Run(tc.label(), func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				state := &sync.Map{}
-				CalculateEffectiveAuthPolicies(context.Background(), topology, kuadrant, state)
-			}
-		})
-	}
-}
-
-// BenchmarkEffectiveAuthPoliciesMultiGateway measures the impact of
-// multiple gateways with routes distributed evenly across them.
-func BenchmarkEffectiveAuthPoliciesMultiGateway(b *testing.B) {
-	cases := []benchTopologyParams{
-		{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 1, attachAuthPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 10, numRoutesPerGW: 30, numRulesPerRoute: 1, attachAuthPolicies: true, policyTarget: "route"},
-	}
-	for _, tc := range cases {
-		topology, kuadrant, _ := buildBenchTopology(b, tc)
-		b.Run(tc.label(), func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				state := &sync.Map{}
-				CalculateEffectiveAuthPolicies(context.Background(), topology, kuadrant, state)
-			}
-		})
-	}
-}
-
-// BenchmarkGetKuadrantFromTopology measures the cost of the Kuadrant CR lookup.
-// Called ~28 times per reconciliation cycle across all reconcilers.
-func BenchmarkGetKuadrantFromTopology(b *testing.B) {
-	cases := []benchTopologyParams{
-		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1},
-		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1},
-	}
-	for _, tc := range cases {
-		topology, _, _ := buildBenchTopology(b, tc)
-		b.Run(tc.label(), func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				GetKuadrantFromTopology(topology, &sync.Map{})
-			}
-		})
-	}
-}
-
-// BenchmarkTopologyBuild measures the cost of constructing the GatewayAPI
-// topology itself, which happens on every reconciliation cycle.
-func BenchmarkTopologyBuild(b *testing.B) {
-	cases := []benchTopologyParams{
-		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1},
-		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1},
-		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, listenersPerGW: 32},
-		{numGatewayClasses: 3, numRoutesPerGW: 100, numRulesPerRoute: 1, listenersPerGW: 16},
-	}
-	for _, tc := range cases {
-		b.Run(tc.label(), func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				buildBenchTopology(b, tc)
+				buildBenchTopology(b, tc.p)
 			}
 		})
 	}
 }
 
 // BenchmarkFullReconciliationCycle simulates a full reconciliation cycle:
-// build topology, look up Kuadrant CR (as each reconciler does), then
-// calculate effective policies for all three policy types.
+// build topology, look up Kuadrant CR, then calculate effective policies
+// for all three policy types.
 func BenchmarkFullReconciliationCycle(b *testing.B) {
-	cases := []benchTopologyParams{
-		{numGatewayClasses: 1, numRoutesPerGW: 10, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 100, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
-		{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"},
-	}
+	p := benchTopologyParams{numGatewayClasses: 1, numRoutesPerGW: 300, numRulesPerRoute: 1, attachAuthPolicies: true, attachRLPolicies: true, attachTRLPolicies: true, policyTarget: "route"}
 
 	authReconciler := &EffectiveAuthPolicyReconciler{}
 	rlpReconciler := &EffectiveRateLimitPolicyReconciler{}
 	trlpReconciler := &EffectiveTokenRateLimitPolicyReconciler{}
 
-	for _, tc := range cases {
-		b.Run(tc.label(), func(b *testing.B) {
-			ctx := context.Background()
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				topology, _, _ := buildBenchTopology(b, tc)
-				state := &sync.Map{}
-				for j := 0; j < 28; j++ {
-					GetKuadrantFromTopology(topology, state)
-				}
-				authReconciler.Reconcile(ctx, nil, topology, nil, state)
-				rlpReconciler.Reconcile(ctx, nil, topology, nil, state)
-				trlpReconciler.Reconcile(ctx, nil, topology, nil, state)
-			}
-		})
+	ctx := context.Background()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		topology, _, _ := buildBenchTopology(b, p)
+		state := &sync.Map{}
+		for j := 0; j < 28; j++ {
+			GetKuadrantFromTopology(topology, state)
+		}
+		authReconciler.Reconcile(ctx, nil, topology, nil, state)
+		rlpReconciler.Reconcile(ctx, nil, topology, nil, state)
+		trlpReconciler.Reconcile(ctx, nil, topology, nil, state)
 	}
 }

--- a/internal/controller/bench_test.go
+++ b/internal/controller/bench_test.go
@@ -1,0 +1,446 @@
+//go:build unit
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	authorinov1beta3 "github.com/kuadrant/authorino/api/v1beta3"
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+
+	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	kuadrantauthorino "github.com/kuadrant/kuadrant-operator/internal/authorino"
+)
+
+type benchTopologyParams struct {
+	numGatewayClasses  int
+	numRoutesPerGW     int
+	numRulesPerRoute   int
+	attachAuthPolicies bool
+	attachRLPolicies   bool
+}
+
+func buildBenchTopology(b *testing.B, params benchTopologyParams) (*machinery.Topology, *kuadrantv1beta1.Kuadrant, *sync.Map) {
+	b.Helper()
+
+	kuadrant := &kuadrantv1beta1.Kuadrant{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kuadrantv1beta1.KuadrantGroupKind.Kind,
+			APIVersion: kuadrantv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuadrant",
+			Namespace: "kuadrant-system",
+			UID:       types.UID("uid-kuadrant"),
+		},
+	}
+
+	store := make(controller.Store)
+	store[string(kuadrant.UID)] = kuadrant
+
+	var gatewayClasses []*gatewayapiv1.GatewayClass
+	var gateways []*gatewayapiv1.Gateway
+	var httpRoutes []*gatewayapiv1.HTTPRoute
+	var policies []machinery.Policy
+
+	for gc := 0; gc < params.numGatewayClasses; gc++ {
+		gcName := fmt.Sprintf("gc-%d", gc)
+		gatewayClass := &gatewayapiv1.GatewayClass{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       machinery.GatewayClassGroupKind.Kind,
+				APIVersion: gatewayapiv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: gcName,
+				UID:  types.UID(fmt.Sprintf("uid-gc-%d", gc)),
+			},
+			Spec: gatewayapiv1.GatewayClassSpec{
+				ControllerName: "kuadrant.io/policy-controller",
+			},
+		}
+		gatewayClasses = append(gatewayClasses, gatewayClass)
+		store[string(gatewayClass.UID)] = gatewayClass
+
+		gwName := fmt.Sprintf("gw-%d", gc)
+		gateway := &gatewayapiv1.Gateway{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       machinery.GatewayGroupKind.Kind,
+				APIVersion: gatewayapiv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      gwName,
+				Namespace: "default",
+				UID:       types.UID(fmt.Sprintf("uid-gw-%d", gc)),
+			},
+			Spec: gatewayapiv1.GatewaySpec{
+				GatewayClassName: gatewayapiv1.ObjectName(gcName),
+				Listeners: []gatewayapiv1.Listener{
+					{
+						Name:     "http",
+						Hostname: ptr.To(gatewayapiv1.Hostname(fmt.Sprintf("*.gw-%d.example.com", gc))),
+					},
+				},
+			},
+		}
+		gateways = append(gateways, gateway)
+		store[string(gateway.UID)] = gateway
+
+		if params.attachAuthPolicies {
+			policy := &kuadrantv1.AuthPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AuthPolicy",
+					APIVersion: kuadrantv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("auth-%d", gc),
+					Namespace: "default",
+					UID:       types.UID(fmt.Sprintf("uid-auth-%d", gc)),
+				},
+				Spec: kuadrantv1.AuthPolicySpec{
+					TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+						LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+							Group: gatewayapiv1alpha2.Group(machinery.GatewayGroupKind.Group),
+							Kind:  gatewayapiv1.Kind(machinery.GatewayGroupKind.Kind),
+							Name:  gatewayapiv1.ObjectName(gwName),
+						},
+					},
+					AuthPolicySpecProper: kuadrantv1.AuthPolicySpecProper{
+						AuthScheme: &kuadrantv1.AuthSchemeSpec{
+							Authentication: map[string]kuadrantv1.MergeableAuthenticationSpec{
+								"jwt": {
+									AuthenticationSpec: authorinov1beta3.AuthenticationSpec{
+										AuthenticationMethodSpec: authorinov1beta3.AuthenticationMethodSpec{
+											Jwt: &authorinov1beta3.JwtAuthenticationSpec{
+												IssuerUrl: "http://auth.example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Status: kuadrantv1.AuthPolicyStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayapiv1alpha2.PolicyConditionAccepted),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			}
+			policies = append(policies, policy)
+			store[string(policy.UID)] = policy
+		}
+
+		if params.attachRLPolicies {
+			policy := &kuadrantv1.RateLimitPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "RateLimitPolicy",
+					APIVersion: kuadrantv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("rlp-%d", gc),
+					Namespace: "default",
+					UID:       types.UID(fmt.Sprintf("uid-rlp-%d", gc)),
+				},
+				Spec: kuadrantv1.RateLimitPolicySpec{
+					TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+						LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+							Group: gatewayapiv1alpha2.Group(machinery.GatewayGroupKind.Group),
+							Kind:  gatewayapiv1.Kind(machinery.GatewayGroupKind.Kind),
+							Name:  gatewayapiv1.ObjectName(gwName),
+						},
+					},
+					RateLimitPolicySpecProper: kuadrantv1.RateLimitPolicySpecProper{
+						Limits: map[string]kuadrantv1.Limit{
+							"requests": {
+								Rates: []kuadrantv1.Rate{
+									{Limit: 10, Window: "10s"},
+								},
+							},
+						},
+					},
+				},
+				Status: kuadrantv1.RateLimitPolicyStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   string(gatewayapiv1alpha2.PolicyConditionAccepted),
+							Status: metav1.ConditionTrue,
+						},
+					},
+				},
+			}
+			policies = append(policies, policy)
+			store[string(policy.UID)] = policy
+		}
+
+		for r := 0; r < params.numRoutesPerGW; r++ {
+			routeName := fmt.Sprintf("route-%d-%d", gc, r)
+			rules := make([]gatewayapiv1.HTTPRouteRule, params.numRulesPerRoute)
+			for k := 0; k < params.numRulesPerRoute; k++ {
+				rules[k] = gatewayapiv1.HTTPRouteRule{
+					Name: ptr.To(gatewayapiv1.SectionName(fmt.Sprintf("rule-%d", k))),
+					Matches: []gatewayapiv1.HTTPRouteMatch{
+						{
+							Path: &gatewayapiv1.HTTPPathMatch{
+								Value: ptr.To(fmt.Sprintf("/%s/rule-%d", routeName, k)),
+							},
+						},
+					},
+					BackendRefs: []gatewayapiv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayapiv1.BackendRef{
+								BackendObjectReference: gatewayapiv1.BackendObjectReference{
+									Name: gatewayapiv1.ObjectName(fmt.Sprintf("svc-%s", routeName)),
+								},
+							},
+						},
+					},
+				}
+			}
+
+			route := &gatewayapiv1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       machinery.HTTPRouteGroupKind.Kind,
+					APIVersion: gatewayapiv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      routeName,
+					Namespace: "default",
+					UID:       types.UID(fmt.Sprintf("uid-route-%d-%d", gc, r)),
+				},
+				Spec: gatewayapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+						ParentRefs: []gatewayapiv1.ParentReference{
+							{Name: gatewayapiv1.ObjectName(gwName)},
+						},
+					},
+					Rules: rules,
+				},
+			}
+			httpRoutes = append(httpRoutes, route)
+			store[string(route.UID)] = route
+		}
+	}
+
+	topology, err := machinery.NewGatewayAPITopology(
+		machinery.WithGatewayClasses(gatewayClasses...),
+		machinery.WithGateways(gateways...),
+		machinery.ExpandGatewayListeners(),
+		machinery.WithHTTPRoutes(httpRoutes...),
+		machinery.ExpandHTTPRouteRules(),
+		machinery.WithGatewayAPITopologyPolicies(policies...),
+		machinery.WithGatewayAPITopologyObjects(kuadrant),
+		machinery.WithGatewayAPITopologyLinks(
+			kuadrantv1beta1.LinkKuadrantToGatewayClasses(store),
+		),
+	)
+	if err != nil {
+		b.Fatalf("failed to build topology: %v", err)
+	}
+
+	state := &sync.Map{}
+
+	return topology, kuadrant, state
+}
+
+// BenchmarkCalculateEffectiveAuthPolicies measures the O(GatewayClasses × RouteRules) loop
+// that calls Paths() for each pair — the most expensive reconciliation path.
+func BenchmarkCalculateEffectiveAuthPolicies(b *testing.B) {
+	cases := []struct {
+		name string
+		p    benchTopologyParams
+	}{
+		{"1gc-10routes", benchTopologyParams{1, 10, 2, true, false}},
+		{"1gc-100routes", benchTopologyParams{1, 100, 2, true, false}},
+		{"1gc-300routes", benchTopologyParams{1, 300, 2, true, false}},
+		{"3gc-100routes", benchTopologyParams{3, 100, 2, true, false}},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			topology, kuadrant, state := buildBenchTopology(b, tc.p)
+			ctx := context.Background()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				CalculateEffectiveAuthPolicies(ctx, topology, kuadrant, state)
+			}
+		})
+	}
+}
+
+// BenchmarkTopologyToDot measures the DAG-to-DOT serialization called every reconciliation cycle.
+func BenchmarkTopologyToDot(b *testing.B) {
+	cases := []struct {
+		name   string
+		routes int
+		rules  int
+	}{
+		{"10obj", 2, 1},
+		{"100obj", 20, 2},
+		{"300obj", 60, 2},
+		{"1000obj", 200, 2},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			topology, _, _ := buildBenchTopology(b, benchTopologyParams{1, tc.routes, tc.rules, false, false})
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				topology.ToDot()
+			}
+		})
+	}
+}
+
+// BenchmarkBuildDesiredAuthConfig measures AuthConfig generation for N route rules.
+func BenchmarkBuildDesiredAuthConfig(b *testing.B) {
+	cases := []struct {
+		name  string
+		rules int
+	}{
+		{"1-rule", 1},
+		{"10-rules", 10},
+		{"100-rules", 100},
+		{"300-rules", 300},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{1, 1, tc.rules, true, false})
+			ctx := context.Background()
+
+			effectivePolicies := CalculateEffectiveAuthPolicies(ctx, topology, kuadrant, state)
+
+			type authConfigInput struct {
+				pathID           string
+				effectivePolicy  EffectiveAuthPolicy
+				name             string
+				namespace        string
+				annotationKey    string
+				routeRuleLocator string
+			}
+			var inputs []authConfigInput
+			for pathID, ep := range effectivePolicies {
+				inputs = append(inputs, authConfigInput{
+					pathID:           pathID,
+					effectivePolicy:  ep,
+					name:             AuthConfigNameForPath(pathID),
+					namespace:        "kuadrant-system",
+					annotationKey:    kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation,
+					routeRuleLocator: ep.Path[len(ep.Path)-1].GetLocator(),
+				})
+			}
+
+			r := &AuthConfigsReconciler{client: nil}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for _, in := range inputs {
+					r.buildDesiredAuthConfig(ctx, in.effectivePolicy, in.name, in.namespace, in.annotationKey, in.routeRuleLocator)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkBuildLimitadorLimits measures merging effective rate limit policies into Limitador limits.
+func BenchmarkBuildLimitadorLimits(b *testing.B) {
+	cases := []struct {
+		name   string
+		routes int
+	}{
+		{"10-policies", 5},
+		{"100-policies", 50},
+		{"300-policies", 150},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			topology, kuadrant, state := buildBenchTopology(b, benchTopologyParams{1, tc.routes, 2, false, true})
+			ctx := context.Background()
+
+			targetables := topology.Targetables()
+			gatewayClasses := targetables.Children(kuadrant)
+			httpRouteRules := targetables.Items(func(o machinery.Object) bool {
+				_, ok := o.(*machinery.HTTPRouteRule)
+				return ok
+			})
+
+			allPolicies := topology.Policies().Items()
+			var rlPolicies []machinery.Policy
+			for _, p := range allPolicies {
+				if _, ok := p.(*kuadrantv1.RateLimitPolicy); ok {
+					rlPolicies = append(rlPolicies, p)
+				}
+			}
+			if len(rlPolicies) == 0 {
+				b.Fatal("no rate limit policies in topology")
+			}
+
+			effectivePolicies := EffectiveRateLimitPolicies{}
+			for _, gc := range gatewayClasses {
+				for _, rule := range httpRouteRules {
+					paths := targetables.Paths(gc, rule)
+					for _, path := range paths {
+						pathID := kuadrantv1.PathID(path)
+						rlp := rlPolicies[0].(*kuadrantv1.RateLimitPolicy)
+						effectivePolicies[pathID] = EffectiveRateLimitPolicy{
+							Path:           path,
+							Spec:           *rlp,
+							SourcePolicies: []string{rlp.GetLocator()},
+						}
+					}
+				}
+			}
+			state.Store(StateEffectiveRateLimitPolicies, effectivePolicies)
+
+			r := &LimitadorLimitsReconciler{client: nil}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				r.buildLimitadorLimits(ctx, state)
+			}
+		})
+	}
+}
+
+// BenchmarkTopologyPaths measures the Paths() DFS traversal — the single most expensive operation.
+func BenchmarkTopologyPaths(b *testing.B) {
+	cases := []struct {
+		name   string
+		p      benchTopologyParams
+	}{
+		{"shallow-narrow", benchTopologyParams{1, 5, 2, false, false}},
+		{"shallow-wide", benchTopologyParams{1, 100, 2, false, false}},
+		{"deep-wide", benchTopologyParams{3, 100, 5, false, false}},
+		{"stress", benchTopologyParams{1, 300, 2, false, false}},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			topology, kuadrant, _ := buildBenchTopology(b, tc.p)
+
+			targetables := topology.Targetables()
+			gatewayClasses := targetables.Children(kuadrant)
+			httpRouteRules := targetables.Items(func(o machinery.Object) bool {
+				_, ok := o.(*machinery.HTTPRouteRule)
+				return ok
+			})
+			if len(gatewayClasses) == 0 || len(httpRouteRules) == 0 {
+				b.Fatal("topology has no gateway classes or route rules")
+			}
+			from := gatewayClasses[0]
+			to := httpRouteRules[len(httpRouteRules)-1]
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				targetables.Paths(from, to)
+			}
+		})
+	}
+}

--- a/internal/controller/bench_test.go
+++ b/internal/controller/bench_test.go
@@ -413,8 +413,8 @@ func BenchmarkBuildLimitadorLimits(b *testing.B) {
 // BenchmarkTopologyPaths measures the Paths() DFS traversal — the single most expensive operation.
 func BenchmarkTopologyPaths(b *testing.B) {
 	cases := []struct {
-		name   string
-		p      benchTopologyParams
+		name string
+		p    benchTopologyParams
 	}{
 		{"shallow-narrow", benchTopologyParams{1, 5, 2, false, false}},
 		{"shallow-wide", benchTopologyParams{1, 100, 2, false, false}},


### PR DESCRIPTION
## Summary

Alternative to [PR #2035](https://github.com/Kuadrant/kuadrant-operator/pull/2035) — runs benchmarks nightly instead of per-PR.

Same benchmarks, same `make test-bench` target, different trigger and comparison strategy.

## How it works

1. Runs nightly at 3:17am UTC on `main`
2. Downloads previous night's results from artifacts
3. Compares with `benchstat` (same 5% threshold, same p<0.05 filter)
4. If regression detected: creates a GitHub issue

## Trade-offs vs per-PR (#2035)

| | Per-PR (#2035) | Nightly (this PR) |
|---|---|---|
| **When regression found** | Before merge | ~24h after merge |
| **Which PR caused it** | Known immediately | Requires bisection |
| **Baseline** | Always available (main branch) | Depends on previous run's artifact |
| **First run / artifact expiry** | Works immediately | No comparison possible |
| **Storage** | None needed | Artifacts (90-day expiry) |
| **CI overhead** | ~8 min per PR (parallel with integration tests) | ~5 min nightly |
| **Workflow complexity** | 95 lines | 105 lines (artifact download, issue creation) |
| **Action on regression** | Author fixes before merge | Triage needed to find which PR |

## Recommendation

This PR exists to demonstrate the trade-offs. I recommend [PR #2035](https://github.com/Kuadrant/kuadrant-operator/pull/2035) (per-PR) because:
- It catches regressions **before** they merge, not after
- It identifies **which PR** caused the regression with zero ambiguity
- It runs in parallel with integration tests that take longer, so it adds **no wall-clock time** to CI
- It requires **no artifact storage** or API calls for baseline retrieval

🤖 Generated with [Claude Code](https://claude.com/claude-code)