### PR TITLE
Wasm service type consolidation

### DIFF
--- a/internal/extension/registry.go
+++ b/internal/extension/registry.go
@@ -1099,11 +1099,6 @@ func (m *RegisteredDataMutator[TResource]) mutateWasmConfig(wasmConfig *wasm.Con
 		methodServiceKeys[key.Policy][key.Name] = wasmServiceKey
 	}
 
-	// Set descriptor service cluster name if there are any dynamic services
-	if len(relevantUpstreamKeys) > 0 {
-		wasmConfig.DescriptorService = "kuadrant-operator-grpc"
-	}
-
 	// Translate pipeline actions into Action entries (deterministic order across policies).
 	// Only include pipeline policies whose stored target refs match this gateway's routes.
 	policyIDs := lo.Uniq(append(lo.Keys(methodServiceKeys), m.store.GetPoliciesWithPipelineActionsForTargetRefs(targetRefs)...))

--- a/internal/extension/registry_test.go
+++ b/internal/extension/registry_test.go
@@ -1202,7 +1202,7 @@ func TestHashUpstreamServiceConfig(t *testing.T) {
 	timeout := "100ms"
 	svc := wasm.Service{
 		Endpoint:    "ext-my-service-8081",
-		Type:        wasm.AuthServiceType,
+		Type:        wasm.DynamicServiceType,
 		FailureMode: wasm.FailureModeDeny,
 		Timeout:     &timeout,
 	}

--- a/internal/extension/registry_test.go
+++ b/internal/extension/registry_test.go
@@ -1275,11 +1275,6 @@ func TestMutateWasmConfig_InjectsUpstreams(t *testing.T) {
 		t.Errorf("Expected 2 services in wasm config, got %d", len(wasmConfig.Services))
 	}
 
-	// Verify descriptor service is set to the expected value
-	if wasmConfig.DescriptorService != "kuadrant-operator-grpc" {
-		t.Errorf("Expected DescriptorService to be 'kuadrant-operator-grpc', got %q", wasmConfig.DescriptorService)
-	}
-
 	// Build a map of cluster names to upstream entries for easy lookup
 	upstreamsByCluster := make(map[string]RegisteredUpstreamEntry)
 	for _, entry := range upstreamEntries {

--- a/internal/wasm/types.go
+++ b/internal/wasm/types.go
@@ -111,16 +111,12 @@ func (s Service) EqualTo(other Service) bool {
 	return true
 }
 
-// +kubebuilder:validation:Enum:=ratelimit;auth;ratelimit-check;ratelimit-report;tracing;dynamic
+// +kubebuilder:validation:Enum:=tracing;dynamic
 type ServiceType string
 
 const (
-	RateLimitServiceType       ServiceType = "ratelimit"
-	RateLimitCheckServiceType  ServiceType = "ratelimit-check"
-	RateLimitReportServiceType ServiceType = "ratelimit-report"
-	AuthServiceType            ServiceType = "auth"
-	TracingServiceType         ServiceType = "tracing"
-	DynamicServiceType         ServiceType = "dynamic"
+	TracingServiceType ServiceType = "tracing"
+	DynamicServiceType ServiceType = "dynamic"
 )
 
 // +kubebuilder:validation:Enum:=deny;allow

--- a/internal/wasm/utils.go
+++ b/internal/wasm/utils.go
@@ -244,9 +244,10 @@ func BuildConfigForActionSet(actionSets []ActionSet, logger *logr.Logger, observ
 	}
 
 	return Config{
-		Services:      serviceBuilder.Build(),
-		ActionSets:    actionSets,
-		Observability: observability,
+		Services:          serviceBuilder.Build(),
+		ActionSets:        actionSets,
+		Observability:     observability,
+		DescriptorService: DescriptorServiceClusterName,
 	}
 }
 

--- a/internal/wasm/utils.go
+++ b/internal/wasm/utils.go
@@ -35,6 +35,16 @@ const (
 	RateLimitReportServiceName = "ratelimit-report-service"
 	AuthServiceName            = "auth-service"
 	TracingServiceName         = "tracing-service"
+
+	DescriptorServiceClusterName = "kuadrant-operator-grpc"
+
+	AuthGrpcService              = "envoy.service.auth.v3.Authorization"
+	AuthGrpcMethod               = "Check"
+	RateLimitGrpcService         = "envoy.service.ratelimit.v3.RateLimitService"
+	RateLimitGrpcMethod          = "ShouldRateLimit"
+	KuadrantRateLimitGrpcService = "kuadrant.service.ratelimit.v1.RateLimitService"
+	RateLimitCheckGrpcMethod     = "CheckRateLimit"
+	RateLimitReportGrpcMethod    = "Report"
 )
 
 type LogLevel int
@@ -169,28 +179,36 @@ func NewServiceBuilder(logger *logr.Logger) *ServiceBuilder {
 	return &ServiceBuilder{
 		services: map[string]Service{
 			AuthServiceName: {
-				Type:        AuthServiceType,
+				Type:        DynamicServiceType,
 				Endpoint:    kuadrant.KuadrantAuthClusterName,
 				FailureMode: AuthServiceFailureMode(logger),
 				Timeout:     ptr.To(AuthServiceTimeout()),
+				GrpcService: ptr.To(AuthGrpcService),
+				GrpcMethod:  ptr.To(AuthGrpcMethod),
 			},
 			RateLimitServiceName: {
-				Type:        RateLimitServiceType,
+				Type:        DynamicServiceType,
 				Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 				FailureMode: RatelimitServiceFailureMode(logger),
 				Timeout:     ptr.To(RatelimitServiceTimeout()),
+				GrpcService: ptr.To(RateLimitGrpcService),
+				GrpcMethod:  ptr.To(RateLimitGrpcMethod),
 			},
 			RateLimitCheckServiceName: {
-				Type:        RateLimitCheckServiceType,
+				Type:        DynamicServiceType,
 				Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 				FailureMode: RatelimitCheckServiceFailureMode(logger),
 				Timeout:     ptr.To(RatelimitCheckServiceTimeout()),
+				GrpcService: ptr.To(KuadrantRateLimitGrpcService),
+				GrpcMethod:  ptr.To(RateLimitCheckGrpcMethod),
 			},
 			RateLimitReportServiceName: {
-				Type:        RateLimitReportServiceType,
+				Type:        DynamicServiceType,
 				Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 				FailureMode: RatelimitReportServiceFailureMode(logger),
 				Timeout:     ptr.To(RatelimitReportServiceTimeout()),
+				GrpcService: ptr.To(KuadrantRateLimitGrpcService),
+				GrpcMethod:  ptr.To(RateLimitReportGrpcMethod),
 			},
 		},
 		logger: logger,

--- a/tests/envoygateway/extension_reconciler_test.go
+++ b/tests/envoygateway/extension_reconciler_test.go
@@ -173,30 +173,39 @@ var _ = Describe("wasm controller", func() {
 			existingWASMConfig, err := wasm.ConfigFromJSON(ext.Spec.Wasm[0].Config)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(existingWASMConfig).To(Equal(&wasm.Config{
+				DescriptorService: wasm.DescriptorServiceClusterName,
 				Services: map[string]wasm.Service{
 					wasm.AuthServiceName: {
-						Type:        wasm.AuthServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To(wasm.AuthGrpcService),
+						GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 					},
 					wasm.RateLimitServiceName: {
-						Type:        wasm.RateLimitServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+						GrpcService: ptr.To(wasm.RateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 					},
 					wasm.RateLimitReportServiceName: {
-						Type:        wasm.RateLimitReportServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 					},
 				},
 				ActionSets: []wasm.ActionSet{
@@ -356,30 +365,39 @@ var _ = Describe("wasm controller", func() {
 			existingWASMConfig, err := wasm.ConfigFromJSON(ext.Spec.Wasm[0].Config)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(existingWASMConfig).To(Equal(&wasm.Config{
+				DescriptorService: wasm.DescriptorServiceClusterName,
 				Services: map[string]wasm.Service{
 					wasm.AuthServiceName: {
-						Type:        wasm.AuthServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To(wasm.AuthGrpcService),
+						GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 					},
 					wasm.RateLimitServiceName: {
-						Type:        wasm.RateLimitServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+						GrpcService: ptr.To(wasm.RateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 					},
 					wasm.RateLimitReportServiceName: {
-						Type:        wasm.RateLimitReportServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 					},
 				},
 				ActionSets: []wasm.ActionSet{

--- a/tests/istio/extension_reconciler_test.go
+++ b/tests/istio/extension_reconciler_test.go
@@ -220,30 +220,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 			existingWASMConfig, err := extractWasmConfigFromEnvoyFilter(existingEnvoyFilter)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(existingWASMConfig).To(Equal(&wasm.Config{
+				DescriptorService: wasm.DescriptorServiceClusterName,
 				Services: map[string]wasm.Service{
 					wasm.AuthServiceName: {
-						Type:        wasm.AuthServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To(wasm.AuthGrpcService),
+						GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 					},
 					wasm.RateLimitServiceName: {
-						Type:        wasm.RateLimitServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+						GrpcService: ptr.To(wasm.RateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 					},
 					wasm.RateLimitReportServiceName: {
-						Type:        wasm.RateLimitReportServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 					},
 				},
 				ActionSets: []wasm.ActionSet{
@@ -505,8 +514,10 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 			Expect(existingWASMConfig.Services).To(HaveKeyWithValue(wasm.RateLimitServiceName, wasm.Service{
 				Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 				FailureMode: wasm.RatelimitServiceFailureMode(&logger),
-				Type:        wasm.RateLimitServiceType,
+				Type:        wasm.DynamicServiceType,
 				Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+				GrpcService: ptr.To(wasm.RateLimitGrpcService),
+				GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 			}))
 			Expect(existingWASMConfig.ActionSets).To(HaveLen(6))
 
@@ -702,30 +713,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 			existingWASMConfig, err := extractWasmConfigFromEnvoyFilter(existingEnvoyFilter)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(existingWASMConfig).To(Equal(&wasm.Config{
+				DescriptorService: wasm.DescriptorServiceClusterName,
 				Services: map[string]wasm.Service{
 					wasm.AuthServiceName: {
-						Type:        wasm.AuthServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To(wasm.AuthGrpcService),
+						GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 					},
 					wasm.RateLimitServiceName: {
-						Type:        wasm.RateLimitServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+						GrpcService: ptr.To(wasm.RateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 					},
 					wasm.RateLimitReportServiceName: {
-						Type:        wasm.RateLimitReportServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 					},
 				},
 				ActionSets: []wasm.ActionSet{
@@ -948,30 +968,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				}
 
 				expectedPlugin := &wasm.Config{
+					DescriptorService: wasm.DescriptorServiceClusterName,
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
-							Type:        wasm.AuthServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.AuthServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+							GrpcService: ptr.To(wasm.AuthGrpcService),
+							GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 						},
 						wasm.RateLimitServiceName: {
-							Type:        wasm.RateLimitServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+							GrpcService: ptr.To(wasm.RateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 						},
 						wasm.RateLimitReportServiceName: {
-							Type:        wasm.RateLimitReportServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1177,30 +1206,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				}
 
 				expectedPlugin := &wasm.Config{
+					DescriptorService: wasm.DescriptorServiceClusterName,
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
-							Type:        wasm.AuthServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.AuthServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+							GrpcService: ptr.To(wasm.AuthGrpcService),
+							GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 						},
 						wasm.RateLimitServiceName: {
-							Type:        wasm.RateLimitServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+							GrpcService: ptr.To(wasm.RateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 						},
 						wasm.RateLimitReportServiceName: {
-							Type:        wasm.RateLimitReportServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1324,30 +1362,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				}
 
 				expectedPlugin := &wasm.Config{
+					DescriptorService: wasm.DescriptorServiceClusterName,
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
-							Type:        wasm.AuthServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.AuthServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+							GrpcService: ptr.To(wasm.AuthGrpcService),
+							GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 						},
 						wasm.RateLimitServiceName: {
-							Type:        wasm.RateLimitServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+							GrpcService: ptr.To(wasm.RateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 						},
 						wasm.RateLimitReportServiceName: {
-							Type:        wasm.RateLimitReportServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1545,30 +1592,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				}
 
 				expectedPlugin := &wasm.Config{
+					DescriptorService: wasm.DescriptorServiceClusterName,
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
-							Type:        wasm.AuthServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.AuthServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+							GrpcService: ptr.To(wasm.AuthGrpcService),
+							GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 						},
 						wasm.RateLimitServiceName: {
-							Type:        wasm.RateLimitServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+							GrpcService: ptr.To(wasm.RateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 						},
 						wasm.RateLimitReportServiceName: {
-							Type:        wasm.RateLimitReportServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1655,30 +1711,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				}
 
 				expectedPlugin := &wasm.Config{
+					DescriptorService: wasm.DescriptorServiceClusterName,
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
-							Type:        wasm.AuthServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.AuthServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+							GrpcService: ptr.To(wasm.AuthGrpcService),
+							GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 						},
 						wasm.RateLimitServiceName: {
-							Type:        wasm.RateLimitServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+							GrpcService: ptr.To(wasm.RateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 						},
 						wasm.RateLimitReportServiceName: {
-							Type:        wasm.RateLimitReportServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1851,30 +1916,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				}
 
 				expectedPlugin := &wasm.Config{
+					DescriptorService: wasm.DescriptorServiceClusterName,
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
-							Type:        wasm.AuthServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.AuthServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+							GrpcService: ptr.To(wasm.AuthGrpcService),
+							GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 						},
 						wasm.RateLimitServiceName: {
-							Type:        wasm.RateLimitServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+							GrpcService: ptr.To(wasm.RateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 						},
 						wasm.RateLimitReportServiceName: {
-							Type:        wasm.RateLimitReportServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -1979,30 +2053,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				}
 
 				expectedPlugin := &wasm.Config{
+					DescriptorService: wasm.DescriptorServiceClusterName,
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
-							Type:        wasm.AuthServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.AuthServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+							GrpcService: ptr.To(wasm.AuthGrpcService),
+							GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 						},
 						wasm.RateLimitServiceName: {
-							Type:        wasm.RateLimitServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+							GrpcService: ptr.To(wasm.RateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 						},
 						wasm.RateLimitReportServiceName: {
-							Type:        wasm.RateLimitReportServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -2211,30 +2294,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				}
 
 				expectedPlugin := &wasm.Config{
+					DescriptorService: wasm.DescriptorServiceClusterName,
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
-							Type:        wasm.AuthServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.AuthServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+							GrpcService: ptr.To(wasm.AuthGrpcService),
+							GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 						},
 						wasm.RateLimitServiceName: {
-							Type:        wasm.RateLimitServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+							GrpcService: ptr.To(wasm.RateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 						},
 						wasm.RateLimitReportServiceName: {
-							Type:        wasm.RateLimitReportServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -2336,30 +2428,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				})
 
 				expectedPlugin := &wasm.Config{
+					DescriptorService: wasm.DescriptorServiceClusterName,
 					Services: map[string]wasm.Service{
 						wasm.AuthServiceName: {
-							Type:        wasm.AuthServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantAuthClusterName,
 							FailureMode: wasm.AuthServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+							GrpcService: ptr.To(wasm.AuthGrpcService),
+							GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 						},
 						wasm.RateLimitCheckServiceName: {
-							Type:        wasm.RateLimitCheckServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 						},
 						wasm.RateLimitServiceName: {
-							Type:        wasm.RateLimitServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+							GrpcService: ptr.To(wasm.RateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 						},
 						wasm.RateLimitReportServiceName: {
-							Type:        wasm.RateLimitReportServiceType,
+							Type:        wasm.DynamicServiceType,
 							Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 							FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 							Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+							GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+							GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 						},
 					},
 					ActionSets: []wasm.ActionSet{
@@ -2527,30 +2628,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 			existingWASMConfig, err := extractWasmConfigFromEnvoyFilter(existingEnvoyFilter)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(existingWASMConfig).To(Equal(&wasm.Config{
+				DescriptorService: wasm.DescriptorServiceClusterName,
 				Services: map[string]wasm.Service{
 					wasm.AuthServiceName: {
-						Type:        wasm.AuthServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To(wasm.AuthGrpcService),
+						GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 					},
 					wasm.RateLimitServiceName: {
-						Type:        wasm.RateLimitServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+						GrpcService: ptr.To(wasm.RateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 					},
 					wasm.RateLimitReportServiceName: {
-						Type:        wasm.RateLimitReportServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 					},
 				},
 				ActionSets: []wasm.ActionSet{
@@ -2624,30 +2734,39 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 			})
 
 			return &wasm.Config{
+				DescriptorService: wasm.DescriptorServiceClusterName,
 				Services: map[string]wasm.Service{
 					wasm.AuthServiceName: {
-						Type:        wasm.AuthServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantAuthClusterName,
 						FailureMode: wasm.AuthServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.AuthServiceTimeout()),
+						GrpcService: ptr.To(wasm.AuthGrpcService),
+						GrpcMethod:  ptr.To(wasm.AuthGrpcMethod),
 					},
 					wasm.RateLimitCheckServiceName: {
-						Type:        wasm.RateLimitCheckServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitCheckServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitCheckServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitCheckGrpcMethod),
 					},
 					wasm.RateLimitServiceName: {
-						Type:        wasm.RateLimitServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitServiceTimeout()),
+						GrpcService: ptr.To(wasm.RateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitGrpcMethod),
 					},
 					wasm.RateLimitReportServiceName: {
-						Type:        wasm.RateLimitReportServiceType,
+						Type:        wasm.DynamicServiceType,
 						Endpoint:    kuadrant.KuadrantRateLimitClusterName,
 						FailureMode: wasm.RatelimitReportServiceFailureMode(&logger),
 						Timeout:     ptr.To(wasm.RatelimitReportServiceTimeout()),
+						GrpcService: ptr.To(wasm.KuadrantRateLimitGrpcService),
+						GrpcMethod:  ptr.To(wasm.RateLimitReportGrpcMethod),
 					},
 				},
 				ActionSets: []wasm.ActionSet{


### PR DESCRIPTION
Follow on from #2089. Now that we're using the new types, and all of the configuration is declarative, we no longer need the custom service types or logic on the wasm-shim side for gRPC type actions - these are all treated the same. The `tracing` one remains for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit gRPC service and method configuration for authorisation and rate-limiting operations, including rate-limit reporting.
  * Added dynamic service routing across gateway and route policy configurations.
  * Added descriptor service cluster configuration for action sets.

* **Bug Fixes**
  * Removed reliance on a dynamically assigned descriptor service.
  * Updated service validation to accept only supported tracing and dynamic service types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->