### PR TITLE
prepare-release: v1.4.6-rc2

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -19,3 +19,8 @@ LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/
 COPY bundle/tests/scorecard /tests/scorecard/
+
+# Quay image expiry
+ARG QUAY_IMAGE_EXPIRY
+ENV QUAY_IMAGE_EXPIRY=${QUAY_IMAGE_EXPIRY:-never}
+LABEL quay.expires-after=${QUAY_IMAGE_EXPIRY}

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -224,14 +224,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.6-rc1
-    createdAt: "2026-07-24T07:45:23Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.6-rc2
+    createdAt: "2026-07-24T09:14:34Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.6-rc1
+  name: kuadrant-operator.v1.4.6-rc2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -753,7 +753,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.4.6-rc1
+                image: quay.io/kuadrant/kuadrant-operator:v1.4.6-rc2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -906,4 +906,4 @@ spec:
     name: console-plugin-latest
   - image: quay.io/kuadrant/console-plugin:v0.1.5
     name: console-plugin-pf5
-  version: 1.4.6-rc1
+  version: 1.4.6-rc2

--- a/bundle/metadata/dependencies.yaml
+++ b/bundle/metadata/dependencies.yaml
@@ -2,7 +2,7 @@ dependencies:
   - type: olm.package
     value:
       packageName: authorino-operator
-      version: "0.23.3"
+      version: "0.23.4"
   - type: olm.package
     value:
       packageName: limitador-operator
@@ -10,4 +10,4 @@ dependencies:
   - type: olm.package
     value:
       packageName: dns-operator
-      version: "0.16.2"
+      version: "0.16.3"

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.4.6-rc1"
-appVersion: "1.4.6-rc1"
+version: "1.4.6-rc2"
+appVersion: "1.4.6-rc2"
 dependencies:
   - name: authorino-operator
     version: 0.23.4

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14059,7 +14059,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.4.6-rc1
+        image: quay.io/kuadrant/kuadrant-operator:v1.4.6-rc2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.6-rc1
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.6-rc2
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.4.6-rc1
+  newTag: v1.4.6-rc2

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.6-rc1
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.6-rc2
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.6-rc1
+  name: kuadrant-operator.v1.4.6-rc2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,4 +88,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.4.6-rc1
+  version: 1.4.6-rc2

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.4.6-rc1"
+  version: "1.4.6-rc2"
 olm:
   channels:
     - "stable"


### PR DESCRIPTION
## Summary
- Bumps version from 1.4.6-rc1 to 1.4.6-rc2
- Fixes stale OLM dependency versions in `bundle/metadata/dependencies.yaml`:
  - authorino-operator: 0.23.3 → 0.23.4
  - dns-operator: 0.16.2 → 0.16.3

rc1's `make prepare-release` didn't regenerate `dependencies.yaml` correctly — it updated `release.yaml` and kustomization refs but missed the OLM dependency metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)