### PR TITLE
fix: pass wasm-shim version to Dockerfile build-arg, prepare v1.5.2-rc1

### DIFF
--- a/.github/workflows/build-images-for-tag-release.yaml
+++ b/.github/workflows/build-images-for-tag-release.yaml
@@ -45,6 +45,7 @@ jobs:
             GIT_SHA=${{ github.sha }}
             DIRTY=false
             VERSION=${{ github.ref_name }}
+            WASM_SHIM_IMAGE=quay.io/kuadrant/wasm-shim:v${{ env.wasmShimVersion }}
 
           dockerfiles: |
             ./Dockerfile

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -224,14 +224,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.1
-    createdAt: "2026-07-15T16:02:35Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.2-rc1
+    createdAt: "2026-07-17T10:08:57Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.5.1
+  name: kuadrant-operator.v1.5.2-rc1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -769,7 +769,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.5.1
+                image: quay.io/kuadrant/kuadrant-operator:v1.5.2-rc1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -928,4 +928,4 @@ spec:
     name: console-plugin-latest
   - image: quay.io/kuadrant/console-plugin:v0.1.5-2
     name: console-plugin-pf5
-  version: 1.5.1
+  version: 1.5.2-rc1

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.5.1"
-appVersion: "1.5.1"
+version: "1.5.2-rc1"
+appVersion: "1.5.2-rc1"
 dependencies:
   - name: authorino-operator
     version: 0.25.2

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14504,7 +14504,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.5.1
+        image: quay.io/kuadrant/kuadrant-operator:v1.5.2-rc1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.5.1
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.5.2-rc1
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,4 +12,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.5.1
+  newTag: v1.5.2-rc1

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.1
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.2-rc1
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.5.1
+  name: kuadrant-operator.v1.5.2-rc1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,4 +88,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.5.1
+  version: 1.5.2-rc1

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.5.1"
+  version: "1.5.2-rc1"
 olm:
   channels:
     - "stable"

--- a/utils/release/load_github_envvar.sh
+++ b/utils/release/load_github_envvar.sh
@@ -31,4 +31,6 @@ if [[ $dry_run == "0" ]]; then
   echo "authorinoOperatorVersion=$AUTHORINO_OPERATOR_VERSION" >> "$GITHUB_ENV"
   echo "dnsOperatorVersion=$DNS_OPERATOR_VERSION" >> "$GITHUB_ENV"
   echo "developerPortalVersion=$DEVELOPERPORTAL_VERSION" >> "$GITHUB_ENV"
+  echo "wasmShimVersion=$WASM_SHIM_VERSION" >> "$GITHUB_ENV"
+  echo "consolePluginVersion=$CONSOLEPLUGIN_VERSION" >> "$GITHUB_ENV"
 fi

--- a/utils/release/load_github_envvar.sh
+++ b/utils/release/load_github_envvar.sh
@@ -21,6 +21,8 @@ if [[ $_log == "1" ]]; then
   log "authorinoOperatorVersion=$AUTHORINO_OPERATOR_VERSION"
   log "dnsOperatorVersion=$DNS_OPERATOR_VERSION"
   log "developerPortalVersion=$DEVELOPERPORTAL_VERSION"
+  log "wasmShimVersion=$WASM_SHIM_VERSION"
+  log "consolePluginVersion=$CONSOLEPLUGIN_VERSION"
 fi
 
 if [[ $dry_run == "0" ]]; then


### PR DESCRIPTION
## Summary

The tag-release workflow builds the operator image with `wasm-shim:latest` instead of the version declared in `release.yaml`. This caused v1.5.1 to ship with the wrong wasm-shim binary.

Two root causes:
1. `load_github_envvar.sh` does not export `WASM_SHIM_VERSION` to `$GITHUB_ENV`
2. The workflow does not pass `WASM_SHIM_IMAGE` as a build-arg to the Dockerfile

This PR fixes both and bumps to v1.5.2-rc1 since v1.5.1 artifacts are already published and consumed downstream.

A broader fix is tracked in #2114 (RFC 0020 rollout).

## Changes

- `utils/release/load_github_envvar.sh`: export `wasmShimVersion` and `consolePluginVersion` to `$GITHUB_ENV`
- `.github/workflows/build-images-for-tag-release.yaml`: pass `WASM_SHIM_IMAGE` build-arg
- `release.yaml`: bump version to `1.5.2-rc1`

## Test plan

- [ ] Trigger a manual `workflow_dispatch` of the tag-release workflow on the `v1.5.2-rc1` tag
- [ ] Verify the build log shows `FROM quay.io/kuadrant/wasm-shim:v0.14.1` instead of `:latest`
- [ ] Verify the resulting operator image embeds the correct wasm plugin binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)