### PR TITLE
Action sets break ties on identifier

### DIFF
--- a/internal/controller/istio_extension_reconciler_test.go
+++ b/internal/controller/istio_extension_reconciler_test.go
@@ -735,6 +735,9 @@ func TestWasmConfigDeterministicSortOrder(t *testing.T) {
 	routeNamespace := "default"
 	creationTimestamp := metav1.Now()
 
+	// Both entries model the same route rule and match reached via two different
+	// listeners, so they share RuleIndex and MatchIndex and tie on every other Less()
+	// field. Only Identifier (unique per listener) breaks the tie deterministically.
 	newMatchConfig := func(actionSetName string) kuadrantgatewayapi.HTTPRouteMatchConfig {
 		return kuadrantgatewayapi.HTTPRouteMatchConfig{
 			Hostname: hostname,
@@ -747,6 +750,8 @@ func TestWasmConfigDeterministicSortOrder(t *testing.T) {
 			CreationTimestamp: creationTimestamp,
 			Namespace:         routeNamespace,
 			Name:              routeName,
+			RuleIndex:         0,
+			MatchIndex:        0,
 			Identifier:        actionSetName,
 			Config: wasm.ActionSet{
 				Name: actionSetName,

--- a/internal/controller/istio_extension_reconciler_test.go
+++ b/internal/controller/istio_extension_reconciler_test.go
@@ -4,10 +4,18 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
+	"maps"
 	"testing"
 
+	"github.com/go-logr/logr"
+	"github.com/samber/lo"
 	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	kuadrantgatewayapi "github.com/kuadrant/kuadrant-operator/internal/gatewayapi"
 	"github.com/kuadrant/kuadrant-operator/internal/wasm"
 )
 
@@ -718,4 +726,82 @@ func TestMergeAndVerifyEdgeCases(t *testing.T) {
 		assert.Equal(t, "auth.identity.alice", result1[0].ConditionalData[0].Predicates[0])
 		assert.Equal(t, "auth.identity.bob", result1[0].ConditionalData[1].Predicates[0])
 	})
+}
+
+func TestWasmConfigDeterministicSortOrder(t *testing.T) {
+	hostname := "example.com"
+	pathPrefix := "/"
+	routeName := "my-route"
+	routeNamespace := "default"
+	creationTimestamp := metav1.Now()
+
+	newMatchConfig := func(actionSetName string) kuadrantgatewayapi.HTTPRouteMatchConfig {
+		return kuadrantgatewayapi.HTTPRouteMatchConfig{
+			Hostname: hostname,
+			HTTPRouteMatch: gatewayapiv1.HTTPRouteMatch{
+				Path: &gatewayapiv1.HTTPPathMatch{
+					Type:  ptr.To(gatewayapiv1.PathMatchPathPrefix),
+					Value: ptr.To(pathPrefix),
+				},
+			},
+			CreationTimestamp: creationTimestamp,
+			Namespace:         routeNamespace,
+			Name:              routeName,
+			Identifier:        actionSetName,
+			Config: wasm.ActionSet{
+				Name: actionSetName,
+				RouteRuleConditions: wasm.RouteRuleConditions{
+					Hostnames:  []string{hostname},
+					Predicates: []string{"request.url_path.startsWith('/')"},
+				},
+			},
+		}
+	}
+
+	configFromHTTPListener := newMatchConfig("aaaa1111")
+	configFromHTTPSListener := newMatchConfig("bbbb2222")
+
+	logger := logr.Discard()
+	serviceBuilder := wasm.NewServiceBuilder(&logger)
+
+	buildConfigJSON := func(configs kuadrantgatewayapi.SortableHTTPRouteMatchConfigs) string {
+		actionSets := lo.Map(configs, func(c kuadrantgatewayapi.HTTPRouteMatchConfig, _ int) wasm.ActionSet {
+			return c.Config.(wasm.ActionSet)
+		})
+		config := wasm.BuildConfigForActionSet(actionSets, &logger, nil, serviceBuilder)
+		configBytes, err := json.Marshal(config)
+		if err != nil {
+			t.Fatalf("failed to marshal config: %v", err)
+		}
+		return string(configBytes)
+	}
+
+	sourceMap := map[string]kuadrantgatewayapi.HTTPRouteMatchConfig{
+		"path-via-http-listener":  configFromHTTPListener,
+		"path-via-https-listener": configFromHTTPSListener,
+	}
+
+	observed := map[string]int{}
+	iterations := 100
+
+	for range iterations {
+		freshMap := make(map[string]kuadrantgatewayapi.HTTPRouteMatchConfig, len(sourceMap))
+		maps.Copy(freshMap, sourceMap)
+		entries := lo.Entries(freshMap)
+
+		group := kuadrantgatewayapi.GroupedHTTPRouteMatchConfigs{}
+		for _, e := range entries {
+			group.Add("gateway-locator", e.Value)
+		}
+		sorted := group.Sorted()
+		configJSON := buildConfigJSON(sorted["gateway-locator"])
+		observed[configJSON]++
+	}
+
+	if len(observed) != 1 {
+		t.Errorf("wasm config is non-deterministic: got %d distinct JSON outputs in %d iterations", len(observed), iterations)
+		for configJSON, count := range observed {
+			t.Logf("  seen %d times: ...%s...", count, configJSON[:80])
+		}
+	}
 }

--- a/internal/gatewayapi/types.go
+++ b/internal/gatewayapi/types.go
@@ -31,6 +31,8 @@ type HTTPRouteMatchConfig struct {
 	CreationTimestamp metav1.Time
 	Namespace         string
 	Name              string
+	RuleIndex         int
+	MatchIndex        int
 	Identifier        string
 	Config            any
 }
@@ -115,6 +117,14 @@ func (c SortableHTTPRouteMatchConfigs) Less(i, j int) bool {
 	jName := fmt.Sprintf("%s/%s", c[j].Namespace, c[j].Name)
 	if iName != jName {
 		return iName < jName
+	}
+
+	// Gateway API precedence within a route: earlier rule wins, then earlier match
+	if c[i].RuleIndex != c[j].RuleIndex {
+		return c[i].RuleIndex < c[j].RuleIndex
+	}
+	if c[i].MatchIndex != c[j].MatchIndex {
+		return c[i].MatchIndex < c[j].MatchIndex
 	}
 
 	// Entries can otherwise be fully equal, the tie breaker is the Identifier

--- a/internal/gatewayapi/types.go
+++ b/internal/gatewayapi/types.go
@@ -31,6 +31,7 @@ type HTTPRouteMatchConfig struct {
 	CreationTimestamp metav1.Time
 	Namespace         string
 	Name              string
+	Identifier        string
 	Config            any
 }
 
@@ -110,7 +111,14 @@ func (c SortableHTTPRouteMatchConfigs) Less(i, j int) bool {
 	}
 
 	// Lexicographically by "{namespace}/{name}"
-	return fmt.Sprintf("%s/%s", c[i].Namespace, c[i].Name) < fmt.Sprintf("%s/%s", c[j].Namespace, c[j].Name)
+	iName := fmt.Sprintf("%s/%s", c[i].Namespace, c[i].Name)
+	jName := fmt.Sprintf("%s/%s", c[j].Namespace, c[j].Name)
+	if iName != jName {
+		return iName < jName
+	}
+
+	// Entries can otherwise be fully equal, the tie breaker is the Identifier
+	return c[i].Identifier < c[j].Identifier
 }
 
 func pathMatchCount(pathMatch *gatewayapiv1.HTTPPathMatch) int {

--- a/internal/wasm/utils.go
+++ b/internal/wasm/utils.go
@@ -282,6 +282,7 @@ func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery
 
 	switch parsed.RouteType {
 	case kuadrantpolicymachinery.RouteTypeHTTP:
+		ruleIndex := httpRuleListIndex(parsed.HTTPRoute, parsed.HTTPRouteRule.Name)
 		configs = lo.FlatMap(kuadrantgatewayapi.HostnamesFromListenerAndHTTPRoute(parsed.Listener.Listener, parsed.HTTPRoute.HTTPRoute), func(hostname gatewayapiv1.Hostname, _ int) []kuadrantgatewayapi.HTTPRouteMatchConfig {
 			// If Matches is empty or nil, use a default catch-all match (matches all requests with PathPrefix "/")
 			matches := parsed.HTTPRouteRule.Matches
@@ -339,15 +340,19 @@ func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery
 					CreationTimestamp: parsed.HTTPRoute.GetCreationTimestamp(),
 					Namespace:         parsed.HTTPRoute.GetNamespace(),
 					Name:              parsed.HTTPRoute.GetName(),
-					// Identifier is the action set name, derived from the full topology path
-					// (including the listener), making it a unique tie-breaker in Less()
-					Identifier: actionSet.Name,
+					RuleIndex:         ruleIndex,
+					MatchIndex:        j,
+					// Identifier is the final tie-breaker in Less() for entries that are
+					// otherwise equal, e.g. the same route attached to two listeners. The
+					// pathID includes the listener, so it distinguishes those entries.
+					Identifier: pathID,
 					Config:     actionSet,
 				}
 			})
 		})
 
 	case kuadrantpolicymachinery.RouteTypeGRPC:
+		ruleIndex := grpcRuleListIndex(parsed.GRPCRoute, parsed.GRPCRouteRule.Name)
 		hostnames := kuadrantgatewayapi.HostnamesFromListenerAndHTTPRoute(parsed.Listener.Listener, &gatewayapiv1.HTTPRoute{
 			Spec: gatewayapiv1.HTTPRouteSpec{
 				Hostnames: parsed.GRPCRoute.Spec.Hostnames,
@@ -430,9 +435,12 @@ func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery
 					CreationTimestamp: parsed.GRPCRoute.GetCreationTimestamp(),
 					Namespace:         parsed.GRPCRoute.GetNamespace(),
 					Name:              parsed.GRPCRoute.GetName(),
-					// Identifier is the action set name, derived from the full topology path
-					// (including the listener), making it a unique tie-breaker in Less()
-					Identifier: actionSet.Name,
+					RuleIndex:         ruleIndex,
+					MatchIndex:        j,
+					// Identifier is the final tie-breaker in Less() for entries that are
+					// otherwise equal, e.g. the same route attached to two listeners. The
+					// pathID includes the listener, so it distinguishes those entries.
+					Identifier: pathID,
 					Config:     actionSet,
 				}
 			})
@@ -448,6 +456,26 @@ func ActionSetNameForPath(pathID string, httpRouteMatchIndex int, hostname strin
 	source := fmt.Sprintf("%s|%d|%s", pathID, httpRouteMatchIndex+1, hostname)
 	hash := sha256.Sum256([]byte(source))
 	return hex.EncodeToString(hash[:])
+}
+
+// httpRuleListIndex returns the position of the named rule within the route's rules,
+// used to honour Gateway API rule-list precedence. Returns len(rules) if not found so
+// the entry sorts last deterministically.
+func httpRuleListIndex(route *machinery.HTTPRoute, name gatewayapiv1.SectionName) int {
+	rules := machinery.HTTPRouteRulesFromHTTPRouteFunc(route, 0)
+	if _, i, found := lo.FindIndexOf(rules, func(r *machinery.HTTPRouteRule) bool { return r.Name == name }); found {
+		return i
+	}
+	return len(rules)
+}
+
+// grpcRuleListIndex mirrors httpRuleListIndex for GRPCRoute rules.
+func grpcRuleListIndex(route *machinery.GRPCRoute, name gatewayapiv1.SectionName) int {
+	rules := machinery.GRPCRouteRulesFromGRPCRouteRule(route, 0)
+	if _, i, found := lo.FindIndexOf(rules, func(r *machinery.GRPCRouteRule) bool { return r.Name == name }); found {
+		return i
+	}
+	return len(rules)
 }
 
 // BuildSkeletonActionSetsForRoute creates ActionSets with proper RouteRuleConditions

--- a/internal/wasm/utils.go
+++ b/internal/wasm/utils.go
@@ -339,7 +339,10 @@ func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery
 					CreationTimestamp: parsed.HTTPRoute.GetCreationTimestamp(),
 					Namespace:         parsed.HTTPRoute.GetNamespace(),
 					Name:              parsed.HTTPRoute.GetName(),
-					Config:            actionSet,
+					// Identifier is the action set name, derived from the full topology path
+					// (including the listener), making it a unique tie-breaker in Less()
+					Identifier: actionSet.Name,
+					Config:     actionSet,
 				}
 			})
 		})
@@ -427,7 +430,10 @@ func BuildActionSetsForPath(ctx context.Context, pathID string, path []machinery
 					CreationTimestamp: parsed.GRPCRoute.GetCreationTimestamp(),
 					Namespace:         parsed.GRPCRoute.GetNamespace(),
 					Name:              parsed.GRPCRoute.GetName(),
-					Config:            actionSet,
+					// Identifier is the action set name, derived from the full topology path
+					// (including the listener), making it a unique tie-breaker in Less()
+					Identifier: actionSet.Name,
+					Config:     actionSet,
 				}
 			})
 		})

--- a/internal/wasm/utils_test.go
+++ b/internal/wasm/utils_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/kuadrant/kuadrant-operator/api/v1beta1"
+	"github.com/kuadrant/policy-machinery/machinery"
 
 	"gotest.tools/assert"
 	"k8s.io/utils/ptr"
@@ -1836,4 +1837,34 @@ func TestConvertGRPCRouteMatchToHTTP(t *testing.T) {
 			assert.Equal(t, tt.expectedHeaders, len(httpRouteMatch.Headers), "headers count mismatch")
 		})
 	}
+}
+
+func TestHTTPRuleListIndex(t *testing.T) {
+	rules := make([]gatewayapiv1.HTTPRouteRule, 11)
+	// A user-set rule name at position 2; all others fall back to the generated "rule-{i+1}".
+	rules[2].Name = ptr.To(gatewayapiv1.SectionName("custom-rule"))
+	route := &machinery.HTTPRoute{
+		HTTPRoute: &gatewayapiv1.HTTPRoute{
+			Spec: gatewayapiv1.HTTPRouteSpec{Rules: rules},
+		},
+	}
+
+	testCases := []struct {
+		name     gatewayapiv1.SectionName
+		expected int
+	}{
+		{"rule-1", 0},
+		{"rule-2", 1},
+		{"custom-rule", 2}, // resolves to its list position, not the generated "rule-3"
+		{"rule-4", 3},
+		{"rule-10", 9},
+		{"rule-11", 10},
+		{"nonexistent", 11}, // not found returns len(rules) so the entry sorts last
+	}
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expected, httpRuleListIndex(route, tc.name), "rule %q", tc.name)
+	}
+
+	// The reason for using the numeric index rather than the name: rule-2 must precede rule-10.
+	assert.Assert(t, httpRuleListIndex(route, "rule-2") < httpRuleListIndex(route, "rule-10"))
 }


### PR DESCRIPTION
The test reproducer fails before the change with different generation, but passes after.

The issue is when there's a `Gateway` with multiple listeners but a single hostname and the same `HTTPRoute`, there's two paths through the `Gateway` that result in the same actions, but only differ by name - when sorted by Go's `sort.Sort` the tie is non-deterministically ordered, resulting in potentially different generation. By falling back to the actionsets name (the unique hash) we can ensure that the order is deterministic in this case.

This did make me wonder though - although I'm hesitant to make this change - should we be deduplicating in this case given that with the same hostname, the first actionset match in the wasm-shim would always win?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when ordering HTTP and gRPC route configurations.
  - Ensured generated WASM configuration output remains deterministic across repeated builds.
  - Prevented route configurations with matching names from producing inconsistent ordering.
  - Preserved Gateway API rule precedence when ordering route matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->