### PR TITLE
fix: read OLM dependency versions from release.yaml instead of Quay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -523,17 +523,17 @@ bundle: opm yq manifests dependencies-manifests kustomize operator-sdk ## Genera
 bundle-post-generate: OPENSHIFT_VERSIONS_ANNOTATION_KEY="com.redhat.openshift.versions"
 # Supports Openshift v4.12+ (https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions)
 bundle-post-generate: OPENSHIFT_SUPPORTED_VERSIONS="v4.14"
-bundle-post-generate: yq opm
+bundle-post-generate: yq
 	# Set Openshift version in bundle annotations
 	$(YQ) -i '.annotations[$(OPENSHIFT_VERSIONS_ANNOTATION_KEY)] = $(OPENSHIFT_SUPPORTED_VERSIONS)' bundle/metadata/annotations.yaml
 	$(YQ) -i '(.annotations[$(OPENSHIFT_VERSIONS_ANNOTATION_KEY)] | key) headComment = "Custom annotations"' bundle/metadata/annotations.yaml
-	# Update operator dependencies
+	# Update operator dependencies from version strings (not Quay images)
 	PATH=$(PROJECT_PATH)/bin:$$PATH; \
-			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh limitador-operator $(LIMITADOR_OPERATOR_BUNDLE_IMG)
+			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh limitador-operator $(LIMITADOR_OPERATOR_VERSION)
 	PATH=$(PROJECT_PATH)/bin:$$PATH; \
-			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh authorino-operator $(AUTHORINO_OPERATOR_BUNDLE_IMG)
+			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh authorino-operator $(AUTHORINO_OPERATOR_VERSION)
 	PATH=$(PROJECT_PATH)/bin:$$PATH; \
-			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh dns-operator $(DNS_OPERATOR_BUNDLE_IMG)
+			 $(PROJECT_PATH)/utils/update-operator-dependencies.sh dns-operator $(DNS_OPERATOR_VERSION)
 ifeq ($(USE_IMAGE_DIGESTS),true)
 	# Deduplicate relatedImages and remove name field (operator-sdk --use-image-digests creates duplicates)
 	$(YQ) -i '.spec.relatedImages |= unique_by(.image) | del(.spec.relatedImages[].name)' bundle/manifests/kuadrant-operator.clusterserviceversion.yaml

--- a/utils/parse-bundle-version.sh
+++ b/utils/parse-bundle-version.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-OPM=$1
-YQ=$2
-BUNDLE_IMAGE=$3
-
-$OPM render $BUNDLE_IMAGE | $YQ eval '.properties[] | select(.type == "olm.package") | .value.version' -

--- a/utils/update-operator-dependencies.sh
+++ b/utils/update-operator-dependencies.sh
@@ -3,11 +3,16 @@
 set -euo pipefail
 
 COMPONENT="${1?:Error \$COMPONENT not set. Bye}"
-IMG="${2?:Error \$IMG not set. Bye}"
+VERSION="${2?:Error \$VERSION not set. Bye}"
+
+# Skip for non-semver versions (e.g. "latest" in dev builds)
+if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+  echo "Skipping $COMPONENT dependency update: version '$VERSION' is not semver"
+  exit 0
+fi
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 DEP_FILE="${SCRIPT_DIR}/../bundle/metadata/dependencies.yaml"
-V="$( ${SCRIPT_DIR}/parse-bundle-version.sh opm yq ${IMG} )"
 
-COMPONENT=$COMPONENT V=$V \
+COMPONENT=$COMPONENT V=$VERSION \
   yq eval '(.dependencies[] | select(.value.packageName == strenv(COMPONENT)).value.version) = strenv(V)' -i $DEP_FILE


### PR DESCRIPTION
\`update-operator-dependencies.sh\` used \`opm render\` to pull bundle images from Quay to extract the OLM package version. If the images weren't pushed yet (common during releases), it failed silently and \`dependencies.yaml\` kept stale versions.

Replace the Quay image lookup with direct version strings from the \`*_OPERATOR_VERSION\` Makefile variables (set from \`release.yaml\` by the release scripts). Delete \`parse-bundle-version.sh\` (no remaining callers), remove \`opm\` from \`bundle-post-generate\` prerequisites.

Fixes #2131

🤖 Generated with [Claude Code](https://claude.com/claude-code)