### PR TITLE
fix: read OLM dependency versions from release.yaml and verify images on Quay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -523,17 +523,17 @@ bundle: opm yq manifests dependencies-manifests kustomize operator-sdk ## Genera
 bundle-post-generate: OPENSHIFT_VERSIONS_ANNOTATION_KEY="com.redhat.openshift.versions"
 # Supports Openshift v4.12+ (https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions)
 bundle-post-generate: OPENSHIFT_SUPPORTED_VERSIONS="v4.14"
-bundle-post-generate: yq opm
+bundle-post-generate: yq
 	# Set Openshift version in bundle annotations
 	$(YQ) -i '.annotations[$(OPENSHIFT_VERSIONS_ANNOTATION_KEY)] = $(OPENSHIFT_SUPPORTED_VERSIONS)' bundle/metadata/annotations.yaml
 	$(YQ) -i '(.annotations[$(OPENSHIFT_VERSIONS_ANNOTATION_KEY)] | key) headComment = "Custom annotations"' bundle/metadata/annotations.yaml
-	# Update operator dependencies
+	# Update operator dependencies from version strings (not Quay images)
 	PATH=$(PROJECT_PATH)/bin:$$PATH; \
-			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh limitador-operator $(LIMITADOR_OPERATOR_BUNDLE_IMG)
+			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh limitador-operator $(LIMITADOR_OPERATOR_VERSION)
 	PATH=$(PROJECT_PATH)/bin:$$PATH; \
-			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh authorino-operator $(AUTHORINO_OPERATOR_BUNDLE_IMG)
+			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh authorino-operator $(AUTHORINO_OPERATOR_VERSION)
 	PATH=$(PROJECT_PATH)/bin:$$PATH; \
-			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh dns-operator $(DNS_OPERATOR_BUNDLE_IMG)
+			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh dns-operator $(DNS_OPERATOR_VERSION)
 ifeq ($(USE_IMAGE_DIGESTS),true)
 	# Deduplicate relatedImages and remove name field (operator-sdk --use-image-digests creates duplicates)
 	$(YQ) -i '.spec.relatedImages |= unique_by(.image) | del(.spec.relatedImages[].name)' bundle/manifests/kuadrant-operator.clusterserviceversion.yaml

--- a/utils/parse-bundle-version.sh
+++ b/utils/parse-bundle-version.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-OPM=$1
-YQ=$2
-BUNDLE_IMAGE=$3
-
-$OPM render $BUNDLE_IMAGE | $YQ eval '.properties[] | select(.type == "olm.package") | .value.version' -

--- a/utils/release/pre-validation/verify_images.sh
+++ b/utils/release/pre-validation/verify_images.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+echo "Verifying dependency images exist on Quay"
+file=$env/release.yaml
+FAILED=0
+
+check_image() {
+  local repo=$1 tag=$2
+  if curl -sf "https://quay.io/api/v1/repository/kuadrant/$repo/tag/?specificTag=$tag" | grep -q '"name"'; then
+    echo "  OK: quay.io/kuadrant/$repo:$tag"
+  else
+    echo "  MISSING: quay.io/kuadrant/$repo:$tag"
+    FAILED=1
+  fi
+}
+
+mod_version() {
+  local v=$1
+  if [[ "$v" == "0.0.0" ]]; then
+    echo "latest"
+  else
+    echo "v$v"
+  fi
+}
+
+# Skip for development (any dependency at 0.0.0 means dev mode)
+kuadrant_version=$(yq '.kuadrant-operator.version' "$file")
+if [[ "$kuadrant_version" == "0.0.0" ]]; then
+  echo "Skipping image verification for development version"
+  exit 0
+fi
+
+# Operator dependencies: check operator + bundle + catalog images
+operators=("authorino-operator" "limitador-operator" "dns-operator")
+for op in "${operators[@]}"; do
+  version=$(yq "(.dependencies.\"$op\")" "$file")
+  tag=$(mod_version "$version")
+  echo "Checking $op $tag images..."
+  check_image "$op" "$tag"
+  check_image "$op-bundle" "$tag"
+  check_image "$op-catalog" "$tag"
+done
+
+# Supporting components: check operator image only
+components=("console-plugin" "wasm-shim" "developer-portal-controller")
+for comp in "${components[@]}"; do
+  version=$(yq "(.dependencies.\"$comp\")" "$file")
+  tag=$(mod_version "$version")
+  echo "Checking $comp $tag image..."
+  check_image "$comp" "$tag"
+done
+
+if [[ $FAILED -ne 0 ]]; then
+  echo "Some dependency images are missing on Quay. Release cannot proceed."
+  exit 1
+fi
+
+echo "All dependency images verified on Quay"

--- a/utils/update-operator-dependencies.sh
+++ b/utils/update-operator-dependencies.sh
@@ -3,11 +3,10 @@
 set -euo pipefail
 
 COMPONENT="${1?:Error \$COMPONENT not set. Bye}"
-IMG="${2?:Error \$IMG not set. Bye}"
+VERSION="${2?:Error \$VERSION not set. Bye}"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 DEP_FILE="${SCRIPT_DIR}/../bundle/metadata/dependencies.yaml"
-V="$( ${SCRIPT_DIR}/parse-bundle-version.sh opm yq ${IMG} )"
 
-COMPONENT=$COMPONENT V=$V \
+COMPONENT=$COMPONENT V=$VERSION \
   yq eval '(.dependencies[] | select(.value.packageName == strenv(COMPONENT)).value.version) = strenv(V)' -i $DEP_FILE


### PR DESCRIPTION
## Summary

Two fixes for issues discovered during the v1.4.6 patch release:

### 1. Read dependency versions from release.yaml instead of Quay (#2131)

`update-operator-dependencies.sh` used `opm render` to pull bundle images from Quay and extract the OLM package version. If the images weren't pushed yet (common timing during releases), it failed silently and `dependencies.yaml` kept stale versions.

**Fix:** Accept version strings directly instead of image URLs. The versions are already available from `release.yaml` via the `*_OPERATOR_VERSION` Makefile variables. Deletes `parse-bundle-version.sh` (no remaining callers) and removes `opm` from `bundle-post-generate` prerequisites.

### 2. Verify dependency images exist on Quay during prepare-release (#2129)

Nothing previously checked that component images actually exist on Quay before generating manifests. Missing images were only discovered after tagging and attempting OLM installation.

**Fix:** Add `verify_images.sh` to the pre-validation phase. It checks all dependency images (operator + bundle + catalog for each operator dependency, plus supporting component images) exist on Quay before proceeding. Skipped in development mode (version 0.0.0).

## Test plan
- [x] `make bundle-post-generate` with version args produces correct `dependencies.yaml`
- [x] `verify_images.sh` passes when all images exist
- [x] `verify_images.sh` fails with exit 1 when any image is missing
- [x] `verify_images.sh` skips for version 0.0.0 (dev mode)

Fixes #2131
Fixes #2129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pre-release validation to confirm required operator and supporting component images are available before a release proceeds.
  - Development versions are recognised automatically during validation.

- **Bug Fixes**
  - Improved dependency version updates by using the configured operator versions directly.
  - Simplified release generation prerequisites by removing the need for an additional command-line tool.
  - Releases now fail early with clear status when required images are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->