### PR TITLE
feat: add component chart sync tool and automation

### DIFF
--- a/.github/workflows/sync-component-chart.yaml
+++ b/.github/workflows/sync-component-chart.yaml
@@ -1,0 +1,187 @@
+# Receives repository_dispatch events from component repos when their Helm
+# charts change. Checks which branches track the dispatched component and
+# source branch (via component-charts/sync.yaml), syncs the chart using the
+# Go sync tool, and creates a PR with the updated chart content and pinned
+# commit SHA. Can also be triggered manually via workflow_dispatch.
+#
+# Currently only targets the default branch. Release branch support will be
+# added once the branch mapping strategy for releases is defined.
+
+name: Sync component chart
+
+on:
+  repository_dispatch:
+    types: [component-chart-sync]
+  workflow_dispatch:
+    inputs:
+      component:
+        description: 'Component name (e.g. dns-operator)'
+        required: true
+        type: string
+      ref:
+        description: 'Source ref from the component repo (e.g. main, release-v1.5)'
+        required: true
+        type: string
+
+concurrency:
+  group: sync-component-${{ github.event.client_payload.component || inputs.component }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  resolve-targets:
+    name: Find target branches
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      branches: ${{ steps.find.outputs.branches }}
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set component and ref
+        id: params
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_COMPONENT: ${{ github.event.client_payload.component }}
+          DISPATCH_REF: ${{ github.event.client_payload.ref }}
+          INPUT_COMPONENT: ${{ inputs.component }}
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            COMPONENT="$DISPATCH_COMPONENT"
+            REF="$DISPATCH_REF"
+          else
+            COMPONENT="$INPUT_COMPONENT"
+            REF="$INPUT_REF"
+          fi
+          if ! echo "$COMPONENT" | grep -qE '^[a-z0-9-]+$'; then
+            echo "Error: invalid component name: $COMPONENT" >&2
+            exit 1
+          fi
+          if ! echo "$REF" | grep -qE '^[a-zA-Z0-9._/-]+$'; then
+            echo "Error: invalid ref: $REF" >&2
+            exit 1
+          fi
+          echo "component=$COMPONENT" >> "$GITHUB_OUTPUT"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Find matching branches
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          COMPONENT: ${{ steps.params.outputs.component }}
+          SOURCE_BRANCH: ${{ steps.params.outputs.ref }}
+        run: |
+          BRANCHES=$(go run ./hack/sync-components/ find-targets \
+            --repo "$REPO" \
+            --component "$COMPONENT" \
+            --source-branch "$SOURCE_BRANCH")
+          echo "Matching branches: $BRANCHES"
+          echo "branches=$BRANCHES" >> "$GITHUB_OUTPUT"
+
+  sync:
+    name: Sync ${{ matrix.target.branch }}
+    needs: resolve-targets
+    if: needs.resolve-targets.outputs.branches != '[]' && needs.resolve-targets.outputs.branches != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.resolve-targets.outputs.branches) }}
+    steps:
+      - name: Set params
+        id: params
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_COMPONENT: ${{ github.event.client_payload.component }}
+          DISPATCH_ACTOR: ${{ github.event.client_payload.actor }}
+          DISPATCH_COMMIT_URL: ${{ github.event.client_payload.commit-url }}
+          INPUT_COMPONENT: ${{ inputs.component }}
+          WORKFLOW_ACTOR: ${{ github.actor }}
+        run: |
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            echo "component=$DISPATCH_COMPONENT" >> "$GITHUB_OUTPUT"
+            echo "actor=$DISPATCH_ACTOR" >> "$GITHUB_OUTPUT"
+            echo "commit-url=$DISPATCH_COMMIT_URL" >> "$GITHUB_OUTPUT"
+          else
+            echo "component=$INPUT_COMPONENT" >> "$GITHUB_OUTPUT"
+            echo "actor=$WORKFLOW_ACTOR" >> "$GITHUB_OUTPUT"
+            echo "commit-url=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout target branch
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+        with:
+          ref: ${{ matrix.target.branch }}
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Sync chart
+        id: sync
+        env:
+          COMPONENT: ${{ steps.params.outputs.component }}
+        run: |
+          RESULT=$(make sync-component-chart COMPONENT="$COMPONENT")
+          echo "$RESULT" | jq .
+          CHANGED=$(echo "$RESULT" | jq -e -r ".\"$COMPONENT\".changed") || { echo "Error: missing changed field" >&2; exit 1; }
+          REPO=$(echo "$RESULT" | jq -e -r ".\"$COMPONENT\".repo") || { echo "Error: missing repo field" >&2; exit 1; }
+          OLD_REF=$(echo "$RESULT" | jq -e -r ".\"$COMPONENT\".\"old-ref\"") || { echo "Error: missing old-ref field" >&2; exit 1; }
+          NEW_REF=$(echo "$RESULT" | jq -e -r ".\"$COMPONENT\".\"new-ref\"") || { echo "Error: missing new-ref field" >&2; exit 1; }
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "old-ref=$OLD_REF" >> "$GITHUB_OUTPUT"
+          echo "new-ref=$NEW_REF" >> "$GITHUB_OUTPUT"
+          echo "new-ref-short=${NEW_REF:0:7}" >> "$GITHUB_OUTPUT"
+          echo "repo=$REPO" >> "$GITHUB_OUTPUT"
+
+      - name: Create Pull Request
+        if: steps.sync.outputs.changed == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8.1.1
+        with:
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
+          commit-message: "chore(deps): update ${{ steps.params.outputs.component }} chart on ${{ matrix.target.branch }} to ${{ steps.sync.outputs.new-ref-short }}"
+          signoff: true
+          sign-commits: true
+          base: ${{ matrix.target.branch }}
+          branch: sync/${{ matrix.target.branch }}/${{ steps.params.outputs.component }}
+          delete-branch: true
+          title: "chore(deps): update ${{ steps.params.outputs.component }} chart on ${{ matrix.target.branch }} to ${{ steps.sync.outputs.new-ref-short }}"
+          body: |
+            Sync ${{ steps.params.outputs.component }} chart from upstream into `${{ matrix.target.branch }}`.
+
+            **Component:** ${{ steps.params.outputs.component }}
+            **Target branch:** `${{ matrix.target.branch }}`
+            **Previous ref:** `${{ steps.sync.outputs.old-ref }}`
+            **New ref:** `${{ steps.sync.outputs.new-ref }}`
+            **Triggered by:** @${{ steps.params.outputs.actor }}${{ steps.params.outputs.commit-url && format(' ([commit]({0}))', steps.params.outputs.commit-url) || '' }}
+
+            [Upstream changes](https://github.com/${{ steps.sync.outputs.repo }}/compare/${{ steps.sync.outputs.old-ref }}...${{ steps.sync.outputs.new-ref }})
+
+            Auto-generated by [sync-component-chart](https://github.com/${{ github.repository }}/actions/workflows/sync-component-chart.yaml)
+
+      - name: Enable auto-merge
+        if: steps.sync.outputs.changed == 'true' && matrix.target.auto-merge == true && steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.KUADRANT_DEV_PAT }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr merge "$PR_NUMBER" --auto --squash --repo "$REPO"

--- a/Makefile
+++ b/Makefile
@@ -390,6 +390,20 @@ dependencies-manifests: ## Update kuadrant dependencies manifests.
 	$(call patch-config,config/dependencies/dns/kustomization.template.yaml,config/dependencies/dns/kustomization.yaml)
 	$(call patch-config,config/dependencies/developer-portal/kustomization.template.yaml,config/dependencies/developer-portal/kustomization.yaml)
 
+COMPONENT_CHARTS_DIR = $(PROJECT_PATH)/component-charts
+
+.PHONY: sync-component-charts
+sync-component-charts: ## Sync component Helm charts from upstream repos.
+	@go run $(PROJECT_PATH)/hack/sync-components/ sync --config $(COMPONENT_CHARTS_DIR)/sync.yaml
+
+.PHONY: sync-component-chart
+sync-component-chart: export COMPONENT := $(COMPONENT)
+sync-component-chart: ## Sync a single component chart. Usage: make sync-component-chart COMPONENT=dns-operator
+ifndef COMPONENT
+	$(error COMPONENT is required. Usage: make sync-component-chart COMPONENT=dns-operator)
+endif
+	@go run $(PROJECT_PATH)/hack/sync-components/ sync --config $(COMPONENT_CHARTS_DIR)/sync.yaml --component "$${COMPONENT}"
+
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/component-charts/README.md
+++ b/component-charts/README.md
@@ -1,0 +1,21 @@
+# Component Charts
+
+This directory contains Helm charts synced from upstream component repos. **Do not edit files in this directory manually** — they are managed by the sync tool and will be overwritten on the next sync.
+
+## How it works
+
+Charts are downloaded as-is from upstream repos based on the configuration in `sync.yaml`. Each component directory contains the complete upstream chart (Chart.yaml, values.yaml, templates/, crds/).
+
+## Syncing
+
+```bash
+# Sync all components
+make sync-component-charts
+
+# Sync a single component
+make sync-component-chart COMPONENT=dns-operator
+```
+
+## Configuration
+
+Edit `sync.yaml` to change which upstream branches are tracked. The `ref` field is managed by the sync tool and updated automatically to the resolved commit SHA — do not edit it manually. To follow a different upstream branch, change `tracked-branch`.

--- a/component-charts/dns-operator/.helmignore
+++ b/component-charts/dns-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/component-charts/dns-operator/Chart.yaml
+++ b/component-charts/dns-operator/Chart.yaml
@@ -1,0 +1,85 @@
+apiVersion: v2
+name: dns-operator
+description: Kubernetes operator responsible for reconciling DNS Record custom resources.
+home: https://kuadrant.io
+icon: https://raw.githubusercontent.com/Kuadrant/kuadrant.github.io/main/static/img/apple-touch-icon.png
+keywords:
+  - dns
+  - kubernetes
+  - kuadrant
+sources:
+  - https://github.com/Kuadrant/dns-operator/
+kubeVersion: ">=1.19.0-0"
+type: application
+# The version will be properly set when the chart is released matching the operator version
+version: "0.0.0"
+appVersion: "0.0.0"
+maintainers:
+  - email: mnairn@redhat.com
+    name: Michael Nairn
+  - email: cbrookes@redhat.com
+    name: Craig Brookes
+  - email: pbrookes@redhat.com
+    name: Phil Brookes
+  - email: didier@redhat.com
+    name: Didier Di Cesare
+annotations:
+  artifacthub.io/category: networking
+  artifacthub.io/crds: |
+    - kind: DNSRecord
+      version: v1alpha1
+      name: dnsrecords.kuadrant.io
+      displayName: DNSRecord
+      description: DNSRecord is the Schema for the dnsrecords API.
+    - kind: DNSHealthCheckProbe
+      version: v1alpha1
+      name: dnshealthcheckprobes.kuadrant.io
+      displayName: DNSHealthCheckProbe
+      description: DNSHealthCheckProbe is the Schema for the dnshealthcheckprobes API.
+  artifacthub.io/crdsExamples: |
+    - apiVersion: kuadrant.io/v1alpha1
+      kind: DNSRecord
+      metadata:
+        labels:
+          app.kubernetes.io/name: dnsrecord
+          app.kubernetes.io/instance: dnsrecord-sample
+          app.kubernetes.io/part-of: dns-operator
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/created-by: dns-operator
+        name: dnsrecord-sample
+      spec:
+            providerRef:
+              name: dns-provider-creds
+            endpoints:
+              - dnsName: dnsrecord-simple.example.com
+                recordTTL: 60
+                recordType: A
+                targets:
+                  - 52.215.108.61
+                  - 52.30.101.221
+    - apiVersion: kuadrant.io/v1alpha1
+      kind: DNSHealthCheckProbe
+      metadata:
+        name: $NAME
+      spec:
+        port: 443
+        hostname: test.com
+        address: 192.168.0.16
+        path: /healthz
+        protocol: HTTPS
+        interval: 60s
+        additionalHeadersRef:
+          name: headers
+        failureThreshold: 5
+        allowInsecureCertificate: True
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Kuadrant
+      url: https://kuadrant.io
+    - name: Github
+      url: https://github.com/Kuadrant/dns-operator
+  artifacthub.io/operator: "true"
+  artifacthub.io/operatorCapabilities: Basic Install
+  artifacthub.io/signKey: |
+    fingerprint: 8A2150B44E1994E1E91ED9E5E19171BE516B79C7
+    url: https://kuadrant.io/helm-charts/kuadrant-public-key.asc

--- a/component-charts/dns-operator/README.md
+++ b/component-charts/dns-operator/README.md
@@ -1,0 +1,21 @@
+# DNS Operator
+
+This is the Helm Chart to install the official Kuadrant DNS Kubernetes Operator
+
+## Installation
+
+```sh
+helm repo add kuadrant https://kuadrant.io/helm-charts/ --force-update
+helm install \
+ dns-operator kuadrant/dns-operator \
+ --create-namespace \
+ --namespace kuadrant-system
+```
+
+### Parameters
+
+**Coming soon!** At the moment, there's no configuration parameters exposed.
+
+## Usage
+
+Read the documentation and user guides in the [Getting Started guide](https://github.com/Kuadrant/dns-operator/?tab=readme-ov-file#getting-started).

--- a/component-charts/dns-operator/templates/manifests.yaml
+++ b/component-charts/dns-operator/templates/manifests.yaml
@@ -1,0 +1,975 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    app.kubernetes.io/managed-by: helm
+  name: dnshealthcheckprobes.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: DNSHealthCheckProbe
+    listKind: DNSHealthCheckProbeList
+    plural: dnshealthcheckprobes
+    singular: dnshealthcheckprobe
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: DNSHealthCheckProbe healthy.
+      jsonPath: .status.healthy
+      name: Healthy
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNSHealthCheckProbe is the Schema for the dnshealthcheckprobes
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSHealthCheckProbeSpec defines the desired state of DNSHealthCheckProbe
+            properties:
+              additionalHeadersRef:
+                description: |-
+                  AdditionalHeadersRef refers to a secret that contains extra headers to send in the probe request, this is primarily useful if an authentication
+                  token is required by the endpoint.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              address:
+                description: Address to connect to the host on (IP Address (A Record)
+                  or hostname (CNAME)).
+                type: string
+              allowInsecureCertificate:
+                description: |-
+                  AllowInsecureCertificate will instruct the health check probe to not fail on a self-signed or otherwise invalid SSL certificate
+                  this is primarily used in development or testing environments and is set by the --insecure-health-checks flag
+                type: boolean
+              failureThreshold:
+                description: |-
+                  FailureThreshold is the number of consecutive failures that must be exceeded for a host to be considered unhealthy.
+                  When the number of consecutive failures exceeds this threshold, the health check will be marked as unhealthy.
+                type: integer
+                x-kubernetes-validations:
+                - message: Failure threshold must be greater than 0
+                  rule: self > 0
+              hostname:
+                description: |-
+                  Hostname is the value sent in the host header, to route the request to the correct service
+                  Represents a root host of the parent DNS Record.
+                type: string
+              interval:
+                description: Interval defines how frequently this probe should execute
+                type: string
+              path:
+                description: |-
+                  Path is the path to append to the host to reach the expected health check.
+                  Must start with "?" or "/", contain only valid URL characters and end with alphanumeric char or "/". For example "/" or "/healthz" are common
+                pattern: ^(?:\?|\/)[\w\-.~:\/?#\[\]@!$&'()*+,;=]+(?:[a-zA-Z0-9]|\/){1}$
+                type: string
+              port:
+                description: Port to connect to the host on. Must be either 80, 443
+                  or 1024-49151
+                type: integer
+                x-kubernetes-validations:
+                - message: Only ports 80, 443, 1024-49151 are allowed
+                  rule: self in [80, 443] || (self >= 1024 && self <= 49151)
+              protocol:
+                description: Protocol to use when connecting to the host, valid values
+                  are "HTTP" or "HTTPS"
+                type: string
+                x-kubernetes-validations:
+                - message: Only HTTP or HTTPS protocols are allowed
+                  rule: self in ['HTTP','HTTPS']
+            type: object
+          status:
+            description: DNSHealthCheckProbeStatus defines the observed state of DNSHealthCheckProbe
+            properties:
+              consecutiveFailures:
+                type: integer
+              healthy:
+                type: boolean
+              observedGeneration:
+                format: int64
+                type: integer
+              reason:
+                type: string
+              status:
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    app.kubernetes.io/managed-by: helm
+  name: dnsrecords.kuadrant.io
+spec:
+  group: kuadrant.io
+  names:
+    kind: DNSRecord
+    listKind: DNSRecordList
+    plural: dnsrecords
+    singular: dnsrecord
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: DNSRecord ready.
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: DNSRecord healthy.
+      jsonPath: .status.conditions[?(@.type=="Healthy")].status
+      name: Healthy
+      priority: 2
+      type: string
+    - description: DNSRecord root host.
+      jsonPath: .spec.rootHost
+      name: Root Host
+      priority: 2
+      type: string
+    - description: DNSRecord owner id.
+      jsonPath: .status.ownerID
+      name: Owner ID
+      priority: 2
+      type: string
+    - description: DNSRecord zone domain name.
+      jsonPath: .status.zoneDomainName
+      name: Zone Domain
+      priority: 2
+      type: string
+    - description: DNSRecord zone id.
+      jsonPath: .status.zoneID
+      name: Zone ID
+      priority: 2
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DNSRecord is the Schema for the dnsrecords API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSRecordSpec defines the desired state of DNSRecord
+            properties:
+              delegate:
+                type: boolean
+                x-kubernetes-validations:
+                - message: delegate is immutable
+                  rule: self == oldSelf
+              endpoints:
+                description: endpoints is a list of endpoints that will be published
+                  into the dns provider.
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                minItems: 0
+                type: array
+              healthCheck:
+                description: |-
+                  HealthCheckSpec configures health checks in the DNS provider.
+                  By default this health check will be applied to each unique DNS A Record for
+                  the listeners assigned to the target gateway
+                properties:
+                  additionalHeadersRef:
+                    description: |-
+                      AdditionalHeadersRef refers to a secret that contains extra headers to send in the probe request, this is primarily useful if an authentication
+                      token is required by the endpoint.
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  failureThreshold:
+                    default: 5
+                    description: |-
+                      FailureThreshold is the number of consecutive failures that must be exceeded for a host to be considered unhealthy.
+                      When the number of consecutive failures exceeds this threshold, the health check will be marked as unhealthy.
+                      Defaults to 5
+                    type: integer
+                    x-kubernetes-validations:
+                    - message: Failure threshold must be greater than 0
+                      rule: self > 0
+                  interval:
+                    default: 5m
+                    description: |-
+                      Interval defines how frequently this probe should execute
+                      Defaults to 5 minutes
+                    type: string
+                  path:
+                    description: |-
+                      Path is the path to append to the host to reach the expected health check.
+                      Must start with "?" or "/", contain only valid URL characters and end with alphanumeric char or "/". For example "/" or "/healthz" are common
+                    pattern: ^(?:\?|\/)[\w\-.~:\/?#\[\]@!$&'()*+,;=]+(?:[a-zA-Z0-9]|\/){1}$
+                    type: string
+                  port:
+                    default: 443
+                    description: |-
+                      Port to connect to the host on. Must be either 80, 443 or 1024-49151
+                      Defaults to port 443
+                    type: integer
+                    x-kubernetes-validations:
+                    - message: Only ports 80, 443, 1024-49151 are allowed
+                      rule: self in [80, 443] || (self >= 1024 && self <= 49151)
+                  protocol:
+                    default: HTTPS
+                    description: |-
+                      Protocol to use when connecting to the host, valid values are "HTTP" or "HTTPS"
+                      Defaults to HTTPS
+                    type: string
+                    x-kubernetes-validations:
+                    - message: Only HTTP or HTTPS protocols are allowed
+                      rule: self in ['HTTP','HTTPS']
+                type: object
+              ownerID:
+                description: |-
+                  ownerID is a unique string used to identify the owner of this record.
+                  If unset or set to an empty string the record UID will be used.
+                maxLength: 36
+                minLength: 6
+                type: string
+                x-kubernetes-validations:
+                - message: OwnerID is immutable
+                  rule: self == oldSelf
+              providerRef:
+                description: ProviderRef is a reference to a provider secret.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              rootHost:
+                description: |-
+                  rootHost is the single root for all endpoints in a DNSRecord.
+                  it is expected all defined endpoints are children of or equal to this rootHost
+                  Must contain at least two groups of valid URL characters separated by a "."
+                maxLength: 255
+                minLength: 1
+                pattern: ^(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)\.(?:[\w\-.~:\/?#[\]@!$&'()*+,;=]+)$
+                type: string
+                x-kubernetes-validations:
+                - message: RootHost is immutable
+                  rule: self == oldSelf
+            required:
+            - rootHost
+            type: object
+            x-kubernetes-validations:
+            - message: OwnerID can't be unset if it was previously set
+              rule: '!has(oldSelf.ownerID) || has(self.ownerID)'
+            - message: OwnerID can't be set if it was previously unset
+              rule: has(oldSelf.ownerID) || !has(self.ownerID)
+            - message: delegate can't be set to true if unset
+              rule: has(oldSelf.delegate) || !has(self.delegate) || self.delegate
+                == false
+            - message: delegate can't be unset if true
+              rule: '!has(oldSelf.delegate) || oldSelf.delegate == false || has(self.delegate)'
+            - message: delegate=true and providerRef are mutually exclusive
+              rule: '!(has(self.providerRef) && has(self.delegate) && self.delegate
+                == true)'
+          status:
+            description: DNSRecordStatus defines the observed state of DNSRecord
+            properties:
+              activeGroups:
+                description: ActiveGroups displays the last read list of active groups
+                type: string
+              conditions:
+                description: |-
+                  conditions are any conditions associated with the record in the dns provider.
+
+                  If publishing the record fails, the "Failed" condition will be set with a
+                  reason and message describing the cause of the failure.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              domainOwners:
+                description: DomainOwners is a list of all the owners working against
+                  the root domain of this record
+                items:
+                  type: string
+                type: array
+              endpoints:
+                description: endpoints are the last endpoints that were successfully
+                  published to the provider zone
+                items:
+                  description: Endpoint is a high-level way of a connection between
+                    a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value
+                          of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, AAAA,
+                        SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with
+                        the same name and type (e.g. Route53 records with routing
+                        policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+              group:
+                description: Group displays the group which the dns-operator belongs
+                  to, if set.
+                type: string
+              healthCheck:
+                properties:
+                  conditions:
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  probes:
+                    items:
+                      properties:
+                        conditions:
+                          items:
+                            description: Condition contains details for one aspect
+                              of the current state of this API Resource.
+                            properties:
+                              lastTransitionTime:
+                                description: |-
+                                  lastTransitionTime is the last time the condition transitioned from one status to another.
+                                  This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                format: date-time
+                                type: string
+                              message:
+                                description: |-
+                                  message is a human readable message indicating details about the transition.
+                                  This may be an empty string.
+                                maxLength: 32768
+                                type: string
+                              observedGeneration:
+                                description: |-
+                                  observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                  For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                  with respect to the current state of the instance.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                              reason:
+                                description: |-
+                                  reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                  Producers of specific condition types may define expected values and meanings for this field,
+                                  and whether the values are considered a guaranteed API.
+                                  The value should be a CamelCase string.
+                                  This field may not be empty.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                type: string
+                              status:
+                                description: status of the condition, one of True,
+                                  False, Unknown.
+                                enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                                type: string
+                              type:
+                                description: type of condition in CamelCase or in
+                                  foo.example.com/CamelCase.
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                            required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                            type: object
+                          type: array
+                        host:
+                          type: string
+                        id:
+                          type: string
+                        ipAddress:
+                          type: string
+                        synced:
+                          type: boolean
+                      required:
+                      - host
+                      - id
+                      - ipAddress
+                      type: object
+                    type: array
+                type: object
+              observedGeneration:
+                description: observedGeneration is the most recently observed generation
+                  of the DNSRecord.
+                format: int64
+                type: integer
+              ownerID:
+                description: ownerID is a unique string used to identify the owner
+                  of this record.
+                type: string
+              providerRef:
+                description: ProviderRef is a reference to a provider secret used
+                  to publish endpoints.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              queuedAt:
+                description: QueuedAt is a time when DNS record was received for the
+                  reconciliation
+                format: date-time
+                type: string
+              remoteRecordStatuses:
+                additionalProperties:
+                  x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  remoteRecordStatuses is a map of cluster IDs and their unique DNSRecordStatus as raw JSON.
+
+                  A CRD can't reference a type within itself so the `apiextensionsv1.JSON` type is used.
+                  Use GetRemoteRecordStatuses to get the converted type.
+                type: object
+              validFor:
+                description: ValidFor indicates duration since the last reconciliation
+                  we consider data in the record to be valid
+                type: string
+              writeCounter:
+                description: |-
+                  WriteCounter represent a number of consecutive write attempts on the same generation of the record.
+                  It is being reset to 0 when the generation changes or there are no changes to write.
+                format: int64
+                type: integer
+              zoneDomainName:
+                description: zoneDomainName is the domain name of the zone that the
+                  dns record is publishing endpoints
+                type: string
+              zoneID:
+                description: zoneID is the provider specific id to which this dns
+                  record is publishing endpoints
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-controller-manager
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: remote-cluster-sa
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-remote-cluster
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-leader-election-role
+  namespace: '{{ .Release.Namespace }}'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: helm
+  name: dns-operator-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnshealthcheckprobes
+  - dnsrecords
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnshealthcheckprobes/finalizers
+  - dnsrecords/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnshealthcheckprobes/status
+  - dnsrecords/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: helm
+  name: dns-operator-remote-cluster-role
+rules:
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - dnsrecords/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-leader-election-rolebinding
+  namespace: '{{ .Release.Namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dns-operator-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: dns-operator-controller-manager
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dns-operator-manager-role
+subjects:
+- kind: ServiceAccount
+  name: dns-operator-controller-manager
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: remote-cluster-rolebinding
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: dns-operator
+  name: dns-operator-remote-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dns-operator-remote-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: dns-operator-remote-cluster
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: helm
+  name: dns-operator-controller-env
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: helm
+    control-plane: dns-operator-controller-manager
+  name: dns-operator-controller-manager-metrics-service
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    targetPort: metrics
+  - name: pprof
+    port: 8082
+    targetPort: pprof
+  selector:
+    control-plane: dns-operator-controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: dns-operator
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: dns-operator
+    control-plane: dns-operator-controller-manager
+  name: dns-operator-controller-manager
+  namespace: '{{ .Release.Namespace }}'
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: dns-operator-controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/managed-by: helm
+        control-plane: dns-operator-controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8080
+        - --leader-elect
+        command:
+        - /manager
+        env:
+        - name: WATCH_NAMESPACES
+          value: ""
+        - name: CLUSTER_SECRET_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        envFrom:
+        - configMapRef:
+            name: dns-operator-controller-env
+        image: quay.io/kuadrant/dns-operator:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 8080
+          name: metrics
+        - containerPort: 8082
+          name: pprof
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: dns-operator-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/component-charts/dns-operator/values.yaml
+++ b/component-charts/dns-operator/values.yaml
@@ -1,0 +1,1 @@
+# For its first iteration, this chart won't be configurable with helm settings

--- a/component-charts/sync.yaml
+++ b/component-charts/sync.yaml
@@ -14,7 +14,7 @@ components:
     repo: Kuadrant/dns-operator
     chart-path: charts/dns-operator
     tracked-branch: main
-    ref: main
+    ref: c6cb081c14a94591e7f5d4082eecbdb7188e19b4
     auto-merge: false
 #  authorino-operator:
 #    repo: Kuadrant/authorino-operator

--- a/component-charts/sync.yaml
+++ b/component-charts/sync.yaml
@@ -1,0 +1,36 @@
+# component-charts/sync.yaml
+# Declares which component Helm charts to sync from upstream repos.
+# Each kuadrant-operator branch maintains its own copy with appropriate refs.
+#
+# Fields:
+#   repo:            GitHub org/repo (e.g. Kuadrant/dns-operator)
+#   chart-path:      Path to Helm chart within the upstream repo
+#   tracked-branch:  Upstream branch this kuadrant-operator branch follows (for dispatch matching)
+#   ref:             Pinned commit SHA (managed by the sync tool, do not edit manually)
+#   auto-merge:      (Optional) If true, sync PRs auto-merge when all branch protection requirements are met (CI, approvals, etc.)
+
+components:
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    chart-path: charts/dns-operator
+    tracked-branch: main
+    ref: main
+    auto-merge: false
+#  authorino-operator:
+#    repo: Kuadrant/authorino-operator
+#    chart-path: charts/authorino-operator
+#    tracked-branch: main
+#    ref: main
+#    auto-merge: false
+#  limitador-operator:
+#    repo: Kuadrant/limitador-operator
+#    chart-path: charts/limitador-operator
+#    tracked-branch: main
+#    ref: main
+#    auto-merge: false
+#  mcp-gateway:
+#    repo: Kuadrant/mcp-gateway
+#    chart-path: charts/mcp-gateway
+#    tracked-branch: main
+#    ref: main
+#    auto-merge: false

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9
 	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.36.11
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools v2.2.0+incompatible
 	istio.io/api v1.22.3-0.20240703105953-437a88321a16
 	istio.io/client-go v1.22.3-0.20240703110620-5f69a1e4c030

--- a/hack/sync-components/README.md
+++ b/hack/sync-components/README.md
@@ -1,0 +1,94 @@
+# sync-components
+
+CLI tool for syncing upstream component Helm charts into `component-charts/`. Downloads charts as-is from GitHub, pins the commit SHA in `component-charts/sync.yaml`, and outputs JSON results.
+
+## Usage
+
+```bash
+# Via make targets
+make sync-component-charts                          # sync all components
+make sync-component-chart COMPONENT=dns-operator    # sync one component
+
+# Direct invocation
+go run ./hack/sync-components/ sync --config component-charts/sync.yaml
+go run ./hack/sync-components/ sync --config component-charts/sync.yaml --component dns-operator
+```
+
+## Subcommands
+
+### sync
+
+Downloads charts from upstream repos and updates the `ref` in `sync.yaml` to the resolved commit SHA. Human-readable progress is written to stderr; JSON results are written to stdout.
+
+```bash
+go run ./hack/sync-components/ sync --config component-charts/sync.yaml --component dns-operator
+```
+
+When the chart has been updated:
+```text
+Syncing dns-operator from Kuadrant/dns-operator@cda782a
+  Previous: abc123def45
+  Updated.
+{
+  "dns-operator": {
+    "repo": "Kuadrant/dns-operator",
+    "old-ref": "abc123def456789...",
+    "new-ref": "cda782a01149775...",
+    "changed": true,
+    "status": "updated"
+  }
+}
+```
+
+When already up to date:
+```text
+Syncing dns-operator from Kuadrant/dns-operator@cda782a
+  No changes (already at cda782a).
+{
+  "dns-operator": {
+    "repo": "Kuadrant/dns-operator",
+    "old-ref": "cda782a01149775...",
+    "new-ref": "cda782a01149775...",
+    "changed": false,
+    "status": "up-to-date"
+  }
+}
+```
+
+### find-targets
+
+Queries the GitHub API to find which branches of a repo have a `sync.yaml` that tracks a given component at a given source branch. Used by the `sync-component-chart` GitHub Actions workflow.
+
+```bash
+go run ./hack/sync-components/ find-targets \
+    --repo Kuadrant/kuadrant-operator \
+    --component dns-operator \
+    --source-branch main
+```
+
+```json
+[{"branch":"main","auto-merge":true}]
+```
+
+Returns `[]` when no branches track the given component at that source branch.
+
+### query
+
+Outputs the tracking configuration for a single component as JSON.
+
+```bash
+go run ./hack/sync-components/ query --config component-charts/sync.yaml --component dns-operator
+```
+
+```json
+{"repo":"Kuadrant/dns-operator","chart-path":"charts/dns-operator","tracked-branch":"main","ref":"cda782a01149775b83062600c119971f45a657fb","auto-merge":true}
+```
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `GH_TOKEN` | GitHub token for API authentication (avoids rate limiting) |
+| `GITHUB_TOKEN` | Alternative to `GH_TOKEN` (set automatically in GitHub Actions) |
+
+Authentication is optional for public repos but recommended to avoid the 60 requests/hour unauthenticated rate limit.

--- a/hack/sync-components/cmd_find_targets.go
+++ b/hack/sync-components/cmd_find_targets.go
@@ -1,0 +1,78 @@
+// cmd_find_targets implements the "find-targets" subcommand: checks the
+// default branch of a given repo for a component-charts/sync.yaml that
+// tracks a given component at a given source branch. Used by the sync
+// workflow to determine whether to sync when a component repo dispatches
+// an event.
+//
+// Currently only checks the default branch. Release branch support can be
+// added later when the branch mapping strategy is better defined.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+)
+
+type targetBranch struct {
+	Branch    string `json:"branch"`
+	AutoMerge bool   `json:"auto-merge"`
+}
+
+func cmdFindTargets(args []string) {
+	fs := flag.NewFlagSet("find-targets", flag.ExitOnError)
+	repo := fs.String("repo", "", "GitHub owner/repo to search (e.g. Kuadrant/kuadrant-operator). "+
+		"The default branch is checked for a component-charts/sync.yaml file")
+	componentName := fs.String("component", "", "Component name to look up in sync.yaml (e.g. dns-operator)")
+	sourceBranch := fs.String("source-branch", "", "The upstream branch that changed (e.g. main). "+
+		"Matched against the tracked-branch field in sync.yaml")
+	fs.Parse(args)
+
+	if *repo == "" || *componentName == "" || *sourceBranch == "" {
+		fmt.Fprintf(os.Stderr, "Error: --repo, --component, and --source-branch are required\n")
+		os.Exit(1)
+	}
+
+	defaultBranch, err := getDefaultBranch(*repo)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error getting default branch: %v\n", err)
+		os.Exit(1)
+	}
+
+	matches := []targetBranch{}
+
+	data, err := getFileContent(*repo, "component-charts/sync.yaml", defaultBranch)
+	if err != nil {
+		var apiErr *ghAPIError
+		if errors.As(err, &apiErr) && apiErr.StatusCode == 404 {
+			if err := json.NewEncoder(os.Stdout).Encode(matches); err != nil {
+				fmt.Fprintf(os.Stderr, "Error writing results: %v\n", err)
+				os.Exit(1)
+			}
+			return
+		}
+		fmt.Fprintf(os.Stderr, "Error fetching sync.yaml from %s@%s: %v\n", *repo, defaultBranch, err)
+		os.Exit(1)
+	}
+
+	cfg, err := loadConfigFromBytes(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error parsing sync.yaml from %s@%s: %v\n", *repo, defaultBranch, err)
+		os.Exit(1)
+	}
+
+	c, ok := cfg.Components[*componentName]
+	if ok && c.TrackedBranch == *sourceBranch {
+		matches = append(matches, targetBranch{
+			Branch:    defaultBranch,
+			AutoMerge: c.AutoMerge,
+		})
+	}
+
+	if err := json.NewEncoder(os.Stdout).Encode(matches); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing results: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/hack/sync-components/cmd_query.go
+++ b/hack/sync-components/cmd_query.go
@@ -1,0 +1,40 @@
+// cmd_query implements the "query" subcommand: reads sync.yaml and outputs
+// the configuration for a given component as JSON.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+)
+
+func cmdQuery(args []string) {
+	fs := flag.NewFlagSet("query", flag.ExitOnError)
+	configPath := fs.String("config", "component-charts/sync.yaml", "Path to sync config file")
+	componentName := fs.String("component", "", "component name (required)")
+	fs.Parse(args)
+
+	if *componentName == "" {
+		fmt.Fprintf(os.Stderr, "Usage: sync-components query --component NAME [--config PATH]\n")
+		os.Exit(1)
+	}
+
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	c, ok := cfg.Components[*componentName]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "Error: component %q not found in config\n", *componentName)
+		os.Exit(1)
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	if err := enc.Encode(c); err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/hack/sync-components/cmd_sync.go
+++ b/hack/sync-components/cmd_sync.go
@@ -1,0 +1,198 @@
+// cmd_sync implements the "sync" subcommand: resolves each component's
+// tracked branch to a commit SHA, downloads the chart at that SHA, and
+// updates the ref in sync.yaml. Outputs JSON results to stdout.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+type syncResult struct {
+	Repo    string `json:"repo"`
+	OldRef  string `json:"old-ref"`
+	NewRef  string `json:"new-ref"`
+	Changed bool   `json:"changed"`
+	Status  string `json:"status"`
+}
+
+func cmdSync(args []string) {
+	fs := flag.NewFlagSet("sync", flag.ExitOnError)
+	configPath := fs.String("config", "component-charts/sync.yaml", "Path to sync config file")
+	componentName := fs.String("component", "", "Sync a specific component (default: all)")
+	fs.Parse(args)
+
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	components := cfg.Components
+	if *componentName != "" {
+		c, ok := cfg.Components[*componentName]
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Error: component %q not found in config\n", *componentName)
+			os.Exit(1)
+		}
+		components = map[string]component{*componentName: c}
+	}
+
+	names := make([]string, 0, len(components))
+	for name := range components {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	results := make(map[string]syncResult)
+	failed := false
+
+	for _, name := range names {
+		result := syncOne(name, components[name], *configPath)
+		results[name] = result
+		if result.Status == "error" {
+			failed = true
+		}
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(results); err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing results: %v\n", err)
+		os.Exit(1)
+	}
+
+	if failed {
+		os.Exit(1)
+	}
+}
+
+func syncOne(name string, c component, configPath string) syncResult {
+	outputBase := filepath.Dir(configPath)
+	chartDir := filepath.Join(outputBase, name)
+
+	resolveRef := c.Ref
+	if c.TrackedBranch != "" {
+		resolveRef = c.TrackedBranch
+	}
+
+	sha, err := resolveCommitSHA(c.Repo, resolveRef)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving %s@%s: %v\n", c.Repo, resolveRef, err)
+		return syncResult{Repo: c.Repo, OldRef: c.Ref, Status: "error"}
+	}
+
+	if sha == c.Ref {
+		fmt.Fprintf(os.Stderr, "Syncing %s from %s@%s\n", name, c.Repo, sha[:12])
+		fmt.Fprintf(os.Stderr, "  No changes (already at %s).\n", sha[:12])
+		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Changed: false, Status: "up-to-date"}
+	}
+
+	fmt.Fprintf(os.Stderr, "Syncing %s from %s@%s\n", name, c.Repo, sha[:12])
+	if c.Ref != "" && c.Ref != c.TrackedBranch {
+		fmt.Fprintf(os.Stderr, "  Previous: %s\n", c.Ref[:min(12, len(c.Ref))])
+	}
+
+	oldHash, _ := hashDir(chartDir) // tolerate missing chart dir on first sync
+
+	tmpDir, err := os.MkdirTemp(outputBase, ".sync-component-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating temp dir: %v\n", err)
+		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Status: "error"}
+	}
+
+	if err := downloadChart(c.Repo, sha, c.ChartPath, tmpDir); err != nil {
+		os.RemoveAll(tmpDir)
+		fmt.Fprintf(os.Stderr, "Error syncing %s: %v\n", name, err)
+		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Status: "error"}
+	}
+
+	newHash, err := hashDir(tmpDir)
+	if err != nil {
+		os.RemoveAll(tmpDir)
+		fmt.Fprintf(os.Stderr, "Error hashing downloaded chart for %s: %v\n", name, err)
+		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Status: "error"}
+	}
+
+	if oldHash == newHash {
+		os.RemoveAll(tmpDir)
+		if err := updateRef(configPath, name, sha); err != nil {
+			fmt.Fprintf(os.Stderr, "Error updating ref for %s: %v\n", name, err)
+			return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Status: "error"}
+		}
+		fmt.Fprintf(os.Stderr, "  Ref updated to %s (chart content unchanged).\n", sha[:12])
+		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Changed: true, Status: "ref-updated"}
+	}
+
+	// Backup existing chart so we can restore if the ref update fails.
+	backupDir := chartDir + ".bak"
+	os.RemoveAll(backupDir)
+	hasBackup := false
+	if _, err := os.Stat(chartDir); err == nil {
+		if err := os.Rename(chartDir, backupDir); err != nil {
+			os.RemoveAll(tmpDir)
+			fmt.Fprintf(os.Stderr, "Error backing up %s: %v\n", chartDir, err)
+			return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Status: "error"}
+		}
+		hasBackup = true
+	}
+
+	if err := os.Rename(tmpDir, chartDir); err != nil {
+		if hasBackup {
+			os.Rename(backupDir, chartDir)
+		}
+		fmt.Fprintf(os.Stderr, "Error moving chart to %s: %v\n", chartDir, err)
+		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Status: "error"}
+	}
+
+	if err := updateRef(configPath, name, sha); err != nil {
+		// Restore backup on ref update failure
+		os.RemoveAll(chartDir)
+		if hasBackup {
+			os.Rename(backupDir, chartDir)
+		}
+		fmt.Fprintf(os.Stderr, "Error updating ref for %s: %v\n", name, err)
+		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Status: "error"}
+	}
+	os.RemoveAll(backupDir)
+	fmt.Fprintf(os.Stderr, "  Updated.\n")
+	return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Changed: true, Status: "updated"}
+}
+
+func hashDir(dir string) (string, error) {
+	h := sha256.New()
+	var files []string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		files = append(files, rel)
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sort.Strings(files)
+	for _, f := range files {
+		fmt.Fprintf(h, "%s\n", f)
+		data, err := os.ReadFile(filepath.Join(dir, f))
+		if err != nil {
+			return "", err
+		}
+		h.Write(data)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/hack/sync-components/config.go
+++ b/hack/sync-components/config.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type component struct {
+	Repo          string `yaml:"repo" json:"repo"`
+	ChartPath     string `yaml:"chart-path" json:"chart-path"`
+	TrackedBranch string `yaml:"tracked-branch" json:"tracked-branch"`
+	Ref           string `yaml:"ref" json:"ref"`
+	AutoMerge     bool   `yaml:"auto-merge" json:"auto-merge"`
+}
+
+type syncConfig struct {
+	Components map[string]component `yaml:"components"`
+}
+
+func loadConfig(path string) (*syncConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config: %w", err)
+	}
+	return loadConfigFromBytes(data)
+}
+
+func loadConfigFromBytes(data []byte) (*syncConfig, error) {
+	var cfg syncConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+
+	if len(cfg.Components) == 0 {
+		return nil, fmt.Errorf("no components defined")
+	}
+
+	for name, c := range cfg.Components {
+		if c.Repo == "" {
+			return nil, fmt.Errorf("component %q: repo is required", name)
+		}
+		if c.ChartPath == "" {
+			return nil, fmt.Errorf("component %q: chart-path is required", name)
+		}
+		if c.Ref == "" {
+			return nil, fmt.Errorf("component %q: ref is required", name)
+		}
+	}
+
+	return &cfg, nil
+}
+
+func updateRef(path, componentName, newRef string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading config: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	inComponent := false
+	updated := false
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if trimmed == componentName+":" {
+			inComponent = true
+			continue
+		}
+
+		if inComponent && strings.HasPrefix(trimmed, "ref:") {
+			indent := line[:len(line)-len(strings.TrimLeft(line, " "))]
+			lines[i] = indent + "ref: " + newRef
+			updated = true
+			inComponent = false
+			continue
+		}
+
+		// Left the component block: a non-empty, non-comment line at a
+		// lower indent level (i.e. not starting with spaces on the raw line).
+		if inComponent && len(trimmed) > 0 && !strings.HasPrefix(trimmed, "#") {
+			leadingSpaces := len(line) - len(strings.TrimLeft(line, " "))
+			if leadingSpaces == 0 {
+				inComponent = false
+			}
+		}
+	}
+
+	if !updated {
+		return fmt.Errorf("ref field for component %q not found in %s", componentName, path)
+	}
+
+	// Write to a temporary file in the same directory and atomically rename
+	// into place to avoid leaving a partial sync.yaml on write failure.
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".sync-yaml-*")
+	if err != nil {
+		return fmt.Errorf("creating temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.WriteString(strings.Join(lines, "\n")); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("writing temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("closing temp file: %w", err)
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/hack/sync-components/config_test.go
+++ b/hack/sync-components/config_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantCount int
+		wantErr   bool
+		check     func(t *testing.T, cfg *syncConfig)
+	}{
+		{
+			name: "single component",
+			yaml: `components:
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    chart-path: charts/dns-operator
+    tracked-branch: main
+    ref: main
+`,
+			wantCount: 1,
+			check: func(t *testing.T, cfg *syncConfig) {
+				c, ok := cfg.Components["dns-operator"]
+				if !ok {
+					t.Fatal("dns-operator not found")
+				}
+				if c.Repo != "Kuadrant/dns-operator" {
+					t.Errorf("repo = %q, want %q", c.Repo, "Kuadrant/dns-operator")
+				}
+				if c.ChartPath != "charts/dns-operator" {
+					t.Errorf("chart-path = %q, want %q", c.ChartPath, "charts/dns-operator")
+				}
+				if c.TrackedBranch != "main" {
+					t.Errorf("tracked-branch = %q, want %q", c.TrackedBranch, "main")
+				}
+				if c.Ref != "main" {
+					t.Errorf("ref = %q, want %q", c.Ref, "main")
+				}
+			},
+		},
+		{
+			name: "multiple components",
+			yaml: `components:
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    chart-path: charts/dns-operator
+    tracked-branch: main
+    ref: main
+  mcp-gateway:
+    repo: Kuadrant/mcp-gateway
+    chart-path: charts/mcp-gateway
+    tracked-branch: main
+    ref: v0.1.0
+`,
+			wantCount: 2,
+			check: func(t *testing.T, cfg *syncConfig) {
+				mcpgw := cfg.Components["mcp-gateway"]
+				if mcpgw.Ref != "v0.1.0" {
+					t.Errorf("mcp-gateway ref = %q, want %q", mcpgw.Ref, "v0.1.0")
+				}
+			},
+		},
+		{
+			name:    "empty file",
+			yaml:    "",
+			wantErr: true,
+		},
+		{
+			name: "missing required field repo",
+			yaml: `components:
+  dns-operator:
+    chart-path: charts/dns-operator
+    tracked-branch: main
+    ref: main
+`,
+			wantErr: true,
+		},
+		{
+			name: "missing required field chart-path",
+			yaml: `components:
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    tracked-branch: main
+    ref: main
+`,
+			wantErr: true,
+		},
+		{
+			name: "missing required field ref",
+			yaml: `components:
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    chart-path: charts/dns-operator
+    tracked-branch: main
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "sync.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cfg, err := loadConfig(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(cfg.Components) != tt.wantCount {
+				t.Errorf("component count = %d, want %d", len(cfg.Components), tt.wantCount)
+			}
+			if tt.check != nil {
+				tt.check(t, cfg)
+			}
+		})
+	}
+}
+
+func TestUpdateRef(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		component string
+		newRef    string
+		wantErr   bool
+	}{
+		{
+			name: "updates ref for component",
+			input: `components:
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    chart-path: charts/dns-operator
+    tracked-branch: main
+    ref: old-sha
+    auto-merge: true
+`,
+			component: "dns-operator",
+			newRef:    "new-sha-abc123",
+		},
+		{
+			name: "preserves comments and other components",
+			input: `# header comment
+components:
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    ref: old-sha
+#  other:
+#    ref: untouched
+`,
+			component: "dns-operator",
+			newRef:    "new-sha",
+		},
+		{
+			name: "component not found",
+			input: `components:
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    ref: old-sha
+`,
+			component: "nonexistent",
+			newRef:    "new-sha",
+			wantErr:   true,
+		},
+		{
+			name: "preserves indentation",
+			input: `components:
+    dns-operator:
+        repo: Kuadrant/dns-operator
+        ref: old-sha
+`,
+			component: "dns-operator",
+			newRef:    "new-sha",
+		},
+		{
+			name: "additional top-level keys below components",
+			input: `components:
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    ref: old-sha
+settings:
+  timeout: 30
+`,
+			component: "dns-operator",
+			newRef:    "new-sha",
+		},
+		{
+			name: "component name is not substring matched",
+			input: `components:
+  dns:
+    repo: Kuadrant/dns
+    ref: keep-this
+  dns-operator:
+    repo: Kuadrant/dns-operator
+    ref: old-sha
+`,
+			component: "dns-operator",
+			newRef:    "new-sha",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "sync.yaml")
+			if err := os.WriteFile(path, []byte(tt.input), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			err := updateRef(path, tt.component, tt.newRef)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var cfg syncConfig
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := yaml.Unmarshal(data, &cfg); err != nil {
+				t.Fatalf("failed to parse updated config: %v", err)
+			}
+			c, ok := cfg.Components[tt.component]
+			if !ok {
+				t.Fatalf("component %q not found in updated config", tt.component)
+			}
+			if c.Ref != tt.newRef {
+				t.Errorf("ref = %q, want %q", c.Ref, tt.newRef)
+			}
+		})
+	}
+}

--- a/hack/sync-components/download.go
+++ b/hack/sync-components/download.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	maxFileSize  = 50 << 20  // 50 MB per file
+	maxTotalSize = 200 << 20 // 200 MB total extraction limit
+)
+
+func downloadChart(repo, ref, chartPath, outputDir string) error {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/tarball/%s", repo, ref)
+
+	body, err := githubGetRaw(url)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+
+	return extractChart(body, chartPath, outputDir)
+}
+
+func extractChart(r io.Reader, chartPath, outputDir string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gz.Close()
+
+	prefix := chartPath + "/"
+	tr := tar.NewReader(gz)
+	found := false
+	var totalSize int64
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading tar: %w", err)
+		}
+
+		// GitHub tarballs have a top-level dir like "Org-Repo-SHA/"
+		parts := strings.SplitN(hdr.Name, "/", 2)
+		if len(parts) < 2 {
+			continue
+		}
+		relPath := parts[1]
+
+		if !strings.HasPrefix(relPath, prefix) {
+			continue
+		}
+		found = true
+
+		innerPath := strings.TrimPrefix(relPath, prefix)
+
+		cleaned := filepath.Clean(innerPath)
+		if filepath.IsAbs(cleaned) || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("invalid path in tarball: %s", relPath)
+		}
+
+		targetPath := filepath.Join(outputDir, cleaned)
+
+		switch hdr.Typeflag {
+		case tar.TypeSymlink, tar.TypeLink:
+			return fmt.Errorf("unsupported tar entry type (symlink) for %s", relPath)
+		case tar.TypeDir:
+			if err := os.MkdirAll(targetPath, 0o755); err != nil {
+				return fmt.Errorf("creating dir %s: %w", targetPath, err)
+			}
+		case tar.TypeReg:
+			if hdr.Size > maxFileSize {
+				return fmt.Errorf("file %s exceeds maximum size (%d > %d)", relPath, hdr.Size, maxFileSize)
+			}
+			totalSize += hdr.Size
+			if totalSize > maxTotalSize {
+				return fmt.Errorf("archive exceeds total extraction limit (%d > %d)", totalSize, maxTotalSize)
+			}
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+				return fmt.Errorf("creating parent dir for %s: %w", targetPath, err)
+			}
+			f, err := os.Create(targetPath)
+			if err != nil {
+				return fmt.Errorf("creating file %s: %w", targetPath, err)
+			}
+			if _, err := io.Copy(f, io.LimitReader(tr, maxFileSize)); err != nil {
+				f.Close()
+				return fmt.Errorf("writing file %s: %w", targetPath, err)
+			}
+			if err := f.Close(); err != nil {
+				return fmt.Errorf("closing file %s: %w", targetPath, err)
+			}
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("chart path %q not found in tarball", chartPath)
+	}
+	return nil
+}

--- a/hack/sync-components/download_test.go
+++ b/hack/sync-components/download_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func buildTestTarball(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name:     name,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tw.Close()
+	gz.Close()
+	return buf.Bytes()
+}
+
+func TestExtractChart(t *testing.T) {
+	tests := []struct {
+		name      string
+		chartPath string
+		files     map[string]string
+		wantFiles map[string]string
+		wantErr   bool
+	}{
+		{
+			name:      "simple chart extraction",
+			chartPath: "charts/dns-operator",
+			files: map[string]string{
+				"Kuadrant-dns-operator-abc1234/charts/dns-operator/Chart.yaml":               "apiVersion: v2\nname: dns-operator",
+				"Kuadrant-dns-operator-abc1234/charts/dns-operator/values.yaml":              "# empty",
+				"Kuadrant-dns-operator-abc1234/charts/dns-operator/templates/manifests.yaml": "kind: Deployment",
+				"Kuadrant-dns-operator-abc1234/README.md":                                    "# DNS Operator",
+				"Kuadrant-dns-operator-abc1234/go.mod":                                       "module foo",
+			},
+			wantFiles: map[string]string{
+				"Chart.yaml":               "apiVersion: v2\nname: dns-operator",
+				"values.yaml":              "# empty",
+				"templates/manifests.yaml": "kind: Deployment",
+			},
+		},
+		{
+			name:      "chart with crds directory",
+			chartPath: "charts/mcp-gateway",
+			files: map[string]string{
+				"Kuadrant-mcp-gateway-def5678/charts/mcp-gateway/Chart.yaml":                           "apiVersion: v2",
+				"Kuadrant-mcp-gateway-def5678/charts/mcp-gateway/values.yaml":                          "image: test",
+				"Kuadrant-mcp-gateway-def5678/charts/mcp-gateway/crds/mcpservers.yaml":                 "kind: CRD",
+				"Kuadrant-mcp-gateway-def5678/charts/mcp-gateway/templates/_helpers.tpl":               "{{/* helpers */}}",
+				"Kuadrant-mcp-gateway-def5678/charts/mcp-gateway/templates/deployment-controller.yaml": "kind: Deployment",
+			},
+			wantFiles: map[string]string{
+				"Chart.yaml":                           "apiVersion: v2",
+				"values.yaml":                          "image: test",
+				"crds/mcpservers.yaml":                 "kind: CRD",
+				"templates/_helpers.tpl":               "{{/* helpers */}}",
+				"templates/deployment-controller.yaml": "kind: Deployment",
+			},
+		},
+		{
+			name:      "chart not found in tarball",
+			chartPath: "charts/nonexistent",
+			files: map[string]string{
+				"Kuadrant-dns-operator-abc1234/charts/dns-operator/Chart.yaml": "apiVersion: v2",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tarball := buildTestTarball(t, tt.files)
+			outputDir := t.TempDir()
+
+			err := extractChart(bytes.NewReader(tarball), tt.chartPath, outputDir)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for relPath, wantContent := range tt.wantFiles {
+				fullPath := filepath.Join(outputDir, relPath)
+				got, err := os.ReadFile(fullPath)
+				if err != nil {
+					t.Errorf("expected file %s not found: %v", relPath, err)
+					continue
+				}
+				if string(got) != wantContent {
+					t.Errorf("file %s content = %q, want %q", relPath, string(got), wantContent)
+				}
+			}
+		})
+	}
+}

--- a/hack/sync-components/github.go
+++ b/hack/sync-components/github.go
@@ -1,0 +1,136 @@
+// Lightweight GitHub API client using net/http. We only need a handful of
+// endpoints (repo info, file contents, commit resolution) so a full client
+// library like google/go-github isn't justified. Revisit if the tool grows
+// to need more GitHub API surface.
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+var httpClient = &http.Client{
+	Timeout: 60 * time.Second,
+}
+
+func newGitHubRequest(method, url string) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if token := os.Getenv("GH_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	} else if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+
+	return req, nil
+}
+
+func githubGet(url string, target any) error {
+	req, err := newGitHubRequest("GET", url)
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return &ghAPIError{StatusCode: resp.StatusCode, URL: url}
+	}
+
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func githubGetRaw(url string) (io.ReadCloser, error) {
+	req, err := newGitHubRequest("GET", url)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP GET %s: %w", url, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, &ghAPIError{StatusCode: resp.StatusCode, URL: url}
+	}
+
+	return resp.Body, nil
+}
+
+func getDefaultBranch(repo string) (string, error) {
+	var repoInfo struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := githubGet(fmt.Sprintf("https://api.github.com/repos/%s", repo), &repoInfo); err != nil {
+		return "", err
+	}
+	return repoInfo.DefaultBranch, nil
+}
+
+type ghAPIError struct {
+	StatusCode int
+	URL        string
+}
+
+func (e *ghAPIError) Error() string {
+	return fmt.Sprintf("HTTP %d from %s", e.StatusCode, e.URL)
+}
+
+func getFileContent(repo, path, ref string) ([]byte, error) {
+	reqURL := fmt.Sprintf("https://api.github.com/repos/%s/contents/%s?ref=%s", repo, path, url.QueryEscape(ref))
+
+	req, err := newGitHubRequest("GET", reqURL)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP GET %s: %w", reqURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, &ghAPIError{StatusCode: resp.StatusCode, URL: reqURL}
+	}
+
+	var file struct {
+		Content  string `json:"content"`
+		Encoding string `json:"encoding"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&file); err != nil {
+		return nil, fmt.Errorf("decoding response from %s: %w", reqURL, err)
+	}
+	if file.Encoding != "base64" {
+		return nil, fmt.Errorf("unexpected encoding %q from %s", file.Encoding, reqURL)
+	}
+	cleaned := strings.ReplaceAll(file.Content, "\n", "")
+	return base64.StdEncoding.DecodeString(cleaned)
+}
+
+func resolveCommitSHA(repo, ref string) (string, error) {
+	var commit struct {
+		SHA string `json:"sha"`
+	}
+	reqURL := fmt.Sprintf("https://api.github.com/repos/%s/commits/%s", repo, url.PathEscape(ref))
+	if err := githubGet(reqURL, &commit); err != nil {
+		return "", err
+	}
+	return commit.SHA, nil
+}

--- a/hack/sync-components/main.go
+++ b/hack/sync-components/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage(1)
+	}
+
+	switch os.Args[1] {
+	case "sync":
+		cmdSync(os.Args[2:])
+	case "find-targets":
+		cmdFindTargets(os.Args[2:])
+	case "query":
+		cmdQuery(os.Args[2:])
+	case "help", "--help", "-h":
+		usage(0)
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown command: %s\n\n", os.Args[1])
+		usage(1)
+	}
+}
+
+func usage(exitCode int) {
+	fmt.Fprintf(os.Stderr, `Usage: sync-components <command> [flags]
+
+Commands:
+  sync           Sync component Helm charts from upstream repos
+  find-targets   Find branches tracking a given component ref
+  query          Output tracking info for a component as JSON
+
+Run 'sync-components <command> --help' for details on a specific command.
+`)
+	os.Exit(exitCode)
+}


### PR DESCRIPTION
## Summary

Implements chart sync tooling and GitHub Actions automation for syncing upstream component Helm charts into kuadrant-operator, per [RFC 0019](https://github.com/Kuadrant/architecture/blob/main/rfcs/0019-olmv1-operator-consolidation.md).

- Go CLI tool (`hack/sync-components/`) with `sync`, `find-targets`, and `query` subcommands
- Config driven via `component-charts/sync.yaml` declaring repo, chart path, tracked branch, and auto-merge per component
- `sync-component-chart.yaml` workflow receives `repository_dispatch` from component repos, syncs charts, and creates PRs
- Ref pinning: sync resolves tracked branch to a commit SHA and updates `sync.yaml`
- PR body includes upstream compare link and actor attribution

Starting with dns-operator only. Other components to be enabled incrementally.

### Follow-ups
- Scheduled daily reconciliation as safety net for missed events
- Release branch sync support (deferred until branch mapping strategy is defined)
- Image digest pinning ([release process simplification](https://gist.github.com/mikenairn/4c729ddd60a6129f84c6919b007430e6))

closes #2154
closes #2155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the DNS Operator Helm chart, including custom resources, monitoring, health checks and access controls.
  * Added automated synchronisation for component Helm charts, with branch tracking, change detection, pull request creation and optional automatic merging.
  * Added commands to synchronise all charts or a selected chart, query configuration and identify synchronisation targets.

* **Documentation**
  * Added installation guidance for the DNS Operator chart and documentation for chart synchronisation, configuration and generated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->