### PR TITLE
fix(observability): use annotated metrics port in istio-pod-monitor

### DIFF
--- a/internal/controller/observability_reconciler.go
+++ b/internal/controller/observability_reconciler.go
@@ -216,7 +216,10 @@ func istioPodMonitorBuild(ns string) *monitoringv1.PodMonitor {
 								"__meta_kubernetes_pod_annotation_prometheus_io_port",
 								"__meta_kubernetes_pod_ip",
 							},
-							Regex:       `(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})`,
+							// Raw-string regex must use \d/\. (not \\d/\\.) so Prometheus
+							// rewrites __address__ to the annotated metrics port (15020)
+							// instead of falling back to status port 15021.
+							Regex:       `(\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})`,
 							Replacement: &istioPodMonitorPortReplacement1,
 							TargetLabel: "__address__",
 						},
@@ -226,7 +229,7 @@ func istioPodMonitorBuild(ns string) *monitoringv1.PodMonitor {
 								"__meta_kubernetes_pod_annotation_prometheus_io_port",
 								"__meta_kubernetes_pod_ip",
 							},
-							Regex:       `(\\d+);((([0-9]+?)(\\.|$)){4})`,
+							Regex:       `(\d+);((([0-9]+?)(\.|$)){4})`,
 							Replacement: &istioPodMonitorPortReplacement2,
 							TargetLabel: "__address__",
 						},

--- a/internal/controller/observability_reconciler.go
+++ b/internal/controller/observability_reconciler.go
@@ -216,9 +216,6 @@ func istioPodMonitorBuild(ns string) *monitoringv1.PodMonitor {
 								"__meta_kubernetes_pod_annotation_prometheus_io_port",
 								"__meta_kubernetes_pod_ip",
 							},
-							// Raw-string regex must use \d/\. (not \\d/\\.) so Prometheus
-							// rewrites __address__ to the annotated metrics port (15020)
-							// instead of falling back to status port 15021.
 							Regex:       `(\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})`,
 							Replacement: &istioPodMonitorPortReplacement1,
 							TargetLabel: "__address__",

--- a/internal/controller/observability_reconciler_test.go
+++ b/internal/controller/observability_reconciler_test.go
@@ -1,0 +1,27 @@
+package controllers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIstioPodMonitorBuild_RegexEscaping(t *testing.T) {
+	pm := istioPodMonitorBuild("test-ns")
+	if len(pm.Spec.PodMetricsEndpoints) == 0 {
+		t.Fatal("expected at least one pod metrics endpoint")
+	}
+
+	var addressRegexes int
+	for _, rc := range pm.Spec.PodMetricsEndpoints[0].RelabelConfigs {
+		if rc.TargetLabel != "__address__" {
+			continue
+		}
+		addressRegexes++
+		if strings.Contains(rc.Regex, `\\d`) {
+			t.Errorf("regex %q contains double-escaped \\d in raw string", rc.Regex)
+		}
+	}
+	if addressRegexes != 2 {
+		t.Errorf("expected 2 __address__ relabel regexes, got %d", addressRegexes)
+	}
+}


### PR DESCRIPTION
Raw-string regexes in istioPodMonitorBuild double-escaped \d/\., so __address__ relabel never matched prometheus.io/port and Prometheus fell back to scraping status port 15021 (/stats/prometheus → 404). Fixes RHAIENG-5557.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed observability relabelling patterns for Istio pod monitoring so IPv4 and IPv6 addresses are matched correctly.
  * Prevented double-escaped regular expressions from affecting pod monitor address processing.
  * Preserved existing monitoring behaviour while improving reliability for metric port rewrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->