### PR TITLE
Fix console plugin broken on OCP 4.20/4.21 after SDK 4.22 upgrade

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -32,11 +32,15 @@ on:
         default: quay.io/kuadrant/developer-portal-controller:latest
         type: string
       relatedImageConsolePluginLatest:
-        description: Related image ConsolePlugin latest (PatternFly 6)
+        description: Related image ConsolePlugin latest (SDK 4.22, pluginAPI >= 4.22.0-0)
         default: quay.io/kuadrant/console-plugin:latest
         type: string
+      relatedImageConsolePluginSDK1:
+        description: Related image ConsolePlugin v0.6.0 (SDK 1.x, pluginAPI "*", for OCP 4.20-4.21)
+        default: quay.io/kuadrant/console-plugin:v0.6.0
+        type: string
       relatedImageConsolePluginPF5:
-        description: Related image ConsolePlugin v0.1.5 (PatternFly 5)
+        description: Related image ConsolePlugin v0.1.5 (PatternFly 5, for OCP < 4.20)
         default: quay.io/kuadrant/console-plugin:v0.1.5-2
         type: string
       consolePluginImageURL:
@@ -86,11 +90,15 @@ on:
         default: quay.io/kuadrant/developer-portal-controller:latest
         type: string
       relatedImageConsolePluginLatest:
-        description: Related image ConsolePlugin latest (PatternFly 6)
+        description: Related image ConsolePlugin latest (SDK 4.22, pluginAPI >= 4.22.0-0)
         default: quay.io/kuadrant/console-plugin:latest
         type: string
+      relatedImageConsolePluginSDK1:
+        description: Related image ConsolePlugin v0.6.0 (SDK 1.x, pluginAPI "*", for OCP 4.20-4.21)
+        default: quay.io/kuadrant/console-plugin:v0.6.0
+        type: string
       relatedImageConsolePluginPF5:
-        description: Related image ConsolePlugin v0.1.5 (PatternFly 5)
+        description: Related image ConsolePlugin v0.1.5 (PatternFly 5, for OCP < 4.20)
         default: quay.io/kuadrant/console-plugin:v0.1.5-2
         type: string
       consolePluginImageURL:
@@ -176,6 +184,8 @@ jobs:
         id: go
       - name: Run make bundle
         id: make-bundle
+        env:
+          RELATED_IMAGE_CONSOLE_PLUGIN_SDK1: ${{ inputs.relatedImageConsolePluginSDK1 }}
         run: |
           make bundle \
             IMG=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.OPERATOR_NAME }}:${{ inputs.kuadrantOperatorTag }} \
@@ -186,6 +196,7 @@ jobs:
             RELATED_IMAGE_WASMSHIM=${{ inputs.relatedImageWasmShim }} \
             RELATED_IMAGE_DEVELOPERPORTAL=${{ inputs.relatedImageDeveloperPortalController }} \
             RELATED_IMAGE_CONSOLE_PLUGIN_LATEST=${{ inputs.relatedImageConsolePluginLatest}} \
+            RELATED_IMAGE_CONSOLE_PLUGIN_SDK1="${RELATED_IMAGE_CONSOLE_PLUGIN_SDK1}" \
             RELATED_IMAGE_CONSOLE_PLUGIN_PF5=${{ inputs.relatedImageConsolePluginPF5}} \
             DEFAULT_CHANNEL=${{ inputs.defaultChannel }} \
             CHANNELS=${{ inputs.channels }}

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,7 @@ else
 RELATED_IMAGE_CONSOLE_PLUGIN_LATEST ?= quay.io/kuadrant/console-plugin:$(CONSOLEPLUGIN_VERSION)
 endif
 
+RELATED_IMAGE_CONSOLE_PLUGIN_SDK1 ?= quay.io/kuadrant/console-plugin:v0.6.0
 RELATED_IMAGE_CONSOLE_PLUGIN_PF5 ?= quay.io/kuadrant/console-plugin:v0.1.5-2
 
 ## gatewayapi-provider
@@ -515,6 +516,9 @@ bundle: opm yq manifests dependencies-manifests kustomize operator-sdk ## Genera
 	# Set desired console-plugin image
 	V="$(RELATED_IMAGE_CONSOLE_PLUGIN_LATEST)" \
 	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_CONSOLE_PLUGIN_LATEST").value) = strenv(V)' -i config/manager/manager.yaml
+	# Set desired console-plugin SDK1 image (OCP 4.20-4.21)
+	V="$(RELATED_IMAGE_CONSOLE_PLUGIN_SDK1)" \
+	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_CONSOLE_PLUGIN_SDK1").value) = strenv(V)' -i config/manager/manager.yaml
 	# Set desired console-plugin PF5 image
 	V="$(RELATED_IMAGE_CONSOLE_PLUGIN_PF5)" \
 	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_CONSOLE_PLUGIN_PF5").value) = strenv(V)' -i config/manager/manager.yaml

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -766,6 +766,8 @@ spec:
                   value: quay.io/kuadrant/developer-portal-controller:latest
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN_LATEST
                   value: quay.io/kuadrant/console-plugin:latest
+                - name: RELATED_IMAGE_CONSOLE_PLUGIN_SDK1
+                  value: quay.io/kuadrant/console-plugin:v0.6.0
                 - name: RELATED_IMAGE_CONSOLE_PLUGIN_PF5
                   value: quay.io/kuadrant/console-plugin:v0.1.5-2
                 - name: OPERATOR_NAMESPACE
@@ -934,6 +936,8 @@ spec:
     name: developerportal
   - image: quay.io/kuadrant/console-plugin:latest
     name: console-plugin-latest
+  - image: quay.io/kuadrant/console-plugin:v0.6.0
+    name: console-plugin-sdk1
   - image: quay.io/kuadrant/console-plugin:v0.1.5-2
     name: console-plugin-pf5
   version: 0.0.0

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14799,6 +14799,8 @@ spec:
           value: quay.io/kuadrant/developer-portal-controller:latest
         - name: RELATED_IMAGE_CONSOLE_PLUGIN_LATEST
           value: quay.io/kuadrant/console-plugin:latest
+        - name: RELATED_IMAGE_CONSOLE_PLUGIN_SDK1
+          value: quay.io/kuadrant/console-plugin:v0.6.0
         - name: RELATED_IMAGE_CONSOLE_PLUGIN_PF5
           value: quay.io/kuadrant/console-plugin:v0.1.5-2
         - name: OPERATOR_NAMESPACE

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -40,6 +40,8 @@ spec:
               value: "quay.io/kuadrant/developer-portal-controller:latest"
             - name: RELATED_IMAGE_CONSOLE_PLUGIN_LATEST
               value: "quay.io/kuadrant/console-plugin:latest"
+            - name: RELATED_IMAGE_CONSOLE_PLUGIN_SDK1
+              value: "quay.io/kuadrant/console-plugin:v0.6.0"
             - name: RELATED_IMAGE_CONSOLE_PLUGIN_PF5
               value: "quay.io/kuadrant/console-plugin:v0.1.5-2"
             - name: OPERATOR_NAMESPACE

--- a/internal/controller/consoleplugin_reconciler_test.go
+++ b/internal/controller/consoleplugin_reconciler_test.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	TestNamespace         = "test-namespace"
-	ConsolePluginImageURL = "quay.io/kuadrant/console-plugin:latest"
+	ConsolePluginImageURL = "quay.io/kuadrant/console-plugin:v0.6.0"
 )
 
 func buildTopologyWithClusterVersion(t *testing.T) *machinery.Topology {
@@ -77,7 +77,8 @@ func buildTopologyWithClusterVersion(t *testing.T) *machinery.Topology {
 // Since this reconciler only runs on Openshift,
 // this unit test will add some coverage
 func TestConsolePluginReconciler(t *testing.T) {
-	t.Setenv(openshift.RelatedImageConsolePluginLatestEnvVar, ConsolePluginImageURL)
+	t.Setenv(openshift.RelatedImageConsolePluginLatestEnvVar, "quay.io/kuadrant/console-plugin:latest")
+	t.Setenv(openshift.RelatedImageConsolePluginSDK1EnvVar, ConsolePluginImageURL)
 	t.Setenv(openshift.RelatedImageConsolePluginPF5EnvVar, "quay.io/kuadrant/console-plugin:v0.1.5")
 
 	scheme := runtime.NewScheme()

--- a/internal/openshift/utils.go
+++ b/internal/openshift/utils.go
@@ -15,11 +15,21 @@ import (
 
 const (
 	RelatedImageConsolePluginLatestEnvVar = "RELATED_IMAGE_CONSOLE_PLUGIN_LATEST"
+	RelatedImageConsolePluginSDK1EnvVar   = "RELATED_IMAGE_CONSOLE_PLUGIN_SDK1"
 	RelatedImageConsolePluginPF5EnvVar    = "RELATED_IMAGE_CONSOLE_PLUGIN_PF5"
-
-	// pf6VersionConstraint defines the minimum OpenShift version that requires PatternFly 6
-	pf6VersionConstraint = ">= 4.20.0-0"
 )
+
+type consolePluginImageRule struct {
+	When     string
+	ImageRef string
+}
+
+// Evaluated top-down; first satisfied constraint wins. "*" is the fallback.
+var consolePluginImageRules = []consolePluginImageRule{
+	{When: ">= 4.22.0-0", ImageRef: RelatedImageConsolePluginLatestEnvVar},
+	{When: ">= 4.20.0-0", ImageRef: RelatedImageConsolePluginSDK1EnvVar},
+	{When: "*", ImageRef: RelatedImageConsolePluginPF5EnvVar},
+}
 
 var (
 	ConsolePluginGVK = schema.GroupVersionKind{
@@ -46,9 +56,7 @@ func IsClusterVersionInstalled(restMapper meta.RESTMapper) (bool, error) {
 }
 
 // GetConsolePluginImageForVersion returns the appropriate console plugin image based on OpenShift version.
-// For OpenShift versions >= 4.20, it returns the latest (PatternFly 6) compatible image from RELATED_IMAGE_CONSOLE_PLUGIN_LATEST.
-// For earlier versions, it returns the PF5 image from RELATED_IMAGE_CONSOLE_PLUGIN_PF5.
-// This ensures proper mirroring in disconnected environments by using RELATED_IMAGE environment variables.
+// Rules are evaluated top-down; the first satisfied semver constraint wins.
 func GetConsolePluginImageForVersion(clusterVersion *configv1.ClusterVersion) (string, error) {
 	openshiftVersion := clusterVersion.Status.Desired.Version
 
@@ -61,22 +69,23 @@ func GetConsolePluginImageForVersion(clusterVersion *configv1.ClusterVersion) (s
 		return "", fmt.Errorf("failed to parse OpenShift version %q: %w", openshiftVersion, err)
 	}
 
-	constraint, err := semver.NewConstraint(pf6VersionConstraint)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse version constraint %q: %w", pf6VersionConstraint, err)
+	for _, rule := range consolePluginImageRules {
+		if rule.When != "*" {
+			constraint, err := semver.NewConstraint(rule.When)
+			if err != nil {
+				return "", fmt.Errorf("failed to parse version constraint %q: %w", rule.When, err)
+			}
+			if !constraint.Check(version) {
+				continue
+			}
+		}
+
+		image := os.Getenv(rule.ImageRef)
+		if image == "" {
+			return "", fmt.Errorf("environment variable %s is not set", rule.ImageRef)
+		}
+		return image, nil
 	}
 
-	var envVarName string
-	if constraint.Check(version) {
-		envVarName = RelatedImageConsolePluginLatestEnvVar
-	} else {
-		envVarName = RelatedImageConsolePluginPF5EnvVar
-	}
-
-	image := os.Getenv(envVarName)
-	if image == "" {
-		return "", fmt.Errorf("environment variable %s is not set", envVarName)
-	}
-
-	return image, nil
+	return "", fmt.Errorf("no console plugin image rule matched OpenShift version %q", openshiftVersion)
 }

--- a/internal/openshift/utils_test.go
+++ b/internal/openshift/utils_test.go
@@ -14,6 +14,7 @@ func TestGetConsolePluginImageForVersion(t *testing.T) {
 		name              string
 		version           string
 		latestEnvVar      string
+		sdk1EnvVar        string
 		pf5EnvVar         string
 		expectedImage     string
 		expectedErrSubstr string
@@ -22,6 +23,7 @@ func TestGetConsolePluginImageForVersion(t *testing.T) {
 			name:          "OpenShift 4.16 uses PF5 env var",
 			version:       "4.16.0",
 			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
 			expectedImage: "quay.io/kuadrant/console-plugin:v0.1.5",
 		},
@@ -29,20 +31,31 @@ func TestGetConsolePluginImageForVersion(t *testing.T) {
 			name:          "OpenShift 4.19 uses PF5 env var",
 			version:       "4.19.0",
 			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
 			expectedImage: "quay.io/kuadrant/console-plugin:v0.1.5",
 		},
 		{
-			name:          "OpenShift 4.20 uses LATEST env var",
+			name:          "OpenShift 4.20 uses SDK1 env var",
 			version:       "4.20.0",
 			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
-			expectedImage: "quay.io/kuadrant/console-plugin:latest",
+			expectedImage: "quay.io/kuadrant/console-plugin:v0.6.0",
 		},
 		{
-			name:          "OpenShift 4.21 uses LATEST env var",
+			name:          "OpenShift 4.21 uses SDK1 env var",
 			version:       "4.21.0",
 			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
+			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
+			expectedImage: "quay.io/kuadrant/console-plugin:v0.6.0",
+		},
+		{
+			name:          "OpenShift 4.22 uses LATEST env var",
+			version:       "4.22.0",
+			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
 			expectedImage: "quay.io/kuadrant/console-plugin:latest",
 		},
@@ -50,27 +63,39 @@ func TestGetConsolePluginImageForVersion(t *testing.T) {
 			name:          "OpenShift 5.0 uses LATEST env var",
 			version:       "5.0.0",
 			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
 			expectedImage: "quay.io/kuadrant/console-plugin:latest",
 		},
 		{
-			name:          "OpenShift 4.20.0-rc.1 pre-release uses LATEST env var",
+			name:          "OpenShift 4.20.0-rc.1 pre-release uses SDK1 env var",
 			version:       "4.20.0-rc.1",
 			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
+			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
+			expectedImage: "quay.io/kuadrant/console-plugin:v0.6.0",
+		},
+		{
+			name:          "OpenShift 4.22.0-rc.1 pre-release uses LATEST env var",
+			version:       "4.22.0-rc.1",
+			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
 			expectedImage: "quay.io/kuadrant/console-plugin:latest",
 		},
 		{
-			name:          "OpenShift 4.20.0-alpha.1 pre-release uses LATEST env var",
+			name:          "OpenShift 4.20.0-alpha.1 pre-release uses SDK1 env var",
 			version:       "4.20.0-alpha.1",
 			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
-			expectedImage: "quay.io/kuadrant/console-plugin:latest",
+			expectedImage: "quay.io/kuadrant/console-plugin:v0.6.0",
 		},
 		{
 			name:          "OpenShift 4.19.0-rc.1 pre-release uses PF5 env var",
 			version:       "4.19.0-rc.1",
 			latestEnvVar:  "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:    "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:     "quay.io/kuadrant/console-plugin:v0.1.5",
 			expectedImage: "quay.io/kuadrant/console-plugin:v0.1.5",
 		},
@@ -78,6 +103,7 @@ func TestGetConsolePluginImageForVersion(t *testing.T) {
 			name:              "Empty version returns error",
 			version:           "",
 			latestEnvVar:      "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:        "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:         "quay.io/kuadrant/console-plugin:v0.1.5",
 			expectedErrSubstr: "OpenShift version is empty",
 		},
@@ -85,6 +111,7 @@ func TestGetConsolePluginImageForVersion(t *testing.T) {
 			name:              "Invalid version returns error",
 			version:           "invalid",
 			latestEnvVar:      "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:        "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:         "quay.io/kuadrant/console-plugin:v0.1.5",
 			expectedErrSubstr: "failed to parse OpenShift version",
 		},
@@ -92,13 +119,23 @@ func TestGetConsolePluginImageForVersion(t *testing.T) {
 			name:              "Missing PF5 env var for old version returns error",
 			version:           "4.18.0",
 			latestEnvVar:      "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:        "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:         "",
 			expectedErrSubstr: "environment variable RELATED_IMAGE_CONSOLE_PLUGIN_PF5 is not set",
 		},
 		{
-			name:              "Missing LATEST env var for new version returns error",
+			name:              "Missing SDK1 env var for 4.20-4.21 returns error",
 			version:           "4.20.0",
+			latestEnvVar:      "quay.io/kuadrant/console-plugin:latest",
+			sdk1EnvVar:        "",
+			pf5EnvVar:         "quay.io/kuadrant/console-plugin:v0.1.5",
+			expectedErrSubstr: "environment variable RELATED_IMAGE_CONSOLE_PLUGIN_SDK1 is not set",
+		},
+		{
+			name:              "Missing LATEST env var for new version returns error",
+			version:           "4.22.0",
 			latestEnvVar:      "",
+			sdk1EnvVar:        "quay.io/kuadrant/console-plugin:v0.6.0",
 			pf5EnvVar:         "quay.io/kuadrant/console-plugin:v0.1.5",
 			expectedErrSubstr: "environment variable RELATED_IMAGE_CONSOLE_PLUGIN_LATEST is not set",
 		},
@@ -106,13 +143,9 @@ func TestGetConsolePluginImageForVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Set environment variables
-			if tt.latestEnvVar != "" {
-				t.Setenv(RelatedImageConsolePluginLatestEnvVar, tt.latestEnvVar)
-			}
-			if tt.pf5EnvVar != "" {
-				t.Setenv(RelatedImageConsolePluginPF5EnvVar, tt.pf5EnvVar)
-			}
+			t.Setenv(RelatedImageConsolePluginLatestEnvVar, tt.latestEnvVar)
+			t.Setenv(RelatedImageConsolePluginSDK1EnvVar, tt.sdk1EnvVar)
+			t.Setenv(RelatedImageConsolePluginPF5EnvVar, tt.pf5EnvVar)
 
 			clusterVersion := &configv1.ClusterVersion{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Summary

- Fixes console plugin load failure on OCP 4.20/4.21 after SDK 4.22 upgrade
- Adds `RELATED_IMAGE_CONSOLE_PLUGIN_SDK1` env var pointing to `console-plugin:v0.6.0` (last SDK 1.x build)
- Replaces hardcoded version switch with a rules-based selector — an ordered list of semver constraints evaluated top-down, first match wins:
  - `>= 4.22.0-0` → `RELATED_IMAGE_CONSOLE_PLUGIN_LATEST` (SDK 4.22)
  - `>= 4.20.0-0` → `RELATED_IMAGE_CONSOLE_PLUGIN_SDK1` (SDK 1.x)
  - `*` → `RELATED_IMAGE_CONSOLE_PLUGIN_PF5` (PatternFly 5)
- Future version boundaries only need a new rule + env var, no selector logic change
- All images present in CSV `relatedImages` for `oc-mirror` support

Closes #2182
Relates to Kuadrant/kuadrant-console-plugin#737

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting compatible Console Plugin images based on OpenShift version.
  * OpenShift 4.22 and later use the latest Console Plugin image, while OpenShift 4.20–4.21 use the SDK 1.x image.
  * Added configuration support for the SDK 1.x Console Plugin image across deployments and bundle builds.

* **Bug Fixes**
  * Improved image selection validation and clearer handling when required image configuration is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->