### PR TITLE
feat: add mcp-gateway umbrella operator integration (POC)

### DIFF
--- a/internal/controller/auth_workflow_helpers.go
+++ b/internal/controller/auth_workflow_helpers.go
@@ -55,6 +55,10 @@ func GetAuthorinoFromTopology(topology *machinery.Topology, state *sync.Map) *au
 func AuthObjectLabels() labels.Set {
 	m := KuadrantManagedObjectLabels()
 	m[authObjectLabelKey] = "true"
+	// Helm-deployed Authorino (charts/authorino) uses --auth-config-label-selector=
+	// authorino.kuadrant.io/managed-by=authorino. Add this label so AuthConfigs are
+	// picked up by the Helm-deployed Authorino, not just by the operator-based one.
+	m["authorino.kuadrant.io/managed-by"] = "authorino"
 	return m
 }
 
@@ -73,7 +77,10 @@ type authorinoServiceInfo struct {
 
 func authorinoServiceInfoFromAuthorino(authorino *authorinooperatorv1beta1.Authorino) authorinoServiceInfo {
 	info := authorinoServiceInfo{
-		Host: fmt.Sprintf("%s-authorino-authorization.%s.svc.cluster.local", authorino.GetName(), authorino.GetNamespace()),
+		// When Authorino is deployed via the Helm chart (charts/authorino), the gRPC service
+		// is named "<release>-auth" (e.g. authorino-auth), not "<name>-authorino-authorization"
+		// which was the naming convention used by the authorino-operator CR-based deployment.
+		Host: fmt.Sprintf("%s-auth.%s.svc.cluster.local", authorino.GetName(), authorino.GetNamespace()),
 		Port: int32(50051), // default authorino grpc authorization service port
 	}
 	if p := authorino.Spec.Listener.Ports.GRPC; p != nil {

--- a/internal/controller/helm_helpers.go
+++ b/internal/controller/helm_helpers.go
@@ -1,5 +1,7 @@
 package controllers
 
+import "strings"
+
 // kindToResource converts Kubernetes Kind to resource name (simple pluralization)
 func kindToResource(kind string) string {
 	switch kind {
@@ -11,14 +13,17 @@ func kindToResource(kind string) string {
 		return "deployments"
 	case "ConfigMap":
 		return "configmaps"
+	case "ClusterRole":
+		return "clusterroles"
 	case "ClusterRoleBinding":
 		return "clusterrolebindings"
+	case "NetworkPolicy":
+		return "networkpolicies"
 	case "Role":
 		return "roles"
 	case "RoleBinding":
 		return "rolebindings"
 	default:
-		// Simple pluralization
-		return kind + "s"
+		return strings.ToLower(kind) + "s"
 	}
 }


### PR DESCRIPTION
## Summary

Two targeted fixes for the umbrella operator Helm-deployed path, on top of Mike Nairn's \`olmv1-umbrella-poc-phase1\` branch. Both are cherry-pick candidates.

### Commits

**\`fix: add ClusterRole and NetworkPolicy cases to kindToResource\`**

\`kindToResource("ClusterRole")\` was falling through to the default \`kind + "s"\` path, producing \`"ClusterRoles"\` (capital C) which the Kubernetes API rejects as a resource name. This doesn't affect ClusterRole application (ClusterRoles are intentionally stripped from chart templates during sync and pre-installed by OLM/Helm), but fixes the default path for any other resource types hitting the fallback — e.g. NetworkPolicy.

**\`fix: align Authorino integration with Helm chart naming conventions\`**

Two fixes needed for AuthPolicy to work when wrapper CRs are removed in phase 2:

1. \`authorinoServiceInfoFromAuthorino()\` uses \`<name>-authorino-authorization\` but the Helm chart creates \`<name>-auth\`
2. \`AuthObjectLabels()\` is missing \`authorino.kuadrant.io/managed-by=authorino\` — the label selector Helm-deployed Authorino uses for AuthConfigs

Note: per Mike's feedback these are not blocking for phase 1 (wrapper CRs still exist), but will be needed in phase 2 when wrapper CRs are removed.

### Related

- mcp-gateway PR: https://github.com/Kuadrant/mcp-gateway/pull/1239