### PR TITLE
Add CRC development setup with network policies and observability

### DIFF
--- a/config/network-policy-standard/authorino-operator.yaml
+++ b/config/network-policy-standard/authorino-operator.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-authorino-operator
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: authorino-operator
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/config/network-policy-standard/authorino.yaml
+++ b/config/network-policy-standard/authorino.yaml
@@ -1,0 +1,47 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-authorino
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      authorino-resource: authorino
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 50051
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 5001
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8083

--- a/config/network-policy-standard/console-plugin.yaml
+++ b/config/network-policy-standard/console-plugin.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-console-plugin
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      app: kuadrant-console-plugin
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-console
+      ports:
+        - protocol: TCP
+          port: 9443

--- a/config/network-policy-standard/deny-all.yaml
+++ b/config/network-policy-standard/deny-all.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: kuadrant-system
+spec:
+  podSelector: {}
+  policyTypes:

--- a/config/network-policy-standard/dns-operator.yaml
+++ b/config/network-policy-standard/dns-operator.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-dns-operator
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: dns-operator-controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/config/network-policy-standard/kuadrant-operator.yaml
+++ b/config/network-policy-standard/kuadrant-operator.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-operator
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      app: kuadrant
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kuadrant-system
+      ports:
+        - protocol: TCP
+          port: 50051
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 8082

--- a/config/network-policy-standard/kustomization.yaml
+++ b/config/network-policy-standard/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - kuadrant-operator.yaml
+  - authorino.yaml
+  - authorino-operator.yaml
+  - console-plugin.yaml
+  - dns-operator.yaml
+  - limitador.yaml
+  - limitador-operator.yaml
+  - deny-all.yaml

--- a/config/network-policy-standard/limitador-operator.yaml
+++ b/config/network-policy-standard/limitador-operator.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-limitador-operator
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      app: limitador-operator
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/config/network-policy-standard/limitador.yaml
+++ b/config/network-policy-standard/limitador.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-limitador
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      app: limitador
+      limitador-resource: limitador
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+      ports:
+        - protocol: TCP
+          port: 8080
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 8081

--- a/config/network-policy/authorino-operator.yaml
+++ b/config/network-policy/authorino-operator.yaml
@@ -1,0 +1,35 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-authorino-operator
+spec:
+  priority: 52
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          control-plane: authorino-operator
+  ingress:
+    - name: allow-metrics
+      action: Allow
+      from:
+        - namespaces: {}
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 8080
+  egress:
+    # this may never be need
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/authorino-operator.yaml
+++ b/config/network-policy/authorino-operator.yaml
@@ -23,6 +23,16 @@ spec:
             port: 8080
   egress:
     # this may never be need
+    - name: allow-otlp-traces
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 4317
     - name: allow-dns
       action: Allow
       to:

--- a/config/network-policy/authorino.yaml
+++ b/config/network-policy/authorino.yaml
@@ -1,0 +1,69 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-authorino
+spec:
+  priority: 51
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          authorino-resource: authorino
+  ingress:
+    - name: allow-authorization-grpc
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 50051
+    - name: allow-authorization-http
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 5001
+    - name: allow-oidc
+      action: Allow
+      from:
+        - namespaces: {}
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 8083
+  egress:
+    - name: allow-external-oidc
+      action: Allow
+      to:
+        - networks:
+            - 0.0.0.0/0
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 443
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/authorino.yaml
+++ b/config/network-policy/authorino.yaml
@@ -48,6 +48,16 @@ spec:
             protocol: TCP
             port: 8083
   egress:
+    - name: allow-otlp-traces
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 4317
     - name: allow-external-oidc
       action: Allow
       to:

--- a/config/network-policy/console-plugin.yaml
+++ b/config/network-policy/console-plugin.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-console-plugin
+spec:
+  priority: 56
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          app: kuadrant-console-plugin
+  ingress:
+    - name: allow-console
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-console
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 9443

--- a/config/network-policy/deny-all.yaml
+++ b/config/network-policy/deny-all.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: BaselineAdminNetworkPolicy
+metadata:
+  name: default
+spec:
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: kuadrant-system
+  ingress:
+    - name: deny-all-ingress
+      action: Deny
+      from:
+        - namespaces: {}
+  egress:
+    - name: deny-all-egress
+      action: Deny
+      to:
+        - namespaces: {}

--- a/config/network-policy/dns-operator.yaml
+++ b/config/network-policy/dns-operator.yaml
@@ -1,0 +1,55 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-dns-operator
+spec:
+  priority: 53
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          control-plane: dns-operator-controller-manager
+  # ingress:
+    # only need if we plan to share the golang exposed metrics.
+    # - name: allow-metrics
+    #   action: Allow
+    #   from:
+    #     - namespaces: {}
+    #   ports:
+    #     - portNumber:
+    #         protocol: TCP
+    #         port: 8080
+  egress:
+    # TODO: Scope 0.0.0.0/0 to specific DNS provider API CIDRs (e.g. AWS, Azure, GCP)
+    - name: allow-external-dns-providers
+      action: Allow
+      to:
+        - networks:
+            - 0.0.0.0/0
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 443
+    # TODO: Scope 0.0.0.0/0 to known remote cluster API server IPs
+    - name: allow-remote-api-servers
+      action: Allow
+      to:
+        - networks:
+            - 0.0.0.0/0
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 6443
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/dns-operator.yaml
+++ b/config/network-policy/dns-operator.yaml
@@ -23,6 +23,16 @@ spec:
     #         protocol: TCP
     #         port: 8080
   egress:
+    - name: allow-otlp-traces
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 4317
     # TODO: Scope 0.0.0.0/0 to specific DNS provider API CIDRs (e.g. AWS, Azure, GCP)
     - name: allow-external-dns-providers
       action: Allow

--- a/config/network-policy/kuadrant-operator.yaml
+++ b/config/network-policy/kuadrant-operator.yaml
@@ -1,0 +1,69 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-operator
+spec:
+  priority: 50
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          app: kuadrant
+          control-plane: controller-manager
+  ingress:
+    # only need if we plan to share the golang exposed metrics.
+    # - name: allow-metrics
+    #   action: Allow
+    #   from:
+    #     - namespaces: {}
+    #   ports:
+    #     - portNumber:
+    #         protocol: TCP
+    #         port: 8080
+    - name: allow-grpc
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: kuadrant-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 50051
+    - name: allow-wasm
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 8082
+  egress:
+    - name: allow-otlp-traces
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 4317
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - kuadrant-operator.yaml
   - authorino.yaml
   - authorino-operator.yaml
+  - console-plugin.yaml
   - dns-operator.yaml
   - limitador.yaml
   - limitador-operator.yaml

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - kuadrant-operator.yaml
+  - authorino.yaml
+  - authorino-operator.yaml
+  - dns-operator.yaml
+  - limitador.yaml
+  - limitador-operator.yaml
+  - deny-all.yaml

--- a/config/network-policy/limitador-operator.yaml
+++ b/config/network-policy/limitador-operator.yaml
@@ -1,0 +1,46 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-limitador-operator
+spec:
+  priority: 55
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          app: limitador-operator
+          control-plane: controller-manager
+  ingress:
+    # need to allow access to the go metrics.
+    # - name: allow-metrics
+    #   action: Allow
+    #   from:
+    #     - namespaces: {}
+    #   ports:
+    #     - portNumber:
+    #         protocol: TCP
+    #         port: 8080
+  egress:
+    - name: allow-otlp-traces
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 4317
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/limitador.yaml
+++ b/config/network-policy/limitador.yaml
@@ -1,0 +1,64 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-limitador
+spec:
+  priority: 54
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          app: limitador
+          limitador-resource: limitador
+  ingress:
+    # Possible need to allow metrics scraping.
+    # - name: allow-status-http
+    #   action: Allow
+    #   from:
+    #     - namespaces:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: openshift-monitoring
+    #     - namespaces:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: openshift-user-workload-monitoring
+    #   ports:
+    #     - portNumber:
+    #         protocol: TCP
+    #         port: 8080
+    - name: allow-grpc
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 8081
+  egress:
+    - name: allow-otlp-traces
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 4317
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/observability/crc/grafana-datasource.yaml
+++ b/config/observability/crc/grafana-datasource.yaml
@@ -1,0 +1,27 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  name: prometheus-crc
+  namespace: monitoring
+spec:
+  datasource:
+    access: proxy
+    isDefault: true
+    jsonData:
+      httpHeaderName1: "Authorization"
+      timeInterval: 5s
+      tlsSkipVerify: true
+    secureJsonData:
+      httpHeaderValue1: "Bearer ${token}"
+    name: prometheus-crc
+    type: prometheus
+    url: "https://thanos-querier.openshift-monitoring.svc:9091"
+  valuesFrom:
+    - targetPath: "secureJsonData.httpHeaderValue1"
+      valueFrom:
+        secretKeyRef:
+          name: grafana-monitoring-token
+          key: token
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana

--- a/config/observability/crc/grafana-sa.yaml
+++ b/config/observability/crc/grafana-sa.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-monitoring
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: grafana-monitoring
+    namespace: monitoring
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-monitoring-token
+  namespace: monitoring
+  annotations:
+    kubernetes.io/service-account.name: grafana-monitoring
+type: kubernetes.io/service-account-token

--- a/config/observability/crc/user-workload-monitoring.yaml
+++ b/config/observability/crc/user-workload-monitoring.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/config/observability/openshift/grafana/dashboards.yaml
+++ b/config/observability/openshift/grafana/dashboards.yaml
@@ -69,3 +69,15 @@ spec:
   configMapRef:
     name: grafana-dns-operator
     key: dns-operator.json
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-kuadrant-pod-resources
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "grafana"
+  configMapRef:
+    name: grafana-kuadrant-pod-resources
+    key: kuadrant-pod-resources.json

--- a/config/observability/openshift/jaeger-route.yaml
+++ b/config/observability/openshift/jaeger-route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: jaeger
+  namespace: observability
+spec:
+  to:
+    kind: Service
+    name: jaeger
+  port:
+    targetPort: http-query
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/config/observability/openshift/jaeger-values.yaml
+++ b/config/observability/openshift/jaeger-values.yaml
@@ -1,0 +1,50 @@
+jaeger:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+storage:
+  type: memory
+
+userconfig:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+  service:
+    extensions: [jaeger_storage, jaeger_query, healthcheckv2]
+    pipelines:
+      traces:
+        receivers: [otlp]
+        exporters: [jaeger_storage_exporter]
+  extensions:
+    healthcheckv2:
+      use_v2: true
+      http:
+        endpoint: 0.0.0.0:13133
+    jaeger_query:
+      storage:
+        traces: memory_store
+    jaeger_storage:
+      backends:
+        memory_store:
+          memory:
+            max_traces: 100000
+  exporters:
+    jaeger_storage_exporter:
+      trace_storage: memory_store

--- a/config/observability/openshift/kube-state-metrics.yaml
+++ b/config/observability/openshift/kube-state-metrics.yaml
@@ -251,10 +251,13 @@ spec:
             memory: 190Mi
         securityContext:
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
           capabilities:
             drop:
               - ALL
           readOnlyRootFilesystem: true
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - containerPort: 8081
           name: https-main

--- a/config/observability/tracing/kustomization.yaml
+++ b/config/observability/tracing/kustomization.yaml
@@ -3,10 +3,6 @@ kind: Kustomization
 
 resources:
   - istio-tracing.yaml
-  - kuadrant-tracing.yaml
-  - limitador-operator-patch.yaml
-  - kuadrant-operator-patch.yaml
-  - istio-patch.yaml
 
 patches:
   - path: istio-patch.yaml
@@ -15,23 +11,3 @@ patches:
       version: v1
       kind: Istio
       name: default
-  - path: kuadrant-tracing.yaml
-    target:
-      group: kuadrant.io
-      version: v1beta1
-      kind: Kuadrant
-      name: kuadrant
-  - path: limitador-operator-patch.yaml
-    target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: limitador-operator-controller-manager
-      namespace: kuadrant-system
-  - path: kuadrant-operator-patch.yaml
-    target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: kuadrant-operator-controller-manager
-      namespace: kuadrant-system

--- a/docs/ossm-support-plan.md
+++ b/docs/ossm-support-plan.md
@@ -1,0 +1,124 @@
+# Plan: Add OSSM 3.x support to CRC Istio setup
+
+## Context
+
+The CRC setup currently installs Istio via the upstream Sail Helm chart. This plan adds optional support for OpenShift Service Mesh (OSSM) 3.x instead — Red Hat's supported Istio distribution, installed via OLM. OSSM 3.x uses the same Sail operator API (`sailoperator.io/v1`) under the hood, so the Istio CR and Gateway resources are compatible.
+
+The existing Sail install uses `helm install sail-operator` + an `Istio` CR. OSSM instead uses an OLM `Subscription` to `servicemeshoperator3` from `redhat-operators`, plus an `IstioCNI` resource (required on OpenShift for non-privileged network interception).
+
+## Approach
+
+Add a `CRC_ISTIO_METHOD` variable (`sail` or `ossm`, default `sail`) that controls which install path `crc-istio-env-setup` uses.
+
+### New manifests: `config/dependencies/istio/ossm/`
+
+**`subscription.yaml`** — OLM Subscription for OSSM 3.x:
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: servicemeshoperator3
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: servicemeshoperator3
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+```
+
+**`istiocni.yaml`** — IstioCNI (required, must be applied before the Istio CR):
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-cni
+---
+apiVersion: sailoperator.io/v1
+kind: IstioCNI
+metadata:
+  name: default
+spec:
+  namespace: istio-cni
+  profile: openshift
+```
+
+**`istio.yaml`** — Istio CR (mirrors the existing Sail one but without pinned version, since OSSM manages versions through operator updates):
+```yaml
+apiVersion: sailoperator.io/v1
+kind: Istio
+metadata:
+  name: default
+spec:
+  namespace: istio-system
+  updateStrategy:
+    type: InPlace
+  values:
+    pilot:
+      autoscaleEnabled: false
+```
+
+### New make target: `ossm-install` in `make/istio.mk`
+
+```makefile
+.PHONY: ossm-install
+ossm-install:
+	kubectl apply -f $(ISTIO_INSTALL_DIR)/ossm/subscription.yaml
+	@echo "[INFO] Waiting for Sail operator CRDs from OSSM..."
+	kubectl wait --for=condition=Established crd/istios.sailoperator.io --timeout=300s
+	kubectl apply -f $(ISTIO_INSTALL_DIR)/ossm/istiocni.yaml
+	kubectl apply -f $(ISTIO_INSTALL_DIR)/ossm/istio.yaml
+
+.PHONY: ossm-uninstall
+ossm-uninstall:
+	-kubectl delete -f $(ISTIO_INSTALL_DIR)/ossm/istio.yaml
+	-kubectl delete -f $(ISTIO_INSTALL_DIR)/ossm/istiocni.yaml
+	-kubectl delete -f $(ISTIO_INSTALL_DIR)/ossm/subscription.yaml
+```
+
+### Update `crc-istio-env-setup` in `make/crc.mk`
+
+Add variable:
+```makefile
+CRC_ISTIO_METHOD ?= sail
+```
+
+Update `crc-istio-env-setup` to dispatch based on `CRC_ISTIO_METHOD`:
+- `sail` — existing behavior (check `helm status`, call `istio-install`)
+- `ossm` — check if OSSM subscription exists, call `ossm-install` if not
+
+The gateway deployment (`deploy-istio-gateway`) is unchanged — OSSM 3.x registers the same `istio` GatewayClass.
+
+## Files to modify
+
+- **`make/istio.mk`** — add `ossm-install` and `ossm-uninstall` targets
+- **`make/crc.mk`** — add `CRC_ISTIO_METHOD` variable, update `crc-istio-env-setup` dispatch logic
+- **Create `config/dependencies/istio/ossm/subscription.yaml`**
+- **Create `config/dependencies/istio/ossm/istiocni.yaml`**
+- **Create `config/dependencies/istio/ossm/istio.yaml`**
+
+## Usage
+
+```bash
+# Default — upstream Sail via Helm (existing behavior)
+make crc-setup GATEWAYAPI_PROVIDER=istio
+
+# OSSM 3.x via OLM
+make crc-setup GATEWAYAPI_PROVIDER=istio CRC_ISTIO_METHOD=ossm
+```
+
+## Verification
+
+1. `make crc-setup GATEWAYAPI_PROVIDER=istio CRC_ISTIO_METHOD=ossm`
+2. `oc get csv -n openshift-operators` — OSSM operator CSV should be `Succeeded`
+3. `oc get istiocni -A` — IstioCNI `default` should be ready
+4. `oc get istio -A` — Istio `default` should be ready
+5. `kubectl get pods -n istio-system` — istiod pod running
+6. `kubectl get gatewayclass istio` — GatewayClass registered
+7. `kubectl get gateway -n gateway-system` — ingressgateway programmed
+
+## References
+
+- [OSSM 3.0 Install Docs](https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/installing/ossm-installing-service-mesh)
+- [Integrate OpenShift Gateway API with OSSM](https://developers.redhat.com/articles/2025/12/09/integrate-openshift-gateway-api-openshift-service-mesh)
+- [Introducing OSSM 3.0 (Red Hat Blog)](https://www.redhat.com/en/blog/introducing-red-hat-openshift-service-mesh-3)

--- a/examples/dashboards/kuadrant-pod-resources.json
+++ b/examples/dashboards/kuadrant-pod-resources.json
@@ -1,0 +1,213 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 2,
+  "links": [],
+  "panels": [
+    {
+      "title": "Memory by Pod",
+      "description": "Per-pod memory working set. Click a pod name to filter the stacked view.",
+      "type": "timeseries",
+      "id": 1,
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "showPoints": "never",
+            "stacking": { "mode": "none" }
+          },
+          "links": [
+            {
+              "title": "Filter stacked view to ${__field.labels.pod}",
+              "url": "/d/kuadrant-pod-resources/kuadrant-pod-resources?var-pod=${__field.labels.pod}&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"kuadrant-system\", container!=\"\", pod=~\"$pod\"})",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "Memory Stacked",
+      "description": "Stacked view of pod memory. Filtered by the pod selector.",
+      "type": "timeseries",
+      "id": 2,
+      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 40,
+            "spanNulls": true,
+            "showPoints": "never",
+            "stacking": { "mode": "normal" }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (pod) (container_memory_working_set_bytes{namespace=\"kuadrant-system\", container!=\"\", pod=~\"$pod\"})",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "CPU by Pod",
+      "description": "Per-pod CPU usage (5m rate). Click a pod name to filter the stacked view.",
+      "type": "timeseries",
+      "id": 3,
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "spanNulls": true,
+            "showPoints": "never",
+            "stacking": { "mode": "none" }
+          },
+          "links": [
+            {
+              "title": "Filter stacked view to ${__field.labels.pod}",
+              "url": "/d/kuadrant-pod-resources/kuadrant-pod-resources?var-pod=${__field.labels.pod}&${__url_time_range}",
+              "targetBlank": false
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"kuadrant-system\", container!=\"\", pod=~\"$pod\"}[5m]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "CPU Stacked",
+      "description": "Stacked view of pod CPU. Filtered by the pod selector.",
+      "type": "timeseries",
+      "id": 4,
+      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 40,
+            "spanNulls": true,
+            "showPoints": "never",
+            "stacking": { "mode": "normal" }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["mean", "max", "lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (pod) (rate(container_cpu_usage_seconds_total{namespace=\"kuadrant-system\", container!=\"\", pod=~\"$pod\"}[5m]))",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": ["kuadrant"],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(container_memory_working_set_bytes{namespace=\"kuadrant-system\", container!=\"\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(container_memory_working_set_bytes{namespace=\"kuadrant-system\", container!=\"\"}, pod)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Kuadrant Pod Resources",
+  "uid": "kuadrant-pod-resources"
+}

--- a/examples/dashboards/kustomization.yaml
+++ b/examples/dashboards/kustomization.yaml
@@ -22,7 +22,10 @@ configMapGenerator:
   - ./controller-resources-metrics.json    
 - name: grafana-dns-operator
   files:
-  - ./dns-operator.json    
+  - ./dns-operator.json
+- name: grafana-kuadrant-pod-resources
+  files:
+  - ./kuadrant-pod-resources.json
 
 generatorOptions:
   disableNameSuffixHash: true

--- a/examples/toystore/crc/authpolicy.yaml
+++ b/examples/toystore/crc/authpolicy.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: toystore
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: toystore
+  rules:
+    authentication:
+      "apikey":
+        apiKey:
+          selector:
+            matchLabels:
+              app: toystore
+        credentials:
+          authorizationHeader:
+            prefix: APIKEY
+    response:
+      success:
+        filters:
+          "ext_auth_data":
+            json:
+              properties:
+                "user-id":
+                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id

--- a/examples/toystore/crc/httproute.yaml
+++ b/examples/toystore/crc/httproute.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: toystore
+  labels:
+    app: toystore
+spec:
+  parentRefs:
+    - name: kuadrant-ingressgateway
+      namespace: gateway-system
+  hostnames: ["toystore.apps-crc.testing"]
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: "/toy"
+          method: GET
+        - path:
+            type: Exact
+            value: "/admin/toy"
+          method: POST
+        - path:
+            type: Exact
+            value: "/admin/toy"
+          method: DELETE
+      backendRefs:
+        - name: toystore
+          port: 80

--- a/examples/toystore/crc/kustomization.yaml
+++ b/examples/toystore/crc/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - route.yaml
+  - httproute.yaml
+  - authpolicy.yaml

--- a/examples/toystore/crc/route.yaml
+++ b/examples/toystore/crc/route.yaml
@@ -1,0 +1,15 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: toystore
+  namespace: gateway-system
+spec:
+  host: toystore.apps-crc.testing
+  to:
+    kind: Service
+    name: kuadrant-ingressgateway-istio
+  port:
+    targetPort: http
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/examples/toystore/crc/route.yaml
+++ b/examples/toystore/crc/route.yaml
@@ -2,7 +2,6 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: toystore
-  namespace: gateway-system
 spec:
   host: toystore.apps-crc.testing
   to:

--- a/hack/start-crc.sh
+++ b/hack/start-crc.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Start a CRC (OpenShift Local) VM for Kuadrant development.
+#
+# Assumes `crc setup` has already been run. Configures CPU and memory,
+# starts the VM, and prints instructions for connecting.
+#
+# Prerequisites:
+#   - crc installed (https://console.redhat.com/openshift/create/local)
+#   - crc setup already completed
+#   - A pull secret configured (prompted on first `crc start`)
+#
+# Usage:
+#   ./hack/start-crc.sh              # Start with defaults (8 CPU, 16 GB RAM)
+#   CRC_CPUS=6 ./hack/start-crc.sh   # Override CPU count
+#   ./hack/start-crc.sh stop         # Stop the VM
+#   ./hack/start-crc.sh status       # Check VM status
+
+set -euo pipefail
+
+CRC_CPUS="${CRC_CPUS:-8}"
+CRC_MEMORY="${CRC_MEMORY:-20480}"
+CRC_DISK="${CRC_DISK:-100}"
+CRC_PULL_SECRET="${CRC_PULL_SECRET:-${HOME}/.crc/pull-secret}"
+
+info()  { echo "[INFO]  $*"; }
+error() { echo "[ERROR] $*" >&2; }
+
+if ! command -v crc > /dev/null 2>&1; then
+    error "crc not found. Install it from: https://console.redhat.com/openshift/create/local"
+    exit 1
+fi
+
+ACTION="${1:-start}"
+
+case "$ACTION" in
+    stop)
+        info "Stopping CRC..."
+        crc stop
+        info "CRC stopped."
+        exit 0
+        ;;
+    status)
+        crc status
+        exit 0
+        ;;
+    start)
+        ;;
+    *)
+        error "Unknown action: $ACTION. Use: start, stop, status"
+        exit 1
+        ;;
+esac
+
+if crc status 2>/dev/null | grep -q "Running"; then
+    info "CRC is already running."
+    crc status
+    echo ""
+    info "To connect: eval \$(crc oc-env)"
+    exit 0
+fi
+
+info "Configuring CRC: ${CRC_CPUS} CPUs, ${CRC_MEMORY} MB RAM, ${CRC_DISK} GB disk, monitoring enabled"
+crc config set cpus "$CRC_CPUS"
+crc config set memory "$CRC_MEMORY"
+crc config set disk-size "$CRC_DISK"
+crc config set enable-cluster-monitoring true
+
+if [[ ! -f "$CRC_PULL_SECRET" ]]; then
+    error "Pull secret not found at: $CRC_PULL_SECRET"
+    error "Download from: https://console.redhat.com/openshift/create/local"
+    error "Save to ~/.crc/pull-secret or set CRC_PULL_SECRET=/path/to/file"
+    exit 1
+fi
+
+info "Starting CRC..."
+crc start --pull-secret-file "$CRC_PULL_SECRET"
+
+echo ""
+info "CRC is running."
+info ""
+info "  Connect:   eval \$(crc oc-env)"
+info "  Console:   crc console"
+info "  Credentials: crc console --credentials"
+info ""
+info "  Then run:  make crc-setup"

--- a/hack/test-toystore.sh
+++ b/hack/test-toystore.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Smoke test for toystore AuthPolicy and RateLimitPolicy on CRC.
+#
+# Usage:
+#   ./hack/test-toystore.sh          # Run all tests
+#   ./hack/test-toystore.sh auth     # Run only auth tests
+#   ./hack/test-toystore.sh rate     # Run only rate limit tests
+
+set -euo pipefail
+
+TOYSTORE_URL="${TOYSTORE_URL:-https://toystore.apps-crc.testing}"
+TOYSTORE_NAMESPACE="${TOYSTORE_NAMESPACE:-toystore}"
+RLP_NAME="${RLP_NAME:-toystore-httproute}"
+CURL="curl -sk --connect-timeout 5 -o /dev/null -w %{http_code}"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1 (expected $2, got $3)"; FAIL=$((FAIL + 1)); }
+
+assert_status() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$desc"
+    else
+        fail "$desc" "$expected" "$actual"
+    fi
+}
+
+request() {
+    local method="${1:-GET}" path="${2:-/toy}" key="${3:-}"
+    local args=(-X "$method")
+    [[ -n "$key" ]] && args+=(-H "Authorization: APIKEY $key")
+    $CURL "${args[@]}" "${TOYSTORE_URL}${path}"
+}
+
+# ── Read rate limits from cluster ──────────────────────────────────
+
+read_limits() {
+    local rlp
+    rlp=$(kubectl get ratelimitpolicy "$RLP_NAME" -n "$TOYSTORE_NAMESPACE" -o json 2>/dev/null) || {
+        echo "[WARN] Could not read RateLimitPolicy ${RLP_NAME} in ${TOYSTORE_NAMESPACE}, using defaults"
+        GET_TOY_LIMIT=5
+        GET_TOY_WINDOW="1m"
+        GLOBAL_LIMIT=6
+        GLOBAL_WINDOW="30s"
+        return
+    }
+
+    GET_TOY_LIMIT=$(echo "$rlp" | jq -r '.spec.limits["get-toy"].rates[0].limit // 5')
+    GET_TOY_WINDOW=$(echo "$rlp" | jq -r '.spec.limits["get-toy"].rates[0].window // "1m"')
+    GLOBAL_LIMIT=$(echo "$rlp" | jq -r '.spec.limits["global"].rates[0].limit // 6')
+    GLOBAL_WINDOW=$(echo "$rlp" | jq -r '.spec.limits["global"].rates[0].window // "30s"')
+}
+
+window_seconds() {
+    local w="$1"
+    if [[ "$w" =~ ^([0-9]+)s$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+    elif [[ "$w" =~ ^([0-9]+)m$ ]]; then
+        echo $((BASH_REMATCH[1] * 60))
+    else
+        echo "60"
+    fi
+}
+
+# ── Auth Tests ──────────────────────────────────────────────────────
+
+test_auth() {
+    echo ""
+    echo "=== Authentication Tests ==="
+    echo ""
+
+    echo "-- Unauthenticated requests should be rejected --"
+    assert_status "GET /toy without key returns 401" \
+        "401" "$(request GET /toy)"
+    assert_status "POST /admin/toy without key returns 401" \
+        "401" "$(request POST /admin/toy)"
+    assert_status "DELETE /admin/toy without key returns 401" \
+        "401" "$(request DELETE /admin/toy)"
+
+    echo ""
+    echo "-- Invalid key should be rejected --"
+    assert_status "GET /toy with wrong key returns 401" \
+        "401" "$(request GET /toy INVALIDKEY)"
+
+    echo ""
+    echo "-- Valid keys should be accepted --"
+    assert_status "GET /toy with Alice key returns 200" \
+        "200" "$(request GET /toy ALICEKEYFORDEMO)"
+    assert_status "GET /toy with Bob key returns 200" \
+        "200" "$(request GET /toy BOBKEYFORDEMO)"
+    assert_status "GET /toy with Admin key returns 200" \
+        "200" "$(request GET /toy IAMADMIN)"
+}
+
+# ── Rate Limit Tests ────────────────────────────────────────────────
+
+wait_for_window() {
+    local seconds="$1"
+    echo ""
+    echo "  (waiting ${seconds}s for rate limit window to reset...)"
+    sleep "$seconds"
+}
+
+test_rate_limit() {
+    read_limits
+
+    # The effective limit for GET /toy is min(get-toy, global)
+    local effective_limit=$GET_TOY_LIMIT
+    if [[ "$GLOBAL_LIMIT" -lt "$effective_limit" ]]; then
+        effective_limit=$GLOBAL_LIMIT
+    fi
+
+    # Send enough requests to exceed the limit
+    local total_requests=$((effective_limit + 2))
+
+    # Wait window is the longer of the two applicable windows
+    local get_toy_secs global_secs wait_secs
+    get_toy_secs=$(window_seconds "$GET_TOY_WINDOW")
+    global_secs=$(window_seconds "$GLOBAL_WINDOW")
+    wait_secs=$get_toy_secs
+    if [[ "$global_secs" -gt "$wait_secs" ]]; then
+        wait_secs=$global_secs
+    fi
+
+    echo ""
+    echo "=== Rate Limit Tests ==="
+    echo ""
+    echo "  Cluster config: get-toy=${GET_TOY_LIMIT}/${GET_TOY_WINDOW}, global=${GLOBAL_LIMIT}/${GLOBAL_WINDOW}"
+    echo "  Effective limit for GET /toy: ${effective_limit} (sending ${total_requests} requests)"
+
+    echo ""
+    echo "-- GET /toy rate limit: ${effective_limit} requests --"
+    wait_for_window $((wait_secs + 2))
+
+    local codes=()
+    for i in $(seq 1 "$total_requests"); do
+        codes+=("$(request GET /toy ALICEKEYFORDEMO)")
+    done
+
+    local ok=0 limited=0
+    for c in "${codes[@]}"; do
+        [[ "$c" == "200" ]] && ok=$((ok + 1))
+        [[ "$c" == "429" ]] && limited=$((limited + 1))
+    done
+
+    echo "  Results: ${ok} x 200, ${limited} x 429 (out of ${total_requests} requests)"
+
+    # Allow ±1 tolerance on the limit boundary
+    local min_ok=$((effective_limit - 1))
+    local max_ok=$((effective_limit + 1))
+    if [[ "$min_ok" -lt 1 ]]; then min_ok=1; fi
+
+    if [[ "$ok" -ge "$min_ok" && "$ok" -le "$max_ok" && "$limited" -ge 1 ]]; then
+        pass "Rate limiting engaged around ${effective_limit} requests (got ${ok} ok)"
+    else
+        fail "Rate limiting" "${min_ok}-${max_ok} ok, 1+ limited" "${ok} ok, ${limited} limited"
+    fi
+}
+
+# ── Main ────────────────────────────────────────────────────────────
+
+SUITE="${1:-all}"
+
+echo "Toystore Policy Smoke Tests"
+echo "URL: $TOYSTORE_URL"
+
+case "$SUITE" in
+    auth)     test_auth ;;
+    rate)     test_rate_limit ;;
+    all)      test_auth; test_rate_limit ;;
+    *)        echo "Usage: $0 [auth|rate|all]"; exit 1 ;;
+esac
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Results: $PASS passed, $FAIL failed"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+[[ "$FAIL" -eq 0 ]]

--- a/make/crc.mk
+++ b/make/crc.mk
@@ -1,0 +1,205 @@
+
+##@ CRC (OpenShift Local)
+
+## Targets to deploy Kuadrant on a CRC cluster for development and network policy testing.
+## Requires: crc installed and running (`./hack/start-crc.sh`), `eval $(crc oc-env)`.
+
+CRC_REGISTRY ?= default-route-openshift-image-registry.apps-crc.testing
+CRC_IMG ?= $(CRC_REGISTRY)/$(KUADRANT_NAMESPACE)/kuadrant-operator:dev
+
+.PHONY: crc-check
+crc-check: ## Verify CRC is running and reachable
+	@command -v crc > /dev/null 2>&1 || { echo "[ERROR] crc not found. Install from: https://console.redhat.com/openshift/create/local"; exit 1; }
+	@crc status 2>/dev/null | grep -q "Running" || { echo "[ERROR] CRC is not running. Start it with: ./hack/start-crc.sh"; exit 1; }
+	@oc whoami > /dev/null 2>&1 || { echo "[ERROR] Cannot reach CRC. Run: eval \$$(crc oc-env)"; exit 1; }
+	@echo "[INFO] CRC is running, logged in as $$(oc whoami)"
+
+.PHONY: crc-registry-login
+crc-registry-login: crc-check ## Log in to the CRC internal registry
+	@oc registry login --insecure=true 2>/dev/null || true
+	@$(CONTAINER_ENGINE) login --tls-verify=false -u $$(oc whoami) -p $$(oc whoami -t) $(CRC_REGISTRY)
+
+TOYSTORE_NAMESPACE ?= toystore
+
+.PHONY: crc-setup
+crc-setup: ## Deploy Kuadrant operator, dependencies, observability, and sample app on CRC
+	$(MAKE) crc-env-setup GATEWAYAPI_PROVIDER=$(GATEWAYAPI_PROVIDER)
+	$(MAKE) crc-network-policies
+	$(MAKE) crc-deploy
+	$(MAKE) crc-deploy-observability
+	$(MAKE) crc-deploy-sample
+
+.PHONY: crc-network-policies
+crc-network-policies: ## Apply network policices to lock down pod to pod connections
+	kubectl apply -k ./config/network-policy
+
+
+.PHONY: crc-env-setup
+crc-env-setup: ## Install dependencies and gateway provider on CRC
+	$(MAKE) crc-check
+	$(MAKE) crc-$(GATEWAYAPI_PROVIDER)-env-setup ISTIO_INSTALL_SAIL=$(ISTIO_INSTALL_SAIL)
+
+.PHONY: crc-k8s-env-setup
+crc-k8s-env-setup: kustomize dependencies-manifests ## Install Kuadrant CRDs and dependencies on CRC (no MetalLB, no metrics-server, no observability CRDs)
+	kubectl create namespace $(KUADRANT_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	$(MAKE) install-cert-manager
+	$(KUSTOMIZE) build config/dependencies | kubectl apply --server-side -f -
+	kubectl -n "$(KUADRANT_NAMESPACE)" wait --timeout=300s --for=condition=Available deployments --all
+	$(MAKE) install
+
+.PHONY: crc-gatewayapi-env-setup
+crc-gatewayapi-env-setup: ## Install GatewayAPI CRDs and crc-k8s-env-setup (skips CRD install — OpenShift manages them)
+	$(MAKE) crc-k8s-env-setup
+
+.PHONY: crc-istio-env-setup
+crc-istio-env-setup: ## Install Istio, gateway, and crc-gatewayapi-env-setup
+	$(MAKE) crc-gatewayapi-env-setup
+	@if $(HELM) status sail-operator -n $(ISTIO_NAMESPACE) > /dev/null 2>&1; then \
+		echo "[INFO] Sail operator already installed, skipping"; \
+	else \
+		$(MAKE) istio-install ISTIO_INSTALL_SAIL=$(ISTIO_INSTALL_SAIL); \
+	fi
+	$(MAKE) deploy-istio-gateway
+	kubectl annotate gateway kuadrant-ingressgateway -n gateway-system \
+		networking.istio.io/service-type=ClusterIP --overwrite
+
+.PHONY: crc-envoygateway-env-setup
+crc-envoygateway-env-setup: ## Install Envoy Gateway and crc-k8s-env-setup
+	$(MAKE) crc-k8s-env-setup
+	@if $(HELM) status eg -n $(EG_NAMESPACE) > /dev/null 2>&1; then \
+		echo "[INFO] Envoy Gateway already installed, skipping"; \
+	else \
+		$(MAKE) envoy-gateway-install; \
+	fi
+	$(MAKE) deploy-eg-gateway
+
+.PHONY: crc-deploy
+crc-deploy: ## Build, push, and deploy the operator on CRC
+	$(MAKE) docker-build IMG=$(CRC_IMG)
+	$(MAKE) crc-registry-login
+	$(MAKE) crc-push IMG=$(CRC_IMG)
+	$(MAKE) deploy IMG=$(CRC_IMG)
+	kubectl -n $(KUADRANT_NAMESPACE) wait --timeout=300s --for=condition=Available deployments --all
+	kubectl apply -f config/install/configure/standard/kuadrant.yaml
+	kubectl -n $(KUADRANT_NAMESPACE) wait --timeout=300s --for=condition=Ready kuadrant/kuadrant
+	@echo "[INFO] Enabling Kuadrant console plugin..."
+	@if oc get consoles.operator.openshift.io cluster -o jsonpath='{.spec.plugins}' 2>/dev/null | grep -q kuadrant-console-plugin; then \
+		echo "[INFO] Console plugin already enabled"; \
+	else \
+		oc patch consoles.operator.openshift.io cluster --type json \
+			--patch '[{"op":"add","path":"/spec/plugins/-","value":"kuadrant-console-plugin"}]'; \
+	fi
+
+.PHONY: crc-push
+crc-push: ## Push operator image to CRC internal registry
+	$(CONTAINER_ENGINE) push --tls-verify=false $(IMG)
+
+.PHONY: crc-deploy-observability
+crc-deploy-observability: kustomize helm ## Deploy observability stack on CRC (Grafana, Jaeger, tracing, dashboards)
+	@echo "[INFO] Enabling user workload monitoring..."
+	kubectl apply -f config/observability/crc/user-workload-monitoring.yaml
+	kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
+	@echo "[INFO] Deploying ServiceMonitors for Kuadrant operators..."
+	kubectl apply -f config/observability/prometheus/monitors/operators.yaml
+	@echo "[INFO] Generating custom-resource-state ConfigMap for kube-state-metrics..."
+	$(KUSTOMIZE) build github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.7.0 | kubectl apply -f -
+	@echo "[INFO] Deploying kube-state-metrics for Kuadrant CRDs..."
+	kubectl apply -f config/observability/openshift/kube-state-metrics.yaml
+	@echo "[INFO] Deploying Istio telemetry for Prometheus metrics..."
+	-kubectl apply -f config/observability/openshift/telemetry.yaml
+	@echo "[INFO] Installing Grafana Operator..."
+	kubectl apply -f config/observability/openshift/grafana/subscription.yaml
+	@echo "[INFO] Waiting for OLM to install Grafana operator..."
+	@for i in $$(seq 1 60); do \
+		kubectl get crd grafanas.grafana.integreatly.org > /dev/null 2>&1 && break; \
+		sleep 5; \
+	done
+	kubectl wait --for=condition=Established crd/grafanas.grafana.integreatly.org --timeout=300s
+	kubectl wait --for=condition=Established crd/grafanadatasources.grafana.integreatly.org --timeout=60s
+	kubectl wait --for=condition=Established crd/grafanadashboards.grafana.integreatly.org --timeout=60s
+	@echo "[INFO] Deploying Grafana service account and RBAC..."
+	kubectl apply -f config/observability/crc/grafana-sa.yaml
+	@echo "[INFO] Deploying Grafana instance..."
+	kubectl apply -n monitoring -f config/observability/openshift/grafana/grafana.yaml
+	@echo "[INFO] Deploying Grafana datasource (CRC-local Thanos)..."
+	kubectl apply -f config/observability/crc/grafana-datasource.yaml
+	@echo "[INFO] Deploying dashboard ConfigMaps..."
+	$(KUSTOMIZE) build examples/dashboards | kubectl apply -f -
+	@echo "[INFO] Deploying GrafanaDashboard resources..."
+	kubectl apply -n monitoring -f config/observability/openshift/grafana/dashboards.yaml
+	@echo "[INFO] Installing Jaeger..."
+	$(MAKE) install-jaeger JAEGER_HELM_EXTRA_ARGS="-f config/observability/openshift/jaeger-values.yaml"
+	kubectl apply -f config/observability/openshift/jaeger-route.yaml
+	@echo "[INFO] Deploying tracing configurations..."
+	$(MAKE) deploy-tracing
+	@echo "[INFO] Observability stack deployed successfully!"
+
+.PHONY: crc-deploy-sample
+crc-deploy-sample: ## Deploy toystore sample app with AuthPolicy and RateLimitPolicy
+	@echo "[INFO] Deploying toystore sample application..."
+	kubectl create namespace $(TOYSTORE_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/toystore.yaml
+	kubectl -n $(TOYSTORE_NAMESPACE) wait --timeout=120s --for=condition=Available deployment/toystore
+	@echo "[INFO] Deploying API key secrets..."
+	kubectl apply -n $(KUADRANT_NAMESPACE) -f examples/toystore/alice-api-key-secret.yaml
+	kubectl apply -n $(KUADRANT_NAMESPACE) -f examples/toystore/bob-api-key-secret.yaml
+	kubectl apply -n $(KUADRANT_NAMESPACE) -f examples/toystore/admin-key-secret.yaml
+	@echo "[INFO] Deploying HTTPRoute (CRC)..."
+	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/crc/httproute.yaml
+	@echo "[INFO] Deploying AuthPolicy..."
+	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/crc/authpolicy.yaml
+	@echo "[INFO] Deploying RateLimitPolicy..."
+	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/ratelimitpolicy_httproute.yaml
+	@echo "[INFO] Creating OpenShift Route for toystore..."
+	kubectl apply -f examples/toystore/crc/route.yaml
+	@echo ""
+	@echo "=== CRC Setup Complete ==="
+	@echo ""
+	@echo "Dashboards:"
+	@echo "  Console:  https://console-openshift-console.apps-crc.testing  (kubeadmin / $$(crc console --credentials 2>/dev/null | grep kubeadmin | sed 's/.*-p //' | sed 's/ .*//'))"
+	@echo "  Grafana:  https://$$(oc get route -n monitoring grafana-route -o jsonpath='{.spec.host}')  (root / secret)"
+	@echo "  Jaeger:   https://$$(oc get route -n observability jaeger -o jsonpath='{.spec.host}')"
+	@echo ""
+	@echo "Toystore sample app:"
+	@echo "  URL:      https://toystore.apps-crc.testing"
+	@echo ""
+	@echo "  Test authenticated request:"
+	@echo "    curl -sk https://toystore.apps-crc.testing/toy -H 'Authorization: APIKEY ALICEKEYFORDEMO'"
+	@echo ""
+	@echo "  Test unauthenticated request (should return 401):"
+	@echo "    curl -sk https://toystore.apps-crc.testing/toy"
+	@echo ""
+	@echo "  Test rate limiting (6 req/30s global limit — 7th should return 429):"
+	@echo '    for i in $$(seq 1 7); do curl -sk -o /dev/null -w "%{http_code}\n" https://toystore.apps-crc.testing/toy -H "Authorization: APIKEY ALICEKEYFORDEMO"; done'
+	@echo ""
+
+.PHONY: crc-cleanup-sample
+crc-cleanup-sample: ## Remove toystore sample app from CRC
+	-kubectl delete -f examples/toystore/crc/route.yaml
+	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/ratelimitpolicy_httproute.yaml
+	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/crc/authpolicy.yaml
+	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/crc/httproute.yaml
+	-kubectl delete -n $(KUADRANT_NAMESPACE) -f examples/toystore/admin-key-secret.yaml
+	-kubectl delete -n $(KUADRANT_NAMESPACE) -f examples/toystore/bob-api-key-secret.yaml
+	-kubectl delete -n $(KUADRANT_NAMESPACE) -f examples/toystore/alice-api-key-secret.yaml
+	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/toystore.yaml
+	-kubectl delete namespace $(TOYSTORE_NAMESPACE)
+
+.PHONY: crc-cleanup-observability
+crc-cleanup-observability: ## Remove observability components from CRC
+	-$(MAKE) uninstall-jaeger
+	-kubectl delete -f config/observability/openshift/jaeger-route.yaml
+	-kubectl delete -n monitoring -f config/observability/openshift/grafana/dashboards.yaml
+	-kubectl delete -f config/observability/crc/grafana-datasource.yaml
+	-kubectl delete -n monitoring -f config/observability/openshift/grafana/grafana.yaml
+	-kubectl delete -f config/observability/crc/grafana-sa.yaml
+	-kubectl delete -f config/observability/openshift/grafana/subscription.yaml
+	-kubectl delete -f config/observability/openshift/kube-state-metrics.yaml
+	-kubectl delete -f config/observability/prometheus/monitors/operators.yaml
+
+.PHONY: crc-cleanup
+crc-cleanup: ## Remove Kuadrant operator and CRDs from CRC (does not stop the VM)
+	-$(MAKE) crc-cleanup-sample
+	-$(MAKE) crc-cleanup-observability
+	-$(MAKE) undeploy
+	-$(MAKE) uninstall

--- a/make/crc.mk
+++ b/make/crc.mk
@@ -31,7 +31,7 @@ crc-setup: ## Deploy Kuadrant operator, dependencies, observability, and sample 
 
 .PHONY: crc-network-policies
 crc-network-policies: ## Apply network policices to lock down pod to pod connections
-	kubectl apply -k ./config/network-policy
+	kubectl apply -k ./config/network-policy-standard
 
 
 .PHONY: crc-env-setup
@@ -80,8 +80,6 @@ crc-deploy: ## Build, push, and deploy the operator on CRC
 	$(MAKE) crc-push IMG=$(CRC_IMG)
 	$(MAKE) deploy IMG=$(CRC_IMG)
 	kubectl -n $(KUADRANT_NAMESPACE) wait --timeout=300s --for=condition=Available deployments --all
-	kubectl apply -f config/install/configure/standard/kuadrant.yaml
-	kubectl -n $(KUADRANT_NAMESPACE) wait --timeout=300s --for=condition=Ready kuadrant/kuadrant
 	@echo "[INFO] Enabling Kuadrant console plugin..."
 	@if oc get consoles.operator.openshift.io cluster -o jsonpath='{.spec.plugins}' 2>/dev/null | grep -q kuadrant-console-plugin; then \
 		echo "[INFO] Console plugin already enabled"; \
@@ -99,8 +97,6 @@ crc-deploy-observability: kustomize helm ## Deploy observability stack on CRC (G
 	@echo "[INFO] Enabling user workload monitoring..."
 	kubectl apply -f config/observability/crc/user-workload-monitoring.yaml
 	kubectl create namespace monitoring --dry-run=client -o yaml | kubectl apply -f -
-	@echo "[INFO] Deploying ServiceMonitors for Kuadrant operators..."
-	kubectl apply -f config/observability/prometheus/monitors/operators.yaml
 	@echo "[INFO] Generating custom-resource-state ConfigMap for kube-state-metrics..."
 	$(KUSTOMIZE) build github.com/Kuadrant/gateway-api-state-metrics/config/kuadrant?ref=0.7.0 | kubectl apply -f -
 	@echo "[INFO] Deploying kube-state-metrics for Kuadrant CRDs..."
@@ -135,15 +131,18 @@ crc-deploy-observability: kustomize helm ## Deploy observability stack on CRC (G
 	@echo "[INFO] Observability stack deployed successfully!"
 
 .PHONY: crc-deploy-sample
-crc-deploy-sample: ## Deploy toystore sample app with AuthPolicy and RateLimitPolicy
-	@echo "[INFO] Deploying toystore sample application..."
+crc-deploy-sample: ## Deploy Kuadrant CR and toystore sample app with AuthPolicy and RateLimitPolicy
 	kubectl create namespace $(TOYSTORE_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
+	@echo "[INFO] Deploying Kuadrant CR to $(TOYSTORE_NAMESPACE)..."
+	sed 's/namespace: kuadrant-system/namespace: $(TOYSTORE_NAMESPACE)/' config/install/configure/standard/kuadrant.yaml | kubectl apply -f -
+	kubectl -n $(TOYSTORE_NAMESPACE) wait --timeout=300s --for=condition=Ready kuadrant/kuadrant
+	@echo "[INFO] Deploying toystore sample application..."
 	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/toystore.yaml
 	kubectl -n $(TOYSTORE_NAMESPACE) wait --timeout=120s --for=condition=Available deployment/toystore
 	@echo "[INFO] Deploying API key secrets..."
-	kubectl apply -n $(KUADRANT_NAMESPACE) -f examples/toystore/alice-api-key-secret.yaml
-	kubectl apply -n $(KUADRANT_NAMESPACE) -f examples/toystore/bob-api-key-secret.yaml
-	kubectl apply -n $(KUADRANT_NAMESPACE) -f examples/toystore/admin-key-secret.yaml
+	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/alice-api-key-secret.yaml
+	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/bob-api-key-secret.yaml
+	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/admin-key-secret.yaml
 	@echo "[INFO] Deploying HTTPRoute (CRC)..."
 	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/crc/httproute.yaml
 	@echo "[INFO] Deploying AuthPolicy..."
@@ -151,7 +150,7 @@ crc-deploy-sample: ## Deploy toystore sample app with AuthPolicy and RateLimitPo
 	@echo "[INFO] Deploying RateLimitPolicy..."
 	kubectl apply -n $(TOYSTORE_NAMESPACE) -f examples/toystore/ratelimitpolicy_httproute.yaml
 	@echo "[INFO] Creating OpenShift Route for toystore..."
-	kubectl apply -f examples/toystore/crc/route.yaml
+	kubectl apply -n gateway-system -f examples/toystore/crc/route.yaml
 	@echo ""
 	@echo "=== CRC Setup Complete ==="
 	@echo ""
@@ -174,15 +173,16 @@ crc-deploy-sample: ## Deploy toystore sample app with AuthPolicy and RateLimitPo
 	@echo ""
 
 .PHONY: crc-cleanup-sample
-crc-cleanup-sample: ## Remove toystore sample app from CRC
-	-kubectl delete -f examples/toystore/crc/route.yaml
+crc-cleanup-sample: ## Remove toystore sample app and Kuadrant CR from CRC
+	-kubectl delete -n gateway-system -f examples/toystore/crc/route.yaml
 	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/ratelimitpolicy_httproute.yaml
 	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/crc/authpolicy.yaml
 	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/crc/httproute.yaml
-	-kubectl delete -n $(KUADRANT_NAMESPACE) -f examples/toystore/admin-key-secret.yaml
-	-kubectl delete -n $(KUADRANT_NAMESPACE) -f examples/toystore/bob-api-key-secret.yaml
-	-kubectl delete -n $(KUADRANT_NAMESPACE) -f examples/toystore/alice-api-key-secret.yaml
+	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/admin-key-secret.yaml
+	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/bob-api-key-secret.yaml
+	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/alice-api-key-secret.yaml
 	-kubectl delete -n $(TOYSTORE_NAMESPACE) -f examples/toystore/toystore.yaml
+	-kubectl -n $(TOYSTORE_NAMESPACE) delete kuadrant/kuadrant
 	-kubectl delete namespace $(TOYSTORE_NAMESPACE)
 
 .PHONY: crc-cleanup-observability
@@ -195,7 +195,6 @@ crc-cleanup-observability: ## Remove observability components from CRC
 	-kubectl delete -f config/observability/crc/grafana-sa.yaml
 	-kubectl delete -f config/observability/openshift/grafana/subscription.yaml
 	-kubectl delete -f config/observability/openshift/kube-state-metrics.yaml
-	-kubectl delete -f config/observability/prometheus/monitors/operators.yaml
 
 .PHONY: crc-cleanup
 crc-cleanup: ## Remove Kuadrant operator and CRDs from CRC (does not stop the VM)

--- a/make/istio.mk
+++ b/make/istio.mk
@@ -40,6 +40,7 @@ sail-install: helm
 		--wait \
 		--timeout=300s \
 		https://github.com/istio-ecosystem/sail-operator/releases/download/$(SAIL_VERSION)/sail-operator-$(SAIL_VERSION).tgz
+	kubectl wait --for=condition=Established crd/istios.sailoperator.io --timeout=300s
 	kubectl apply -f $(ISTIO_INSTALL_DIR)/sail/istio.yaml
 
 .PHONY: sail-uninstall

--- a/make/observability.mk
+++ b/make/observability.mk
@@ -21,6 +21,7 @@ dashboard-cleanup:
 
 JAEGER_NAMESPACE ?= observability
 JAEGER_RELEASE_NAME ?= jaeger
+JAEGER_HELM_EXTRA_ARGS ?=
 
 .PHONY: install-jaeger
 install-jaeger: helm ## Install Jaeger v2 using Helm for distributed tracing
@@ -30,7 +31,8 @@ install-jaeger: helm ## Install Jaeger v2 using Helm for distributed tracing
 	$(HELM) repo update jaegertracing
 	$(HELM) upgrade --install $(JAEGER_RELEASE_NAME) jaegertracing/jaeger \
 		--namespace $(JAEGER_NAMESPACE) \
-		--wait
+		--wait \
+		$(JAEGER_HELM_EXTRA_ARGS)
 	@echo "✅ Jaeger v2 installed successfully!"
 	@echo "   Service: $(JAEGER_RELEASE_NAME).$(JAEGER_NAMESPACE).svc.cluster.local:4317 (OTLP gRPC)"
 	@echo "   Query UI: make jaeger-port-forward (then open http://localhost:16686)"

--- a/make/observability.mk
+++ b/make/observability.mk
@@ -53,6 +53,13 @@ jaeger-port-forward: ## Port-forward to Jaeger Query UI (http://localhost:16686)
 deploy-tracing: kustomize ## Apply tracing configurations for Istio and Kuadrant components
 	@echo "Deploying tracing configurations via kustomize..."
 	$(KUSTOMIZE) build config/observability/tracing | kubectl apply -f -
+	@echo "[INFO] Patching Kuadrant CR with tracing configuration..."
+	kubectl patch kuadrant/kuadrant -n $(TOYSTORE_NAMESPACE) --type merge \
+		-p '{"spec":{"observability":{"enable":true,"tracing":{"defaultEndpoint":"rpc://jaeger.observability.svc.cluster.local:4317","insecure":true},"dataPlane":{"httpHeaderIdentifier":"x-request-id"}}}}'
+	@echo "[INFO] Patching operator deployments with OTEL env vars..."
+	kubectl patch deployment kuadrant-operator-controller-manager -n $(KUADRANT_NAMESPACE) --type strategic \
+		-p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","env":[{"name":"OTEL_EXPORTER_OTLP_ENDPOINT","value":"rpc://jaeger.observability.svc.cluster.local:4317"},{"name":"OTEL_EXPORTER_OTLP_INSECURE","value":"true"}]}]}}}}'
+	kubectl patch deployment limitador-operator-controller-manager -n $(KUADRANT_NAMESPACE) --type strategic \
+		-p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","env":[{"name":"OTEL_EXPORTER_OTLP_ENDPOINT","value":"rpc://jaeger.observability.svc.cluster.local:4317"},{"name":"OTEL_EXPORTER_OTLP_INSECURE","value":"true"}]}]}}}}'
 	@echo "✅ Tracing configurations applied"
-	@echo "   Note: Operator patches require manual kubectl patch (see config/observability/tracing/README.md)"
 	@echo "   Open Jaeger UI: make jaeger-port-forward"


### PR DESCRIPTION
# Summary

This branch adds a complete development environment setup for deploying Kuadrant on a CRC (OpenShift Local) cluster. It provides make targets for installing the operator, dependencies, observability tooling, and a sample application, along with AdminNetworkPolicies to lock down pod-to-pod communication in the kuadrant-system namespace.

This work is primarily for local development and network policy testing. It may not be merged to main.

# What's Included

- **CRC make targets** (`make/crc.mk`): A full lifecycle for CRC-based development -- `crc-setup` orchestrates environment setup, operator build/push/deploy, observability stack, and sample app deployment. Includes cleanup targets for teardown.
- **AdminNetworkPolicies**: A deny-by-default network policy model for the kuadrant-system namespace using Kubernetes AdminNetworkPolicy (v1alpha1). Each component (kuadrant-operator, authorino, authorino-operator, limitador, limitador-operator, dns-operator) gets its own policy allowing only the specific ingress/egress it needs, with a BaselineAdminNetworkPolicy denying everything else.
- **CRC observability**: OpenShift-specific Grafana datasource configuration using a ServiceAccount token to authenticate against the in-cluster Thanos querier. Includes user workload monitoring enablement, Jaeger with OpenShift-compatible security contexts, and an OpenShift Route for the Jaeger UI.
- **Kuadrant Pod Resources dashboard**: A Grafana dashboard showing per-pod memory and CPU usage for the kuadrant-system namespace, with stacked and individual views and click-to-filter interactivity.
- **Toystore CRC examples**: CRC-specific HTTPRoute, AuthPolicy, and OpenShift Route for the toystore sample app, configured for the `apps-crc.testing` domain.
- **CRC start script** (`hack/start-crc.sh`): Configures and starts a CRC VM with sensible defaults for Kuadrant development (8 CPU, 20 GB RAM, 100 GB disk, monitoring enabled).
- **Toystore smoke tests** (`hack/test-toystore.sh`): Automated smoke tests verifying AuthPolicy (unauthenticated rejection, invalid/valid API keys) and RateLimitPolicy (rate limiting engagement) against the deployed toystore app.
- **OSSM 3.x support plan**: A design document for adding optional OpenShift Service Mesh 3.x support as an alternative to upstream Sail for Istio installation.
- **OpenShift security hardening**: Adds `runAsNonRoot` and `seccompProfile: RuntimeDefault` to kube-state-metrics to satisfy OpenShift restricted SCC requirements. Adds OpenShift-compatible Jaeger Helm values that clear uid/gid fields and set required security contexts.
- **Sail install reliability**: Adds a `kubectl wait --for=condition=Established` for the Istio CRD after Sail Helm install, preventing races where the Istio CR is applied before the CRD is registered.
- **Jaeger Helm extensibility**: Adds a `JAEGER_HELM_EXTRA_ARGS` variable to `make/observability.mk`, allowing the CRC setup to pass OpenShift-specific values without modifying the shared target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenShift Local (CRC) setup, deployment, observability, sample application, and cleanup workflows.
  * Added secure Toystore routing and API-key authentication examples, with smoke tests for authentication and rate limiting.
  * Added Grafana pod-resource dashboards, Prometheus integration, user workload monitoring, and Jaeger access.
  * Added optional OSSM 3.x support guidance.
* **Security**
  * Added network policies with default-deny traffic and explicit access for required services.
  * Strengthened workload security settings, including non-root execution and restricted capabilities.
* **Documentation**
  * Added instructions for configuring and validating OSSM support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->