### PR TITLE
fix(docs): add identity filter to egress workload identity AuthPolicy

### DIFF
--- a/doc/user-guides/egress/egress-gateway.md
+++ b/doc/user-guides/egress/egress-gateway.md
@@ -209,11 +209,20 @@ spec:
         patternMatching:
           patterns:
             - predicate: auth.identity.user.username.startsWith('system:serviceaccount:egress-test:')
+    response:
+      success:
+        filters:
+          "identity":
+            json:
+              properties:
+                username:
+                  selector: auth.identity.user.username
 EOF
 ```
 
 - `authentication.workload-sa` - validates the SA token via TokenReview. Unauthenticated requests are rejected (401).
 - `authorization.allowed-namespaces` - restricts access to workloads from the `egress-test` namespace. Workloads from other namespaces are rejected (403). Add additional patterns with `||` to allow more namespaces.
+- `response.success.filters.identity` - exposes the resolved identity (username) as dynamic metadata. This is required for policies that reference `auth.identity.*` expressions, such as per-workload rate limiting.
 
 Verify access control:
 


### PR DESCRIPTION
## Summary

- Adds `response.success.filters` section to the workload-identity `AuthPolicy` in the egress gateway guide
- Without this, the wasm-shim cannot resolve `auth.identity.username` in RateLimitPolicy counter expressions, causing per-workload rate limiting to silently fail (`failureMode: allow` lets all requests through)
- Matches the pattern used in the ingress authenticated rate limiting guide (`authenticated-rl-with-jwt-and-k8s-authnz.md`)

## Context

The gap was introduced in PR #1896 (April 2026) which added the egress gateway doc. The workload-identity AuthPolicy was missing the `response.success.filters` section needed to expose identity as dynamic metadata for RLP counter expressions. The ingress guide already had this section, but it was missed for egress.

Discovered during downstream doc porting (#2151). The `NoSuchKey("identity")` CEL error in wasm-shim logs confirmed the AuthConfig had `numResponseItems: 0` — Authorino authenticated requests correctly but did not pass identity data back through dynamic metadata.

## Test plan

- [x] Verified on Kind cluster: without the filter, all 10 requests return 200 (counter fails silently); with the filter, requests 1-5 return 200, requests 6-10 return 429
- [x] Confirmed AuthConfig shows `numResponseItems: 1` after the fix

Fixes part of #2151

🤖 Generated with [Claude Code](https://claude.com/claude-code)