### PR TITLE
Replace EnvoyFilter targetRef with workloadSelector

### DIFF
--- a/internal/controller/istio_auth_cluster_reconciler.go
+++ b/internal/controller/istio_auth_cluster_reconciler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kuadrant/policy-machinery/machinery"
 	"github.com/samber/lo"
 	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
-	istiov1beta1 "istio.io/api/type/v1beta1"
 	istioclientgonetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,9 +139,9 @@ func (r *IstioAuthClusterReconciler) Reconcile(ctx context.Context, _ []controll
 
 		// update
 		existingEnvoyFilter.Spec = istioapinetworkingv1alpha3.EnvoyFilter{
-			TargetRefs:    desiredEnvoyFilter.Spec.TargetRefs,
-			ConfigPatches: desiredEnvoyFilter.Spec.ConfigPatches,
-			Priority:      desiredEnvoyFilter.Spec.Priority,
+			WorkloadSelector: desiredEnvoyFilter.Spec.WorkloadSelector,
+			ConfigPatches:    desiredEnvoyFilter.Spec.ConfigPatches,
+			Priority:         desiredEnvoyFilter.Spec.Priority,
 		}
 
 		existingEnvoyFilterUnstructured, err := controller.Destruct(existingEnvoyFilter)
@@ -211,11 +210,9 @@ func (r *IstioAuthClusterReconciler) buildDesiredEnvoyFilter(authorino *authorin
 			},
 		},
 		Spec: istioapinetworkingv1alpha3.EnvoyFilter{
-			TargetRefs: []*istiov1beta1.PolicyTargetReference{
-				{
-					Group: machinery.GatewayGroupKind.Group,
-					Kind:  machinery.GatewayGroupKind.Kind,
-					Name:  gateway.GetName(),
+			WorkloadSelector: &istioapinetworkingv1alpha3.WorkloadSelector{
+				Labels: map[string]string{
+					kuadrantistio.GatewayNameLabel: gateway.GetName(),
 				},
 			},
 		},

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
-	istiov1beta1 "istio.io/api/type/v1beta1"
 	istioclientgonetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -184,7 +183,8 @@ func (r *IstioExtensionReconciler) Reconcile(ctx context.Context, _ []controller
 		// update
 		existingEnvoyFilter.Spec.ConfigPatches = desiredEnvoyFilter.Spec.ConfigPatches
 		existingEnvoyFilter.Spec.Priority = desiredEnvoyFilter.Spec.Priority
-		existingEnvoyFilter.Spec.TargetRefs = desiredEnvoyFilter.Spec.TargetRefs
+		existingEnvoyFilter.Spec.WorkloadSelector = desiredEnvoyFilter.Spec.WorkloadSelector
+		existingEnvoyFilter.Spec.TargetRefs = nil
 
 		existingEnvoyFilterUnstructured, err := controller.Destruct(existingEnvoyFilter)
 		if err != nil {
@@ -286,8 +286,8 @@ func (r *IstioExtensionReconciler) reconcileUpstreamClusters(ctx context.Context
 		}
 
 		existing.Spec = istioapinetworkingv1alpha3.EnvoyFilter{
-			TargetRefs:    desiredEnvoyFilter.Spec.TargetRefs,
-			ConfigPatches: desiredEnvoyFilter.Spec.ConfigPatches,
+			WorkloadSelector: desiredEnvoyFilter.Spec.WorkloadSelector,
+			ConfigPatches:    desiredEnvoyFilter.Spec.ConfigPatches,
 		}
 		unstructured, err := controller.Destruct(existing)
 		if err != nil {
@@ -351,11 +351,9 @@ func buildUpstreamEnvoyFilter(logger logr.Logger, gateway *machinery.Gateway, up
 			},
 		},
 		Spec: istioapinetworkingv1alpha3.EnvoyFilter{
-			TargetRefs: []*istiov1beta1.PolicyTargetReference{
-				{
-					Group: machinery.GatewayGroupKind.Group,
-					Kind:  machinery.GatewayGroupKind.Kind,
-					Name:  gateway.GetName(),
+			WorkloadSelector: &istioapinetworkingv1alpha3.WorkloadSelector{
+				Labels: map[string]string{
+					kuadrantistio.GatewayNameLabel: gateway.GetName(),
 				},
 			},
 		},
@@ -695,11 +693,9 @@ func buildIstioEnvoyFilterForGateway(gateway *machinery.Gateway, wasmConfig wasm
 			},
 		},
 		Spec: istioapinetworkingv1alpha3.EnvoyFilter{
-			TargetRefs: []*istiov1beta1.PolicyTargetReference{
-				{
-					Group: machinery.GatewayGroupKind.Group,
-					Kind:  machinery.GatewayGroupKind.Kind,
-					Name:  gateway.GetName(),
+			WorkloadSelector: &istioapinetworkingv1alpha3.WorkloadSelector{
+				Labels: map[string]string{
+					kuadrantistio.GatewayNameLabel: gateway.GetName(),
 				},
 			},
 			ConfigPatches: configPatches,

--- a/internal/controller/istio_ratelimit_cluster_reconciler.go
+++ b/internal/controller/istio_ratelimit_cluster_reconciler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/kuadrant/policy-machinery/machinery"
 	"github.com/samber/lo"
 	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
-	istiov1beta1 "istio.io/api/type/v1beta1"
 	istioclientgonetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -163,9 +162,9 @@ func (r *IstioRateLimitClusterReconciler) Reconcile(ctx context.Context, _ []con
 
 		// update
 		existingEnvoyFilter.Spec = istioapinetworkingv1alpha3.EnvoyFilter{
-			TargetRefs:    desiredEnvoyFilter.Spec.TargetRefs,
-			ConfigPatches: desiredEnvoyFilter.Spec.ConfigPatches,
-			Priority:      desiredEnvoyFilter.Spec.Priority,
+			WorkloadSelector: desiredEnvoyFilter.Spec.WorkloadSelector,
+			ConfigPatches:    desiredEnvoyFilter.Spec.ConfigPatches,
+			Priority:         desiredEnvoyFilter.Spec.Priority,
 		}
 
 		existingEnvoyFilterUnstructured, err := controller.Destruct(existingEnvoyFilter)
@@ -236,11 +235,9 @@ func (r *IstioRateLimitClusterReconciler) buildDesiredEnvoyFilter(limitador *lim
 			},
 		},
 		Spec: istioapinetworkingv1alpha3.EnvoyFilter{
-			TargetRefs: []*istiov1beta1.PolicyTargetReference{
-				{
-					Group: machinery.GatewayGroupKind.Group,
-					Kind:  machinery.GatewayGroupKind.Kind,
-					Name:  gateway.GetName(),
+			WorkloadSelector: &istioapinetworkingv1alpha3.WorkloadSelector{
+				Labels: map[string]string{
+					kuadrantistio.GatewayNameLabel: gateway.GetName(),
 				},
 			},
 		},

--- a/internal/controller/istio_tracing_cluster_reconciler.go
+++ b/internal/controller/istio_tracing_cluster_reconciler.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kuadrant/policy-machinery/machinery"
 	"github.com/samber/lo"
 	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
-	istiov1beta1 "istio.io/api/type/v1beta1"
 	istioclientgonetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,9 +141,9 @@ func (r *IstioTracingClusterReconciler) Reconcile(ctx context.Context, _ []contr
 
 		// Update
 		existingEnvoyFilter.Spec = istioapinetworkingv1alpha3.EnvoyFilter{
-			TargetRefs:    desiredEnvoyFilter.Spec.TargetRefs,
-			ConfigPatches: desiredEnvoyFilter.Spec.ConfigPatches,
-			Priority:      desiredEnvoyFilter.Spec.Priority,
+			WorkloadSelector: desiredEnvoyFilter.Spec.WorkloadSelector,
+			ConfigPatches:    desiredEnvoyFilter.Spec.ConfigPatches,
+			Priority:         desiredEnvoyFilter.Spec.Priority,
 		}
 
 		existingEnvoyFilterUnstructured, err := controller.Destruct(existingEnvoyFilter)
@@ -216,11 +215,9 @@ func (r *IstioTracingClusterReconciler) buildDesiredEnvoyFilter(kuadrant *kuadra
 			},
 		},
 		Spec: istioapinetworkingv1alpha3.EnvoyFilter{
-			TargetRefs: []*istiov1beta1.PolicyTargetReference{
-				{
-					Group: machinery.GatewayGroupKind.Group,
-					Kind:  machinery.GatewayGroupKind.Kind,
-					Name:  gateway.GetName(),
+			WorkloadSelector: &istioapinetworkingv1alpha3.WorkloadSelector{
+				Labels: map[string]string{
+					kuadrantistio.GatewayNameLabel: gateway.GetName(),
 				},
 			},
 		},

--- a/internal/istio/utils.go
+++ b/internal/istio/utils.go
@@ -3,6 +3,7 @@ package istio
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	"github.com/kuadrant/policy-machinery/controller"
 	"github.com/kuadrant/policy-machinery/machinery"
@@ -11,7 +12,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	istioapimetav1alpha1 "istio.io/api/meta/v1alpha1"
 	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
-	istioapiv1beta1 "istio.io/api/type/v1beta1"
 	istioclientgoextensionv1alpha1 "istio.io/client-go/pkg/apis/extensions/v1alpha1"
 	istioclientgonetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
@@ -24,23 +24,16 @@ import (
 	"github.com/kuadrant/kuadrant-operator/internal/utils"
 )
 
+const GatewayNameLabel = "gateway.networking.k8s.io/gateway-name"
+
 var (
 	EnvoyFiltersResource       = istioclientgonetworkingv1alpha3.SchemeGroupVersion.WithResource("envoyfilters")
 	WasmPluginsResource        = istioclientgoextensionv1alpha1.SchemeGroupVersion.WithResource("wasmplugins")
 	PeerAuthenticationResource = istiosecurityv1.SchemeGroupVersion.WithResource("peerauthentications")
 
 	EnvoyFilterGroupKind        = schema.GroupKind{Group: istioclientgonetworkingv1alpha3.GroupName, Kind: "EnvoyFilter"}
-	WasmPluginGroupKind         = schema.GroupKind{Group: istioclientgoextensionv1alpha1.GroupName, Kind: "WasmPlugin"}
 	PeerAuthenticationGroupKind = schema.GroupKind{Group: istiosecurityv1.GroupName, Kind: "PeerAuthentication"}
 )
-
-func EqualTargetRefs(a, b []*istioapiv1beta1.PolicyTargetReference) bool {
-	return len(a) == len(b) && lo.EveryBy(a, func(aTargetRef *istioapiv1beta1.PolicyTargetReference) bool {
-		return lo.SomeBy(b, func(bTargetRef *istioapiv1beta1.PolicyTargetReference) bool {
-			return aTargetRef.Group == bTargetRef.Group && aTargetRef.Kind == bTargetRef.Kind && aTargetRef.Name == bTargetRef.Name && aTargetRef.Namespace == bTargetRef.Namespace
-		})
-	})
-}
 
 // BuildEnvoyFilterClusterPatch returns an envoy config patch that adds a cluster to the gateway.
 func BuildEnvoyFilterClusterPatch(host string, port int, mtls bool, clusterPatchBuilder func(string, int, bool) map[string]any) ([]*istioapinetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectPatch, error) {
@@ -163,7 +156,7 @@ func buildWasmFilterConfig(wasmURL, imagePullSecret, imageSHA, clusterName strin
 }
 
 func EqualEnvoyFilters(a, b *istioclientgonetworkingv1alpha3.EnvoyFilter) bool {
-	if a.Spec.Priority != b.Spec.Priority || !EqualTargetRefs(a.Spec.TargetRefs, b.Spec.TargetRefs) {
+	if a.Spec.Priority != b.Spec.Priority || !maps.Equal(a.Spec.WorkloadSelector.GetLabels(), b.Spec.WorkloadSelector.GetLabels()) {
 		return false
 	}
 
@@ -294,21 +287,6 @@ func IsIstioInstalled(restMapper meta.RESTMapper) (bool, error) {
 	return true, nil
 }
 
-func LinkGatewayToWasmPlugin(objs controller.Store) machinery.LinkFunc {
-	gateways := lo.Map(objs.FilterByGroupKind(machinery.GatewayGroupKind), func(obj controller.Object, _ int) machinery.Object {
-		return &machinery.Gateway{Gateway: obj.(*gatewayapiv1.Gateway)}
-	})
-
-	return machinery.LinkFunc{
-		From: machinery.GatewayGroupKind,
-		To:   WasmPluginGroupKind,
-		Func: func(child machinery.Object) []machinery.Object {
-			wasmPlugin := child.(*controller.RuntimeObject).Object.(*istioclientgoextensionv1alpha1.WasmPlugin)
-			return lo.Filter(gateways, istioTargetRefsIncludeObjectFunc(wasmPlugin.Spec.TargetRefs, wasmPlugin.GetNamespace()))
-		},
-	}
-}
-
 func LinkGatewayToEnvoyFilter(objs controller.Store) machinery.LinkFunc {
 	gateways := lo.Map(objs.FilterByGroupKind(machinery.GatewayGroupKind), func(obj controller.Object, _ int) machinery.Object {
 		return &machinery.Gateway{Gateway: obj.(*gatewayapiv1.Gateway)}
@@ -319,39 +297,28 @@ func LinkGatewayToEnvoyFilter(objs controller.Store) machinery.LinkFunc {
 		To:   EnvoyFilterGroupKind,
 		Func: func(child machinery.Object) []machinery.Object {
 			envoyFilter := child.(*controller.RuntimeObject).Object.(*istioclientgonetworkingv1alpha3.EnvoyFilter)
-			return lo.Filter(gateways, istioTargetRefsIncludeObjectFunc(envoyFilter.Spec.TargetRefs, envoyFilter.GetNamespace()))
+			gatewayName := envoyFilter.Spec.WorkloadSelector.GetLabels()[GatewayNameLabel]
+			if gatewayName == "" {
+				// todo(remove): fallback migration of targetRefs to workloadSelector
+				for _, ref := range envoyFilter.Spec.TargetRefs {
+					group := ref.GetGroup()
+					if group == "" {
+						group = machinery.GatewayGroupKind.Group
+					}
+					kind := ref.GetKind()
+					if kind == "" {
+						kind = machinery.GatewayGroupKind.Kind
+					}
+					if group == machinery.GatewayGroupKind.Group && kind == machinery.GatewayGroupKind.Kind {
+						gatewayName = ref.GetName()
+						break
+					}
+				}
+			}
+			return lo.Filter(gateways, func(obj machinery.Object, _ int) bool {
+				return obj.GetName() == gatewayName && obj.GetNamespace() == envoyFilter.GetNamespace()
+			})
 		},
-	}
-}
-
-func istioTargetRefsIncludeObjectFunc(targetRefs []*istioapiv1beta1.PolicyTargetReference, defaultNamespace string) func(machinery.Object, int) bool {
-	return func(obj machinery.Object, _ int) bool {
-		groupKind := obj.GroupVersionKind().GroupKind()
-		return lo.SomeBy(targetRefs, func(targetRef *istioapiv1beta1.PolicyTargetReference) bool {
-			if targetRef == nil {
-				return false
-			}
-			group := targetRef.GetGroup()
-			if group == "" {
-				group = machinery.GatewayGroupKind.Group
-			}
-			kind := targetRef.GetKind()
-			if kind == "" {
-				kind = machinery.GatewayGroupKind.Kind
-			}
-			name := targetRef.GetName()
-			if name == "" {
-				return false
-			}
-			namespace := targetRef.GetNamespace()
-			if namespace == "" {
-				namespace = defaultNamespace
-			}
-			return group == groupKind.Group &&
-				kind == groupKind.Kind &&
-				name == obj.GetName() &&
-				namespace == obj.GetNamespace()
-		})
 	}
 }
 

--- a/internal/istio/utils_test.go
+++ b/internal/istio/utils_test.go
@@ -12,11 +12,10 @@ import (
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
-	istiov1beta1 "istio.io/api/type/v1beta1"
+	istiotypev1beta1 "istio.io/api/type/v1beta1"
 	istioclientgonetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istiosecurityv1 "istio.io/client-go/pkg/apis/security/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 )
@@ -43,11 +42,9 @@ func testBasicEnvoyFilter(t *testing.T) *istioclientgonetworkingv1alpha3.EnvoyFi
 		},
 		Spec: istioapinetworkingv1alpha3.EnvoyFilter{
 			Priority: 1,
-			TargetRefs: []*istiov1beta1.PolicyTargetReference{
-				{
-					Group: gwapiv1.SchemeGroupVersion.Group,
-					Kind:  "Gateway",
-					Name:  "gw1",
+			WorkloadSelector: &istioapinetworkingv1alpha3.WorkloadSelector{
+				Labels: map[string]string{
+					GatewayNameLabel: "gw1",
 				},
 			},
 			ConfigPatches: []*istioapinetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectPatch{
@@ -79,10 +76,26 @@ func TestEqualEnvoyFilters(t *testing.T) {
 		assert.Assert(subT, EqualEnvoyFilters(a, b))
 	})
 
-	t.Run("different targetrefs", func(subT *testing.T) {
+	t.Run("different workload selector", func(subT *testing.T) {
 		a := testBasicEnvoyFilter(subT)
 		b := testBasicEnvoyFilter(subT)
-		b.Spec.TargetRefs[0].Name = "othergw"
+		b.Spec.WorkloadSelector = &istioapinetworkingv1alpha3.WorkloadSelector{
+			Labels: map[string]string{
+				GatewayNameLabel: "othergw",
+			},
+		}
+		assert.Assert(subT, !EqualEnvoyFilters(a, b))
+	})
+
+	t.Run("detects upgrade from targetRefs to workloadSelector", func(subT *testing.T) {
+		a := testBasicEnvoyFilter(subT)
+		a.Spec.WorkloadSelector = nil
+		a.Spec.TargetRefs = []*istiotypev1beta1.PolicyTargetReference{{
+			Group: "gateway.networking.k8s.io",
+			Kind:  "Gateway",
+			Name:  "gw1",
+		}}
+		b := testBasicEnvoyFilter(subT)
 		assert.Assert(subT, !EqualEnvoyFilters(a, b))
 	})
 
@@ -302,283 +315,6 @@ func TestEqualEnvoyFilters(t *testing.T) {
 		// With proto.Equal, these identical Match structures should be equal
 		assert.Assert(subT, EqualEnvoyFilters(a, b),
 			"EnvoyFilters with identical HTTP_FILTER Match structures should be equal")
-	})
-}
-
-func TestEqualTargetRefs(t *testing.T) {
-
-	t.Run("equal target refs", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		assert.Assert(subT, EqualTargetRefs(a, b))
-	})
-
-	t.Run("empty slices are equal", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{}
-		b := []*istiov1beta1.PolicyTargetReference{}
-		assert.Assert(subT, EqualTargetRefs(a, b))
-	})
-
-	t.Run("nil slices are equal", func(subT *testing.T) {
-		var a []*istiov1beta1.PolicyTargetReference
-		var b []*istiov1beta1.PolicyTargetReference
-		assert.Assert(subT, EqualTargetRefs(a, b))
-	})
-
-	t.Run("different lengths", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw2",
-				Namespace: "ns1",
-			},
-		}
-		assert.Assert(subT, !EqualTargetRefs(a, b))
-	})
-
-	t.Run("different group", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     "different.group",
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		assert.Assert(subT, !EqualTargetRefs(a, b))
-	})
-
-	t.Run("different kind", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "HTTPRoute",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		assert.Assert(subT, !EqualTargetRefs(a, b))
-	})
-
-	t.Run("different name", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw2",
-				Namespace: "ns1",
-			},
-		}
-		assert.Assert(subT, !EqualTargetRefs(a, b))
-	})
-
-	t.Run("different namespace", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns2",
-			},
-		}
-		assert.Assert(subT, !EqualTargetRefs(a, b))
-	})
-
-	t.Run("order independent - same refs different order", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw2",
-				Namespace: "ns2",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw2",
-				Namespace: "ns2",
-			},
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		assert.Assert(subT, EqualTargetRefs(a, b))
-	})
-
-	t.Run("multiple refs with one different", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw2",
-				Namespace: "ns2",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw3",
-				Namespace: "ns2",
-			},
-		}
-		assert.Assert(subT, !EqualTargetRefs(a, b))
-	})
-
-	t.Run("duplicate refs in both slices", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		assert.Assert(subT, EqualTargetRefs(a, b))
-	})
-
-	t.Run("empty string fields", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     "",
-				Kind:      "",
-				Name:      "",
-				Namespace: "",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     "",
-				Kind:      "",
-				Name:      "",
-				Namespace: "",
-			},
-		}
-		assert.Assert(subT, EqualTargetRefs(a, b))
-	})
-
-	t.Run("empty vs non-empty string fields", func(subT *testing.T) {
-		a := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     "",
-				Kind:      "",
-				Name:      "",
-				Namespace: "",
-			},
-		}
-		b := []*istiov1beta1.PolicyTargetReference{
-			{
-				Group:     gwapiv1.SchemeGroupVersion.Group,
-				Kind:      "Gateway",
-				Name:      "gw1",
-				Namespace: "ns1",
-			},
-		}
-		assert.Assert(subT, !EqualTargetRefs(a, b))
 	})
 }
 

--- a/tests/istio/extension_reconciler_test.go
+++ b/tests/istio/extension_reconciler_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/structpb"
 	istioapinetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
+	istiotypev1beta1 "istio.io/api/type/v1beta1"
 	istioclientgonetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -210,11 +211,9 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 			err = testClient().Get(ctx, envoyFilterKey, existingEnvoyFilter)
 			// must exist
 			Expect(err).ToNot(HaveOccurred())
-			// has the correct target ref
-			Expect(existingEnvoyFilter.Spec.TargetRefs).To(Not(BeEmpty()))
-			Expect(existingEnvoyFilter.Spec.TargetRefs[0].Group).To(Equal("gateway.networking.k8s.io"))
-			Expect(existingEnvoyFilter.Spec.TargetRefs[0].Kind).To(Equal("Gateway"))
-			Expect(existingEnvoyFilter.Spec.TargetRefs[0].Name).To(Equal(gateway.Name))
+			// has the correct workload selector
+			Expect(existingEnvoyFilter.Spec.WorkloadSelector).ToNot(BeNil())
+			Expect(existingEnvoyFilter.Spec.WorkloadSelector.Labels).To(HaveKeyWithValue("gateway.networking.k8s.io/gateway-name", gateway.Name))
 			// has config patches
 			Expect(existingEnvoyFilter.Spec.ConfigPatches).To(Not(BeEmpty()))
 			existingWASMConfig, err := extractWasmConfigFromEnvoyFilter(existingEnvoyFilter)
@@ -358,6 +357,81 @@ var _ = Describe("Rate Limiting EnvoyFilter controller", func() {
 				g.Expect(testClient().Get(ctx, envoyFilterKey, existingEnvoyFilter)).To(Succeed())
 				g.Expect(existingEnvoyFilter.Spec.ConfigPatches).ToNot(BeEmpty())
 				g.Expect(len(existingEnvoyFilter.Spec.ConfigPatches)).To(Equal(originalPatchCount))
+			}, "10s", "1s").Should(Succeed())
+		}, testTimeOut)
+
+		It("envoyfilter targetRefs should be cleared when workloadSelector is applied", func(ctx SpecContext) {
+			// create httproute
+			httpRoute := tests.BuildBasicHttpRoute(routeName, TestGatewayName, testNamespace, []string{"*.example.com"})
+			err := testClient().Create(ctx, httpRoute)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(tests.RouteIsAccepted(ctx, testClient(), client.ObjectKeyFromObject(httpRoute))).WithContext(ctx).Should(BeTrue())
+
+			// create ratelimitpolicy
+			rlp := &kuadrantv1.RateLimitPolicy{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "RateLimitPolicy", APIVersion: kuadrantv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: rlpName, Namespace: testNamespace},
+				Spec: kuadrantv1.RateLimitPolicySpec{
+					TargetRef: gatewayapiv1alpha2.LocalPolicyTargetReferenceWithSectionName{
+						LocalPolicyTargetReference: gatewayapiv1alpha2.LocalPolicyTargetReference{
+							Group: gatewayapiv1.GroupName,
+							Kind:  "HTTPRoute",
+							Name:  gatewayapiv1.ObjectName(routeName),
+						},
+					},
+					RateLimitPolicySpecProper: kuadrantv1.RateLimitPolicySpecProper{
+						Limits: map[string]kuadrantv1.Limit{
+							"l1": {
+								Rates: []kuadrantv1.Rate{
+									{
+										Limit: 1, Window: kuadrantv1.Duration("3m"),
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err = testClient().Create(ctx, rlp)
+			Expect(err).ToNot(HaveOccurred())
+
+			rlpKey := client.ObjectKeyFromObject(rlp)
+			Eventually(assertPolicyIsAcceptedAndEnforced(ctx, rlpKey)).WithContext(ctx).Should(BeTrue())
+
+			envoyFilterKey := client.ObjectKey{Name: wasm.ExtensionName(gateway.GetName()), Namespace: testNamespace}
+			Eventually(tests.EnvoyFilterIsAvailable(ctx, testClient(), envoyFilterKey)).WithContext(ctx).Should(BeTrue())
+			existingEnvoyFilter := &istioclientgonetworkingv1alpha3.EnvoyFilter{}
+			err = testClient().Get(ctx, envoyFilterKey, existingEnvoyFilter)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(existingEnvoyFilter.Spec.TargetRefs).To(BeEmpty())
+
+			// Simulate a pre-existing EnvoyFilter that used targetRefs instead of workloadSelector
+			existingEnvoyFilter.Spec.TargetRefs = []*istiotypev1beta1.PolicyTargetReference{{
+				Group: "gateway.networking.k8s.io",
+				Kind:  "Gateway",
+				Name:  gateway.GetName(),
+			}}
+			existingEnvoyFilter.Spec.WorkloadSelector = nil
+			err = testClient().Update(ctx, existingEnvoyFilter)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Trigger reconcile by updating the RLP
+			Expect(testClient().Get(ctx, rlpKey, rlp)).To(Succeed())
+			original := rlp.DeepCopy()
+			if rlp.Annotations == nil {
+				rlp.Annotations = map[string]string{}
+			}
+			rlp.Annotations["trigger-reconcile"] = "true"
+			patch := client.MergeFrom(original)
+			Expect(testClient().Patch(ctx, rlp, patch)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testClient().Get(ctx, envoyFilterKey, existingEnvoyFilter)).To(Succeed())
+				g.Expect(existingEnvoyFilter.Spec.TargetRefs).To(BeEmpty())
+				g.Expect(existingEnvoyFilter.Spec.WorkloadSelector).ToNot(BeNil())
+				g.Expect(existingEnvoyFilter.Spec.WorkloadSelector.Labels).To(HaveKeyWithValue("gateway.networking.k8s.io/gateway-name", gateway.Name))
 			}, "10s", "1s").Should(Succeed())
 		}, testTimeOut)
 


### PR DESCRIPTION
I've seen that on Istio v1.26.x we unintentionally affect all gateways in the target namespace rather than the targeted gateway only - due to this istio issue https://github.com/istio/istio/issues/56417

While we still support istio v1.26.x we should use `workloadSelector` instead of `targetRef`.

To reproduce, I created two `Gateway`s and `HTTPRoute`s with the same hostname and backend, and created an `AuthPolicy` targeting just one. By inspecting envoy config on the two gateways I could see both were affected by our `EnvoyFilter`s, and requests to either `Gateway` are affected by the `AuthPolicy` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Enhancements

- EnvoyFilters now target gateways using gateway-name workload selectors.
- Improved consistency across authentication, extension, rate-limiting and tracing integrations.
- Existing configurations with outdated target references are migrated automatically.

## Bug Fixes

- Resolved reconciliation issues where EnvoyFilters could retain stale gateway associations.
- Improved gateway-to-EnvoyFilter matching by considering gateway name and namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->