### PR TITLE
chore(deps): update dns-operator chart on main to cdf775c

### DIFF
--- a/component-charts/dns-operator/templates/manifests.yaml
+++ b/component-charts/dns-operator/templates/manifests.yaml
@@ -628,11 +628,6 @@ spec:
                 required:
                 - name
                 type: object
-              queuedAt:
-                description: QueuedAt is a time when DNS record was received for the
-                  reconciliation
-                format: date-time
-                type: string
               remoteRecordStatuses:
                 additionalProperties:
                   x-kubernetes-preserve-unknown-fields: true
@@ -642,10 +637,6 @@ spec:
                   A CRD can't reference a type within itself so the `apiextensionsv1.JSON` type is used.
                   Use GetRemoteRecordStatuses to get the converted type.
                 type: object
-              validFor:
-                description: ValidFor indicates duration since the last reconciliation
-                  we consider data in the record to be valid
-                type: string
               writeCounter:
                 description: |-
                   WriteCounter represent a number of consecutive write attempts on the same generation of the record.

--- a/component-charts/sync.yaml
+++ b/component-charts/sync.yaml
@@ -14,7 +14,7 @@ components:
     repo: Kuadrant/dns-operator
     chart-path: charts/dns-operator
     tracked-branch: main
-    ref: c6cb081c14a94591e7f5d4082eecbdb7188e19b4
+    ref: cdf775c9ff606305b9773e985820d885d5b660f5
     auto-merge: false
 #  authorino-operator:
 #    repo: Kuadrant/authorino-operator


### PR DESCRIPTION
Sync dns-operator chart from upstream into `main`.

**Component:** dns-operator
**Target branch:** `main`
**Previous ref:** `c6cb081c14a94591e7f5d4082eecbdb7188e19b4`
**New ref:** `cdf775c9ff606305b9773e985820d885d5b660f5`
**Triggered by:** @github-merge-queue[bot] (https://github.com/Kuadrant/dns-operator/commit/2f681731567b6bbd0072d075b2d6bc328d65504f)

[Upstream changes](https://github.com/Kuadrant/dns-operator/compare/c6cb081c14a94591e7f5d4082eecbdb7188e19b4...cdf775c9ff606305b9773e985820d885d5b660f5)

Auto-generated by https://github.com/Kuadrant/kuadrant-operator/actions/runs/32481422022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete `queuedAt` and `validFor` fields from DNS record status information.
  * Updated the DNS operator chart reference to ensure the latest compatible version is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->