### PR TITLE
Stabilize EnvoyFilter wasm config ordering

### DIFF
--- a/internal/controller/envoy_gateway_extension_reconciler.go
+++ b/internal/controller/envoy_gateway_extension_reconciler.go
@@ -431,8 +431,8 @@ func (r *EnvoyGatewayExtensionReconciler) buildWasmConfigs(ctx context.Context, 
 	tokenRateLimitPaths := lo.Entries(lo.MapValues(effectiveTokenRateLimitPoliciesMap, func(p EffectiveTokenRateLimitPolicy, _ string) []machinery.Targetable { return p.Path }))
 	allPaths = append(allPaths, tokenRateLimitPaths...)
 
-	// unique paths by key
-	paths := lo.UniqBy(allPaths, func(e lo.Entry[string, []machinery.Targetable]) string { return e.Key })
+	// unique paths by key with deterministic ordering
+	paths := uniqueSortedPaths(allPaths)
 
 	wasmActionSets := kuadrantgatewayapi.GroupedHTTPRouteMatchConfigs{}
 	celValidationIssues := celvalidator.NewIssueCollection()

--- a/internal/controller/istio_extension_reconciler.go
+++ b/internal/controller/istio_extension_reconciler.go
@@ -445,8 +445,8 @@ func (r *IstioExtensionReconciler) buildWasmConfigs(ctx context.Context, topolog
 	tokenRateLimitPaths := lo.Entries(lo.MapValues(effectiveTokenRateLimitPoliciesMap, func(p EffectiveTokenRateLimitPolicy, _ string) []machinery.Targetable { return p.Path }))
 	allPaths = append(allPaths, tokenRateLimitPaths...)
 
-	// unique paths by key
-	paths := lo.UniqBy(allPaths, func(e lo.Entry[string, []machinery.Targetable]) string { return e.Key })
+	// unique paths by key with deterministic ordering
+	paths := uniqueSortedPaths(allPaths)
 
 	logger.V(1).Info("processing paths for wasm config", "totalPaths", len(paths))
 

--- a/internal/controller/path_utils.go
+++ b/internal/controller/path_utils.go
@@ -1,0 +1,24 @@
+package controllers
+
+import (
+	"slices"
+
+	"github.com/samber/lo"
+
+	"github.com/kuadrant/policy-machinery/machinery"
+)
+
+func uniqueSortedPaths(allPaths []lo.Entry[string, []machinery.Targetable]) []lo.Entry[string, []machinery.Targetable] {
+	paths := lo.UniqBy(allPaths, func(e lo.Entry[string, []machinery.Targetable]) string { return e.Key })
+	slices.SortFunc(paths, func(a, b lo.Entry[string, []machinery.Targetable]) int {
+		switch {
+		case a.Key < b.Key:
+			return -1
+		case a.Key > b.Key:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return paths
+}

--- a/internal/gatewayapi/types.go
+++ b/internal/gatewayapi/types.go
@@ -3,6 +3,7 @@ package gatewayapi
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,6 +103,15 @@ func (c SortableHTTPRouteMatchConfigs) Less(i, j int) bool {
 		return qCountI > qCountJ
 	}
 
+	// Deterministic tie-break for equally specific route matches.
+	// Without this, sort may permute equal-priority matches between reconciles,
+	// generating semantically identical but byte-different WASM config payloads.
+	matchKeyI := canonicalHTTPRouteMatchKey(c[i].HTTPRouteMatch)
+	matchKeyJ := canonicalHTTPRouteMatchKey(c[j].HTTPRouteMatch)
+	if matchKeyI != matchKeyJ {
+		return matchKeyI < matchKeyJ
+	}
+
 	// Creation Timestamp
 	p1Time := ptr.To(c[i].CreationTimestamp)
 	p2Time := ptr.To(c[j].CreationTimestamp)
@@ -111,6 +121,51 @@ func (c SortableHTTPRouteMatchConfigs) Less(i, j int) bool {
 
 	// Lexicographically by "{namespace}/{name}"
 	return fmt.Sprintf("%s/%s", c[i].Namespace, c[i].Name) < fmt.Sprintf("%s/%s", c[j].Namespace, c[j].Name)
+}
+
+func canonicalHTTPRouteMatchKey(m gatewayapiv1.HTTPRouteMatch) string {
+	var method string
+	if m.Method != nil {
+		method = string(*m.Method)
+	}
+
+	var pathType, pathValue string
+	if m.Path != nil {
+		if m.Path.Type != nil {
+			pathType = string(*m.Path.Type)
+		}
+		if m.Path.Value != nil {
+			pathValue = *m.Path.Value
+		}
+	}
+
+	headers := make([]string, 0, len(m.Headers))
+	for _, h := range m.Headers {
+		hType := ""
+		if h.Type != nil {
+			hType = string(*h.Type)
+		}
+		headers = append(headers, fmt.Sprintf("%s|%s|%s", h.Name, hType, h.Value))
+	}
+	sort.Strings(headers)
+
+	queries := make([]string, 0, len(m.QueryParams))
+	for _, q := range m.QueryParams {
+		qType := ""
+		if q.Type != nil {
+			qType = string(*q.Type)
+		}
+		queries = append(queries, fmt.Sprintf("%s|%s|%s", q.Name, qType, q.Value))
+	}
+	sort.Strings(queries)
+
+	return strings.Join([]string{
+		method,
+		pathType,
+		pathValue,
+		strings.Join(headers, ","),
+		strings.Join(queries, ","),
+	}, "||")
 }
 
 func pathMatchCount(pathMatch *gatewayapiv1.HTTPPathMatch) int {

--- a/internal/gatewayapi/types_sort_test.go
+++ b/internal/gatewayapi/types_sort_test.go
@@ -64,7 +64,7 @@ func TestSortableHTTPRouteMatchConfigsDeterministicTieBreak(t *testing.T) {
 				Value: ptr.To("/v1/chat/completions"),
 			},
 			Headers: []gatewayapiv1.HTTPHeaderMatch{
-				{Name: "x-a", Type: &headerType, Value: "1"},
+				{Name: "x-b", Type: &headerType, Value: "1"},
 			},
 		},
 	}
@@ -79,7 +79,7 @@ func TestSortableHTTPRouteMatchConfigsDeterministicTieBreak(t *testing.T) {
 				Value: ptr.To("/v1/chat/completions"),
 			},
 			Headers: []gatewayapiv1.HTTPHeaderMatch{
-				{Name: "x-b", Type: &headerType, Value: "1"},
+				{Name: "x-a", Type: &headerType, Value: "1"},
 			},
 		},
 	}
@@ -87,6 +87,6 @@ func TestSortableHTTPRouteMatchConfigsDeterministicTieBreak(t *testing.T) {
 	configs := SortableHTTPRouteMatchConfigs{b, a}
 	sort.Sort(configs)
 
-	assert.Equal(t, configs[0].Name, "a")
-	assert.Equal(t, configs[1].Name, "b")
+	assert.Equal(t, configs[0].Name, "b")
+	assert.Equal(t, configs[1].Name, "a")
 }

--- a/internal/gatewayapi/types_sort_test.go
+++ b/internal/gatewayapi/types_sort_test.go
@@ -1,0 +1,92 @@
+//go:build unit
+
+package gatewayapi
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestCanonicalHTTPRouteMatchKeyStableForReorderedHeadersAndQueries(t *testing.T) {
+	pathType := gatewayapiv1.PathMatchPathPrefix
+	headerType := gatewayapiv1.HeaderMatchExact
+	queryType := gatewayapiv1.QueryParamMatchExact
+
+	base := gatewayapiv1.HTTPRouteMatch{
+		Path: &gatewayapiv1.HTTPPathMatch{
+			Type:  &pathType,
+			Value: ptr.To("/v1/chat/completions"),
+		},
+		Headers: []gatewayapiv1.HTTPHeaderMatch{
+			{Name: "x-b", Type: &headerType, Value: "2"},
+			{Name: "x-a", Type: &headerType, Value: "1"},
+		},
+		QueryParams: []gatewayapiv1.HTTPQueryParamMatch{
+			{Name: "q-b", Type: &queryType, Value: "2"},
+			{Name: "q-a", Type: &queryType, Value: "1"},
+		},
+	}
+
+	reordered := gatewayapiv1.HTTPRouteMatch{
+		Path: base.Path,
+		Headers: []gatewayapiv1.HTTPHeaderMatch{
+			{Name: "x-a", Type: &headerType, Value: "1"},
+			{Name: "x-b", Type: &headerType, Value: "2"},
+		},
+		QueryParams: []gatewayapiv1.HTTPQueryParamMatch{
+			{Name: "q-a", Type: &queryType, Value: "1"},
+			{Name: "q-b", Type: &queryType, Value: "2"},
+		},
+	}
+
+	assert.Equal(t, canonicalHTTPRouteMatchKey(base), canonicalHTTPRouteMatchKey(reordered))
+}
+
+func TestSortableHTTPRouteMatchConfigsDeterministicTieBreak(t *testing.T) {
+	pathType := gatewayapiv1.PathMatchPathPrefix
+	headerType := gatewayapiv1.HeaderMatchExact
+	now := metav1.NewTime(time.Now())
+
+	a := HTTPRouteMatchConfig{
+		Hostname:          "example.com",
+		CreationTimestamp: now,
+		Namespace:         "ns",
+		Name:              "a",
+		HTTPRouteMatch: gatewayapiv1.HTTPRouteMatch{
+			Path: &gatewayapiv1.HTTPPathMatch{
+				Type:  &pathType,
+				Value: ptr.To("/v1/chat/completions"),
+			},
+			Headers: []gatewayapiv1.HTTPHeaderMatch{
+				{Name: "x-a", Type: &headerType, Value: "1"},
+			},
+		},
+	}
+	b := HTTPRouteMatchConfig{
+		Hostname:          "example.com",
+		CreationTimestamp: now,
+		Namespace:         "ns",
+		Name:              "b",
+		HTTPRouteMatch: gatewayapiv1.HTTPRouteMatch{
+			Path: &gatewayapiv1.HTTPPathMatch{
+				Type:  &pathType,
+				Value: ptr.To("/v1/chat/completions"),
+			},
+			Headers: []gatewayapiv1.HTTPHeaderMatch{
+				{Name: "x-b", Type: &headerType, Value: "1"},
+			},
+		},
+	}
+
+	configs := SortableHTTPRouteMatchConfigs{b, a}
+	sort.Sort(configs)
+
+	assert.Equal(t, configs[0].Name, "a")
+	assert.Equal(t, configs[1].Name, "b")
+}


### PR DESCRIPTION
## Summary
- add deterministic sorting for grouped topology paths before wasm config generation in both Istio and Envoy Gateway extension reconcilers
- add deterministic HTTPRoute match tie-break key to prevent unstable ordering for equally specific matches
- add unit tests validating canonical key stability and deterministic match ordering

## Why
Equivalent policy inputs were producing semantically identical but byte-different wasm config payloads due to nondeterministic ordering, causing unnecessary reconcile churn.

## Test plan
- [x] `go test ./...`
- [x] `go test -tags unit ./internal/gatewayapi`
- [x] `make pre-commit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when processing WASM configuration paths by removing duplicates and applying stable ordering.
  - Ensured HTTP route matches are ordered deterministically, including cases with equivalent specificity.
  - Stabilised ordering regardless of the arrangement of headers and query parameters.

- **Tests**
  - Added coverage confirming consistent route matching and deterministic tie-breaking behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->