### PR TITLE
feat: kuadrant CR has now owner reference to Authconfigs

### DIFF
--- a/api/v1beta1/kuadrant_types.go
+++ b/api/v1beta1/kuadrant_types.go
@@ -79,7 +79,7 @@ func (k *Kuadrant) IsDeveloperPortalEnabled() bool {
 }
 
 // GetOwnerReference returns the owner reference pointing to this Kuadrant CR,
-func (k *Kuadrant) GetOwnerReference() []metav1.OwnerReference {
+func (k *Kuadrant) BuildOwnerReference() []metav1.OwnerReference {
 	if k == nil {
 		return nil
 	}

--- a/api/v1beta1/kuadrant_types.go
+++ b/api/v1beta1/kuadrant_types.go
@@ -78,6 +78,23 @@ func (k *Kuadrant) IsDeveloperPortalEnabled() bool {
 	return k.Spec.Components.DeveloperPortal.Enabled
 }
 
+// GetOwnerReference returns the owner reference pointing to this Kuadrant CR,
+func (k *Kuadrant) GetOwnerReference() []metav1.OwnerReference {
+	if k == nil {
+		return nil
+	}
+	return []metav1.OwnerReference{
+		{
+			APIVersion:         GroupVersion.String(),
+			Kind:               KuadrantGroupKind.Kind,
+			Name:               k.GetName(),
+			UID:                k.GetUID(),
+			BlockOwnerDeletion: ptr.To(true),
+			Controller:         ptr.To(true),
+		},
+	}
+}
+
 // KuadrantSpec defines the desired state of Kuadrant
 type KuadrantSpec struct {
 	Observability Observability `json:"observability,omitempty"`

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -85,7 +85,7 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 	desiredAuthConfigs := make(map[k8stypes.NamespacedName]struct{})
 	modifiedAuthConfigs := []string{}
 
-	kuadrantCROwnerReference := kuadrantCR.GetOwnerReference()
+	kuadrantCROwnerReference := kuadrantCR.BuildOwnerReference()
 
 	for pathID, effectivePolicy := range effectivePoliciesMap {
 		authConfigName, modified := r.reconcileAuthConfigForPath(ctx, pathID, effectivePolicy, authConfigsNamespace, kuadrantCROwnerReference, topology, errorRegistry)

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/utils/ptr"
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
@@ -65,6 +64,10 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 	authConfigsNamespace := authorino.GetNamespace()
 
 	kuadrantCR := GetKuadrantFromTopology(topology, state)
+	if kuadrantCR == nil {
+		logger.V(1).Info("kuadrant resource not found in the topology")
+		return nil
+	}
 
 	effectivePolicies, ok := state.Load(StateEffectiveAuthPolicies)
 	if !ok {
@@ -81,8 +84,10 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 	desiredAuthConfigs := make(map[k8stypes.NamespacedName]struct{})
 	modifiedAuthConfigs := []string{}
 
+	kuadrantCROwnerReference := kuadrantCR.GetOwnerReference()
+
 	for pathID, effectivePolicy := range effectivePoliciesMap {
-		authConfigName, modified := r.reconcileAuthConfigForPath(ctx, pathID, effectivePolicy, authConfigsNamespace, kuadrantCR, topology, errorRegistry)
+		authConfigName, modified := r.reconcileAuthConfigForPath(ctx, pathID, effectivePolicy, authConfigsNamespace, kuadrantCROwnerReference, topology, errorRegistry)
 		if authConfigName == "" {
 			continue
 		}
@@ -127,7 +132,7 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 
 // reconcileAuthConfigForPath reconciles the AuthConfig for a single effective policy path.
 // It returns the authConfigName (empty if the path is invalid) and whether the object was modified.
-func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, pathID string, effectivePolicy EffectiveAuthPolicy, authConfigsNamespace string, kuadrantCR *kuadrantv1beta1.Kuadrant, topology *machinery.Topology, errorRegistry *ErrorRegistry) (string, bool) {
+func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, pathID string, effectivePolicy EffectiveAuthPolicy, authConfigsNamespace string, kuadrantCROwnerReference []metav1.OwnerReference, topology *machinery.Topology, errorRegistry *ErrorRegistry) (string, bool) {
 	logger := controller.LoggerFromContext(ctx).WithName("AuthConfigsReconciler")
 
 	parsed, err := kuadrantpolicymachinery.ParseTopologyPath(effectivePolicy.Path)
@@ -154,7 +159,7 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 	defer span.End()
 
 	authConfigName := AuthConfigNameForPath(pathID)
-	desiredAuthConfig := r.buildDesiredAuthConfig(spanCtx, effectivePolicy, authConfigName, authConfigsNamespace, kuadrantCR, annotationKey, routeRuleLocator)
+	desiredAuthConfig := r.buildDesiredAuthConfig(spanCtx, effectivePolicy, authConfigName, authConfigsNamespace, kuadrantCROwnerReference, annotationKey, routeRuleLocator)
 
 	span.SetAttributes(
 		attribute.String("namespace", desiredAuthConfig.GetNamespace()),
@@ -251,24 +256,7 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 	return authConfigName, true
 }
 
-// authConfigOwnerReferences returns the owner references to set on managed AuthConfigs.
-func authConfigOwnerReferences(kuadrantCR *kuadrantv1beta1.Kuadrant) []metav1.OwnerReference {
-	if kuadrantCR == nil {
-		return nil
-	}
-	return []metav1.OwnerReference{
-		{
-			APIVersion:         kuadrantv1beta1.GroupVersion.String(),
-			Kind:               kuadrantv1beta1.KuadrantGroupKind.Kind,
-			Name:               kuadrantCR.GetName(),
-			UID:                kuadrantCR.GetUID(),
-			BlockOwnerDeletion: ptr.To(true),
-			Controller:         ptr.To(true),
-		},
-	}
-}
-
-func (r *AuthConfigsReconciler) buildDesiredAuthConfig(ctx context.Context, effectivePolicy EffectiveAuthPolicy, name, namespace string, kuadrantCR *kuadrantv1beta1.Kuadrant, annotationKey, routeRuleLocator string) *authorinov1beta3.AuthConfig {
+func (r *AuthConfigsReconciler) buildDesiredAuthConfig(ctx context.Context, effectivePolicy EffectiveAuthPolicy, name, namespace string, kuadrantCROwnerReference []metav1.OwnerReference, annotationKey, routeRuleLocator string) *authorinov1beta3.AuthConfig {
 	authConfig := &authorinov1beta3.AuthConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AuthConfig",
@@ -281,7 +269,7 @@ func (r *AuthConfigsReconciler) buildDesiredAuthConfig(ctx context.Context, effe
 				annotationKey: routeRuleLocator,
 			},
 			Labels:          AuthObjectLabels(),
-			OwnerReferences: authConfigOwnerReferences(kuadrantCR),
+			OwnerReferences: kuadrantCROwnerReference,
 		},
 		Spec: authorinov1beta3.AuthConfigSpec{
 			Hosts: []string{name},
@@ -404,14 +392,11 @@ func equalAuthConfigs(existing, desired *authorinov1beta3.AuthConfig) bool {
 		return false
 	}
 
-	// owner references (only enforced when a desired owner is set, so we don't
-	// churn or strip references when the Kuadrant CR is momentarily unavailable)
-	if desiredOwners := desired.GetOwnerReferences(); len(desiredOwners) > 0 &&
-		!reflect.DeepEqual(existing.GetOwnerReferences(), desiredOwners) {
+	// check for match of ownerReferences
+	if !reflect.DeepEqual(existing.GetOwnerReferences(), desired.GetOwnerReferences()) {
 		return false
 	}
 
-	// spec
 	return reflect.DeepEqual(existing.Spec, desired.Spec)
 }
 
@@ -436,9 +421,7 @@ func applyAuthConfigUpdate(ctx context.Context, existing, desired *authorinov1be
 	existing.Spec = desired.Spec
 	existing.Labels = desired.Labels
 
-	if desiredOwners := desired.GetOwnerReferences(); len(desiredOwners) > 0 {
-		existing.SetOwnerReferences(desiredOwners)
-	}
+	existing.SetOwnerReferences(desired.GetOwnerReferences())
 
 	// Update route-rule back-ref annotations
 	if existing.Annotations == nil {

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/utils/ptr"
 
 	kuadrantv1 "github.com/kuadrant/kuadrant-operator/api/v1"
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
@@ -63,6 +64,8 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 	}
 	authConfigsNamespace := authorino.GetNamespace()
 
+	kuadrantCR := GetKuadrantFromTopology(topology, state)
+
 	effectivePolicies, ok := state.Load(StateEffectiveAuthPolicies)
 	if !ok {
 		logger.Error(ErrMissingStateEffectiveAuthPolicies, "failed to reconcile authconfig objects")
@@ -79,7 +82,7 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 	modifiedAuthConfigs := []string{}
 
 	for pathID, effectivePolicy := range effectivePoliciesMap {
-		authConfigName, modified := r.reconcileAuthConfigForPath(ctx, pathID, effectivePolicy, authConfigsNamespace, topology, errorRegistry)
+		authConfigName, modified := r.reconcileAuthConfigForPath(ctx, pathID, effectivePolicy, authConfigsNamespace, kuadrantCR, topology, errorRegistry)
 		if authConfigName == "" {
 			continue
 		}
@@ -124,7 +127,7 @@ func (r *AuthConfigsReconciler) Reconcile(ctx context.Context, _ []controller.Re
 
 // reconcileAuthConfigForPath reconciles the AuthConfig for a single effective policy path.
 // It returns the authConfigName (empty if the path is invalid) and whether the object was modified.
-func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, pathID string, effectivePolicy EffectiveAuthPolicy, authConfigsNamespace string, topology *machinery.Topology, errorRegistry *ErrorRegistry) (string, bool) {
+func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, pathID string, effectivePolicy EffectiveAuthPolicy, authConfigsNamespace string, kuadrantCR *kuadrantv1beta1.Kuadrant, topology *machinery.Topology, errorRegistry *ErrorRegistry) (string, bool) {
 	logger := controller.LoggerFromContext(ctx).WithName("AuthConfigsReconciler")
 
 	parsed, err := kuadrantpolicymachinery.ParseTopologyPath(effectivePolicy.Path)
@@ -151,7 +154,7 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 	defer span.End()
 
 	authConfigName := AuthConfigNameForPath(pathID)
-	desiredAuthConfig := r.buildDesiredAuthConfig(spanCtx, effectivePolicy, authConfigName, authConfigsNamespace, annotationKey, routeRuleLocator)
+	desiredAuthConfig := r.buildDesiredAuthConfig(spanCtx, effectivePolicy, authConfigName, authConfigsNamespace, kuadrantCR, annotationKey, routeRuleLocator)
 
 	span.SetAttributes(
 		attribute.String("namespace", desiredAuthConfig.GetNamespace()),
@@ -248,7 +251,24 @@ func (r *AuthConfigsReconciler) reconcileAuthConfigForPath(ctx context.Context, 
 	return authConfigName, true
 }
 
-func (r *AuthConfigsReconciler) buildDesiredAuthConfig(ctx context.Context, effectivePolicy EffectiveAuthPolicy, name, namespace string, annotationKey, routeRuleLocator string) *authorinov1beta3.AuthConfig {
+// authConfigOwnerReferences returns the owner references to set on managed AuthConfigs.
+func authConfigOwnerReferences(kuadrantCR *kuadrantv1beta1.Kuadrant) []metav1.OwnerReference {
+	if kuadrantCR == nil {
+		return nil
+	}
+	return []metav1.OwnerReference{
+		{
+			APIVersion:         kuadrantv1beta1.GroupVersion.String(),
+			Kind:               kuadrantv1beta1.KuadrantGroupKind.Kind,
+			Name:               kuadrantCR.GetName(),
+			UID:                kuadrantCR.GetUID(),
+			BlockOwnerDeletion: ptr.To(true),
+			Controller:         ptr.To(true),
+		},
+	}
+}
+
+func (r *AuthConfigsReconciler) buildDesiredAuthConfig(ctx context.Context, effectivePolicy EffectiveAuthPolicy, name, namespace string, kuadrantCR *kuadrantv1beta1.Kuadrant, annotationKey, routeRuleLocator string) *authorinov1beta3.AuthConfig {
 	authConfig := &authorinov1beta3.AuthConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AuthConfig",
@@ -260,7 +280,8 @@ func (r *AuthConfigsReconciler) buildDesiredAuthConfig(ctx context.Context, effe
 			Annotations: map[string]string{
 				annotationKey: routeRuleLocator,
 			},
-			Labels: AuthObjectLabels(),
+			Labels:          AuthObjectLabels(),
+			OwnerReferences: authConfigOwnerReferences(kuadrantCR),
 		},
 		Spec: authorinov1beta3.AuthConfigSpec{
 			Hosts: []string{name},
@@ -383,6 +404,13 @@ func equalAuthConfigs(existing, desired *authorinov1beta3.AuthConfig) bool {
 		return false
 	}
 
+	// owner references (only enforced when a desired owner is set, so we don't
+	// churn or strip references when the Kuadrant CR is momentarily unavailable)
+	if desiredOwners := desired.GetOwnerReferences(); len(desiredOwners) > 0 &&
+		!reflect.DeepEqual(existing.GetOwnerReferences(), desiredOwners) {
+		return false
+	}
+
 	// spec
 	return reflect.DeepEqual(existing.Spec, desired.Spec)
 }
@@ -407,6 +435,10 @@ func authConfigAnnotationKeyForRouteType(routeType kuadrantpolicymachinery.Route
 func applyAuthConfigUpdate(ctx context.Context, existing, desired *authorinov1beta3.AuthConfig) {
 	existing.Spec = desired.Spec
 	existing.Labels = desired.Labels
+
+	if desiredOwners := desired.GetOwnerReferences(); len(desiredOwners) > 0 {
+		existing.SetOwnerReferences(desiredOwners)
+	}
 
 	// Update route-rule back-ref annotations
 	if existing.Annotations == nil {

--- a/internal/controller/authconfigs_reconciler.go
+++ b/internal/controller/authconfigs_reconciler.go
@@ -18,6 +18,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
 
@@ -392,12 +393,58 @@ func equalAuthConfigs(existing, desired *authorinov1beta3.AuthConfig) bool {
 		return false
 	}
 
-	// check for match of ownerReferences
-	if !reflect.DeepEqual(existing.GetOwnerReferences(), desired.GetOwnerReferences()) {
+	// owner references: only our own (Kuadrant-managed) references need to
+	// match. References added by third parties are ignored, and ordering is
+	// irrelevant.
+	if !equalKuadrantOwnerReferences(existing.GetOwnerReferences(), desired.GetOwnerReferences()) {
 		return false
 	}
 
 	return reflect.DeepEqual(existing.Spec, desired.Spec)
+}
+
+func isKuadrantOwnerReference(ref metav1.OwnerReference) bool {
+	gv, err := schema.ParseGroupVersion(ref.APIVersion)
+	if err != nil {
+		return false
+	}
+	return gv.Group == kuadrantv1beta1.KuadrantGroupKind.Group && ref.Kind == kuadrantv1beta1.KuadrantGroupKind.Kind
+}
+
+// kuadrantOwnerReferences returns only the Kuadrant-managed owner references.
+func kuadrantOwnerReferences(refs []metav1.OwnerReference) []metav1.OwnerReference {
+	return lo.Filter(refs, func(ref metav1.OwnerReference, _ int) bool {
+		return isKuadrantOwnerReference(ref)
+	})
+}
+
+// equalKuadrantOwnerReferences reports whether the Kuadrant-managed owner
+// references match between existing and desired, ignoring any third-party
+// references and ordering.
+func equalKuadrantOwnerReferences(existing, desired []metav1.OwnerReference) bool {
+	existingOurs := kuadrantOwnerReferences(existing)
+	desiredOurs := kuadrantOwnerReferences(desired)
+	if len(existingOurs) != len(desiredOurs) {
+		return false
+	}
+	return lo.EveryBy(desiredOurs, func(d metav1.OwnerReference) bool {
+		return lo.ContainsBy(existingOurs, func(e metav1.OwnerReference) bool {
+			return reflect.DeepEqual(e, d)
+		})
+	})
+}
+
+// upsertKuadrantOwnerReference returns the existing owner references with the
+// Kuadrant-managed reference replaced by the desired one. Third-party references
+// are preserved, and stale Kuadrant references
+func upsertKuadrantOwnerReference(existing, desired []metav1.OwnerReference) []metav1.OwnerReference {
+	preserved := lo.Filter(existing, func(ref metav1.OwnerReference, _ int) bool {
+		return !isKuadrantOwnerReference(ref)
+	})
+	if ref, found := lo.Find(desired, isKuadrantOwnerReference); found {
+		preserved = append(preserved, ref)
+	}
+	return preserved
 }
 
 // authConfigAnnotationKeyForRouteType returns the appropriate annotation key for the given route type.
@@ -415,13 +462,11 @@ func authConfigAnnotationKeyForRouteType(routeType kuadrantpolicymachinery.Route
 	}
 }
 
-// applyAuthConfigUpdate applies the desired state to an existing AuthConfig.
-// It updates the spec, labels, and route-rule annotations while preserving other annotations.
 func applyAuthConfigUpdate(ctx context.Context, existing, desired *authorinov1beta3.AuthConfig) {
 	existing.Spec = desired.Spec
 	existing.Labels = desired.Labels
 
-	existing.SetOwnerReferences(desired.GetOwnerReferences())
+	existing.SetOwnerReferences(upsertKuadrantOwnerReference(existing.GetOwnerReferences(), desired.GetOwnerReferences()))
 
 	// Update route-rule back-ref annotations
 	if existing.Annotations == nil {

--- a/internal/controller/authconfigs_reconciler_test.go
+++ b/internal/controller/authconfigs_reconciler_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 
 	authorinov1beta3 "github.com/kuadrant/authorino/api/v1beta3"
+	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	kuadrantauthorino "github.com/kuadrant/kuadrant-operator/internal/authorino"
@@ -65,8 +67,20 @@ func TestAuthConfigOwnerReferences(t *testing.T) {
 	})
 }
 
+func buildUnrelatedOwnerReference() metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion:         "example.com/v1",
+		Kind:               "ThirdParty",
+		Name:               "third-party",
+		UID:                "third-party-uid-999",
+		BlockOwnerDeletion: ptr.To(true),
+		Controller:         ptr.To(false),
+	}
+}
+
 func TestEqualAuthConfigs(t *testing.T) {
 	ownerRefs := buildKuadrantCR().GetOwnerReference()
+	unrelatedRef := buildUnrelatedOwnerReference()
 
 	baseAuthConfig := &authorinov1beta3.AuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -201,6 +215,50 @@ func TestEqualAuthConfigs(t *testing.T) {
 				return ac
 			}(),
 			want: true,
+		},
+		{
+			name: "unrelated owner reference on existing is ignored",
+			existing: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				ac.OwnerReferences = append([]metav1.OwnerReference{unrelatedRef}, ownerRefs...)
+				return ac
+			}(),
+			desired: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				ac.OwnerReferences = ownerRefs
+				return ac
+			}(),
+			want: true,
+		},
+		{
+			name: "owner references match regardless of order",
+			existing: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				ac.OwnerReferences = append(ownerRefs, unrelatedRef)
+				return ac
+			}(),
+			desired: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				ac.OwnerReferences = ownerRefs
+				return ac
+			}(),
+			want: true,
+		},
+		{
+			name: "stale kuadrant owner reference differs",
+			existing: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				staleRef := ownerRefs[0]
+				staleRef.UID = "stale-kuadrant-uid"
+				ac.OwnerReferences = []metav1.OwnerReference{staleRef}
+				return ac
+			}(),
+			desired: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				ac.OwnerReferences = ownerRefs
+				return ac
+			}(),
+			want: false,
 		},
 	}
 
@@ -369,6 +427,101 @@ func TestApplyAuthConfigUpdate(t *testing.T) {
 			validate: func(t *testing.T, updated *authorinov1beta3.AuthConfig, desired *authorinov1beta3.AuthConfig) {
 				if !reflect.DeepEqual(updated.GetOwnerReferences(), ownerRefs) {
 					t.Errorf("owner reference not applied: got %v", updated.GetOwnerReferences())
+				}
+			},
+		},
+		{
+			name: "preserves unrelated owner reference while adding kuadrant reference",
+			existing: &authorinov1beta3.AuthConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "default",
+					OwnerReferences: []metav1.OwnerReference{buildUnrelatedOwnerReference()},
+					Annotations: map[string]string{
+						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
+					},
+				},
+				Spec: authorinov1beta3.AuthConfigSpec{
+					Hosts: []string{"test.example.com"},
+				},
+			},
+			desired: &authorinov1beta3.AuthConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Annotations: map[string]string{
+						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
+					},
+					OwnerReferences: ownerRefs,
+				},
+				Spec: authorinov1beta3.AuthConfigSpec{
+					Hosts: []string{"test.example.com"},
+				},
+			},
+			validate: func(t *testing.T, updated *authorinov1beta3.AuthConfig, desired *authorinov1beta3.AuthConfig) {
+				refs := updated.GetOwnerReferences()
+				if !lo.ContainsBy(refs, func(r metav1.OwnerReference) bool {
+					return reflect.DeepEqual(r, buildUnrelatedOwnerReference())
+				}) {
+					t.Errorf("unrelated owner reference should be preserved: got %v", refs)
+				}
+				if !lo.ContainsBy(refs, func(r metav1.OwnerReference) bool {
+					return reflect.DeepEqual(r, ownerRefs[0])
+				}) {
+					t.Errorf("kuadrant owner reference should be added: got %v", refs)
+				}
+			},
+		},
+		{
+			name: "replaces stale kuadrant owner reference and keeps unrelated one",
+			existing: &authorinov1beta3.AuthConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					OwnerReferences: []metav1.OwnerReference{
+						buildUnrelatedOwnerReference(),
+						func() metav1.OwnerReference {
+							stale := ownerRefs[0]
+							stale.UID = "stale-kuadrant-uid"
+							return stale
+						}(),
+					},
+					Annotations: map[string]string{
+						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
+					},
+				},
+				Spec: authorinov1beta3.AuthConfigSpec{
+					Hosts: []string{"test.example.com"},
+				},
+			},
+			desired: &authorinov1beta3.AuthConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Annotations: map[string]string{
+						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
+					},
+					OwnerReferences: ownerRefs,
+				},
+				Spec: authorinov1beta3.AuthConfigSpec{
+					Hosts: []string{"test.example.com"},
+				},
+			},
+			validate: func(t *testing.T, updated *authorinov1beta3.AuthConfig, desired *authorinov1beta3.AuthConfig) {
+				refs := updated.GetOwnerReferences()
+				kuadrantRefs := lo.Filter(refs, func(r metav1.OwnerReference, _ int) bool {
+					return r.Kind == kuadrantv1beta1.KuadrantGroupKind.Kind
+				})
+				if len(kuadrantRefs) != 1 {
+					t.Fatalf("expected exactly one kuadrant owner reference, got %d: %v", len(kuadrantRefs), refs)
+				}
+				if kuadrantRefs[0].UID != ownerRefs[0].UID {
+					t.Errorf("expected current kuadrant UID %q, got %q", ownerRefs[0].UID, kuadrantRefs[0].UID)
+				}
+				if !lo.ContainsBy(refs, func(r metav1.OwnerReference) bool {
+					return reflect.DeepEqual(r, buildUnrelatedOwnerReference())
+				}) {
+					t.Errorf("unrelated owner reference should be preserved: got %v", refs)
 				}
 			},
 		},

--- a/internal/controller/authconfigs_reconciler_test.go
+++ b/internal/controller/authconfigs_reconciler_test.go
@@ -30,14 +30,15 @@ func buildKuadrantCR() *kuadrantv1beta1.Kuadrant {
 
 func TestAuthConfigOwnerReferences(t *testing.T) {
 	t.Run("returns nil when Kuadrant CR is nil", func(t *testing.T) {
-		if refs := authConfigOwnerReferences(nil); refs != nil {
+		var nilCR *kuadrantv1beta1.Kuadrant
+		if refs := nilCR.GetOwnerReference(); refs != nil {
 			t.Errorf("expected nil owner references, got %v", refs)
 		}
 	})
 
 	t.Run("builds a controller owner reference to the Kuadrant CR", func(t *testing.T) {
 		kuadrantCR := buildKuadrantCR()
-		refs := authConfigOwnerReferences(kuadrantCR)
+		refs := kuadrantCR.GetOwnerReference()
 
 		if len(refs) != 1 {
 			t.Fatalf("expected exactly one owner reference, got %d", len(refs))
@@ -65,7 +66,7 @@ func TestAuthConfigOwnerReferences(t *testing.T) {
 }
 
 func TestEqualAuthConfigs(t *testing.T) {
-	ownerRefs := authConfigOwnerReferences(buildKuadrantCR())
+	ownerRefs := buildKuadrantCR().GetOwnerReference()
 
 	baseAuthConfig := &authorinov1beta3.AuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -201,16 +202,6 @@ func TestEqualAuthConfigs(t *testing.T) {
 			}(),
 			want: true,
 		},
-		{
-			name: "no desired owner reference does not force inequality",
-			existing: func() *authorinov1beta3.AuthConfig {
-				ac := baseAuthConfig.DeepCopy()
-				ac.OwnerReferences = ownerRefs
-				return ac
-			}(),
-			desired: baseAuthConfig.DeepCopy(),
-			want:    true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -224,7 +215,7 @@ func TestEqualAuthConfigs(t *testing.T) {
 }
 
 func TestApplyAuthConfigUpdate(t *testing.T) {
-	ownerRefs := authConfigOwnerReferences(buildKuadrantCR())
+	ownerRefs := buildKuadrantCR().GetOwnerReference()
 
 	tests := []struct {
 		name     string
@@ -378,39 +369,6 @@ func TestApplyAuthConfigUpdate(t *testing.T) {
 			validate: func(t *testing.T, updated *authorinov1beta3.AuthConfig, desired *authorinov1beta3.AuthConfig) {
 				if !reflect.DeepEqual(updated.GetOwnerReferences(), ownerRefs) {
 					t.Errorf("owner reference not applied: got %v", updated.GetOwnerReferences())
-				}
-			},
-		},
-		{
-			name: "does not strip owner reference when desired has none",
-			existing: &authorinov1beta3.AuthConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "test",
-					Namespace:       "default",
-					OwnerReferences: ownerRefs,
-					Annotations: map[string]string{
-						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
-					},
-				},
-				Spec: authorinov1beta3.AuthConfigSpec{
-					Hosts: []string{"test.example.com"},
-				},
-			},
-			desired: &authorinov1beta3.AuthConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-					Annotations: map[string]string{
-						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
-					},
-				},
-				Spec: authorinov1beta3.AuthConfigSpec{
-					Hosts: []string{"test.example.com"},
-				},
-			},
-			validate: func(t *testing.T, updated *authorinov1beta3.AuthConfig, desired *authorinov1beta3.AuthConfig) {
-				if !reflect.DeepEqual(updated.GetOwnerReferences(), ownerRefs) {
-					t.Errorf("owner reference should be preserved: got %v", updated.GetOwnerReferences())
 				}
 			},
 		},

--- a/internal/controller/authconfigs_reconciler_test.go
+++ b/internal/controller/authconfigs_reconciler_test.go
@@ -33,14 +33,14 @@ func buildKuadrantCR() *kuadrantv1beta1.Kuadrant {
 func TestAuthConfigOwnerReferences(t *testing.T) {
 	t.Run("returns nil when Kuadrant CR is nil", func(t *testing.T) {
 		var nilCR *kuadrantv1beta1.Kuadrant
-		if refs := nilCR.GetOwnerReference(); refs != nil {
+		if refs := nilCR.BuildOwnerReference(); refs != nil {
 			t.Errorf("expected nil owner references, got %v", refs)
 		}
 	})
 
 	t.Run("builds a controller owner reference to the Kuadrant CR", func(t *testing.T) {
 		kuadrantCR := buildKuadrantCR()
-		refs := kuadrantCR.GetOwnerReference()
+		refs := kuadrantCR.BuildOwnerReference()
 
 		if len(refs) != 1 {
 			t.Fatalf("expected exactly one owner reference, got %d", len(refs))
@@ -79,7 +79,7 @@ func buildUnrelatedOwnerReference() metav1.OwnerReference {
 }
 
 func TestEqualAuthConfigs(t *testing.T) {
-	ownerRefs := buildKuadrantCR().GetOwnerReference()
+	ownerRefs := buildKuadrantCR().BuildOwnerReference()
 	unrelatedRef := buildUnrelatedOwnerReference()
 
 	baseAuthConfig := &authorinov1beta3.AuthConfig{
@@ -273,7 +273,7 @@ func TestEqualAuthConfigs(t *testing.T) {
 }
 
 func TestApplyAuthConfigUpdate(t *testing.T) {
-	ownerRefs := buildKuadrantCR().GetOwnerReference()
+	ownerRefs := buildKuadrantCR().BuildOwnerReference()
 
 	tests := []struct {
 		name     string

--- a/internal/controller/authconfigs_reconciler_test.go
+++ b/internal/controller/authconfigs_reconciler_test.go
@@ -4,15 +4,69 @@ package controllers
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	authorinov1beta3 "github.com/kuadrant/authorino/api/v1beta3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
 	kuadrantauthorino "github.com/kuadrant/kuadrant-operator/internal/authorino"
 )
 
+func buildKuadrantCR() *kuadrantv1beta1.Kuadrant {
+	return &kuadrantv1beta1.Kuadrant{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       kuadrantv1beta1.KuadrantGroupKind.Kind,
+			APIVersion: kuadrantv1beta1.GroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kuadrant",
+			Namespace: "kuadrant-system",
+			UID:       "test-uid-123",
+		},
+	}
+}
+
+func TestAuthConfigOwnerReferences(t *testing.T) {
+	t.Run("returns nil when Kuadrant CR is nil", func(t *testing.T) {
+		if refs := authConfigOwnerReferences(nil); refs != nil {
+			t.Errorf("expected nil owner references, got %v", refs)
+		}
+	})
+
+	t.Run("builds a controller owner reference to the Kuadrant CR", func(t *testing.T) {
+		kuadrantCR := buildKuadrantCR()
+		refs := authConfigOwnerReferences(kuadrantCR)
+
+		if len(refs) != 1 {
+			t.Fatalf("expected exactly one owner reference, got %d", len(refs))
+		}
+		ref := refs[0]
+		if ref.APIVersion != kuadrantv1beta1.GroupVersion.String() {
+			t.Errorf("unexpected APIVersion: got %q", ref.APIVersion)
+		}
+		if ref.Kind != kuadrantv1beta1.KuadrantGroupKind.Kind {
+			t.Errorf("unexpected Kind: got %q", ref.Kind)
+		}
+		if ref.Name != kuadrantCR.GetName() {
+			t.Errorf("unexpected Name: got %q", ref.Name)
+		}
+		if ref.UID != kuadrantCR.GetUID() {
+			t.Errorf("unexpected UID: got %q", ref.UID)
+		}
+		if ref.BlockOwnerDeletion == nil || !*ref.BlockOwnerDeletion {
+			t.Errorf("expected BlockOwnerDeletion to be true")
+		}
+		if ref.Controller == nil || !*ref.Controller {
+			t.Errorf("expected Controller to be true")
+		}
+	})
+}
+
 func TestEqualAuthConfigs(t *testing.T) {
+	ownerRefs := authConfigOwnerReferences(buildKuadrantCR())
+
 	baseAuthConfig := &authorinov1beta3.AuthConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -123,6 +177,40 @@ func TestEqualAuthConfigs(t *testing.T) {
 			desired: baseAuthConfig.DeepCopy(),
 			want:    false,
 		},
+		{
+			name:     "desired owner reference missing from existing",
+			existing: baseAuthConfig.DeepCopy(),
+			desired: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				ac.OwnerReferences = ownerRefs
+				return ac
+			}(),
+			want: false,
+		},
+		{
+			name: "matching owner references",
+			existing: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				ac.OwnerReferences = ownerRefs
+				return ac
+			}(),
+			desired: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				ac.OwnerReferences = ownerRefs
+				return ac
+			}(),
+			want: true,
+		},
+		{
+			name: "no desired owner reference does not force inequality",
+			existing: func() *authorinov1beta3.AuthConfig {
+				ac := baseAuthConfig.DeepCopy()
+				ac.OwnerReferences = ownerRefs
+				return ac
+			}(),
+			desired: baseAuthConfig.DeepCopy(),
+			want:    true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -136,6 +224,8 @@ func TestEqualAuthConfigs(t *testing.T) {
 }
 
 func TestApplyAuthConfigUpdate(t *testing.T) {
+	ownerRefs := authConfigOwnerReferences(buildKuadrantCR())
+
 	tests := []struct {
 		name     string
 		existing *authorinov1beta3.AuthConfig
@@ -259,6 +349,72 @@ func TestApplyAuthConfigUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "sets owner reference from desired",
+			existing: &authorinov1beta3.AuthConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Annotations: map[string]string{
+						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
+					},
+				},
+				Spec: authorinov1beta3.AuthConfigSpec{
+					Hosts: []string{"test.example.com"},
+				},
+			},
+			desired: &authorinov1beta3.AuthConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Annotations: map[string]string{
+						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
+					},
+					OwnerReferences: ownerRefs,
+				},
+				Spec: authorinov1beta3.AuthConfigSpec{
+					Hosts: []string{"test.example.com"},
+				},
+			},
+			validate: func(t *testing.T, updated *authorinov1beta3.AuthConfig, desired *authorinov1beta3.AuthConfig) {
+				if !reflect.DeepEqual(updated.GetOwnerReferences(), ownerRefs) {
+					t.Errorf("owner reference not applied: got %v", updated.GetOwnerReferences())
+				}
+			},
+		},
+		{
+			name: "does not strip owner reference when desired has none",
+			existing: &authorinov1beta3.AuthConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "test",
+					Namespace:       "default",
+					OwnerReferences: ownerRefs,
+					Annotations: map[string]string{
+						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
+					},
+				},
+				Spec: authorinov1beta3.AuthConfigSpec{
+					Hosts: []string{"test.example.com"},
+				},
+			},
+			desired: &authorinov1beta3.AuthConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+					Annotations: map[string]string{
+						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/route#rule-1",
+					},
+				},
+				Spec: authorinov1beta3.AuthConfigSpec{
+					Hosts: []string{"test.example.com"},
+				},
+			},
+			validate: func(t *testing.T, updated *authorinov1beta3.AuthConfig, desired *authorinov1beta3.AuthConfig) {
+				if !reflect.DeepEqual(updated.GetOwnerReferences(), ownerRefs) {
+					t.Errorf("owner reference should be preserved: got %v", updated.GetOwnerReferences())
+				}
+			},
+		},
+		{
 			name: "ensures reconciliation converges",
 			existing: &authorinov1beta3.AuthConfig{
 				ObjectMeta: metav1.ObjectMeta{
@@ -285,6 +441,7 @@ func TestApplyAuthConfigUpdate(t *testing.T) {
 					Annotations: map[string]string{
 						kuadrantauthorino.AuthConfigHTTPRouteRuleAnnotation: "default/new-route#rule-2",
 					},
+					OwnerReferences: ownerRefs,
 				},
 				Spec: authorinov1beta3.AuthConfigSpec{
 					Hosts: []string{"test.example.com"},


### PR DESCRIPTION
### What

Adds a controller `ownerReference` pointing from every operator-managed Authorino `AuthConfig` back to the `Kuadrant` CR. As a result, deleting the `Kuadrant` CR now cascades — Kubernetes' garbage collector automatically deletes all managed `AuthConfig`s — without any explicit teardown code.

### Changes

`internal/controller/authconfigs_reconciler.go`:
- New helper `authConfigOwnerReferences(kuadrantCR)` builds the owner reference (`Controller: true`, `BlockOwnerDeletion: true`); returns `nil` when the CR is unavailable.

- `Reconcile` fetches the `Kuadrant` CR from the topology and threads it through `reconcileAuthConfigForPath` → `buildDesiredAuthConfig`, which now stamps the owner reference onto every desired `AuthConfig`.

- `equalAuthConfigs` now compares owner references, so **pre-existing** `AuthConfig`s (created before this change) are detected as out-of-date and get the reference back-filled on the next reconcile.

- `applyAuthConfigUpdate` writes the owner reference onto existing objects during updates.

Both `equalAuthConfigs` and `applyAuthConfigUpdate` guard on `len(desiredOwners) > 0`, so a momentarily-unavailable `Kuadrant` CR (e.g. mid-deletion) never strips an existing reference or causes an infinite update loop.

`internal/controller/authconfigs_reconciler_test.go`:
- `TestAuthConfigOwnerReferences` — verifies the reference is built correctly and is `nil` for a `nil` CR.
- `TestEqualAuthConfigs` — added cases for missing/matching owner refs and the no-desired-ref guard.
- `TestApplyAuthConfigUpdate` — added cases confirming the ref is applied, and never stripped when none is desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Managed AuthConfig resources now receive an owner reference to the associated Kuadrant resource.
  * Added support for retrieving a Kuadrant resource’s owner reference.

* **Bug Fixes**
  * Improved AuthConfig comparison and reconciliation to ensure updates converge correctly.
  * Unrelated owner references are retained, while outdated Kuadrant references are replaced.
  * Owner references are applied consistently during AuthConfig updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->