### PR TITLE
Extensions handshake with operator

### DIFF
--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -18,6 +18,7 @@ package extension
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io"
@@ -86,7 +87,12 @@ func NewManager(location string, logger logr.Logger, sync io.Writer, client dyna
 	logger = logger.WithName("extension")
 
 	for _, name := range names {
-		if oopExtension, e := NewOOPExtension(name, location, service, interceptor, logger, sync); e == nil {
+		credential := make([]byte, 32)
+		if _, e := rand.Read(credential); e != nil {
+			return Manager{}, fmt.Errorf("failed to generate credential for extension %s: %w", name, e)
+		}
+		service.sessionStore.SetCredential(name, credential)
+		if oopExtension, e := NewOOPExtension(name, location, credential, service, interceptor, logger, sync); e == nil {
 			extensions = append(extensions, &oopExtension)
 		} else {
 			if err == nil {

--- a/internal/extension/oop.go
+++ b/internal/extension/oop.go
@@ -18,6 +18,7 @@ package extension
 
 import (
 	"bufio"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -40,6 +41,7 @@ type OOPExtension struct {
 	name         string
 	executable   string
 	socket       string
+	credential   []byte
 	cmd          *exec.Cmd
 	server       *grpc.Server
 	service      extpb.ExtensionServiceServer
@@ -51,7 +53,7 @@ type OOPExtension struct {
 	completionWg sync.WaitGroup
 }
 
-func NewOOPExtension(name string, location string, service extpb.ExtensionServiceServer, interceptor *AuthInterceptor, logger logr.Logger, sync io.Writer) (OOPExtension, error) {
+func NewOOPExtension(name string, location string, credential []byte, service extpb.ExtensionServiceServer, interceptor *AuthInterceptor, logger logr.Logger, sync io.Writer) (OOPExtension, error) {
 	var err error
 	var stat os.FileInfo
 
@@ -65,6 +67,7 @@ func NewOOPExtension(name string, location string, service extpb.ExtensionServic
 	return OOPExtension{
 		name:        name,
 		socket:      fmt.Sprintf("/tmp/kuadrant/%s/%s", name, defaultUnixSocket),
+		credential:  credential,
 		executable:  executable,
 		service:     service,
 		interceptor: interceptor,
@@ -85,6 +88,10 @@ func (p *OOPExtension) Start() error {
 	}
 
 	cmd := exec.Command(p.executable, p.socket) // #nosec G204
+	cmd.Env = append(os.Environ(),
+		"KUADRANT_EXTENSION_NAME="+p.name,
+		"KUADRANT_EXTENSION_CREDENTIAL="+hex.EncodeToString(p.credential),
+	)
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {

--- a/pkg/extension/controller/builder.go
+++ b/pkg/extension/controller/builder.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -116,6 +117,20 @@ func (b *Builder) Build() (*ExtensionController, error) {
 	}
 	socketPath := os.Args[1]
 
+	extensionName := os.Getenv("KUADRANT_EXTENSION_NAME")
+	if extensionName == "" {
+		return nil, errors.New("KUADRANT_EXTENSION_NAME environment variable is required")
+	}
+
+	credentialHex := os.Getenv("KUADRANT_EXTENSION_CREDENTIAL")
+	if credentialHex == "" {
+		return nil, errors.New("KUADRANT_EXTENSION_CREDENTIAL environment variable is required")
+	}
+	credential, err := hex.DecodeString(credentialHex)
+	if err != nil {
+		return nil, fmt.Errorf("KUADRANT_EXTENSION_CREDENTIAL is not valid hex: %w", err)
+	}
+
 	extClient, err := newExtensionClient(socketPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create extension client: %w", err)
@@ -172,6 +187,8 @@ func (b *Builder) Build() (*ExtensionController, error) {
 		manager:         mgr,
 		logger:          b.logger,
 		extensionClient: extClient,
+		extensionName:   extensionName,
+		credential:      credential,
 		eventCache:      eventCache,
 		BaseReconciler:  basereconciler.NewBaseReconciler(mgr.GetClient(), mgr.GetScheme(), mgr.GetAPIReader()),
 	}, nil

--- a/pkg/extension/controller/client.go
+++ b/pkg/extension/controller/client.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"time"
@@ -14,17 +15,37 @@ import (
 	extpb "github.com/kuadrant/kuadrant-operator/pkg/extension/grpc/v1"
 )
 
+const sessionMetadataKey = "x-kuadrant-session"
+
+type sessionCredentials struct {
+	token string
+}
+
+func (c *sessionCredentials) GetRequestMetadata(_ context.Context, _ ...string) (map[string]string, error) {
+	if c.token == "" {
+		return nil, nil
+	}
+	return map[string]string{sessionMetadataKey: c.token}, nil
+}
+
+func (c *sessionCredentials) RequireTransportSecurity() bool {
+	return false
+}
+
 // extensionClient wraps the gRPC client connection to the core extension
 // service over a unix domain socket and exposes a subset of RPCs used by the
 // controller layer.
 type extensionClient struct {
-	conn   *grpc.ClientConn
-	client extpb.ExtensionServiceClient
+	conn    *grpc.ClientConn
+	client  extpb.ExtensionServiceClient
+	session *sessionCredentials
 }
 
 // newExtensionClient dials the unix domain socket at socketPath and returns a
 // ready extensionClient.
 func newExtensionClient(socketPath string) (*extensionClient, error) {
+	session := &sessionCredentials{}
+
 	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
 		return (&net.Dialer{}).DialContext(ctx, "unix", socketPath)
 	}
@@ -33,15 +54,33 @@ func newExtensionClient(socketPath string) (*extensionClient, error) {
 		"unix://"+socketPath,
 		grpc.WithContextDialer(dialer),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(session),
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	return &extensionClient{
-		conn:   conn,
-		client: extpb.NewExtensionServiceClient(conn),
+		conn:    conn,
+		client:  extpb.NewExtensionServiceClient(conn),
+		session: session,
 	}, nil
+}
+
+func (ec *extensionClient) handshake(ctx context.Context, name string, credential []byte, policyKind string) error {
+	resp, err := ec.client.Handshake(ctx, &extpb.HandshakeRequest{
+		Name:       name,
+		Credential: credential,
+		PolicyKind: policyKind,
+	})
+	if err != nil {
+		return fmt.Errorf("handshake RPC failed: %w", err)
+	}
+	if !resp.Accepted {
+		return fmt.Errorf("handshake rejected: %s", resp.Reason)
+	}
+	ec.session.token = resp.SessionToken
+	return nil
 }
 
 //lint:ignore U1000

--- a/pkg/extension/controller/controller.go
+++ b/pkg/extension/controller/controller.go
@@ -63,6 +63,8 @@ type ExtensionController struct {
 	logger          logr.Logger
 	manager         ctrlruntime.Manager
 	extensionClient *extensionClient
+	extensionName   string
+	credential      []byte
 	eventCache      *EventTypeCache
 
 	*basereconciler.BaseReconciler // TODO(didierofrivia): Next iteration, use policy machinery
@@ -70,6 +72,13 @@ type ExtensionController struct {
 
 // Start launches the controller manager and begins processing events.
 func (ec *ExtensionController) Start(ctx context.Context) error {
+	handshakeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := ec.extensionClient.handshake(handshakeCtx, ec.extensionName, ec.credential, ec.config.PolicyKind); err != nil {
+		return fmt.Errorf("extension handshake failed: %w", err)
+	}
+	ec.logger.Info("handshake accepted", "extension", ec.extensionName, "policyKind", ec.config.PolicyKind)
+
 	stopCh := make(chan struct{})
 	// todo(adam-cattermole): how big do we make the reconcile event channel?
 	//	 how many should we queue before we block?

--- a/pkg/extension/controller/controller_test.go
+++ b/pkg/extension/controller/controller_test.go
@@ -297,14 +297,87 @@ func TestBuilderMissingSocketPath(t *testing.T) {
 	assert.ErrorContains(t, err, "missing socket path")
 }
 
+func TestHandshake_Success(t *testing.T) {
+	var capturedReq *extpb.HandshakeRequest
+	mock := &mockExtensionServiceClient{
+		handshakeFn: func(_ context.Context, in *extpb.HandshakeRequest, _ ...grpc.CallOption) (*extpb.HandshakeResponse, error) {
+			capturedReq = in
+			return &extpb.HandshakeResponse{
+				Accepted:     true,
+				SessionToken: "returned-token",
+			}, nil
+		},
+	}
+
+	session := &sessionCredentials{}
+	ec := &extensionClient{client: mock, session: session}
+
+	err := ec.handshake(context.Background(), "my-ext", []byte("credential-value"), "MyPolicy")
+	assert.NilError(t, err)
+	assert.Equal(t, session.token, "returned-token")
+	assert.Equal(t, capturedReq.Name, "my-ext")
+	assert.Equal(t, capturedReq.PolicyKind, "MyPolicy")
+	assert.DeepEqual(t, capturedReq.Credential, []byte("credential-value"))
+}
+
+func TestHandshake_Rejected(t *testing.T) {
+	mock := &mockExtensionServiceClient{
+		handshakeFn: func(_ context.Context, _ *extpb.HandshakeRequest, _ ...grpc.CallOption) (*extpb.HandshakeResponse, error) {
+			return &extpb.HandshakeResponse{
+				Accepted: false,
+				Reason:   "handshake failed",
+			}, nil
+		},
+	}
+
+	session := &sessionCredentials{}
+	ec := &extensionClient{client: mock, session: session}
+
+	err := ec.handshake(context.Background(), "my-ext", []byte("bad-cred"), "MyPolicy")
+	assert.ErrorContains(t, err, "handshake rejected")
+	assert.Equal(t, session.token, "")
+}
+
+func TestHandshake_RPCError(t *testing.T) {
+	mock := &mockExtensionServiceClient{
+		handshakeFn: func(_ context.Context, _ *extpb.HandshakeRequest, _ ...grpc.CallOption) (*extpb.HandshakeResponse, error) {
+			return nil, fmt.Errorf("connection refused")
+		},
+	}
+
+	session := &sessionCredentials{}
+	ec := &extensionClient{client: mock, session: session}
+
+	err := ec.handshake(context.Background(), "my-ext", []byte("cred"), "MyPolicy")
+	assert.ErrorContains(t, err, "handshake RPC failed")
+	assert.Equal(t, session.token, "")
+}
+
+func TestSessionCredentials_GetRequestMetadata(t *testing.T) {
+	creds := &sessionCredentials{}
+
+	md, err := creds.GetRequestMetadata(context.Background())
+	assert.NilError(t, err)
+	assert.Assert(t, md == nil)
+
+	creds.token = "my-session-token"
+	md, err = creds.GetRequestMetadata(context.Background())
+	assert.NilError(t, err)
+	assert.Equal(t, md[sessionMetadataKey], "my-session-token")
+}
+
 // mockExtensionServiceClient implements extpb.ExtensionServiceClient for testing.
 type mockExtensionServiceClient struct {
+	handshakeFn            func(ctx context.Context, in *extpb.HandshakeRequest, opts ...grpc.CallOption) (*extpb.HandshakeResponse, error)
 	registerActionMethodFn func(ctx context.Context, in *extpb.RegisterActionMethodRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	pipelineCommitFn       func(ctx context.Context, in *extpb.PipelineCommitRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
-func (m *mockExtensionServiceClient) Handshake(_ context.Context, _ *extpb.HandshakeRequest, _ ...grpc.CallOption) (*extpb.HandshakeResponse, error) {
-	return nil, nil
+func (m *mockExtensionServiceClient) Handshake(ctx context.Context, in *extpb.HandshakeRequest, opts ...grpc.CallOption) (*extpb.HandshakeResponse, error) {
+	if m.handshakeFn != nil {
+		return m.handshakeFn(ctx, in, opts...)
+	}
+	return &extpb.HandshakeResponse{Accepted: true, SessionToken: "test-token"}, nil
 }
 func (m *mockExtensionServiceClient) Ping(_ context.Context, _ *extpb.PingRequest, _ ...grpc.CallOption) (*extpb.PongResponse, error) {
 	return nil, nil


### PR DESCRIPTION
Implements the handshake proto for the built-in extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure credential generation and session-based authentication for extension connections.
  - Extensions now perform a handshake before starting and receive a session token for subsequent requests.
  - Added validation for required extension identity and credential settings.

- **Bug Fixes**
  - Improved handling and reporting of rejected or failed extension handshakes.
  - Invalid credential values are now rejected with a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->