### PR TITLE
feat: verify dependency images exist on Quay during prepare-release

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -284,6 +284,8 @@ jobs:
         with:
           go-version-file: go.mod
         id: go
+      - name: Install crane
+        uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # ratchet:imjasonh/setup-crane@v0.1
       - name: Check bundles and manifests
         run: make verify-prepare-release
 

--- a/utils/release/pre-validation/verify_images.sh
+++ b/utils/release/pre-validation/verify_images.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+echo "Verifying dependency images exist on Quay"
+file=$env/release.yaml
+FAILED=0
+
+check_image() {
+  local repo=$1 tag=$2
+  if curl -sf "https://quay.io/api/v1/repository/kuadrant/$repo/tag/?specificTag=$tag" | grep -q '"name"'; then
+    echo "  OK: quay.io/kuadrant/$repo:$tag"
+  else
+    echo "  MISSING: quay.io/kuadrant/$repo:$tag"
+    FAILED=1
+  fi
+}
+
+mod_version() {
+  local v=$1
+  if [[ "$v" == "0.0.0" ]]; then
+    echo "latest"
+  else
+    echo "v$v"
+  fi
+}
+
+# Skip for development (any dependency at 0.0.0 means dev mode)
+kuadrant_version=$(yq '.kuadrant-operator.version' "$file")
+if [[ "$kuadrant_version" == "0.0.0" ]]; then
+  echo "Skipping image verification for development version"
+  exit 0
+fi
+
+# Operator dependencies: check operator + bundle + catalog images
+operators=("authorino-operator" "limitador-operator" "dns-operator")
+for op in "${operators[@]}"; do
+  version=$(yq "(.dependencies.\"$op\")" "$file")
+  tag=$(mod_version "$version")
+  echo "Checking $op $tag images..."
+  check_image "$op" "$tag"
+  check_image "$op-bundle" "$tag"
+  check_image "$op-catalog" "$tag"
+done
+
+# Supporting components: check operator image only
+components=("console-plugin" "wasm-shim" "developer-portal-controller")
+for comp in "${components[@]}"; do
+  version=$(yq "(.dependencies.\"$comp\")" "$file")
+  tag=$(mod_version "$version")
+  echo "Checking $comp $tag image..."
+  check_image "$comp" "$tag"
+done
+
+if [[ $FAILED -ne 0 ]]; then
+  echo "Some dependency images are missing on Quay. Release cannot proceed."
+  exit 1
+fi
+
+echo "All dependency images verified on Quay"

--- a/utils/release/pre-validation/verify_images.sh
+++ b/utils/release/pre-validation/verify_images.sh
@@ -4,6 +4,12 @@ echo "Verifying dependency images exist on Quay"
 file=$env/release.yaml
 FAILED=0
 
+# Check Quay API is reachable before proceeding
+if ! curl -sf "https://quay.io/api/v1/discovery" > /dev/null 2>&1; then
+  echo "Cannot reach Quay API — verify network connectivity"
+  exit 1
+fi
+
 check_image() {
   local repo=$1 tag=$2
   if curl -sf "https://quay.io/api/v1/repository/kuadrant/$repo/tag/?specificTag=$tag" | grep -q '"name"'; then
@@ -34,6 +40,10 @@ fi
 operators=("authorino-operator" "limitador-operator" "dns-operator")
 for op in "${operators[@]}"; do
   version=$(yq "(.dependencies.\"$op\")" "$file")
+  if [[ "$version" == "0.0.0" ]]; then
+    echo "Skipping $op (version 0.0.0)"
+    continue
+  fi
   tag=$(mod_version "$version")
   echo "Checking $op $tag images..."
   check_image "$op" "$tag"
@@ -45,6 +55,10 @@ done
 components=("console-plugin" "wasm-shim" "developer-portal-controller")
 for comp in "${components[@]}"; do
   version=$(yq "(.dependencies.\"$comp\")" "$file")
+  if [[ "$version" == "0.0.0" ]]; then
+    echo "Skipping $comp (version 0.0.0)"
+    continue
+  fi
   tag=$(mod_version "$version")
   echo "Checking $comp $tag image..."
   check_image "$comp" "$tag"

--- a/utils/release/pre-validation/verify_images.sh
+++ b/utils/release/pre-validation/verify_images.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+if [[ -z "${env:-}" ]]; then
+  echo "ERROR: \$env is not set"
+  exit 1
+fi
+
+if ! command -v crane &>/dev/null; then
+  echo "WARNING: crane not installed, skipping image verification"
+  exit 0
+fi
+
 echo "Verifying dependency images exist on Quay"
 file=$env/release.yaml
 FAILED=0

--- a/utils/release/pre-validation/verify_images.sh
+++ b/utils/release/pre-validation/verify_images.sh
@@ -4,18 +4,13 @@ echo "Verifying dependency images exist on Quay"
 file=$env/release.yaml
 FAILED=0
 
-# Check Quay API is reachable before proceeding
-if ! curl -sf "https://quay.io/api/v1/discovery" > /dev/null 2>&1; then
-  echo "Cannot reach Quay API — verify network connectivity"
-  exit 1
-fi
-
 check_image() {
-  local repo=$1 tag=$2
-  if curl -sf "https://quay.io/api/v1/repository/kuadrant/$repo/tag/?specificTag=$tag" | grep -q '"name"'; then
-    echo "  OK: quay.io/kuadrant/$repo:$tag"
+  local image=$1
+  local output
+  if output=$(crane digest "$image" 2>&1); then
+    echo "  OK: $image ($output)"
   else
-    echo "  MISSING: quay.io/kuadrant/$repo:$tag"
+    echo "  MISSING: $image — $output"
     FAILED=1
   fi
 }
@@ -46,12 +41,12 @@ for op in "${operators[@]}"; do
   fi
   tag=$(mod_version "$version")
   echo "Checking $op $tag images..."
-  check_image "$op" "$tag"
-  check_image "$op-bundle" "$tag"
-  check_image "$op-catalog" "$tag"
+  check_image "quay.io/kuadrant/$op:$tag"
+  check_image "quay.io/kuadrant/$op-bundle:$tag"
+  check_image "quay.io/kuadrant/$op-catalog:$tag"
 done
 
-# Supporting components: check operator image only
+# Supporting components: check image only
 components=("console-plugin" "wasm-shim" "developer-portal-controller")
 for comp in "${components[@]}"; do
   version=$(yq "(.dependencies.\"$comp\")" "$file")
@@ -61,7 +56,7 @@ for comp in "${components[@]}"; do
   fi
   tag=$(mod_version "$version")
   echo "Checking $comp $tag image..."
-  check_image "$comp" "$tag"
+  check_image "quay.io/kuadrant/$comp:$tag"
 done
 
 if [[ $FAILED -ne 0 ]]; then


### PR DESCRIPTION
Add \`verify_images.sh\` to the pre-validation phase of \`prepare-release\`. It checks all dependency images (operator + bundle + catalog for each operator dependency, plus supporting component images) exist on Quay before generating manifests. Skipped in dev mode (version 0.0.0).

Previously, missing images were only discovered after tagging and attempting OLM installation.

Fixes #2129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release validation now checks that all required dependency container images are available before proceeding.
  - Missing images are reported clearly, and validation fails early to prevent incomplete releases.
  - Development configurations can skip image checks when using the default unpublished version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->