### PR TITLE
Extensions secret reconciler

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2026-08-12T13:03:49Z"
+    createdAt: "2026-08-18T12:33:42Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -850,6 +850,14 @@ spec:
           - patch
         serviceAccountName: developer-portal-controller-manager
       - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups:
           - ""
           resources:

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -13869,6 +13869,24 @@ metadata:
   labels:
     app: kuadrant
     app.kubernetes.io/managed-by: helm
+  name: kuadrant-operator-extension-auth-role
+  namespace: '{{ .Release.Namespace }}'
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: kuadrant
+    app.kubernetes.io/managed-by: helm
   name: kuadrant-operator-leader-election-role
   namespace: '{{ .Release.Namespace }}'
 rules:
@@ -14598,6 +14616,23 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: developer-portal-controller-manager
+  namespace: '{{ .Release.Namespace }}'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: kuadrant
+    app.kubernetes.io/managed-by: helm
+  name: kuadrant-operator-extension-auth-rolebinding
+  namespace: '{{ .Release.Namespace }}'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kuadrant-operator-extension-auth-role
+subjects:
+- kind: ServiceAccount
+  name: kuadrant-operator-controller-manager
   namespace: '{{ .Release.Namespace }}'
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,6 +50,8 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/env"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -236,6 +238,11 @@ func main() {
 		)
 	}
 
+	operatorNamespace := env.GetString("OPERATOR_NAMESPACE", "")
+	if operatorNamespace == "" {
+		panic("OPERATOR_NAMESPACE environment variable must be set")
+	}
+
 	options := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsserver.Options{BindAddress: metricsAddr},
@@ -244,10 +251,16 @@ func main() {
 		PprofBindAddress:       pprofAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "f139389e.kuadrant.io",
-	}
-
-	if env.GetString("OPERATOR_NAMESPACE", "") == "" {
-		panic("OPERATOR_NAMESPACE environment variable must be set")
+		// Restrict caching secrets to operator namespace
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Secret{}: {
+					Namespaces: map[string]cache.Config{
+						operatorNamespace: {},
+					},
+				},
+			},
+		},
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)

--- a/config/rbac/extension_auth_role.yaml
+++ b/config/rbac/extension_auth_role.yaml
@@ -1,0 +1,15 @@
+# Permissions to read the Secret supplying standalone extension credentials
+# Secret read permissions for the operator namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: extension-auth-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/rbac/extension_auth_role_binding.yaml
+++ b/config/rbac/extension_auth_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extension-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-auth-role
+subjects:
+- kind: ServiceAccount
+  name: controller-manager
+  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,19 +1,22 @@
 resources:
-# All RBAC will be applied under this service account in
-# the deployment namespace. You may comment out this resource
-# if your manager will use a service account that exists at
-# runtime. Be sure to update RoleBinding and ClusterRoleBinding
-# subjects if changing service account names.
-- service_account.yaml
-- role.yaml
-- role_binding.yaml
-- leader_election_role.yaml
-- leader_election_role_binding.yaml
-# DevPortal ClusterRoles for API management
-- api_admin_clusterrole.yaml
-- api_owner_clusterrole.yaml
-- api_consumer_clusterrole.yaml
-- api_catalog_browser_clusterrole.yaml
+  # All RBAC will be applied under this service account in
+  # the deployment namespace. You may comment out this resource
+  # if your manager will use a service account that exists at
+  # runtime. Be sure to update RoleBinding and ClusterRoleBinding
+  # subjects if changing service account names.
+  - service_account.yaml
+  - role.yaml
+  - role_binding.yaml
+  - leader_election_role.yaml
+  - leader_election_role_binding.yaml
+  # Extensions namespace-scoped role
+  - extension_auth_role.yaml
+  - extension_auth_role_binding.yaml
+  # DevPortal ClusterRoles for API management
+  - api_admin_clusterrole.yaml
+  - api_owner_clusterrole.yaml
+  - api_consumer_clusterrole.yaml
+  - api_catalog_browser_clusterrole.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/internal/controller/extension_auth_secret_reconciler.go
+++ b/internal/controller/extension_auth_secret_reconciler.go
@@ -47,7 +47,12 @@ func (r *ExtensionAuthSecretReconciler) Reconcile(eventCtx context.Context, _ []
 		credentials = secret.Data
 	}
 
-	logger.V(1).Info("syncing extension auth secret credentials", "count", len(credentials))
-	r.store.SyncSecretCredentials(credentials)
+	result := r.store.SyncSecretCredentials(credentials)
+	if result.Changed() {
+		logger.Info("extension auth secret credentials changed",
+			"added", result.Added, "rotated", result.Rotated, "removed", result.Removed, "total", len(credentials))
+	} else {
+		logger.V(1).Info("extension auth secret credentials unchanged", "count", len(credentials))
+	}
 	return nil
 }

--- a/internal/controller/extension_auth_secret_reconciler.go
+++ b/internal/controller/extension_auth_secret_reconciler.go
@@ -1,0 +1,53 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kuadrant/kuadrant-operator/internal/extension"
+)
+
+type ExtensionAuthSecretReconciler struct {
+	store      *extension.SessionStore
+	namespace  string
+	secretName string
+}
+
+func NewExtensionAuthSecretReconciler(store *extension.SessionStore, namespace, secretName string) *ExtensionAuthSecretReconciler {
+	return &ExtensionAuthSecretReconciler{
+		store:      store,
+		namespace:  namespace,
+		secretName: secretName,
+	}
+}
+
+func (r *ExtensionAuthSecretReconciler) Reconcile(eventCtx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
+	logger := controller.LoggerFromContext(eventCtx).WithName("ExtensionAuthSecretReconciler")
+
+	credentials := map[string][]byte{}
+	secrets := topology.Objects().Items(func(o machinery.Object) bool {
+		return o.GetName() == r.secretName &&
+			o.GetNamespace() == r.namespace &&
+			o.GroupVersionKind().GroupKind() == SecretGroupKind
+	})
+	if len(secrets) > 0 {
+		runtimeObj, ok := secrets[0].(*controller.RuntimeObject)
+		if !ok {
+			return fmt.Errorf("auth secret %s/%s has unexpected topology type %T", r.namespace, r.secretName, secrets[0])
+		}
+		secret, ok := runtimeObj.Object.(*corev1.Secret)
+		if !ok {
+			return fmt.Errorf("auth secret %s/%s has unexpected object type %T", r.namespace, r.secretName, runtimeObj.Object)
+		}
+		credentials = secret.Data
+	}
+
+	logger.V(1).Info("syncing extension auth secret credentials", "count", len(credentials))
+	r.store.SyncSecretCredentials(credentials)
+	return nil
+}

--- a/internal/controller/extension_auth_secret_reconciler_test.go
+++ b/internal/controller/extension_auth_secret_reconciler_test.go
@@ -1,0 +1,98 @@
+//go:build unit
+
+package controllers
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/kuadrant/kuadrant-operator/internal/extension"
+)
+
+const (
+	testAuthSecretNamespace = "kuadrant-system"
+	testAuthSecretName      = "kuadrant-extension-auth"
+)
+
+func authSecretRuntimeObject(data map[string][]byte) *controller.RuntimeObject {
+	return &controller.RuntimeObject{
+		Object: &corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       SecretGroupKind.Kind,
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testAuthSecretName,
+				Namespace: testAuthSecretNamespace,
+			},
+			Data: data,
+		},
+	}
+}
+
+func TestExtensionAuthSecretReconciler_SyncsCredentialsFromSecret(t *testing.T) {
+	store := extension.NewSessionStore(logr.Discard())
+	reconciler := NewExtensionAuthSecretReconciler(store, testAuthSecretNamespace, testAuthSecretName)
+
+	cred := []byte("0123456789abcdef0123456789abcdef")
+	topology, err := machinery.NewTopology(machinery.WithObjects(authSecretRuntimeObject(map[string][]byte{"standalone": cred})))
+	if err != nil {
+		t.Fatalf("failed to create topology: %v", err)
+	}
+
+	if err := reconciler.Reconcile(context.Background(), nil, topology, nil, &sync.Map{}); err != nil {
+		t.Fatalf("expected reconcile to succeed, got: %v", err)
+	}
+
+	if _, err := store.Authenticate("standalone", cred, "StandalonePolicy"); err != nil {
+		t.Fatalf("expected credential to be synced into store, got: %v", err)
+	}
+}
+
+func TestExtensionAuthSecretReconciler_AbsentSecretPrunesCredentials(t *testing.T) {
+	store := extension.NewSessionStore(logr.Discard())
+	reconciler := NewExtensionAuthSecretReconciler(store, testAuthSecretNamespace, testAuthSecretName)
+
+	cred := []byte("0123456789abcdef0123456789abcdef")
+	store.SyncSecretCredentials(map[string][]byte{"standalone": cred})
+
+	topology, err := machinery.NewTopology()
+	if err != nil {
+		t.Fatalf("failed to create topology: %v", err)
+	}
+
+	if err := reconciler.Reconcile(context.Background(), nil, topology, nil, &sync.Map{}); err != nil {
+		t.Fatalf("expected reconcile to succeed, got: %v", err)
+	}
+
+	if _, err := store.Authenticate("standalone", cred, "StandalonePolicy"); err == nil {
+		t.Fatal("expected credential to be pruned when secret is absent")
+	}
+}
+
+func TestExtensionAuthSecretReconciler_UnexpectedObjectTypeReturnsError(t *testing.T) {
+	store := extension.NewSessionStore(logr.Discard())
+	reconciler := NewExtensionAuthSecretReconciler(store, testAuthSecretNamespace, testAuthSecretName)
+
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(SecretGroupKind.WithVersion("v1"))
+	obj.SetName(testAuthSecretName)
+	obj.SetNamespace(testAuthSecretNamespace)
+
+	topology, err := machinery.NewTopology(machinery.WithObjects(&controller.RuntimeObject{Object: obj}))
+	if err != nil {
+		t.Fatalf("failed to create topology: %v", err)
+	}
+
+	if err := reconciler.Reconcile(context.Background(), nil, topology, nil, &sync.Map{}); err == nil {
+		t.Fatal("expected reconcile to return an error for unexpected object type")
+	}
+}

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -60,6 +60,7 @@ var (
 	kuadrantManagedLabelKey = "kuadrant.io/managed"
 
 	ConfigMapGroupKind = schema.GroupKind{Group: corev1.GroupName, Kind: "ConfigMap"}
+	SecretGroupKind    = schema.GroupKind{Group: corev1.GroupName, Kind: "Secret"}
 
 	SecretsResource = corev1.SchemeGroupVersion.WithResource("secrets")
 )
@@ -232,6 +233,8 @@ type BootOptionsBuilder struct {
 	isPrometheusOperatorInstalled    bool
 	isOpenShiftServerConfigInstalled bool
 	isUsingExtensions                bool
+
+	extensionManager *extension.Manager
 
 	// Error tracking for non-blocking errors
 	errorTracker   *PersistentErrorTracker
@@ -697,13 +700,12 @@ func (b *BootOptionsBuilder) getExtensionsOptions() []controller.ControllerOptio
 		return opts
 	}
 	extManager.SetChangeNotifier(extManager.TriggerReconciliation)
-
-	secretName := env.GetString("EXTENSION_AUTH_SECRET", "kuadrant-extension-auth")
+	b.extensionManager = &extManager
 
 	opts = append(opts, controller.WithRunnable(
 		"extension manager",
 		func(*controller.Controller) controller.Runnable {
-			return &extManager
+			return b.extensionManager
 		},
 	), controller.WithRunnable(
 		"extension auth secret watcher",
@@ -711,7 +713,7 @@ func (b *BootOptionsBuilder) getExtensionsOptions() []controller.ControllerOptio
 			&corev1.Secret{},
 			SecretsResource,
 			operatorNamespace,
-			controller.FilterResourcesByField[*corev1.Secret](fmt.Sprintf("metadata.name=%s", secretName)),
+			controller.FilterResourcesByField[*corev1.Secret](fmt.Sprintf("metadata.name=%s", extension.AuthSecretName())),
 		),
 	), controller.WithObjectKinds(SecretGroupKind))
 	return opts
@@ -813,6 +815,12 @@ func (b *BootOptionsBuilder) Reconciler() controller.ReconcileFunc {
 	if b.isAuthorinoOperatorInstalled {
 		mainWorkflow.Tasks = append(mainWorkflow.Tasks,
 			traceReconcileFunc("workflow.authorino", NewAuthorinoReconciler(b.client, b.isOpenShiftServerConfigInstalled).Subscription().Reconcile))
+	}
+
+	if b.extensionManager != nil {
+		mainWorkflow.Tasks = append(mainWorkflow.Tasks,
+			traceReconcileFunc("workflow.extension_auth_secret",
+				NewExtensionAuthSecretReconciler(b.extensionManager.SessionStore(), operatorNamespace, extension.AuthSecretName()).Reconcile))
 	}
 
 	// Wrap the entire main workflow with tracing

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -60,6 +60,8 @@ var (
 	kuadrantManagedLabelKey = "kuadrant.io/managed"
 
 	ConfigMapGroupKind = schema.GroupKind{Group: corev1.GroupName, Kind: "ConfigMap"}
+
+	SecretsResource = corev1.SchemeGroupVersion.WithResource("secrets")
 )
 
 // gateway-api permissions
@@ -696,12 +698,22 @@ func (b *BootOptionsBuilder) getExtensionsOptions() []controller.ControllerOptio
 	}
 	extManager.SetChangeNotifier(extManager.TriggerReconciliation)
 
+	secretName := env.GetString("EXTENSION_AUTH_SECRET", "kuadrant-extension-auth")
+
 	opts = append(opts, controller.WithRunnable(
 		"extension manager",
 		func(*controller.Controller) controller.Runnable {
 			return &extManager
 		},
-	))
+	), controller.WithRunnable(
+		"extension auth secret watcher",
+		controller.Watch(
+			&corev1.Secret{},
+			SecretsResource,
+			operatorNamespace,
+			controller.FilterResourcesByField[*corev1.Secret](fmt.Sprintf("metadata.name=%s", secretName)),
+		),
+	), controller.WithObjectKinds(SecretGroupKind))
 	return opts
 }
 

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -56,8 +56,13 @@ import (
 
 const defaultExtensionServicePort = 50052
 const defaultWarmupTimeout = 30 * time.Second
+const defaultAuthSecretName = "kuadrant-extension-auth" //nolint:gosec
 
 var ErrNoExtensionsFound = errors.New("no extensions found")
+
+func AuthSecretName() string {
+	return env.GetString("EXTENSION_AUTH_SECRET", defaultAuthSecretName)
+}
 
 type ChangeNotifier func(reason string) error
 

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -55,6 +55,7 @@ import (
 )
 
 const defaultExtensionServicePort = 50052
+const defaultWarmupTimeout = 30 * time.Second
 
 var ErrNoExtensionsFound = errors.New("no extensions found")
 
@@ -142,6 +143,8 @@ func (m *Manager) Start() error {
 		m.logger.Error(e, "failed to start descriptor server")
 		err = fmt.Errorf("descriptor server: %w", e)
 	}
+
+	m.beginWarmup()
 
 	if e := m.startExtensionServer(); e != nil {
 		m.logger.Error(e, "failed to start extension server")
@@ -243,6 +246,28 @@ func (m *Manager) stopDescriptorServer() {
 	}
 
 	m.descriptorServer = nil
+}
+
+func (m *Manager) beginWarmup() {
+	builtinNames := make([]string, 0, len(m.extensions))
+	for _, extension := range m.extensions {
+		builtinNames = append(builtinNames, extension.Name())
+	}
+
+	m.sessionStore.BeginWarmup(builtinNames, warmupTimeout(m.logger))
+}
+
+func warmupTimeout(logger logr.Logger) time.Duration {
+	value := env.GetString("EXTENSIONS_WARMUP_TIMEOUT", "")
+	if value == "" {
+		return defaultWarmupTimeout
+	}
+	timeout, err := time.ParseDuration(value)
+	if err != nil || timeout <= 0 {
+		logger.Error(err, "invalid EXTENSIONS_WARMUP_TIMEOUT, using default", "value", value, "default", defaultWarmupTimeout)
+		return defaultWarmupTimeout
+	}
+	return timeout
 }
 
 func (m *Manager) startExtensionServer() error {
@@ -436,6 +461,15 @@ func (s *extensionService) Handshake(_ context.Context, request *extpb.Handshake
 		return &extpb.HandshakeResponse{
 			Accepted: false,
 			Reason:   "name is required",
+		}, nil
+	}
+
+	// Built-in extensions claim their policy kinds first
+	if !s.sessionStore.handshakeAdmitted(request.Name) {
+		s.logger.Info("handshake rejected during warmup", "extension", request.Name, "policyKind", request.PolicyKind)
+		return &extpb.HandshakeResponse{
+			Accepted: false,
+			Reason:   "warmup in progress",
 		}, nil
 	}
 

--- a/internal/extension/manager.go
+++ b/internal/extension/manager.go
@@ -19,6 +19,7 @@ package extension
 import (
 	"context"
 	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -103,10 +104,12 @@ func NewManager(location string, logger logr.Logger, sync io.Writer, client dyna
 	}
 
 	for _, name := range names {
-		credential := make([]byte, 32)
-		if _, e := rand.Read(credential); e != nil {
+		raw := make([]byte, 32)
+		if _, e := rand.Read(raw); e != nil {
 			return Manager{}, fmt.Errorf("failed to generate credential for extension %s: %w", name, e)
 		}
+
+		credential := []byte(hex.EncodeToString(raw))
 		service.sessionStore.SetCredential(name, credential)
 		if oopExtension, e := NewOOPExtension(name, location, credential, extensionPort, logger, sync); e == nil {
 			extensions = append(extensions, &oopExtension)

--- a/internal/extension/manager_test.go
+++ b/internal/extension/manager_test.go
@@ -5,8 +5,10 @@ package extension
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc/codes"
@@ -137,6 +139,61 @@ func TestHandshake_AuthFailure_GenericReason(t *testing.T) {
 	}
 	if resp.Reason != "handshake failed" {
 		t.Fatalf("expected generic reason %q, got %q", "handshake failed", resp.Reason)
+	}
+}
+
+func TestHandshake_WarmupGate_RejectsStandaloneDuringWarmup(t *testing.T) {
+	svc := newTestExtensionService()
+	cred := validCredential()
+	svc.sessionStore.SetCredential("builtin", cred)
+	svc.sessionStore.SetCredential("standalone", cred)
+	svc.sessionStore.BeginWarmup([]string{"builtin"}, time.Minute)
+
+	resp, err := svc.Handshake(context.Background(), &extpb.HandshakeRequest{
+		Name:       "standalone",
+		Credential: cred,
+		PolicyKind: "StandalonePolicy",
+	})
+	if err != nil {
+		t.Fatalf("expected no gRPC error, got: %v", err)
+	}
+	if resp.Accepted {
+		t.Fatal("expected standalone handshake to be rejected while warmup is in progress")
+	}
+	if resp.Reason != "warmup in progress" {
+		t.Fatalf("expected reason %q, got %q", "warmup in progress", resp.Reason)
+	}
+}
+
+func TestHandshake_WarmupGate_AllowsStandaloneAfterBuiltinRegisters(t *testing.T) {
+	svc := newTestExtensionService()
+	cred := validCredential()
+	svc.sessionStore.SetCredential("builtin", cred)
+	svc.sessionStore.SetCredential("standalone", cred)
+	svc.sessionStore.BeginWarmup([]string{"builtin"}, time.Minute)
+
+	builtinResp, err := svc.Handshake(context.Background(), &extpb.HandshakeRequest{
+		Name:       "builtin",
+		Credential: cred,
+		PolicyKind: "BuiltinPolicy",
+	})
+	if err != nil {
+		t.Fatalf("expected no gRPC error for built-in handshake, got: %v", err)
+	}
+	if !builtinResp.Accepted {
+		t.Fatalf("expected built-in handshake to be accepted during warmup, got reason: %s", builtinResp.Reason)
+	}
+
+	resp, err := svc.Handshake(context.Background(), &extpb.HandshakeRequest{
+		Name:       "standalone",
+		Credential: cred,
+		PolicyKind: "StandalonePolicy",
+	})
+	if err != nil {
+		t.Fatalf("expected no gRPC error, got: %v", err)
+	}
+	if !resp.Accepted {
+		t.Fatalf("expected standalone handshake to be accepted after warmup completed, got reason: %s", resp.Reason)
 	}
 }
 
@@ -1383,5 +1440,38 @@ func TestPipelineCommit_ChangeNotifierError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed to trigger reconciliation") {
 		t.Errorf("Expected error about failed reconciliation, got: %v", err)
+	}
+}
+
+func TestWarmupTimeout(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		expected time.Duration
+	}{
+		{"seconds", "5s", 5 * time.Second},
+		{"minutes", "1m", time.Minute},
+		{"hours", "1h", time.Hour},
+		{"unset uses default", "", defaultWarmupTimeout},
+		{"zero uses default", "0s", defaultWarmupTimeout},
+		{"negative uses default", "-5s", defaultWarmupTimeout},
+		{"unparsable uses default", "notaduration", defaultWarmupTimeout},
+		{"bare number uses default", "30", defaultWarmupTimeout},
+		{"overflowing value uses default", "9999999999999h", defaultWarmupTimeout},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.value == "" {
+				t.Setenv("EXTENSIONS_WARMUP_TIMEOUT", "")
+				os.Unsetenv("EXTENSIONS_WARMUP_TIMEOUT")
+			} else {
+				t.Setenv("EXTENSIONS_WARMUP_TIMEOUT", tc.value)
+			}
+
+			if got := warmupTimeout(logr.Discard()); got != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, got)
+			}
+		})
 	}
 }

--- a/internal/extension/oop.go
+++ b/internal/extension/oop.go
@@ -18,7 +18,6 @@ package extension
 
 import (
 	"bufio"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -73,7 +72,7 @@ func (p *OOPExtension) Start() error {
 	cmd := exec.Command(p.executable) // #nosec G204
 	cmd.Env = append(os.Environ(),
 		"KUADRANT_EXTENSION_NAME="+p.name,
-		"KUADRANT_EXTENSION_CREDENTIAL="+hex.EncodeToString(p.credential),
+		"KUADRANT_EXTENSION_CREDENTIAL="+string(p.credential),
 		fmt.Sprintf("KUADRANT_EXTENSION_ADDRESS=localhost:%d", p.port),
 	)
 

--- a/internal/extension/session.go
+++ b/internal/extension/session.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 )
@@ -28,16 +29,64 @@ type SessionStore struct {
 	extensions  map[string]string
 	policyKinds map[string]string // policy kind -> extension name
 	logger      logr.Logger
+	// Warmup gate
+	builtinNames   map[string]struct{}
+	warmupComplete bool
 }
 
 func NewSessionStore(logger logr.Logger) *SessionStore {
 	return &SessionStore{
-		credentials: make(map[string][]byte),
-		sessions:    make(map[string]string),
-		extensions:  make(map[string]string),
-		policyKinds: make(map[string]string),
-		logger:      logger,
+		credentials:    make(map[string][]byte),
+		sessions:       make(map[string]string),
+		extensions:     make(map[string]string),
+		policyKinds:    make(map[string]string),
+		logger:         logger,
+		builtinNames:   make(map[string]struct{}),
+		warmupComplete: true,
 	}
+}
+
+func (s *SessionStore) BeginWarmup(builtinNames []string, timeout time.Duration) {
+	s.mu.Lock()
+	for _, name := range builtinNames {
+		s.builtinNames[name] = struct{}{}
+	}
+	s.warmupComplete = s.allBuiltinsRegisteredLocked()
+	pending := !s.warmupComplete
+	s.mu.Unlock()
+
+	if !pending {
+		return
+	}
+
+	time.AfterFunc(timeout, func() {
+		s.mu.Lock()
+		elapsed := !s.warmupComplete
+		s.warmupComplete = true
+		s.mu.Unlock()
+		if elapsed {
+			s.logger.Info("warmup timeout elapsed, admitting standalone extensions", "timeout", timeout)
+		}
+	})
+}
+
+// handshakeAdmitted reports whether extension may handshake now
+func (s *SessionStore) handshakeAdmitted(name string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if _, ok := s.builtinNames[name]; ok {
+		return true
+	}
+	return s.warmupComplete
+}
+
+func (s *SessionStore) allBuiltinsRegisteredLocked() bool {
+	for name := range s.builtinNames {
+		if _, ok := s.extensions[name]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *SessionStore) SetCredential(name string, credential []byte) {
@@ -98,6 +147,11 @@ func (s *SessionStore) Authenticate(name string, credential []byte, policyKind s
 	s.sessions[token] = name
 	s.extensions[name] = token
 	s.policyKinds[policyKind] = name
+
+	if !s.warmupComplete && s.allBuiltinsRegisteredLocked() {
+		s.warmupComplete = true
+	}
+
 	return token, nil
 }
 

--- a/internal/extension/session.go
+++ b/internal/extension/session.go
@@ -32,6 +32,7 @@ type SessionStore struct {
 	// Warmup gate
 	builtinNames   map[string]struct{}
 	warmupComplete bool
+	secretNames    map[string]struct{}
 }
 
 func NewSessionStore(logger logr.Logger) *SessionStore {
@@ -43,6 +44,7 @@ func NewSessionStore(logger logr.Logger) *SessionStore {
 		logger:         logger,
 		builtinNames:   make(map[string]struct{}),
 		warmupComplete: true,
+		secretNames:    make(map[string]struct{}),
 	}
 }
 
@@ -92,7 +94,10 @@ func (s *SessionStore) allBuiltinsRegisteredLocked() bool {
 func (s *SessionStore) SetCredential(name string, credential []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.setCredentialLocked(name, credential)
+}
 
+func (s *SessionStore) setCredentialLocked(name string, credential []byte) {
 	stored := make([]byte, len(credential))
 	copy(stored, credential)
 
@@ -104,6 +109,28 @@ func (s *SessionStore) SetCredential(name string, credential []byte) {
 	}
 
 	s.credentials[name] = stored
+}
+
+func (s *SessionStore) SyncSecretCredentials(credentials map[string][]byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for name, credential := range credentials {
+		if _, isBuiltin := s.builtinNames[name]; isBuiltin {
+			continue
+		}
+		s.setCredentialLocked(name, credential)
+		s.secretNames[name] = struct{}{}
+	}
+
+	for name := range s.secretNames {
+		if _, present := credentials[name]; present {
+			continue
+		}
+		delete(s.credentials, name)
+		s.revokeByNameLocked(name)
+		delete(s.secretNames, name)
+	}
 }
 
 func (s *SessionStore) RemoveCredential(name string) bool {

--- a/internal/extension/session.go
+++ b/internal/extension/session.go
@@ -111,16 +111,35 @@ func (s *SessionStore) setCredentialLocked(name string, credential []byte) {
 	s.credentials[name] = stored
 }
 
-func (s *SessionStore) SyncSecretCredentials(credentials map[string][]byte) {
+type CredentialSyncResult struct {
+	Added   int
+	Rotated int
+	Removed int
+}
+
+func (r CredentialSyncResult) Changed() bool {
+	return r.Added > 0 || r.Rotated > 0 || r.Removed > 0
+}
+
+func (s *SessionStore) SyncSecretCredentials(credentials map[string][]byte) CredentialSyncResult {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	var result CredentialSyncResult
 	for name, credential := range credentials {
 		if _, isBuiltin := s.builtinNames[name]; isBuiltin {
 			continue
 		}
+		existing, existed := s.credentials[name]
+		unchanged := existed && subtle.ConstantTimeCompare(existing, credential) == 1
 		s.setCredentialLocked(name, credential)
 		s.secretNames[name] = struct{}{}
+		switch {
+		case !existed:
+			result.Added++
+		case !unchanged:
+			result.Rotated++
+		}
 	}
 
 	for name := range s.secretNames {
@@ -130,7 +149,10 @@ func (s *SessionStore) SyncSecretCredentials(credentials map[string][]byte) {
 		delete(s.credentials, name)
 		s.revokeByNameLocked(name)
 		delete(s.secretNames, name)
+		result.Removed++
 	}
+
+	return result
 }
 
 func (s *SessionStore) RemoveCredential(name string) bool {

--- a/internal/extension/session_test.go
+++ b/internal/extension/session_test.go
@@ -6,9 +6,14 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 )
+
+func gateOpen(store *SessionStore) bool {
+	return store.handshakeAdmitted("standalone")
+}
 
 func newTestSessionStore() *SessionStore {
 	return NewSessionStore(logr.Discard())
@@ -334,4 +339,89 @@ func TestSessionStore_ConcurrentAccess(t *testing.T) {
 
 func extensionName(i int) string {
 	return "ext-" + string(rune('a'+i))
+}
+
+func TestSessionStore_Warmup_OpenByDefault(t *testing.T) {
+	store := newTestSessionStore()
+
+	if !gateOpen(store) {
+		t.Fatal("expected warmup gate to be open before BeginWarmup is called")
+	}
+}
+
+func TestSessionStore_Warmup_NoBuiltinsOpensImmediately(t *testing.T) {
+	store := newTestSessionStore()
+
+	store.BeginWarmup(nil, time.Minute)
+
+	if !gateOpen(store) {
+		t.Fatal("expected warmup gate to be open when there are no built-ins to wait for")
+	}
+}
+
+func TestSessionStore_Warmup_HeldUntilBuiltinRegisters(t *testing.T) {
+	store := newTestSessionStore()
+	cred := validCredential()
+	store.SetCredential("builtin", cred)
+
+	store.BeginWarmup([]string{"builtin"}, time.Minute)
+
+	if gateOpen(store) {
+		t.Fatal("expected warmup gate to be closed while built-in is unregistered")
+	}
+	if !store.handshakeAdmitted("builtin") {
+		t.Fatal("expected built-in to be admitted during warmup")
+	}
+
+	if _, err := store.Authenticate("builtin", cred, "BuiltinPolicy"); err != nil {
+		t.Fatalf("expected built-in authentication to succeed, got: %v", err)
+	}
+
+	if !gateOpen(store) {
+		t.Fatal("expected warmup gate to open once all built-ins registered")
+	}
+}
+
+func TestSessionStore_Warmup_HeldUntilAllBuiltinsRegister(t *testing.T) {
+	store := newTestSessionStore()
+	credA := validCredential()
+	credB := []byte("abcdefghijklmnopqrstuvwxyz012345")
+	store.SetCredential("builtin-a", credA)
+	store.SetCredential("builtin-b", credB)
+
+	store.BeginWarmup([]string{"builtin-a", "builtin-b"}, time.Minute)
+
+	if _, err := store.Authenticate("builtin-a", credA, "PolicyA"); err != nil {
+		t.Fatalf("expected built-in-a authentication to succeed, got: %v", err)
+	}
+	if gateOpen(store) {
+		t.Fatal("expected warmup gate to remain closed until every built-in registers")
+	}
+
+	if _, err := store.Authenticate("builtin-b", credB, "PolicyB"); err != nil {
+		t.Fatalf("expected built-in-b authentication to succeed, got: %v", err)
+	}
+	if !gateOpen(store) {
+		t.Fatal("expected warmup gate to open once every built-in registered")
+	}
+}
+
+func TestSessionStore_Warmup_TimeoutOpensGate(t *testing.T) {
+	store := newTestSessionStore()
+	store.SetCredential("builtin", validCredential())
+
+	store.BeginWarmup([]string{"builtin"}, 10*time.Millisecond)
+
+	if gateOpen(store) {
+		t.Fatal("expected warmup gate to be closed immediately after BeginWarmup")
+	}
+
+	deadline := time.After(time.Second)
+	for !gateOpen(store) {
+		select {
+		case <-deadline:
+			t.Fatal("expected warmup gate to open after timeout elapsed")
+		case <-time.After(time.Millisecond):
+		}
+	}
 }

--- a/internal/extension/session_test.go
+++ b/internal/extension/session_test.go
@@ -444,6 +444,34 @@ func TestSessionStore_SyncSecretCredentials_DoesNotPruneBuiltin(t *testing.T) {
 	}
 }
 
+func TestSessionStore_SyncSecretCredentials_ReportsChanges(t *testing.T) {
+	store := newTestSessionStore()
+	store.SetCredential("builtin", validCredential())
+	store.BeginWarmup([]string{"builtin"}, time.Minute)
+
+	first := validCredential()
+	if result := store.SyncSecretCredentials(map[string][]byte{"a": first, "b": validCredential()}); result != (CredentialSyncResult{Added: 2}) {
+		t.Fatalf("expected two additions, got: %+v", result)
+	}
+
+	rotated := []byte("abcdefghijklmnopqrstuvwxyz012345")
+	if result := store.SyncSecretCredentials(map[string][]byte{"a": rotated, "b": validCredential()}); result != (CredentialSyncResult{Rotated: 1}) {
+		t.Fatalf("expected one rotation, got: %+v", result)
+	}
+
+	if result := store.SyncSecretCredentials(map[string][]byte{"a": rotated}); result != (CredentialSyncResult{Removed: 1}) {
+		t.Fatalf("expected one removal, got: %+v", result)
+	}
+
+	if result := store.SyncSecretCredentials(map[string][]byte{"a": rotated}); result.Changed() {
+		t.Fatalf("expected no changes on identical sync, got: %+v", result)
+	}
+
+	if result := store.SyncSecretCredentials(map[string][]byte{"a": rotated, "builtin": rotated}); result.Changed() {
+		t.Fatalf("expected built-in to be ignored and no changes reported, got: %+v", result)
+	}
+}
+
 func TestSessionStore_Warmup_OpenByDefault(t *testing.T) {
 	store := newTestSessionStore()
 

--- a/internal/extension/session_test.go
+++ b/internal/extension/session_test.go
@@ -341,6 +341,109 @@ func extensionName(i int) string {
 	return "ext-" + string(rune('a'+i))
 }
 
+func TestSessionStore_SyncSecretCredentials_AddsCredential(t *testing.T) {
+	store := newTestSessionStore()
+	cred := validCredential()
+
+	store.SyncSecretCredentials(map[string][]byte{"standalone": cred})
+
+	token, err := store.Authenticate("standalone", cred, "StandalonePolicy")
+	if err != nil {
+		t.Fatalf("expected authentication to succeed after sync, got: %v", err)
+	}
+	if token == "" {
+		t.Fatal("expected non-empty session token")
+	}
+}
+
+func TestSessionStore_SyncSecretCredentials_ChangedCredentialRevokesSession(t *testing.T) {
+	store := newTestSessionStore()
+	cred := validCredential()
+	store.SyncSecretCredentials(map[string][]byte{"standalone": cred})
+
+	token, err := store.Authenticate("standalone", cred, "StandalonePolicy")
+	if err != nil {
+		t.Fatalf("expected authentication to succeed, got: %v", err)
+	}
+
+	newCred := []byte("abcdefghijklmnopqrstuvwxyz012345")
+	store.SyncSecretCredentials(map[string][]byte{"standalone": newCred})
+
+	if _, ok := store.ValidateSession(token); ok {
+		t.Fatal("expected old session to be revoked after credential change")
+	}
+
+	if _, err := store.Authenticate("standalone", newCred, "StandalonePolicy"); err != nil {
+		t.Fatalf("expected re-authentication with new credential to succeed, got: %v", err)
+	}
+}
+
+func TestSessionStore_SyncSecretCredentials_UnchangedCredentialPreservesSession(t *testing.T) {
+	store := newTestSessionStore()
+	cred := validCredential()
+	store.SyncSecretCredentials(map[string][]byte{"standalone": cred})
+
+	token, err := store.Authenticate("standalone", cred, "StandalonePolicy")
+	if err != nil {
+		t.Fatalf("expected authentication to succeed, got: %v", err)
+	}
+
+	sameCred := make([]byte, len(cred))
+	copy(sameCred, cred)
+	store.SyncSecretCredentials(map[string][]byte{"standalone": sameCred})
+
+	if _, ok := store.ValidateSession(token); !ok {
+		t.Fatal("expected session to remain valid when synced credential is unchanged")
+	}
+}
+
+func TestSessionStore_SyncSecretCredentials_RemovedKeyRevokesSession(t *testing.T) {
+	store := newTestSessionStore()
+	cred := validCredential()
+	store.SyncSecretCredentials(map[string][]byte{"standalone": cred})
+
+	token, err := store.Authenticate("standalone", cred, "StandalonePolicy")
+	if err != nil {
+		t.Fatalf("expected authentication to succeed, got: %v", err)
+	}
+
+	store.SyncSecretCredentials(map[string][]byte{})
+
+	if _, ok := store.ValidateSession(token); ok {
+		t.Fatal("expected session to be revoked after credential removed from secret")
+	}
+
+	if _, err := store.Authenticate("standalone", cred, "StandalonePolicy"); !errors.Is(err, ErrUnknownExtension) {
+		t.Fatalf("expected ErrUnknownExtension after credential pruned, got: %v", err)
+	}
+}
+
+func TestSessionStore_SyncSecretCredentials_DoesNotOverwriteBuiltin(t *testing.T) {
+	store := newTestSessionStore()
+	builtinCred := validCredential()
+	store.SetCredential("builtin", builtinCred)
+	store.BeginWarmup([]string{"builtin"}, time.Minute)
+
+	store.SyncSecretCredentials(map[string][]byte{"builtin": []byte("abcdefghijklmnopqrstuvwxyz012345")})
+
+	if _, err := store.Authenticate("builtin", builtinCred, "BuiltinPolicy"); err != nil {
+		t.Fatalf("expected built-in credential to be preserved, got: %v", err)
+	}
+}
+
+func TestSessionStore_SyncSecretCredentials_DoesNotPruneBuiltin(t *testing.T) {
+	store := newTestSessionStore()
+	builtinCred := validCredential()
+	store.SetCredential("builtin", builtinCred)
+	store.BeginWarmup([]string{"builtin"}, time.Minute)
+
+	store.SyncSecretCredentials(map[string][]byte{"standalone": []byte("abcdefghijklmnopqrstuvwxyz012345")})
+
+	if _, err := store.Authenticate("builtin", builtinCred, "BuiltinPolicy"); err != nil {
+		t.Fatalf("expected built-in credential to survive sync, got: %v", err)
+	}
+}
+
 func TestSessionStore_Warmup_OpenByDefault(t *testing.T) {
 	store := newTestSessionStore()
 

--- a/pkg/extension/controller/builder.go
+++ b/pkg/extension/controller/builder.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -121,14 +120,11 @@ func (b *Builder) Build() (*ExtensionController, error) {
 		return nil, errors.New("KUADRANT_EXTENSION_NAME environment variable is required")
 	}
 
-	credentialHex := os.Getenv("KUADRANT_EXTENSION_CREDENTIAL")
-	if credentialHex == "" {
+	credentialValue := os.Getenv("KUADRANT_EXTENSION_CREDENTIAL")
+	if credentialValue == "" {
 		return nil, errors.New("KUADRANT_EXTENSION_CREDENTIAL environment variable is required")
 	}
-	credential, err := hex.DecodeString(credentialHex)
-	if err != nil {
-		return nil, fmt.Errorf("KUADRANT_EXTENSION_CREDENTIAL is not valid hex: %w", err)
-	}
+	credential := []byte(credentialValue)
 
 	extClient, err := newExtensionClient(address)
 	if err != nil {


### PR DESCRIPTION
Add the extensions secret reconciler and fix two outstanding issues:

- The credential was assumed hex which didn't match the intended opaque string
- Built-in extensions can leverage the warmup gate to ensure they claim their policy kinds before standalone extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Extension authentication credentials can now be synchronised automatically from a Kubernetes Secret.
  - Added a configurable warm-up period before standalone extensions can connect.
  - Built-in extensions remain available during warm-up, with access opening once readiness conditions are met.
  - Credential additions, rotations and removals are handled automatically, including session revocation when required.

- **Bug Fixes**
  - Extension credentials are now handled consistently as raw values rather than encoded strings.
  - Added secure, namespace-scoped permissions for reading authentication Secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->