### PR TITLE
Add AdminNetworkPolicies for kuadrant-system namespace

### DIFF
--- a/config/network-policy/authorino-operator.yaml
+++ b/config/network-policy/authorino-operator.yaml
@@ -1,0 +1,35 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-authorino-operator
+spec:
+  priority: 52
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          control-plane: authorino-operator
+  ingress:
+    - name: allow-metrics
+      action: Allow
+      from:
+        - namespaces: {}
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 8080
+  egress:
+    # this may never be need
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/authorino.yaml
+++ b/config/network-policy/authorino.yaml
@@ -1,0 +1,69 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-authorino
+spec:
+  priority: 51
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          authorino-resource: authorino
+  ingress:
+    - name: allow-authorization-grpc
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 50051
+    - name: allow-authorization-http
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 5001
+    - name: allow-oidc
+      action: Allow
+      from:
+        - namespaces: {}
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 8083
+  egress:
+    - name: allow-external-oidc
+      action: Allow
+      to:
+        - networks:
+            - 0.0.0.0/0
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 443
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/console-plugin.yaml
+++ b/config/network-policy/console-plugin.yaml
@@ -1,0 +1,25 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-console-plugin
+spec:
+  priority: 56
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          app: kuadrant-console-plugin
+  ingress:
+    - name: allow-console
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-console
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 9443

--- a/config/network-policy/deny-all.yaml
+++ b/config/network-policy/deny-all.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: BaselineAdminNetworkPolicy
+metadata:
+  name: default
+spec:
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: kuadrant-system
+  ingress:
+    - name: deny-all-ingress
+      action: Deny
+      from:
+        - namespaces: {}
+  egress:
+    - name: deny-all-egress
+      action: Deny
+      to:
+        - namespaces: {}

--- a/config/network-policy/dns-operator.yaml
+++ b/config/network-policy/dns-operator.yaml
@@ -1,0 +1,55 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-dns-operator
+spec:
+  priority: 53
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          control-plane: dns-operator-controller-manager
+  # ingress:
+    # only need if we plan to share the golang exposed metrics.
+    # - name: allow-metrics
+    #   action: Allow
+    #   from:
+    #     - namespaces: {}
+    #   ports:
+    #     - portNumber:
+    #         protocol: TCP
+    #         port: 8080
+  egress:
+    # TODO: Scope 0.0.0.0/0 to specific DNS provider API CIDRs (e.g. AWS, Azure, GCP)
+    - name: allow-external-dns-providers
+      action: Allow
+      to:
+        - networks:
+            - 0.0.0.0/0
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 443
+    # TODO: Scope 0.0.0.0/0 to known remote cluster API server IPs
+    - name: allow-remote-api-servers
+      action: Allow
+      to:
+        - networks:
+            - 0.0.0.0/0
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 6443
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/kuadrant-operator.yaml
+++ b/config/network-policy/kuadrant-operator.yaml
@@ -1,0 +1,69 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-operator
+spec:
+  priority: 50
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          app: kuadrant
+          control-plane: controller-manager
+  ingress:
+    # only need if we plan to share the golang exposed metrics.
+    # - name: allow-metrics
+    #   action: Allow
+    #   from:
+    #     - namespaces: {}
+    #   ports:
+    #     - portNumber:
+    #         protocol: TCP
+    #         port: 8080
+    - name: allow-grpc
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: kuadrant-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 50051
+    - name: allow-wasm
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 8082
+  egress:
+    - name: allow-otlp-traces
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 4317
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - kuadrant-operator.yaml
   - authorino.yaml
   - authorino-operator.yaml
+  - console-plugin.yaml
   - dns-operator.yaml
   - limitador.yaml
   - limitador-operator.yaml

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - kuadrant-operator.yaml
+  - authorino.yaml
+  - authorino-operator.yaml
+  - dns-operator.yaml
+  - limitador.yaml
+  - limitador-operator.yaml
+  - deny-all.yaml

--- a/config/network-policy/limitador-operator.yaml
+++ b/config/network-policy/limitador-operator.yaml
@@ -1,0 +1,46 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-limitador-operator
+spec:
+  priority: 55
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          app: limitador-operator
+          control-plane: controller-manager
+  ingress:
+    # need to allow access to the go metrics.
+    # - name: allow-metrics
+    #   action: Allow
+    #   from:
+    #     - namespaces: {}
+    #   ports:
+    #     - portNumber:
+    #         protocol: TCP
+    #         port: 8080
+  egress:
+    - name: allow-otlp-traces
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 4317
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/network-policy/limitador.yaml
+++ b/config/network-policy/limitador.yaml
@@ -1,0 +1,64 @@
+apiVersion: policy.networking.k8s.io/v1alpha1
+kind: AdminNetworkPolicy
+metadata:
+  name: kuadrant-limitador
+spec:
+  priority: 54
+  subject:
+    pods:
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kuadrant-system
+      podSelector:
+        matchLabels:
+          app: limitador
+          limitador-resource: limitador
+  ingress:
+    # Possible need to allow metrics scraping.
+    # - name: allow-status-http
+    #   action: Allow
+    #   from:
+    #     - namespaces:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: openshift-monitoring
+    #     - namespaces:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: openshift-user-workload-monitoring
+    #   ports:
+    #     - portNumber:
+    #         protocol: TCP
+    #         port: 8080
+    - name: allow-grpc
+      action: Allow
+      from:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 8081
+  egress:
+    - name: allow-otlp-traces
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - portNumber:
+            protocol: TCP
+            port: 4317
+    - name: allow-dns
+      action: Allow
+      to:
+        - namespaces:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - portNumber:
+            protocol: UDP
+            port: 5353

--- a/config/networkpolicy/authorino-operator.yaml
+++ b/config/networkpolicy/authorino-operator.yaml
@@ -1,0 +1,28 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-authorino-operator
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: authorino-operator
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # controller-runtime metrics
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353

--- a/config/networkpolicy/authorino.yaml
+++ b/config/networkpolicy/authorino.yaml
@@ -1,0 +1,57 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-authorino
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      authorino-resource: authorino
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # gRPC ext-auth from Envoy
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 50051
+    # HTTP ext-auth from Envoy
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 5001
+    # OIDC discovery endpoint
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8083
+  egress:
+    # External OIDC provider communication
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353

--- a/config/networkpolicy/console-plugin.yaml
+++ b/config/networkpolicy/console-plugin.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-console-plugin
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      app: kuadrant-console-plugin
+  policyTypes:
+    - Ingress
+  ingress:
+    # OpenShift console fetching plugin assets
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-console
+      ports:
+        - protocol: TCP
+          port: 9443

--- a/config/networkpolicy/deny-all.yaml
+++ b/config/networkpolicy/deny-all.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: kuadrant-system
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/config/networkpolicy/dns-operator.yaml
+++ b/config/networkpolicy/dns-operator.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-dns-operator
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: dns-operator-controller-manager
+  policyTypes:
+    - Egress
+  egress:
+    # TODO: Scope 0.0.0.0/0 to specific DNS provider API CIDRs (e.g. AWS, Azure, GCP)
+    # External DNS provider APIs
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+    # TODO: Scope 0.0.0.0/0 to known remote cluster API server IPs
+    # Remote cluster API servers (multi-cluster)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 6443
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353

--- a/config/networkpolicy/kuadrant-operator.yaml
+++ b/config/networkpolicy/kuadrant-operator.yaml
@@ -1,0 +1,50 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-operator
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      app: kuadrant
+      control-plane: controller-manager
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # gRPC for OOP extensions
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kuadrant-system
+      ports:
+        - protocol: TCP
+          port: 50051
+    # wasm plugin binary fetch
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 8082
+  egress:
+    # OTLP trace export
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - protocol: TCP
+          port: 4317
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353

--- a/config/networkpolicy/kustomization.yaml
+++ b/config/networkpolicy/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - kuadrant-operator.yaml
+  - authorino.yaml
+  - authorino-operator.yaml
+  - console-plugin.yaml
+  - dns-operator.yaml
+  - limitador.yaml
+  - limitador-operator.yaml
+  - deny-all.yaml

--- a/config/networkpolicy/limitador-operator.yaml
+++ b/config/networkpolicy/limitador-operator.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-limitador-operator
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      app: limitador-operator
+      control-plane: controller-manager
+  policyTypes:
+    - Egress
+  egress:
+    # OTLP trace export
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - protocol: TCP
+          port: 4317
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353

--- a/config/networkpolicy/limitador.yaml
+++ b/config/networkpolicy/limitador.yaml
@@ -1,0 +1,42 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kuadrant-limitador
+  namespace: kuadrant-system
+spec:
+  podSelector:
+    matchLabels:
+      app: limitador
+      limitador-resource: limitador
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # gRPC rate limit checks from Envoy
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: gateway-system
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-system
+      ports:
+        - protocol: TCP
+          port: 8081
+  egress:
+    # OTLP trace export
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: observability
+      ports:
+        - protocol: TCP
+          port: 4317
+    # DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+      ports:
+        - protocol: UDP
+          port: 5353


### PR DESCRIPTION

# Summary

Introduces a deny-by-default network policy model for the `kuadrant-system` namespace using Kubernetes AdminNetworkPolicy and BaselineAdminNetworkPolicy (`policy.networking.k8s.io/v1alpha1`). A `BaselineAdminNetworkPolicy` denies all ingress and egress for the namespace, and per-component `AdminNetworkPolicy` resources selectively allow only the traffic each component requires.

Components covered:

- **kuadrant-operator** (priority 50): gRPC from extensions, wasm serving to gateway/istio namespaces, OTLP trace export, DNS
- **authorino** (priority 51): authorization gRPC/HTTP from gateway/istio, OIDC discovery endpoint, external OIDC provider egress, DNS
- **authorino-operator** (priority 52): metrics scraping, DNS
- **dns-operator** (priority 53): external DNS provider API egress, remote API server egress, DNS
- **limitador** (priority 54): gRPC from gateway/istio, OTLP trace export, DNS
- **limitador-operator** (priority 55): OTLP trace export, DNS

A kustomization overlay is provided for standalone application via `kubectl apply -k config/network-policy/`.

> **Note:** This PR is intended as a reference and may not be merged. See the draft PR [#2121](https://github.com/Kuadrant/kuadrant-operator/pull/2121) which includes this work as part of a broader CRC development setup that can be used to test these policies locally.
