### PR TITLE
prepare-release: v1.5.2

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -224,14 +224,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.2-rc1
-    createdAt: "2026-07-17T10:08:57Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.2
+    createdAt: "2026-07-23T11:42:43Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.5.2-rc1
+  name: kuadrant-operator.v1.5.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -769,7 +769,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.5.2-rc1
+                image: quay.io/kuadrant/kuadrant-operator:v1.5.2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -928,4 +928,4 @@ spec:
     name: console-plugin-latest
   - image: quay.io/kuadrant/console-plugin:v0.1.5-2
     name: console-plugin-pf5
-  version: 1.5.2-rc1
+  version: 1.5.2

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.5.2-rc1"
-appVersion: "1.5.2-rc1"
+version: "1.5.2"
+appVersion: "1.5.2"
 dependencies:
   - name: authorino-operator
     version: 0.25.2

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14504,7 +14504,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.5.2-rc1
+        image: quay.io/kuadrant/kuadrant-operator:v1.5.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.5.2-rc1
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.5.2
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,4 +12,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.5.2-rc1
+  newTag: v1.5.2

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.2-rc1
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.5.2
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.5.2-rc1
+  name: kuadrant-operator.v1.5.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,4 +88,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.5.2-rc1
+  version: 1.5.2

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.5.2-rc1"
+  version: "1.5.2"
 olm:
   channels:
     - "stable"


### PR DESCRIPTION
## Summary
- Bump version from `1.5.2-rc1` to `1.5.2` in `release.yaml`
- Regenerate manifests via `make prepare-release`

No code changes — version bump only from the RC.

**Dependencies (unchanged from RC):**
- Authorino Operator v0.25.2
- Limitador Operator v0.18.3
- DNS Operator v0.17.1
- WASM Shim v0.14.1
- Console Plugin v0.4.1
- Developer Portal Controller v0.2.1

## Next steps
Once CI passes and this merges: tag `v1.5.2` on the merge commit, create GitHub Release (non-prerelease).

🤖 Generated with [Claude Code](https://claude.com/claude-code)