### PR TITLE
fix: component chart sync permissions and missing charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ endif
 IMG ?= $(IMAGE_TAG_BASE):$(IMAGE_TAG)
 
 # Directories containing unit & integration test packages
-UNIT_DIRS := ./pkg/... ./api/... ./internal/...
+UNIT_DIRS := ./pkg/... ./api/... ./internal/... ./hack/sync-components...
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/hack/sync-components/cmd_sync.go
+++ b/hack/sync-components/cmd_sync.go
@@ -88,7 +88,13 @@ func syncOne(name string, c component, configPath string) syncResult {
 		return syncResult{Repo: c.Repo, OldRef: c.Ref, Status: "error"}
 	}
 
-	if sha == c.Ref {
+	// Check if chart directory exists before declaring up-to-date
+	chartExists := false
+	if stat, err := os.Stat(chartDir); err == nil && stat.IsDir() {
+		chartExists = true
+	}
+
+	if sha == c.Ref && chartExists {
 		fmt.Fprintf(os.Stderr, "Syncing %s from %s@%s\n", name, c.Repo, sha[:12])
 		fmt.Fprintf(os.Stderr, "  No changes (already at %s).\n", sha[:12])
 		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Changed: false, Status: "up-to-date"}
@@ -148,6 +154,19 @@ func syncOne(name string, c component, configPath string) syncResult {
 			os.Rename(backupDir, chartDir)
 		}
 		fmt.Fprintf(os.Stderr, "Error moving chart to %s: %v\n", chartDir, err)
+		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Status: "error"}
+	}
+
+	// Fix permissions on the chart directory (os.MkdirTemp creates with 0700).
+	// A failure here must not be treated as a warning: it would leave the
+	// installed chart directory inaccessible to non-root consumers (e.g. the
+	// container image's non-root runtime user) while still reporting success.
+	if err := os.Chmod(chartDir, 0o755); err != nil {
+		os.RemoveAll(chartDir)
+		if hasBackup {
+			os.Rename(backupDir, chartDir)
+		}
+		fmt.Fprintf(os.Stderr, "Error setting permissions on %s: %v\n", chartDir, err)
 		return syncResult{Repo: c.Repo, OldRef: c.Ref, NewRef: sha, Status: "error"}
 	}
 

--- a/hack/sync-components/cmd_sync_test.go
+++ b/hack/sync-components/cmd_sync_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeGitHubTransport serves canned responses for the two GitHub endpoints
+// syncOne depends on (commit resolution and tarball download), so tests can
+// exercise the real sync logic without hitting the network.
+type fakeGitHubTransport struct {
+	sha     string
+	tarball []byte
+}
+
+func (f *fakeGitHubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	url := req.URL.String()
+	switch {
+	case strings.Contains(url, "/commits/"):
+		body := fmt.Sprintf(`{"sha":%q}`, f.sha)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}, nil
+	case strings.Contains(url, "/tarball/"):
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader(f.tarball)),
+			Header:     make(http.Header),
+		}, nil
+	default:
+		return nil, fmt.Errorf("fakeGitHubTransport: unexpected request %s", url)
+	}
+}
+
+// writeSyncConfig writes a minimal single-component sync.yaml and returns the
+// loaded component alongside the config file path.
+func writeSyncConfig(t *testing.T, dir, name, ref string) (component, string) {
+	t.Helper()
+	configPath := filepath.Join(dir, "sync.yaml")
+	content := fmt.Sprintf(`components:
+  %s:
+    repo: Kuadrant/%s
+    chart-path: charts/%s
+    tracked-branch: main
+    ref: %s
+    auto-merge: false
+`, name, name, name, ref)
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	return cfg.Components[name], configPath
+}
+
+// TestSyncOne_MissingChartDirectory verifies the fix for a bug where syncOne
+// would report "up-to-date" and skip downloading whenever the resolved SHA
+// already matched sync.yaml's ref -- even if the local chart directory was
+// missing (e.g. the component was only just uncommented, or its chart was
+// deleted). It must always download when the local directory is absent.
+func TestSyncOne_MissingChartDirectory(t *testing.T) {
+	sha := "abc123def4567890abc123def4567890abc123d"
+	tarball := buildTestTarball(t, map[string]string{
+		"Kuadrant-widget-abc123d/charts/widget/Chart.yaml":  "apiVersion: v2\nname: widget",
+		"Kuadrant-widget-abc123d/charts/widget/values.yaml": "# empty",
+	})
+
+	origClient := httpClient
+	httpClient = &http.Client{Transport: &fakeGitHubTransport{sha: sha, tarball: tarball}}
+	defer func() { httpClient = origClient }()
+
+	dir := t.TempDir()
+	c, configPath := writeSyncConfig(t, dir, "widget", sha)
+
+	// The chart directory does not exist on disk even though c.Ref already
+	// equals the SHA that will be resolved -- this is exactly the scenario
+	// that used to be silently skipped.
+	result := syncOne("widget", c, configPath)
+
+	if result.Status == "up-to-date" {
+		t.Fatal("expected chart to be downloaded when local directory is missing, got up-to-date")
+	}
+	if result.Status == "error" {
+		t.Fatalf("unexpected error status: %+v", result)
+	}
+
+	chartDir := filepath.Join(dir, "widget")
+	if _, err := os.Stat(filepath.Join(chartDir, "Chart.yaml")); err != nil {
+		t.Fatalf("expected chart to be downloaded to %s: %v", chartDir, err)
+	}
+
+	info, err := os.Stat(chartDir)
+	if err != nil {
+		t.Fatalf("stat chart dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Errorf("chart dir permission = %v, want 0755", got)
+	}
+}
+
+// TestSyncOne_UpToDateWhenChartPresent is the counterpart to
+// TestSyncOne_MissingChartDirectory: when the ref matches AND the chart
+// directory already exists, syncOne must skip the download.
+func TestSyncOne_UpToDateWhenChartPresent(t *testing.T) {
+	sha := "abc123def4567890abc123def4567890abc123d"
+
+	origClient := httpClient
+	httpClient = &http.Client{Transport: &fakeGitHubTransport{sha: sha}}
+	defer func() { httpClient = origClient }()
+
+	dir := t.TempDir()
+	c, configPath := writeSyncConfig(t, dir, "widget", sha)
+
+	chartDir := filepath.Join(dir, "widget")
+	if err := os.MkdirAll(chartDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(chartDir, "Chart.yaml"), []byte("apiVersion: v2"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result := syncOne("widget", c, configPath)
+	if result.Status != "up-to-date" {
+		t.Fatalf("expected up-to-date, got %+v", result)
+	}
+}

--- a/hack/sync-components/download.go
+++ b/hack/sync-components/download.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 const (
@@ -28,6 +29,15 @@ func downloadChart(repo, ref, chartPath, outputDir string) error {
 }
 
 func extractChart(r io.Reader, chartPath, outputDir string) error {
+	// MkdirAll/OpenFile's mode argument is masked by the process umask, so a
+	// restrictive umask (some CI runners and hardened shells set one) would
+	// otherwise silently produce directories/files more restrictive than the
+	// 0755/0644 requested below. Zeroing the umask for the duration of
+	// extraction makes the requested modes apply exactly, regardless of the
+	// caller's environment, without needing to chmod anything after the fact.
+	oldUmask := syscall.Umask(0)
+	defer syscall.Umask(oldUmask)
+
 	gz, err := gzip.NewReader(r)
 	if err != nil {
 		return fmt.Errorf("gzip reader: %w", err)
@@ -87,7 +97,7 @@ func extractChart(r io.Reader, chartPath, outputDir string) error {
 			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 				return fmt.Errorf("creating parent dir for %s: %w", targetPath, err)
 			}
-			f, err := os.Create(targetPath)
+			f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 			if err != nil {
 				return fmt.Errorf("creating file %s: %w", targetPath, err)
 			}

--- a/hack/sync-components/download_test.go
+++ b/hack/sync-components/download_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -115,5 +116,55 @@ func TestExtractChart(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestExtractChart_PermissionsUnderRestrictiveUmask verifies extracted files
+// and directories get their intended permissions even when the process umask
+// would otherwise mask them out. os.OpenFile/os.MkdirAll's mode argument is
+// ANDed with ~umask by the OS, so extractChart zeroes the umask for the
+// duration of extraction rather than relying on the creation mode alone.
+// Includes a deeply nested file with no explicit tar directory entries for
+// any of its ancestors, since those are created purely as a side effect of
+// os.MkdirAll and are just as exposed to the umask as anything named directly
+// in the tarball.
+func TestExtractChart_PermissionsUnderRestrictiveUmask(t *testing.T) {
+	old := syscall.Umask(0o077)
+	defer syscall.Umask(old)
+
+	files := map[string]string{
+		"Kuadrant-dns-operator-abc1234/charts/dns-operator/Chart.yaml":                       "apiVersion: v2\nname: dns-operator",
+		"Kuadrant-dns-operator-abc1234/charts/dns-operator/templates/manifests.yaml":         "kind: Deployment",
+		"Kuadrant-dns-operator-abc1234/charts/dns-operator/templates/tests/nested/deep.yaml": "kind: Test",
+	}
+	tarball := buildTestTarball(t, files)
+	outputDir := t.TempDir()
+
+	if err := extractChart(bytes.NewReader(tarball), "charts/dns-operator", outputDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, relPath := range []string{"Chart.yaml", "templates/manifests.yaml", "templates/tests/nested/deep.yaml"} {
+		info, err := os.Stat(filepath.Join(outputDir, relPath))
+		if err != nil {
+			t.Fatalf("stat %s: %v", relPath, err)
+		}
+		if got := info.Mode().Perm(); got != 0o644 {
+			t.Errorf("file %s permission = %v, want 0644 (umask should not affect this)", relPath, got)
+		}
+	}
+
+	// outputDir itself (".") is created by the caller before extractChart
+	// runs (os.MkdirTemp in the real cmd_sync.go flow, always 0700 regardless
+	// of umask) -- fixing it is the caller's responsibility, not
+	// extractChart's, so it's deliberately not asserted on here.
+	for _, relPath := range []string{"templates", "templates/tests", "templates/tests/nested"} {
+		info, err := os.Stat(filepath.Join(outputDir, relPath))
+		if err != nil {
+			t.Fatalf("stat %s: %v", relPath, err)
+		}
+		if got := info.Mode().Perm(); got != 0o755 {
+			t.Errorf("dir %s permission = %v, want 0755 (umask should not affect this, including ancestors with no tar entry of their own)", relPath, got)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Two fixes to `hack/sync-components`:

- **Missing chart directory:** `syncOne` treated a resolved-SHA match as "up-to-date" and skipped downloading whenever the ref already matched `sync.yaml` — even when the local chart directory was missing (e.g. a component was just uncommented). It now checks the directory actually exists before treating a ref match as up-to-date.
- **Permissions under a restrictive umask:** `os.MkdirAll`/`os.OpenFile`'s mode argument is masked by the process umask, so extracted files/directories could land more restrictive than the requested `0644`/`0755` (e.g. `0600`/`0700` under a `077` umask) — regardless of nesting depth or how many ancestor directories get created in one call. Extraction now zeroes the process umask (`syscall.Umask(0)`) for its duration, so every created path gets exactly the requested mode with no follow-up `os.Chmod` needed at all.
- Separately, a failed `os.Chmod` fixing `os.MkdirTemp`'s hardcoded `0700` on the newly-installed chart directory was only logged as a warning, letting sync report success and rewrite `sync.yaml`'s ref while leaving the chart directory broken. This is now a hard error that restores the backup (or removes the broken directory), matching the existing `updateRef`-failure error path.

Add tests for the missing-directory fix, and for umask-independent extraction (including a deeply nested path with no explicit tar directory entries for any ancestor, proving the fix isn't limited to the innermost directory a tar entry happens to name). Wire `hack/sync-components` into `UNIT_DIRS` so `make test-unit` covers this package.

## Test plan

- [x] `go test ./hack/sync-components/...` passes
- [x] Verified new tests fail against the pre-fix code and pass with the fix
- [x] `make sync-component-charts` manually verified to produce `0755`/`0644` permissions and to re-download charts with a missing local directory
- [x] `golangci-lint run hack/sync-components/...` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected component synchronisation when the configured revision matches but the local chart directory is missing.
  - Ensured downloaded chart files and directories consistently receive the intended permissions.
  - Failed permission updates now correctly report an error and restore the previous chart where possible.

- **Tests**
  - Added coverage for missing and existing chart directories.
  - Added validation of file and directory permissions under restrictive system settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->