### PR TITLE
feat: consolidate mcp-gateway into kuadrant-operator

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -23,6 +23,14 @@ on:
         description: Related image DNS Operator
         default: quay.io/kuadrant/dns-operator:latest
         type: string
+      relatedImageMcpGateway:
+        description: Related image MCP Gateway Controller
+        default: ghcr.io/kuadrant/mcp-controller:latest
+        type: string
+      relatedImageMcpGatewayBroker:
+        description: Related image MCP Gateway Broker
+        default: ghcr.io/kuadrant/mcp-gateway:latest
+        type: string
       relatedImageWasmShim:
         description: Related image WASM Shim
         default: quay.io/kuadrant/wasm-shim:latest
@@ -80,6 +88,14 @@ on:
       relatedImageDnsOperator:
         description: Related image DNS Operator
         default: quay.io/kuadrant/dns-operator:latest
+        type: string
+      relatedImageMcpGateway:
+        description: Related image MCP Gateway Controller
+        default: ghcr.io/kuadrant/mcp-controller:latest
+        type: string
+      relatedImageMcpGatewayBroker:
+        description: Related image MCP Gateway Broker
+        default: ghcr.io/kuadrant/mcp-gateway:latest
         type: string
       relatedImageWasmShim:
         description: Related image WASM Shim
@@ -193,6 +209,8 @@ jobs:
             AUTHORINO_OPERATOR_BUNDLE_IMG=${{ inputs.authorinoBundleImg }} \
             LIMITADOR_OPERATOR_BUNDLE_IMG=${{ inputs.limitadorBundleImg }} \
             RELATED_IMAGE_DNS_OPERATOR=${{ inputs.relatedImageDnsOperator }} \
+            RELATED_IMAGE_MCP_GATEWAY=${{ inputs.relatedImageMcpGateway }} \
+            RELATED_IMAGE_MCP_GATEWAY_BROKER=${{ inputs.relatedImageMcpGatewayBroker }} \
             RELATED_IMAGE_WASMSHIM=${{ inputs.relatedImageWasmShim }} \
             RELATED_IMAGE_DEVELOPERPORTAL=${{ inputs.relatedImageDeveloperPortalController }} \
             RELATED_IMAGE_CONSOLE_PLUGIN_LATEST=${{ inputs.relatedImageConsolePluginLatest}} \

--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -32,6 +32,36 @@ jobs:
           DIGEST=$(crane digest quay.io/kuadrant/dns-operator:latest)
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
           echo "DNS operator latest digest: ${DIGEST}"
+  mcp-gateway-latest-digest:
+    name: Get the digest sha of the latest mcp-gateway controller docker image
+    runs-on: ubuntu-latest
+    outputs:
+      mcp_gateway_digest: ${{ steps.mcp-gateway-get-digest.outputs.digest }}
+    steps:
+      - name: Install crane
+        uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # ratchet:imjasonh/setup-crane@v0.1
+      - id: mcp-gateway-get-digest
+        name: Get digest of latest mcp-gateway controller image
+        run: |
+          # Get the manifest digest of the latest tag (works for both single-arch and multi-arch images)
+          DIGEST=$(crane digest ghcr.io/kuadrant/mcp-controller:latest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "MCP gateway controller latest digest: ${DIGEST}"
+  mcp-gateway-broker-latest-digest:
+    name: Get the digest sha of the latest mcp-gateway broker docker image
+    runs-on: ubuntu-latest
+    outputs:
+      mcp_gateway_broker_digest: ${{ steps.mcp-gateway-broker-get-digest.outputs.digest }}
+    steps:
+      - name: Install crane
+        uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # ratchet:imjasonh/setup-crane@v0.1
+      - id: mcp-gateway-broker-get-digest
+        name: Get digest of latest mcp-gateway broker image
+        run: |
+          # Get the manifest digest of the latest tag (works for both single-arch and multi-arch images)
+          DIGEST=$(crane digest ghcr.io/kuadrant/mcp-gateway:latest)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "MCP gateway broker latest digest: ${DIGEST}"
   wasmshim-latest-digest:
     name: Get the digest sha of the latest wasmshim docker image
     runs-on: ubuntu-latest
@@ -96,6 +126,8 @@ jobs:
     needs:
       - release-date
       - dns-operator-latest-digest
+      - mcp-gateway-latest-digest
+      - mcp-gateway-broker-latest-digest
       - wasmshim-latest-digest
       - devportal-controlller-latest-digest
       - console-plugin-latest-digest
@@ -109,6 +141,8 @@ jobs:
       authorinoBundleImg: quay.io/kuadrant/authorino-operator-bundle:${{ needs.release-date.outputs.release_date }}
       limitadorBundleImg: quay.io/kuadrant/limitador-operator-bundle:${{ needs.release-date.outputs.release_date }}
       relatedImageDnsOperator: quay.io/kuadrant/dns-operator@${{ needs.dns-operator-latest-digest.outputs.dns_operator_digest }}
+      relatedImageMcpGateway: ghcr.io/kuadrant/mcp-controller@${{ needs.mcp-gateway-latest-digest.outputs.mcp_gateway_digest }}
+      relatedImageMcpGatewayBroker: ghcr.io/kuadrant/mcp-gateway@${{ needs.mcp-gateway-broker-latest-digest.outputs.mcp_gateway_broker_digest }}
       relatedImageWasmShim: quay.io/kuadrant/wasm-shim@${{ needs.wasmshim-latest-digest.outputs.wasmshim_digest }}
       relatedImageDeveloperPortalController: quay.io/kuadrant/developer-portal-controller@${{ needs.devportal-controlller-latest-digest.outputs.devportal_controller_digest }}
       relatedImageConsolePluginLatest: quay.io/kuadrant/console-plugin@${{ needs.console-plugin-latest-digest.outputs.console_plugin_digest }}

--- a/.github/workflows/build-images-nightly.yaml
+++ b/.github/workflows/build-images-nightly.yaml
@@ -33,13 +33,18 @@ jobs:
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
           echo "DNS operator latest digest: ${DIGEST}"
   mcp-gateway-latest-digest:
-    name: Get the digest sha of the latest mcp-gateway controller docker image
+    name: Get the digest shas of the latest mcp-gateway controller and broker docker images
     runs-on: ubuntu-latest
     outputs:
       mcp_gateway_digest: ${{ steps.mcp-gateway-get-digest.outputs.digest }}
+      mcp_gateway_broker_digest: ${{ steps.mcp-gateway-broker-get-digest.outputs.digest }}
     steps:
       - name: Install crane
         uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # ratchet:imjasonh/setup-crane@v0.1
+      # Controller and broker are separate image repos with independently
+      # tagged :latest, so resolving both digests in the same job run
+      # (rather than two separate jobs scheduled independently) narrows the
+      # window in which the two could resolve to a mismatched release.
       - id: mcp-gateway-get-digest
         name: Get digest of latest mcp-gateway controller image
         run: |
@@ -47,14 +52,6 @@ jobs:
           DIGEST=$(crane digest ghcr.io/kuadrant/mcp-controller:latest)
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
           echo "MCP gateway controller latest digest: ${DIGEST}"
-  mcp-gateway-broker-latest-digest:
-    name: Get the digest sha of the latest mcp-gateway broker docker image
-    runs-on: ubuntu-latest
-    outputs:
-      mcp_gateway_broker_digest: ${{ steps.mcp-gateway-broker-get-digest.outputs.digest }}
-    steps:
-      - name: Install crane
-        uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # ratchet:imjasonh/setup-crane@v0.1
       - id: mcp-gateway-broker-get-digest
         name: Get digest of latest mcp-gateway broker image
         run: |
@@ -127,7 +124,6 @@ jobs:
       - release-date
       - dns-operator-latest-digest
       - mcp-gateway-latest-digest
-      - mcp-gateway-broker-latest-digest
       - wasmshim-latest-digest
       - devportal-controlller-latest-digest
       - console-plugin-latest-digest
@@ -142,7 +138,7 @@ jobs:
       limitadorBundleImg: quay.io/kuadrant/limitador-operator-bundle:${{ needs.release-date.outputs.release_date }}
       relatedImageDnsOperator: quay.io/kuadrant/dns-operator@${{ needs.dns-operator-latest-digest.outputs.dns_operator_digest }}
       relatedImageMcpGateway: ghcr.io/kuadrant/mcp-controller@${{ needs.mcp-gateway-latest-digest.outputs.mcp_gateway_digest }}
-      relatedImageMcpGatewayBroker: ghcr.io/kuadrant/mcp-gateway@${{ needs.mcp-gateway-broker-latest-digest.outputs.mcp_gateway_broker_digest }}
+      relatedImageMcpGatewayBroker: ghcr.io/kuadrant/mcp-gateway@${{ needs.mcp-gateway-latest-digest.outputs.mcp_gateway_broker_digest }}
       relatedImageWasmShim: quay.io/kuadrant/wasm-shim@${{ needs.wasmshim-latest-digest.outputs.wasmshim_digest }}
       relatedImageDeveloperPortalController: quay.io/kuadrant/developer-portal-controller@${{ needs.devportal-controlller-latest-digest.outputs.devportal_controller_digest }}
       relatedImageConsolePluginLatest: quay.io/kuadrant/console-plugin@${{ needs.console-plugin-latest-digest.outputs.console_plugin_digest }}

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,21 @@ else
 RELATED_IMAGE_DNS_OPERATOR ?= quay.io/kuadrant/dns-operator:$(DNS_OPERATOR_VERSION)
 endif
 
+## mcp-gateway
+MCP_GATEWAY_VERSION ?= latest
+mcp_gateway_version_is_semantic := $(call is_semantic_version,$(MCP_GATEWAY_VERSION))
+
+ifeq (latest,$(MCP_GATEWAY_VERSION))
+RELATED_IMAGE_MCP_GATEWAY ?= ghcr.io/kuadrant/mcp-controller:latest
+RELATED_IMAGE_MCP_GATEWAY_BROKER ?= ghcr.io/kuadrant/mcp-gateway:latest
+else ifeq (true,$(mcp_gateway_version_is_semantic))
+RELATED_IMAGE_MCP_GATEWAY ?= ghcr.io/kuadrant/mcp-controller:v$(MCP_GATEWAY_VERSION)
+RELATED_IMAGE_MCP_GATEWAY_BROKER ?= ghcr.io/kuadrant/mcp-gateway:v$(MCP_GATEWAY_VERSION)
+else
+RELATED_IMAGE_MCP_GATEWAY ?= ghcr.io/kuadrant/mcp-controller:$(MCP_GATEWAY_VERSION)
+RELATED_IMAGE_MCP_GATEWAY_BROKER ?= ghcr.io/kuadrant/mcp-gateway:$(MCP_GATEWAY_VERSION)
+endif
+
 ## wasm-shim
 WASM_SHIM_VERSION ?= latest
 shim_version_is_semantic := $(call is_semantic_version,$(WASM_SHIM_VERSION))
@@ -441,6 +456,8 @@ run: export OPERATOR_NAMESPACE := $(OPERATOR_NAMESPACE)
 run: export WASM_SERVER_FILE_PATH := $(WASM_BIN)
 run: export CHARTS_PATH := $(PROJECT_PATH)/component-charts
 run: export RELATED_IMAGE_DNS_OPERATOR := $(RELATED_IMAGE_DNS_OPERATOR)
+run: export RELATED_IMAGE_MCP_GATEWAY := $(RELATED_IMAGE_MCP_GATEWAY)
+run: export RELATED_IMAGE_MCP_GATEWAY_BROKER := $(RELATED_IMAGE_MCP_GATEWAY_BROKER)
 run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 run: DIRTY=$(shell $(PROJECT_PATH)/utils/check-git-dirty.sh || echo "unknown")
 run: generate fmt vet $(WASM_BIN) ## Run a controller from your host.
@@ -500,6 +517,12 @@ set-related-images: yq ## Set RELATED_IMAGE_* env vars in config/manager/manager
 	# Set desired dns-operator image
 	V="$(RELATED_IMAGE_DNS_OPERATOR)" \
 	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_DNS_OPERATOR").value) = strenv(V)' -i config/manager/manager.yaml
+	# Set desired mcp-gateway controller image
+	V="$(RELATED_IMAGE_MCP_GATEWAY)" \
+	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_MCP_GATEWAY").value) = strenv(V)' -i config/manager/manager.yaml
+	# Set desired mcp-gateway broker image
+	V="$(RELATED_IMAGE_MCP_GATEWAY_BROKER)" \
+	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_MCP_GATEWAY_BROKER").value) = strenv(V)' -i config/manager/manager.yaml
 	# Set desired Wasm-shim image
 	V="$(RELATED_IMAGE_WASMSHIM)" \
 	$(YQ) eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_WASMSHIM").value) = strenv(V)' -i config/manager/manager.yaml

--- a/Makefile
+++ b/Makefile
@@ -450,14 +450,26 @@ $(WASM_BIN): ## Fetch and extract the wasm-shim binary from the OCI image.
 	$(CONTAINER_ENGINE) pull $(RELATED_IMAGE_WASMSHIM)
 	$(CONTAINER_ENGINE) save $(RELATED_IMAGE_WASMSHIM) | tar xf - --to-stdout $$($(CONTAINER_ENGINE) save $(RELATED_IMAGE_WASMSHIM) | tar tf - | grep -E '^[a-f0-9]+\.tar$$' | while IFS= read -r layer; do $(CONTAINER_ENGINE) save $(RELATED_IMAGE_WASMSHIM) | tar xf - --to-stdout "$$layer" | tar tf - 2>/dev/null | grep -q plugin.wasm && echo "$$layer"; done | head -1) | tar xf - -C $(WASM_BIN_DIR)
 
+# Shared env vars needed by any target that runs the controller against
+# component charts (local `run` and integration tests). One place to add a
+# new component's RELATED_IMAGE_* var instead of updating every target.
+define LOCAL_RUN_ENV
+$(1): export OPERATOR_NAMESPACE := $(OPERATOR_NAMESPACE)
+$(1): export CHARTS_PATH := $(PROJECT_PATH)/component-charts
+$(1): export RELATED_IMAGE_DNS_OPERATOR := $(RELATED_IMAGE_DNS_OPERATOR)
+$(1): export RELATED_IMAGE_MCP_GATEWAY := $(RELATED_IMAGE_MCP_GATEWAY)
+$(1): export RELATED_IMAGE_MCP_GATEWAY_BROKER := $(RELATED_IMAGE_MCP_GATEWAY_BROKER)
+$(1): export RELATED_IMAGE_WASMSHIM := $(RELATED_IMAGE_WASMSHIM)
+$(1): export RELATED_IMAGE_DEVELOPERPORTAL := $(RELATED_IMAGE_DEVELOPERPORTAL)
+$(1): export RELATED_IMAGE_CONSOLE_PLUGIN_LATEST := $(RELATED_IMAGE_CONSOLE_PLUGIN_LATEST)
+$(1): export RELATED_IMAGE_CONSOLE_PLUGIN_SDK1 := $(RELATED_IMAGE_CONSOLE_PLUGIN_SDK1)
+$(1): export RELATED_IMAGE_CONSOLE_PLUGIN_PF5 := $(RELATED_IMAGE_CONSOLE_PLUGIN_PF5)
+endef
+$(foreach t,run test-bare-k8s-integration test-gatewayapi-env-integration test-istio-env-integration test-envoygateway-env-integration test-integration,$(eval $(call LOCAL_RUN_ENV,$(t))))
+
 run: export LOG_LEVEL = debug
 run: export LOG_MODE = development
-run: export OPERATOR_NAMESPACE := $(OPERATOR_NAMESPACE)
 run: export WASM_SERVER_FILE_PATH := $(WASM_BIN)
-run: export CHARTS_PATH := $(PROJECT_PATH)/component-charts
-run: export RELATED_IMAGE_DNS_OPERATOR := $(RELATED_IMAGE_DNS_OPERATOR)
-run: export RELATED_IMAGE_MCP_GATEWAY := $(RELATED_IMAGE_MCP_GATEWAY)
-run: export RELATED_IMAGE_MCP_GATEWAY_BROKER := $(RELATED_IMAGE_MCP_GATEWAY_BROKER)
 run: GIT_SHA=$(shell git rev-parse HEAD || echo "unknown")
 run: DIRTY=$(shell $(PROJECT_PATH)/utils/check-git-dirty.sh || echo "unknown")
 run: generate fmt vet $(WASM_BIN) ## Run a controller from your host.

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2026-09-01T10:29:19Z"
+    createdAt: "2026-09-04T15:43:03Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -441,6 +441,9 @@ spec:
           resourceNames:
           - dnshealthcheckprobes.kuadrant.io
           - dnsrecords.kuadrant.io
+          - mcpgatewayextensions.mcp.kuadrant.io
+          - mcpserverregistrations.mcp.kuadrant.io
+          - mcpvirtualservers.mcp.kuadrant.io
           resources:
           - customresourcedefinitions
           verbs:
@@ -773,6 +776,7 @@ spec:
           resourceNames:
           - dns-operator-manager-rolebinding
           - dns-operator-remote-cluster-rolebinding
+          - mcp-gateway-controller
           resources:
           - clusterrolebindings
           verbs:
@@ -792,6 +796,7 @@ spec:
           resourceNames:
           - dns-operator-manager-role
           - dns-operator-remote-cluster-role
+          - mcp-gateway-controller
           resources:
           - clusterroles
           verbs:
@@ -868,6 +873,10 @@ spec:
                   value: quay.io/kuadrant/console-plugin:v0.1.5-2
                 - name: RELATED_IMAGE_DNS_OPERATOR
                   value: quay.io/kuadrant/dns-operator:latest
+                - name: RELATED_IMAGE_MCP_GATEWAY
+                  value: ghcr.io/kuadrant/mcp-controller:latest
+                - name: RELATED_IMAGE_MCP_GATEWAY_BROKER
+                  value: ghcr.io/kuadrant/mcp-gateway:latest
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -1041,4 +1050,8 @@ spec:
     name: console-plugin-pf5
   - image: quay.io/kuadrant/dns-operator:latest
     name: dns-operator
+  - image: ghcr.io/kuadrant/mcp-controller:latest
+    name: mcp-gateway
+  - image: ghcr.io/kuadrant/mcp-gateway:latest
+    name: mcp-gateway-broker
   version: 0.0.0

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14513,6 +14513,9 @@ rules:
   resourceNames:
   - dnshealthcheckprobes.kuadrant.io
   - dnsrecords.kuadrant.io
+  - mcpgatewayextensions.mcp.kuadrant.io
+  - mcpserverregistrations.mcp.kuadrant.io
+  - mcpvirtualservers.mcp.kuadrant.io
   resources:
   - customresourcedefinitions
   verbs:
@@ -14845,6 +14848,7 @@ rules:
   resourceNames:
   - dns-operator-manager-rolebinding
   - dns-operator-remote-cluster-rolebinding
+  - mcp-gateway-controller
   resources:
   - clusterrolebindings
   verbs:
@@ -14864,6 +14868,7 @@ rules:
   resourceNames:
   - dns-operator-manager-role
   - dns-operator-remote-cluster-role
+  - mcp-gateway-controller
   resources:
   - clusterroles
   verbs:
@@ -15102,6 +15107,10 @@ spec:
           value: quay.io/kuadrant/console-plugin:v0.1.5-2
         - name: RELATED_IMAGE_DNS_OPERATOR
           value: quay.io/kuadrant/dns-operator:latest
+        - name: RELATED_IMAGE_MCP_GATEWAY
+          value: ghcr.io/kuadrant/mcp-controller:latest
+        - name: RELATED_IMAGE_MCP_GATEWAY_BROKER
+          value: ghcr.io/kuadrant/mcp-gateway:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/component-charts/mcp-gateway/.helmignore
+++ b/component-charts/mcp-gateway/.helmignore
@@ -1,0 +1,31 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*.sh
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# OS generated files
+Thumbs.db
+# Helm
+*.tgz
+.helmignore
+# Local development
+*.local

--- a/component-charts/mcp-gateway/Chart.yaml
+++ b/component-charts/mcp-gateway/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: mcp-gateway
+description: A Kubernetes gateway for aggregating and routing Model Context Protocol (MCP) servers
+type: application
+version: 0.9.0
+appVersion: "0.9.0"
+home: https://github.com/Kuadrant/mcp-gateway
+sources:
+  - https://github.com/Kuadrant/mcp-gateway
+maintainers:
+  - name: Kuadrant Team
+    url: https://github.com/Kuadrant
+keywords:
+  - mcp
+  - model-context-protocol
+  - gateway
+  - broker
+  - controller
+annotations:
+  category: Infrastructure

--- a/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
+++ b/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpgatewayextensions.yaml
@@ -1,0 +1,689 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: mcpgatewayextensions.mcp.kuadrant.io
+spec:
+  group: mcp.kuadrant.io
+  names:
+    kind: MCPGatewayExtension
+    listKind: MCPGatewayExtensionList
+    plural: mcpgatewayextensions
+    shortNames:
+    - mcpge
+    singular: mcpgatewayextension
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready status
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MCPGatewayExtension extends a Gateway API Gateway to handle the Model Context Protocol (MCP).
+          When created, the controller will:
+          - Deploy a broker-router Deployment and Service in the MCPGatewayExtension's namespace
+          - Create an EnvoyFilter in the Gateway's namespace to route MCP traffic to the broker
+          - Configure the Envoy proxy to use the external processor for MCP request handling
+
+          The broker aggregates tools from upstream MCP servers registered via MCPServerRegistration
+          resources, while the router handles MCP protocol parsing and request routing.
+
+          Cross-namespace references to Gateways require a ReferenceGrant in the Gateway's namespace.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of MCPGatewayExtension
+            properties:
+              backendPingIntervalSeconds:
+                default: 60
+                description: backendPingIntervalSeconds specifies how often the broker
+                  pings upstream MCP servers.
+                format: int32
+                maximum: 7200
+                minimum: 10
+                type: integer
+              caCertBundleRef:
+                description: |-
+                  caCertBundleRef references a Secret containing a PEM-encoded CA certificate
+                  bundle used as the base trust pool for:
+                  - broker connections to all upstream MCP servers (per-server caCertSecretRef appends)
+                  - 2025-11-25 protocol hairpin requests to the gateway HTTPS listener
+                  2026-07-28 MCP calls do not hairpin and do not use this bundle for gateway TLS.
+                  Include both the gateway listener CA and upstream CAs when they differ.
+                  The Secret must have the label mcp.kuadrant.io/secret=true.
+                properties:
+                  key:
+                    default: ca.crt
+                    description: |-
+                      key is the key within the Secret that contains the CA bundle PEM data.
+                      If not specified, defaults to "ca.crt".
+                    type: string
+                  name:
+                    description: name is the name of the Secret resource.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              httpRouteManagement:
+                default: Enabled
+                description: |-
+                  httpRouteManagement controls whether the operator manages the gateway HTTPRoute.
+                  Enabled: creates and manages the HTTPRoute (default).
+                  Disabled: does not create an HTTPRoute.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+              logLevel:
+                description: |-
+                  logLevel controls the broker-router log verbosity.
+                  Maps to the broker's --log-level flag: debug=-4, info=0, warn=4, error=8.
+                  When unset, the operator-wide BROKER_ROUTER_LOG_LEVEL default (if configured) is used.
+                enum:
+                - debug
+                - info
+                - warn
+                - error
+                type: string
+              maxBodyBytes:
+                default: 1048576
+                description: |-
+                  maxBodyBytes caps the size of any body the router buffers, in bytes.
+                  Applies to request/response prefix stripping and guardrails checks.
+                format: int32
+                minimum: 1
+                type: integer
+              oauthProtectedResource:
+                description: |-
+                  oauthProtectedResource configures the OAuth protected resource metadata
+                  served at /.well-known/oauth-protected-resource. When set, the controller
+                  injects the corresponding OAUTH_* env vars into the broker-router deployment.
+                properties:
+                  authorizationServers:
+                    description: authorizationServers lists the OAuth authorization
+                      server URLs.
+                    items:
+                      pattern: ^https?://[^,]+$
+                      type: string
+                    maxItems: 10
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  bearerMethodsSupported:
+                    description: |-
+                      bearerMethodsSupported lists the supported bearer token methods.
+                      Defaults to ["header"].
+                    items:
+                      type: string
+                    maxItems: 10
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  resource:
+                    description: |-
+                      resource is the URI of the protected resource.
+                      Defaults to https://<publicHost>/mcp.
+                    maxLength: 2048
+                    type: string
+                  resourceName:
+                    description: |-
+                      resourceName is the human-readable name for this resource.
+                      Defaults to "MCP Server".
+                    maxLength: 253
+                    type: string
+                  scopesSupported:
+                    description: |-
+                      scopesSupported lists the supported OAuth scopes.
+                      Defaults to ["basic"].
+                    items:
+                      type: string
+                    maxItems: 50
+                    type: array
+                    x-kubernetes-list-type: atomic
+                required:
+                - authorizationServers
+                type: object
+              privateHost:
+                description: |-
+                  privateHost overrides the internal host used for hair-pinning requests
+                  back through the gateway. Defaults to
+                  <gateway>-<gatewayClassName>.<ns>.svc.cluster.local:<port>, with an https://
+                  scheme prefix when the targeted Gateway listener uses the HTTPS protocol. The
+                  value supplied here is honoured verbatim, so an operator can include a
+                  scheme (e.g. "https://my-gw:443") or pin to a different port.
+                type: string
+              publicHost:
+                description: |-
+                  publicHost overrides the public host derived from the listener hostname.
+                  Use when the listener has a wildcard and you need a specific host.
+                type: string
+              sessionStore:
+                description: |-
+                  sessionStore references a secret for redis-based session storage.
+                  The secret must exist in the MCPGatewayExtension namespace and contain a CACHE_CONNECTION_STRING key.
+                  The value is injected as CACHE_CONNECTION_STRING into the broker-router deployment.
+                  When not set, in-memory session storage is used.
+                properties:
+                  secretName:
+                    description: |-
+                      secretName is the name of the secret containing the CACHE_CONNECTION_STRING key.
+                      The value should be a redis connection string: redis://<user>:<pass>@<host>:<port>/<db>
+                    minLength: 1
+                    type: string
+                required:
+                - secretName
+                type: object
+              targetRef:
+                description: |-
+                  targetRef specifies the Gateway to extend with MCP protocol support.
+                  The controller will create an EnvoyFilter targeting this Gateway's Envoy proxy.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: group is the group of the target resource.
+                    enum:
+                    - gateway.networking.k8s.io
+                    type: string
+                  kind:
+                    default: Gateway
+                    description: kind is the kind of the target resource.
+                    enum:
+                    - Gateway
+                    type: string
+                  name:
+                    description: name is the name of the target resource.
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: namespace of the target resource (optional, defaults
+                      to same namespace)
+                    type: string
+                  sectionName:
+                    description: |-
+                      sectionName is the name of a listener on the target Gateway. The controller will
+                      read the listener's port and hostname to configure the MCP Gateway instance.
+                      Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+                      different namespaces may target different listeners on the same Gateway, provided
+                      those listeners use different ports.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                - sectionName
+                type: object
+              trustedHeadersKey:
+                description: |-
+                  trustedHeadersKey configures trusted-header key pair for JWT-based tool filtering.
+                  When set, the public key secret is wired into the broker deployment.
+                properties:
+                  generate:
+                    default: Disabled
+                    description: |-
+                      generate controls whether the operator generates an ECDSA P-256 key pair.
+                      Enabled: creates <secretName> (public key) and <secretName>-private (private key)
+                      in the MCPGatewayExtension namespace with owner references.
+                      Disabled: the secret must already exist (default).
+                      Changing this field requires deleting the existing secrets first to ensure
+                      the public and private keys are a matching pair.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of the secret containing the public key used by the broker
+                      to verify trusted-header JWTs. The secret must have a data entry with key "key"
+                      containing the PEM-encoded public key.
+                      When Generate is Enabled, the operator creates this secret.
+                      When Generate is Disabled, this secret must already exist in the namespace.
+                    minLength: 1
+                    type: string
+                required:
+                - secretName
+                type: object
+              urlElicitation:
+                default: Disabled
+                description: |-
+                  urlElicitation controls whether URL-based token elicitation is enabled.
+                  Enabled: creates a separate /tokens HTTPRoute and passes --enable-url-elicitation to the broker.
+                  Disabled: no /tokens route is created (default).
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            required:
+            - targetRef
+            type: object
+          status:
+            description: status defines the observed state of MCPGatewayExtension
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the MCPGatewayExtension.
+                  The Ready condition indicates whether the broker-router deployment is running
+                  and the EnvoyFilter has been successfully applied to the target Gateway.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Ready status
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: mcp.kuadrant.io/v1alpha1 MCPGatewayExtension is deprecated;
+      migrate to mcp.kuadrant.io/v1
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MCPGatewayExtension extends a Gateway API Gateway to handle the Model Context Protocol (MCP).
+          When created, the controller will:
+          - Deploy a broker-router Deployment and Service in the MCPGatewayExtension's namespace
+          - Create an EnvoyFilter in the Gateway's namespace to route MCP traffic to the broker
+          - Configure the Envoy proxy to use the external processor for MCP request handling
+
+          The broker aggregates tools from upstream MCP servers registered via MCPServerRegistration
+          resources, while the router handles MCP protocol parsing and request routing.
+
+          Cross-namespace references to Gateways require a ReferenceGrant in the Gateway's namespace.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of MCPGatewayExtension
+            properties:
+              backendPingIntervalSeconds:
+                default: 60
+                description: backendPingIntervalSeconds specifies how often the broker
+                  pings upstream MCP servers.
+                format: int32
+                maximum: 7200
+                minimum: 10
+                type: integer
+              caCertBundleRef:
+                description: |-
+                  caCertBundleRef references a Secret containing a PEM-encoded CA certificate
+                  bundle used as the base trust pool for:
+                  - broker connections to all upstream MCP servers (per-server caCertSecretRef appends)
+                  - 2025-11-25 protocol hairpin requests to the gateway HTTPS listener
+                  2026-07-28 MCP calls do not hairpin and do not use this bundle for gateway TLS.
+                  Include both the gateway listener CA and upstream CAs when they differ.
+                  The Secret must have the label mcp.kuadrant.io/secret=true.
+                properties:
+                  key:
+                    default: ca.crt
+                    description: |-
+                      key is the key within the Secret that contains the CA bundle PEM data.
+                      If not specified, defaults to "ca.crt".
+                    type: string
+                  name:
+                    description: name is the name of the Secret resource.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              httpRouteManagement:
+                default: Enabled
+                description: |-
+                  httpRouteManagement controls whether the operator manages the gateway HTTPRoute.
+                  Enabled: creates and manages the HTTPRoute (default).
+                  Disabled: does not create an HTTPRoute.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+              logLevel:
+                description: |-
+                  logLevel controls the broker-router log verbosity.
+                  Maps to the broker's --log-level flag: debug=-4, info=0, warn=4, error=8.
+                  When unset, the operator-wide BROKER_ROUTER_LOG_LEVEL default (if configured) is used.
+                enum:
+                - debug
+                - info
+                - warn
+                - error
+                type: string
+              oauthProtectedResource:
+                description: |-
+                  oauthProtectedResource configures the OAuth protected resource metadata
+                  served at /.well-known/oauth-protected-resource. When set, the controller
+                  injects the corresponding OAUTH_* env vars into the broker-router deployment.
+                properties:
+                  authorizationServers:
+                    description: authorizationServers lists the OAuth authorization
+                      server URLs.
+                    items:
+                      pattern: ^https?://[^,]+$
+                      type: string
+                    maxItems: 10
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  bearerMethodsSupported:
+                    description: |-
+                      bearerMethodsSupported lists the supported bearer token methods.
+                      Defaults to ["header"].
+                    items:
+                      type: string
+                    maxItems: 10
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  resource:
+                    description: |-
+                      resource is the URI of the protected resource.
+                      Defaults to https://<publicHost>/mcp.
+                    maxLength: 2048
+                    type: string
+                  resourceName:
+                    description: |-
+                      resourceName is the human-readable name for this resource.
+                      Defaults to "MCP Server".
+                    maxLength: 253
+                    type: string
+                  scopesSupported:
+                    description: |-
+                      scopesSupported lists the supported OAuth scopes.
+                      Defaults to ["basic"].
+                    items:
+                      type: string
+                    maxItems: 50
+                    type: array
+                    x-kubernetes-list-type: atomic
+                required:
+                - authorizationServers
+                type: object
+              privateHost:
+                description: |-
+                  privateHost overrides the internal host used for hair-pinning requests
+                  back through the gateway. Defaults to
+                  <gateway>-<gatewayClassName>.<ns>.svc.cluster.local:<port>, with an https://
+                  scheme prefix when the targeted Gateway listener uses the HTTPS protocol. The
+                  value supplied here is honoured verbatim, so an operator can include a
+                  scheme (e.g. "https://my-gw:443") or pin to a different port.
+                type: string
+              publicHost:
+                description: |-
+                  publicHost overrides the public host derived from the listener hostname.
+                  Use when the listener has a wildcard and you need a specific host.
+                type: string
+              sessionStore:
+                description: |-
+                  sessionStore references a secret for redis-based session storage.
+                  The secret must exist in the MCPGatewayExtension namespace and contain a CACHE_CONNECTION_STRING key.
+                  The value is injected as CACHE_CONNECTION_STRING into the broker-router deployment.
+                  When not set, in-memory session storage is used.
+                properties:
+                  secretName:
+                    description: |-
+                      secretName is the name of the secret containing the CACHE_CONNECTION_STRING key.
+                      The value should be a redis connection string: redis://<user>:<pass>@<host>:<port>/<db>
+                    minLength: 1
+                    type: string
+                required:
+                - secretName
+                type: object
+              targetRef:
+                description: |-
+                  targetRef specifies the Gateway to extend with MCP protocol support.
+                  The controller will create an EnvoyFilter targeting this Gateway's Envoy proxy.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: group is the group of the target resource.
+                    enum:
+                    - gateway.networking.k8s.io
+                    type: string
+                  kind:
+                    default: Gateway
+                    description: kind is the kind of the target resource.
+                    enum:
+                    - Gateway
+                    type: string
+                  name:
+                    description: name is the name of the target resource.
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: namespace of the target resource (optional, defaults
+                      to same namespace)
+                    type: string
+                  sectionName:
+                    description: |-
+                      sectionName is the name of a listener on the target Gateway. The controller will
+                      read the listener's port and hostname to configure the MCP Gateway instance.
+                      Only one MCPGatewayExtension is allowed per namespace. MCPGatewayExtensions in
+                      different namespaces may target different listeners on the same Gateway, provided
+                      those listeners use different ports.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                - sectionName
+                type: object
+              trustedHeadersKey:
+                description: |-
+                  trustedHeadersKey configures trusted-header key pair for JWT-based tool filtering.
+                  When set, the public key secret is wired into the broker deployment.
+                properties:
+                  generate:
+                    default: Disabled
+                    description: |-
+                      generate controls whether the operator generates an ECDSA P-256 key pair.
+                      Enabled: creates <secretName> (public key) and <secretName>-private (private key)
+                      in the MCPGatewayExtension namespace with owner references.
+                      Disabled: the secret must already exist (default).
+                      Changing this field requires deleting the existing secrets first to ensure
+                      the public and private keys are a matching pair.
+                    enum:
+                    - Enabled
+                    - Disabled
+                    type: string
+                  secretName:
+                    description: |-
+                      secretName is the name of the secret containing the public key used by the broker
+                      to verify trusted-header JWTs. The secret must have a data entry with key "key"
+                      containing the PEM-encoded public key.
+                      When Generate is Enabled, the operator creates this secret.
+                      When Generate is Disabled, this secret must already exist in the namespace.
+                    minLength: 1
+                    type: string
+                required:
+                - secretName
+                type: object
+              urlElicitation:
+                default: Disabled
+                description: |-
+                  urlElicitation controls whether URL-based token elicitation is enabled.
+                  Enabled: creates a separate /tokens HTTPRoute and passes --enable-url-elicitation to the broker.
+                  Disabled: no /tokens route is created (default).
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            required:
+            - targetRef
+            type: object
+          status:
+            description: status defines the observed state of MCPGatewayExtension
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the MCPGatewayExtension.
+                  The Ready condition indicates whether the broker-router deployment is running
+                  and the EnvoyFilter has been successfully applied to the target Gateway.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}

--- a/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -1,0 +1,587 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: mcpserverregistrations.mcp.kuadrant.io
+spec:
+  group: mcp.kuadrant.io
+  names:
+    kind: MCPServerRegistration
+    listKind: MCPServerRegistrationList
+    plural: mcpserverregistrations
+    shortNames:
+    - mcpsr
+    singular: mcpserverregistration
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Prefix for federation
+      jsonPath: .spec.prefix
+      name: Prefix
+      type: string
+    - description: Target HTTPRoute.  MCP Gateway only supports routes with a single
+        BackendRef
+      jsonPath: .spec.targetRef.name
+      name: Target
+      type: string
+    - description: MCP endpoint path
+      jsonPath: .spec.path
+      name: Path
+      type: string
+    - description: Ready status
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: Server categories for discovery
+      jsonPath: .spec.category
+      name: Category
+      type: string
+    - jsonPath: .spec.credentialRef.name
+      name: Credentials
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: MCPServerRegistration registers an upstream MCP server for tool
+          federation through the gateway.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of MCPServerRegistration.
+            properties:
+              caCertSecretRef:
+                description: |-
+                  caCertSecretRef references a Secret containing a PEM-encoded CA certificate bundle.
+                  The broker uses this CA to verify TLS connections to the upstream MCP server.
+                  The referenced Secret must have the label mcp.kuadrant.io/secret=true.
+                  If key is not specified, defaults to "ca.crt".
+                properties:
+                  key:
+                    default: ca.crt
+                    description: |-
+                      key is the key within the Secret that contains the CA certificate PEM data.
+                      If not specified, defaults to "ca.crt".
+                    type: string
+                  name:
+                    description: name is the name of the Secret resource.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              category:
+                default:
+                - uncategorised
+                description: |-
+                  category assigns one or more categories to this MCP server for tool discovery.
+                  Used by the discover_tools meta-tool to allow agents to filter servers by category.
+                items:
+                  maxLength: 128
+                  minLength: 1
+                  type: string
+                maxItems: 3
+                type: array
+                x-kubernetes-list-type: atomic
+              credentialRef:
+                description: |-
+                  credentialRef references a Secret containing authentication credentials for the MCP server.
+                  The Secret should contain a key with the authentication token or credentials.
+                  The controller will aggregate these credentials and make them available to the broker via environment variables following the pattern: KAGENTI_{MCP_NAME}_CRED
+                  Used exclusively by the broker for tool discovery and session management. Never injected into client tools/call requests.
+                properties:
+                  key:
+                    default: token
+                    description: |-
+                      key is the key within the Secret that contains the credential value.
+                      If not specified, defaults to "token".
+                    type: string
+                  name:
+                    description: name is the name of the Secret resource.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              hint:
+                description: |-
+                  hint provides a short description of what this MCP server offers.
+                  Returned by the discover_tools meta-tool to help agents decide which tools to select.
+                maxLength: 256
+                type: string
+              path:
+                default: /mcp
+                description: |-
+                  path specifies the URL path where the MCP server endpoint is exposed.
+                  If not specified, defaults to "/mcp".
+                  This allows connecting to MCP servers that use custom paths like "/v1/mcp" or "/api/mcp".
+                type: string
+              prefix:
+                description: |-
+                  prefix is the prefix to add to all federated capabilities from referenced servers.
+                  This helps avoid naming conflicts when aggregating tools from multiple sources.
+                  For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
+                pattern: ^[a-z0-9][a-z0-9_]*$
+                type: string
+                x-kubernetes-validations:
+                - message: prefix is immutable once set
+                  rule: self == oldSelf
+              state:
+                default: Enabled
+                description: |-
+                  state dictates whether the broker should maintain a connection to this server.
+                  When set to Disabled, the broker will remove any registered tools and stop connecting to the server.
+                  The server can be re-enabled at any time by setting this field back to Enabled.
+                  Defaults to Enabled.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+              tags:
+                description: |-
+                  tags is an optional list of arbitrary labels for this MCP server.
+                  Tags are propagated to the broker and exposed via the gateway's list_tags and filter_tools_by_tags tools.
+                items:
+                  maxLength: 128
+                  minLength: 1
+                  type: string
+                maxItems: 10
+                type: array
+                x-kubernetes-list-type: atomic
+              targetRef:
+                description: |-
+                  targetRef specifies an HTTPRoute that points to a backend MCP server.
+                  The referenced HTTPRoute should have a backend service that implements the MCP protocol.
+                  The controller will discover the backend service from this HTTPRoute and configure
+                  the broker to federate tools from that MCP server.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: group is the group of the target resource.
+                    enum:
+                    - gateway.networking.k8s.io
+                    type: string
+                  kind:
+                    default: HTTPRoute
+                    description: kind is the kind of the target resource.
+                    enum:
+                    - HTTPRoute
+                    type: string
+                  name:
+                    description: name is the name of the target resource.
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: namespace of the target resource (optional, defaults
+                      to same namespace).
+                    type: string
+                required:
+                - name
+                type: object
+              tokenURLElicitation:
+                description: |-
+                  tokenURLElicitation enables per-user token collection via URL elicitation.
+                  When set, the router uses the MCP spec's URLElicitationRequiredError (-32042) flow
+                  to collect tokens from capable clients at tool-call time.
+                properties:
+                  url:
+                    description: |-
+                      url overrides the default broker token page URL.
+                      When set, users are directed to this external URL (e.g. a Vault UI) instead of the broker's built-in page.
+                    pattern: ^https?://
+                    type: string
+                type: object
+              userSpecificList:
+                default: Disabled
+                description: |-
+                  userSpecificList indicates that this MCP server returns different tools
+                  per user based on their credentials. When Enabled, the broker fetches tools
+                  from this server on each tools/list request using the user's session
+                  headers, rather than caching the service account's tool list.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: prefix is required when userSpecificList is Enabled
+              rule: 'self.userSpecificList != "Enabled" || self.prefix != "" '
+          status:
+            description: status defines the observed state of MCPServerRegistration.
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the latest available observations of the MCPServerRegistration's state.
+                  Common conditions include 'Ready' to indicate if all referenced servers are accessible.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Prefix for federation
+      jsonPath: .spec.prefix
+      name: Prefix
+      type: string
+    - description: Target HTTPRoute.  MCP Gateway only supports routes with a single
+        BackendRef
+      jsonPath: .spec.targetRef.name
+      name: Target
+      type: string
+    - description: MCP endpoint path
+      jsonPath: .spec.path
+      name: Path
+      type: string
+    - description: Ready status
+      jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - description: Server categories for discovery
+      jsonPath: .spec.category
+      name: Category
+      type: string
+    - jsonPath: .spec.credentialRef.name
+      name: Credentials
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: mcp.kuadrant.io/v1alpha1 MCPServerRegistration is deprecated;
+      migrate to mcp.kuadrant.io/v1
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MCPServerRegistration registers an upstream MCP server for tool
+          federation through the gateway.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of MCPServerRegistration.
+            properties:
+              caCertSecretRef:
+                description: |-
+                  caCertSecretRef references a Secret containing a PEM-encoded CA certificate bundle.
+                  The broker uses this CA to verify TLS connections to the upstream MCP server.
+                  The referenced Secret must have the label mcp.kuadrant.io/secret=true.
+                  If key is not specified, defaults to "ca.crt".
+                properties:
+                  key:
+                    default: ca.crt
+                    description: |-
+                      key is the key within the Secret that contains the CA certificate PEM data.
+                      If not specified, defaults to "ca.crt".
+                    type: string
+                  name:
+                    description: name is the name of the Secret resource.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              category:
+                default:
+                - uncategorised
+                description: |-
+                  category assigns one or more categories to this MCP server for tool discovery.
+                  Used by the discover_tools meta-tool to allow agents to filter servers by category.
+                items:
+                  maxLength: 128
+                  minLength: 1
+                  type: string
+                maxItems: 3
+                type: array
+                x-kubernetes-list-type: atomic
+              credentialRef:
+                description: |-
+                  credentialRef references a Secret containing authentication credentials for the MCP server.
+                  The Secret should contain a key with the authentication token or credentials.
+                  The controller will aggregate these credentials and make them available to the broker via environment variables following the pattern: KAGENTI_{MCP_NAME}_CRED
+                  Used exclusively by the broker for tool discovery and session management. Never injected into client tools/call requests.
+                properties:
+                  key:
+                    default: token
+                    description: |-
+                      key is the key within the Secret that contains the credential value.
+                      If not specified, defaults to "token".
+                    type: string
+                  name:
+                    description: name is the name of the Secret resource.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              hint:
+                description: |-
+                  hint provides a short description of what this MCP server offers.
+                  Returned by the discover_tools meta-tool to help agents decide which tools to select.
+                maxLength: 256
+                type: string
+              path:
+                default: /mcp
+                description: |-
+                  path specifies the URL path where the MCP server endpoint is exposed.
+                  If not specified, defaults to "/mcp".
+                  This allows connecting to MCP servers that use custom paths like "/v1/mcp" or "/api/mcp".
+                type: string
+              prefix:
+                description: |-
+                  prefix is the prefix to add to all federated capabilities from referenced servers.
+                  This helps avoid naming conflicts when aggregating tools from multiple sources.
+                  For example, if two servers both provide a 'search' tool, prefixes like 'server1_' and 'server2_' ensure they can coexist as 'server1_search' and 'server2_search'.
+                pattern: ^[a-z0-9][a-z0-9_]*$
+                type: string
+                x-kubernetes-validations:
+                - message: prefix is immutable once set
+                  rule: self == oldSelf
+              state:
+                default: Enabled
+                description: |-
+                  state dictates whether the broker should maintain a connection to this server.
+                  When set to Disabled, the broker will remove any registered tools and stop connecting to the server.
+                  The server can be re-enabled at any time by setting this field back to Enabled.
+                  Defaults to Enabled.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+              tags:
+                description: |-
+                  tags is an optional list of arbitrary labels for this MCP server.
+                  Tags are propagated to the broker and exposed via the gateway's list_tags and filter_tools_by_tags tools.
+                items:
+                  maxLength: 128
+                  minLength: 1
+                  type: string
+                maxItems: 10
+                type: array
+                x-kubernetes-list-type: atomic
+              targetRef:
+                description: |-
+                  targetRef specifies an HTTPRoute that points to a backend MCP server.
+                  The referenced HTTPRoute should have a backend service that implements the MCP protocol.
+                  The controller will discover the backend service from this HTTPRoute and configure
+                  the broker to federate tools from that MCP server.
+                properties:
+                  group:
+                    default: gateway.networking.k8s.io
+                    description: group is the group of the target resource.
+                    enum:
+                    - gateway.networking.k8s.io
+                    type: string
+                  kind:
+                    default: HTTPRoute
+                    description: kind is the kind of the target resource.
+                    enum:
+                    - HTTPRoute
+                    type: string
+                  name:
+                    description: name is the name of the target resource.
+                    minLength: 1
+                    type: string
+                  namespace:
+                    description: namespace of the target resource (optional, defaults
+                      to same namespace).
+                    type: string
+                required:
+                - name
+                type: object
+              tokenURLElicitation:
+                description: |-
+                  tokenURLElicitation enables per-user token collection via URL elicitation.
+                  When set, the router uses the MCP spec's URLElicitationRequiredError (-32042) flow
+                  to collect tokens from capable clients at tool-call time.
+                properties:
+                  url:
+                    description: |-
+                      url overrides the default broker token page URL.
+                      When set, users are directed to this external URL (e.g. a Vault UI) instead of the broker's built-in page.
+                    pattern: ^https?://
+                    type: string
+                type: object
+              userSpecificList:
+                default: Disabled
+                description: |-
+                  userSpecificList indicates that this MCP server returns different tools
+                  per user based on their credentials. When Enabled, the broker fetches tools
+                  from this server on each tools/list request using the user's session
+                  headers, rather than caching the service account's tool list.
+                enum:
+                - Enabled
+                - Disabled
+                type: string
+            required:
+            - targetRef
+            type: object
+            x-kubernetes-validations:
+            - message: prefix is required when userSpecificList is Enabled
+              rule: 'self.userSpecificList != "Enabled" || self.prefix != "" '
+          status:
+            description: status defines the observed state of MCPServerRegistration.
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the latest available observations of the MCPServerRegistration's state.
+                  Common conditions include 'Ready' to indicate if all referenced servers are accessible.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}

--- a/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpvirtualservers.yaml
+++ b/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpvirtualservers.yaml
@@ -1,0 +1,287 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.0
+  name: mcpvirtualservers.mcp.kuadrant.io
+spec:
+  group: mcp.kuadrant.io
+  names:
+    kind: MCPVirtualServer
+    listKind: MCPVirtualServerList
+    plural: mcpvirtualservers
+    shortNames:
+    - mcpvs
+    singular: mcpvirtualserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready condition
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.tools.length()
+      name: Tools
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MCPVirtualServer defines a virtual server that exposes a specific set of tools.
+          It enables tool-level access control and federation by specifying which tools
+          should be accessible through this virtual endpoint.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of MCPVirtualServer.
+            properties:
+              description:
+                description: description provides a human-readable description of
+                  this virtual server's purpose.
+                type: string
+              prompts:
+                description: |-
+                  prompts specifies the list of prompt names to expose through this virtual server.
+                  When omitted, all prompts are exposed.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              tools:
+                description: |-
+                  tools specifies the list of tool names to expose through this virtual server.
+                  These tools must be available from the underlying MCP servers configured in the system.
+                items:
+                  type: string
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - tools
+            type: object
+          status:
+            description: status defines the observed state of MCPVirtualServer.
+            properties:
+              conditions:
+                description: conditions represent the latest available observations
+                  of the MCPVirtualServer's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Ready condition
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.tools.length()
+      name: Tools
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    deprecationWarning: mcp.kuadrant.io/v1alpha1 MCPVirtualServer is deprecated; migrate
+      to mcp.kuadrant.io/v1
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MCPVirtualServer defines a virtual server that exposes a specific set of tools.
+          It enables tool-level access control and federation by specifying which tools
+          should be accessible through this virtual endpoint.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of MCPVirtualServer.
+            properties:
+              description:
+                description: description provides a human-readable description of
+                  this virtual server's purpose.
+                type: string
+              prompts:
+                description: |-
+                  prompts specifies the list of prompt names to expose through this virtual server.
+                  When omitted, all prompts are exposed.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: atomic
+              tools:
+                description: |-
+                  tools specifies the list of tool names to expose through this virtual server.
+                  These tools must be available from the underlying MCP servers configured in the system.
+                items:
+                  type: string
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+            required:
+            - tools
+            type: object
+          status:
+            description: status defines the observed state of MCPVirtualServer.
+            properties:
+              conditions:
+                description: conditions represent the latest available observations
+                  of the MCPVirtualServer's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}

--- a/component-charts/mcp-gateway/templates/NOTES.txt
+++ b/component-charts/mcp-gateway/templates/NOTES.txt
@@ -1,0 +1,38 @@
+1. Check the status of your deployment:
+  kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/instance={{ .Release.Name }}"
+
+2. Verify MCPGatewayExtension is ready:
+  kubectl get mcpgatewayextension -n {{ .Release.Namespace }}
+
+3. Once the MCPGatewayExtension is ready, verify the broker-router deployment:
+  kubectl get deployment mcp-gateway -n {{ .Release.Namespace }}
+
+4. Verify EnvoyFilter was created (in the Gateway namespace):
+  kubectl get envoyfilter -n {{ .Values.mcpGatewayExtension.gatewayRef.namespace }} -l app.kubernetes.io/managed-by=mcp-gateway-controller
+
+5. Connect MCP servers by creating MCPServerRegistration resources:
+  kubectl apply -f - <<EOF
+  apiVersion: mcp.kuadrant.io/v1
+  kind: MCPServerRegistration
+  metadata:
+    name: my-mcp-server
+    namespace: {{ .Release.Namespace }}
+  spec:
+    prefix: "myserver_"
+    targetRef:
+      group: "gateway.networking.k8s.io"
+      kind: "HTTPRoute"
+      name: "my-server-route"
+  EOF
+
+6. Access your MCP Gateway at: http://{{ .Values.gateway.publicHost }}:{{ .Values.gateway.port }}/mcp
+   (Adjust hostname/port based on your Gateway configuration)
+
+7. View logs for troubleshooting:
+  # Broker/Router logs
+  kubectl logs -n {{ .Release.Namespace }} deployment/mcp-gateway
+
+  # Controller logs
+  kubectl logs -n {{ .Release.Namespace }} deployment/{{ include "mcp-gateway.fullname" . }}-controller
+
+For more information, visit: https://github.com/Kuadrant/mcp-gateway

--- a/component-charts/mcp-gateway/templates/_helpers.tpl
+++ b/component-charts/mcp-gateway/templates/_helpers.tpl
@@ -1,0 +1,93 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mcp-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mcp-gateway.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mcp-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mcp-gateway.labels" -}}
+helm.sh/chart: {{ include "mcp-gateway.chart" . }}
+{{ include "mcp-gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mcp-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Controller selector labels - distinct from broker to avoid service selector overlap
+*/}}
+{{- define "mcp-gateway.controllerSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "mcp-gateway.name" . }}-controller
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the controller service account to use
+*/}}
+{{- define "mcp-gateway.controllerServiceAccountName" -}}
+{{ include "mcp-gateway.fullname" . }}-controller
+{{- end }}
+
+
+{{/*
+Docker image name gateway
+*/}}
+{{- define "mcp-gateway.image" -}}
+{{- if contains "@" .Values.image.repository -}}
+{{ .Values.image.repository }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end -}}
+{{- end }}
+
+
+{{/*
+Docker image name controller
+*/}}
+{{- define "mcp-controller.image" -}}
+{{- if contains "@" .Values.imageController.repository -}}
+{{ .Values.imageController.repository }}
+{{- else -}}
+{{ .Values.imageController.repository }}:{{ .Values.imageController.tag | default .Chart.AppVersion }}
+{{- end -}}
+{{- end }}

--- a/component-charts/mcp-gateway/templates/deployment-controller.yaml
+++ b/component-charts/mcp-gateway/templates/deployment-controller.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.controller.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "mcp-gateway.controllerServiceAccountName" . }}
+      containers:
+        - name: mcp-controller
+          image: {{ include "mcp-controller.image" . }}
+          imagePullPolicy: {{ .Values.imageController.pullPolicy }}
+          command:
+            - ./mcp_controller
+            - --log-level=0
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: RELATED_IMAGE_ROUTER_BROKER
+              value: {{ include "mcp-gateway.image" . }}
+          ports:
+            - name: health
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 8082
+              protocol: TCP
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+{{- end }}

--- a/component-charts/mcp-gateway/templates/gateway-nodeport.yaml
+++ b/component-charts/mcp-gateway/templates/gateway-nodeport.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.gateway.nodePort.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.gateway.name | default (include "mcp-gateway.fullname" .) }}-nodeport
+  namespace: {{ .Values.gateway.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: {{ .Values.gateway.name | default (include "mcp-gateway.fullname" .) }}
+spec:
+  type: NodePort
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  selector:
+    gateway.networking.k8s.io/gateway-name: {{ .Values.gateway.name | default (include "mcp-gateway.fullname" .) }}
+  sessionAffinity: None
+  ports:
+    {{- if .Values.gateway.nodePort.statusPort.enabled }}
+    - name: status-port
+      appProtocol: tcp
+      port: 15021
+      targetPort: 15021
+      protocol: TCP
+      {{- if .Values.gateway.nodePort.statusPort.nodePort }}
+      nodePort: {{ .Values.gateway.nodePort.statusPort.nodePort }}
+      {{- end }}
+    {{- end }}
+    - name: mcp
+      appProtocol: http
+      port: {{ .Values.gateway.port }}
+      targetPort: {{ .Values.gateway.port }}
+      protocol: TCP
+      {{- if .Values.gateway.nodePort.mcpPort }}
+      nodePort: {{ .Values.gateway.nodePort.mcpPort }}
+      {{- end }}
+{{- end }}

--- a/component-charts/mcp-gateway/templates/gateway.yaml
+++ b/component-charts/mcp-gateway/templates/gateway.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.gateway.create }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ .Values.gateway.name | default (include "mcp-gateway.fullname" .) }}
+  namespace: {{ .Values.gateway.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    istio: ingressgateway
+    gateway.io/name: {{ .Values.gateway.name | default (include "mcp-gateway.fullname" .) }}
+spec:
+  gatewayClassName: {{ .Values.gateway.gatewayClassName }}
+  listeners:
+    - name: mcp
+      hostname: {{ .Values.gateway.publicHost | quote }}
+      port: {{ .Values.gateway.port }}
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: {{ .Values.gateway.allowedRoutes.from }}
+    - name: mcps
+      hostname: {{ .Values.gateway.internalHostPattern | quote }}
+      port: {{ .Values.gateway.port }}
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: {{ .Values.gateway.allowedRoutes.from }}
+{{- with .Values.gateway.additionalListeners }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/component-charts/mcp-gateway/templates/mcpgatewayextension.yaml
+++ b/component-charts/mcp-gateway/templates/mcpgatewayextension.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.mcpGatewayExtension.create }}
+apiVersion: mcp.kuadrant.io/v1
+kind: MCPGatewayExtension
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-extension
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.mcpGatewayExtension.gatewayRef.name }}
+    {{- if .Values.mcpGatewayExtension.gatewayRef.namespace }}
+    namespace: {{ .Values.mcpGatewayExtension.gatewayRef.namespace }}
+    {{- end }}
+    sectionName: {{ .Values.mcpGatewayExtension.gatewayRef.sectionName }}
+  {{- if .Values.gateway.publicHost }}
+  publicHost: {{ .Values.gateway.publicHost | quote }}
+  {{- end }}
+  privateHost: {{ printf "%s-%s.%s.svc.cluster.local:%v" .Values.gateway.name .Values.gateway.gatewayClassName .Values.gateway.namespace .Values.gateway.port | quote }}
+  {{- if .Values.broker.pollInterval }}
+  backendPingIntervalSeconds: {{ .Values.broker.pollInterval }}
+  {{- end }}
+  {{- /* pass-through fields */ -}}
+  {{- with .Values.mcpGatewayExtension.httpRouteManagement }}
+  httpRouteManagement: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.mcpGatewayExtension.sessionStore.secretName }}
+  sessionStore:
+    secretName: {{ .Values.mcpGatewayExtension.sessionStore.secretName | quote }}
+  {{- end }}
+  {{- if or .Values.mcpGatewayExtension.trustedHeadersKey.generate .Values.mcpGatewayExtension.trustedHeadersKey.secretName }}
+  trustedHeadersKey:
+    {{- with .Values.mcpGatewayExtension.trustedHeadersKey.generate }}
+    generate: {{ . | quote }}
+    {{- end }}
+    {{- with .Values.mcpGatewayExtension.trustedHeadersKey.secretName }}
+    secretName: {{ . | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/component-charts/mcp-gateway/templates/networkpolicy-controller.yaml
+++ b/component-charts/mcp-gateway/templates/networkpolicy-controller.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.networkPolicy.enabled .Values.controller.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: 8081
+          protocol: TCP
+        - port: 8082
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+        - port: 53
+          protocol: TCP
+        - port: 53
+          protocol: UDP
+{{- end }}

--- a/component-charts/mcp-gateway/templates/rbac.yaml
+++ b/component-charts/mcp-gateway/templates/rbac.yaml
@@ -1,0 +1,147 @@
+{{- /* DO NOT EDIT rules - synced from config/rbac/role.yaml by 'make sync-rbac' */ -}}
+{{- if .Values.controller.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mcp-gateway-controller
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: controller
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - serviceaccounts
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways/status
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - httproutes/status
+    verbs:
+      - update
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - referencegrants
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - mcp.kuadrant.io
+    resources:
+      - mcpgatewayextensions
+      - mcpserverregistrations
+      - mcpvirtualservers
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - mcp.kuadrant.io
+    resources:
+      - mcpgatewayextensions/finalizers
+      - mcpvirtualservers/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - mcp.kuadrant.io
+    resources:
+      - mcpgatewayextensions/status
+      - mcpserverregistrations/status
+      - mcpvirtualservers/status
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - envoyfilters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "mcp-gateway.fullname" . }}-controller
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mcp-gateway-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "mcp-gateway.controllerServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/component-charts/mcp-gateway/templates/referencegrant.yaml
+++ b/component-charts/mcp-gateway/templates/referencegrant.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.mcpGatewayExtension.create .Values.mcpGatewayExtension.gatewayRef.namespace }}
+{{- if ne .Values.mcpGatewayExtension.gatewayRef.namespace .Release.Namespace }}
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: allow-{{ .Values.mcpGatewayExtension.gatewayRef.name }}
+  namespace: {{ .Values.mcpGatewayExtension.gatewayRef.namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+spec:
+  from:
+    - group: mcp.kuadrant.io
+      kind: MCPGatewayExtension
+      namespace: {{ .Release.Namespace }}
+  to:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+{{- end }}
+{{- end }}

--- a/component-charts/mcp-gateway/templates/serviceaccount.yaml
+++ b/component-charts/mcp-gateway/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.controller.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mcp-gateway.controllerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+    component: controller
+{{- end }}

--- a/component-charts/mcp-gateway/templates/tests/test-connection.yaml
+++ b/component-charts/mcp-gateway/templates/tests/test-connection.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mcp-gateway.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  restartPolicy: Never
+  containers:
+  - name: test-connection
+    image: curlimages/curl:8.5.0
+    command: ['sh', '-c']
+    args:
+      - |
+        set -e
+        echo "Testing MCP Gateway connection..."
+
+        # Test mcp-gateway health endpoint
+        echo "Checking mcp-gateway health endpoint..."
+        curl -f http://mcp-gateway.{{ .Release.Namespace }}.svc.cluster.local:8080/healthz
+        
+        echo "All tests passed!"

--- a/component-charts/mcp-gateway/templates/tests/test-status.yaml
+++ b/component-charts/mcp-gateway/templates/tests/test-status.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mcp-gateway.fullname" . }}-test-status"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "mcp-gateway.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  restartPolicy: Never
+  containers:
+  - name: test-status
+    image: curlimages/curl:8.5.0
+    command: ['sh', '-c']
+    args:
+      - |
+        set -e
+        echo "Testing MCP Gateway status endpoint..."
+        
+        # Test status endpoint returns valid JSON
+        response=$(curl -s http://mcp-gateway.{{ .Release.Namespace }}.svc.cluster.local:8080/status)
+        echo "Status response: $response"
+        
+        # Check if response contains expected fields
+        echo "$response" | grep -q "servers" || (echo "Status response missing 'servers' field" && exit 1)
+        echo "$response" | grep -q "totalServers" || (echo "Status response missing 'totalServers' field" && exit 1)
+        
+        echo "Status endpoint test passed!"

--- a/component-charts/mcp-gateway/values.yaml
+++ b/component-charts/mcp-gateway/values.yaml
@@ -1,0 +1,110 @@
+# Default values for mcp-gateway.
+# This is a YAML-formatted file.
+
+# Image configuration for mcp-gateway broker-router (deployed by controller)
+image:
+  repository: ghcr.io/kuadrant/mcp-gateway
+  # tag defaults to Chart.appVersion if empty
+  tag: ""
+
+# Image configuration for mcp-controller
+imageController:
+  repository: ghcr.io/kuadrant/mcp-controller
+  # tag defaults to Chart.appVersion if empty
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Controller configuration
+controller:
+  # Enable/disable controller deployment
+  enabled: true
+
+# Broker configuration (applied to broker-router deployed by controller)
+broker:
+  # How often (in seconds) the broker pings upstream MCP servers
+  pollInterval: 60
+  # Enable discover_tools and select_tools meta-tools
+  discoveryToolsEnabled: true
+  # Tool count above which real tools are hidden, only meta-tools shown. 0 = never hide.
+  discoveryToolThreshold: 0
+
+# Gateway configuration
+gateway:
+  # publicHost set the value for --mcp-gateway-public-host flag
+  publicHost: mcp.127-0-0-1.sslip.io
+  # Create a Gateway resource
+  create: false
+  # Name of the Gateway (defaults to release fullname)
+  name: "mcp-gateway"
+  # Namespace for the Gateway (defaults to release namespace)
+  namespace: "gateway-system"
+  # Gateway class name (e.g., istio, openshift-default, nginx)
+  gatewayClassName: istio
+  # Port for listeners
+  port: 8080
+  # Internal wildcard hostname pattern for MCP server routes
+  internalHostPattern: "*.mcp.local"
+  # Allowed routes configuration
+  allowedRoutes:
+    # Which namespaces can attach routes (All, Same, or Selector)
+    from: All
+  # Additional listeners to add to the Gateway
+  additionalListeners: []
+  # Example:
+  # - name: custom-listener
+  #   hostname: "custom.example.com"
+  #   port: 8080
+  #   protocol: HTTP
+  #   allowedRoutes:
+  #     namespaces:
+  #       from: All
+  # NodePort service for the Gateway (for local development/Kind clusters)
+  nodePort:
+    # Create a NodePort service for the Gateway
+    create: false
+    # NodePort for the MCP port (keep inside the k8s static subrange
+    # 30000-30085 so dynamic nodePort allocation will not collide with it)
+    mcpPort: 30071
+    # Status port configuration (Istio health check port)
+    statusPort:
+      enabled: false
+      # NodePort for the status port (leave empty for auto-assignment)
+      nodePort: null
+
+# MCPGatewayExtension configuration
+mcpGatewayExtension:
+  # Create an MCPGatewayExtension resource
+  create: true
+  # Gateway reference - the Gateway this MCP Gateway instance is responsible for
+  gatewayRef:
+    # Name of the Gateway
+    name: mcp-gateway
+    # Namespace of the Gateway (if different from release namespace, a ReferenceGrant will be created)
+    namespace: gateway-system
+    # Name of the listener on the Gateway to target (required)
+    sectionName: mcp
+  
+  # advanced configuration fields
+  
+  # Whether the controller should manage the HTTPRoute for the broker. 
+  # Options: Enabled | Disabled (default is Enabled if omitted)
+  httpRouteManagement: ""
+
+  # Configuration for the session store used by the gateway
+  sessionStore:
+    # The name of the secret containing session storage credentials
+    secretName: ""
+
+  # Configuration for the public/private key pair used for header signing
+  trustedHeadersKey:
+    # Whether to automatically generate a key pair. Options: Enabled | Disabled
+    generate: ""
+    # The name of the secret containing a pre-existing key pair
+    secretName: ""
+
+# Network policy for the controller pod only. The broker-router NetworkPolicy is
+# created and owned automatically by the controller at runtime, in the
+# MCPGatewayExtension's own namespace. It allows ingress on ports 8080 and
+# 50051 only from the target Gateway's namespace, so it is not templated here.
+networkPolicy:
+  enabled: false

--- a/component-charts/sync.yaml
+++ b/component-charts/sync.yaml
@@ -28,9 +28,9 @@ components:
 #    tracked-branch: main
 #    ref: main
 #    auto-merge: false
-#  mcp-gateway:
-#    repo: Kuadrant/mcp-gateway
-#    chart-path: charts/mcp-gateway
-#    tracked-branch: main
-#    ref: main
-#    auto-merge: false
+  mcp-gateway:
+    repo: Kuadrant/mcp-gateway
+    chart-path: charts/mcp-gateway
+    tracked-branch: main
+    ref: 9552329dcf51846db61befe32d08c7b38d26c9af
+    auto-merge: false

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -46,6 +46,10 @@ spec:
               value: "quay.io/kuadrant/console-plugin:v0.1.5-2"
             - name: RELATED_IMAGE_DNS_OPERATOR
               value: "quay.io/kuadrant/dns-operator:latest"
+            - name: RELATED_IMAGE_MCP_GATEWAY
+              value: "ghcr.io/kuadrant/mcp-controller:latest"
+            - name: RELATED_IMAGE_MCP_GATEWAY_BROKER
+              value: "ghcr.io/kuadrant/mcp-gateway:latest"
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,6 +48,9 @@ rules:
   resourceNames:
   - dnshealthcheckprobes.kuadrant.io
   - dnsrecords.kuadrant.io
+  - mcpgatewayextensions.mcp.kuadrant.io
+  - mcpserverregistrations.mcp.kuadrant.io
+  - mcpvirtualservers.mcp.kuadrant.io
   resources:
   - customresourcedefinitions
   verbs:
@@ -380,6 +383,7 @@ rules:
   resourceNames:
   - dns-operator-manager-rolebinding
   - dns-operator-remote-cluster-rolebinding
+  - mcp-gateway-controller
   resources:
   - clusterrolebindings
   verbs:
@@ -399,6 +403,7 @@ rules:
   resourceNames:
   - dns-operator-manager-role
   - dns-operator-remote-cluster-role
+  - mcp-gateway-controller
   resources:
   - clusterroles
   verbs:

--- a/internal/controlplane/deployer.go
+++ b/internal/controlplane/deployer.go
@@ -86,6 +86,20 @@ func allComponents() []Component {
 			DeploymentName: "dns-operator-controller-manager",
 			CRDNames:       []string{"dnsrecords.kuadrant.io", "dnshealthcheckprobes.kuadrant.io"},
 		},
+		{
+			Name:           "mcp-gateway",
+			ChartPath:      chartsBasePath + "/mcp-gateway",
+			DeploymentName: "mcp-gateway-controller",
+			CRDNames:       []string{"mcpgatewayextensions.mcp.kuadrant.io", "mcpserverregistrations.mcp.kuadrant.io", "mcpvirtualservers.mcp.kuadrant.io"},
+			ChartValues: map[string]any{
+				"mcpGatewayExtension": map[string]any{"create": false},
+				"gateway":             map[string]any{"create": false},
+			},
+			ChartValueOverrides: []ChartValueOverride{
+				&ImageSplitValue{ImageValue: ImageValue{EnvVar: "RELATED_IMAGE_MCP_GATEWAY", ValueKey: "imageController", Description: "controller"}},
+				&ImageSplitValue{ImageValue: ImageValue{EnvVar: "RELATED_IMAGE_MCP_GATEWAY_BROKER", ValueKey: "image", Description: "broker"}},
+			},
+		},
 	}
 }
 

--- a/internal/controlplane/deployer_test.go
+++ b/internal/controlplane/deployer_test.go
@@ -26,6 +26,12 @@ func TestDefaultComponents(t *testing.T) {
 			wantChart:  chartsBasePath + "/dns-operator",
 			wantEnvVar: "RELATED_IMAGE_DNS_OPERATOR",
 		},
+		{
+			name:                    "mcp-gateway is registered",
+			wantName:                "mcp-gateway",
+			wantChart:               chartsBasePath + "/mcp-gateway",
+			wantChartValueOverrides: 2,
+		},
 	}
 
 	if len(components) != len(tests) {

--- a/internal/controlplane/kuadrant_control_plane_controller.go
+++ b/internal/controlplane/kuadrant_control_plane_controller.go
@@ -28,15 +28,15 @@ const requeueInterval = 5 * time.Minute
 
 // Component deployer RBAC — CRD management
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create;list;watch
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,resourceNames=dnsrecords.kuadrant.io;dnshealthcheckprobes.kuadrant.io,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,resourceNames=dnsrecords.kuadrant.io;dnshealthcheckprobes.kuadrant.io;mcpgatewayextensions.mcp.kuadrant.io;mcpserverregistrations.mcp.kuadrant.io;mcpvirtualservers.mcp.kuadrant.io,verbs=get;list;watch;update;patch
 
 // Component deployer RBAC — ClusterRole management
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=dns-operator-manager-role;dns-operator-remote-cluster-role,verbs=get;update;patch;bind;escalate
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=dns-operator-manager-role;dns-operator-remote-cluster-role;mcp-gateway-controller,verbs=get;update;patch;bind;escalate
 
 // Component deployer RBAC — ClusterRoleBinding management
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,resourceNames=dns-operator-manager-rolebinding;dns-operator-remote-cluster-rolebinding,verbs=delete;get;update;patch
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,resourceNames=dns-operator-manager-rolebinding;dns-operator-remote-cluster-rolebinding;mcp-gateway-controller,verbs=delete;get;update;patch
 
 // Component deployer RBAC — namespace-scoped Role and RoleBinding management
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=create;delete;get;list;watch;update;patch
@@ -91,6 +91,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	})
 
 	if err := r.updateStatus(ctx, cp, deployErr); err != nil {
+		if apierrors.IsConflict(err) {
+			r.logger.V(1).Info("status update conflict, requeuing", "error", err)
+			return ctrl.Result{RequeueAfter: time.Second}, nil
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/internal/controlplane/olm_cleanup.go
+++ b/internal/controlplane/olm_cleanup.go
@@ -118,6 +118,7 @@ func (c *OLMCleaner) Cleanup(ctx context.Context) OLMCleanupResult {
 	// Add component migrate functions here once it's consolidated.
 	migrations := []func(context.Context) (ComponentCleanupResult, error){
 		c.migrateDNSOperator,
+		c.migrateMCPGateway,
 	}
 
 	var results []ComponentCleanupResult
@@ -212,14 +213,94 @@ func (c *OLMCleaner) migrateDNSOperator(ctx context.Context) (ComponentCleanupRe
 	}
 
 	// 4. Subscription
-	subName, err := c.deleteSubscriptionForPackage(ctx, pkg)
+	subName, err := c.deleteSubscriptionForPackage(ctx, c.namespace, pkg)
 	if err != nil {
 		return result, fmt.Errorf("deleting Subscription: %w", err)
 	}
 	result.SubscriptionName = subName
 
 	// 5. CSV
-	csvName, err := c.deleteCSVForPackage(ctx, pkg)
+	csvName, err := c.deleteCSVForPackage(ctx, c.namespace, pkg)
+	if err != nil {
+		return result, fmt.Errorf("deleting CSV: %w", err)
+	}
+	result.CSVName = csvName
+
+	return result, nil
+}
+
+// mcpGatewayNamespace is where mcp-gateway's pre-consolidation OLM install
+// lives: unlike dns-operator (and authorino/limitador-operator, once
+// migrated), it was installed into its own dedicated namespace ("mcp-system",
+// per upstream's config/deploy/olm/kustomization.yaml) rather than alongside
+// kuadrant-operator, so its Subscription, CSV, and Deployment are not in
+// c.namespace.
+const mcpGatewayNamespace = "mcp-system"
+
+// migrateMCPGateway deletes mcp-gateway's orphaned OLM Subscription and CSV.
+// Unlike dns-operator, its Deployment ("mcp-gateway-controller", in
+// mcpGatewayNamespace, a separate namespace from the rest of the operator)
+// does not need protecting from the CSV deletion's cascade: the consolidated
+// kuadrant-operator deploys its own replacement from the embedded chart into
+// its own namespace, and nothing else in the cluster has that old Deployment
+// as an owner -- the mcp-gateway operator sets ownerReferences on everything
+// it manages (broker/router Deployment, Service, ServiceAccount, HTTPRoute,
+// signing-key Secrets) to the MCPGatewayExtension CR it's reconciling, never
+// to its own controller Deployment. So letting the old Deployment go away
+// with its CSV is safe and correct, not just tolerated.
+//
+// In order:
+//
+//  1. Strip OLM ownerReferences and labels from the cluster-scoped CRDs
+//     "mcpgatewayextensions.mcp.kuadrant.io",
+//     "mcpserverregistrations.mcp.kuadrant.io", and
+//     "mcpvirtualservers.mcp.kuadrant.io". OLM likely doesn't actually
+//     delete CRDs on CSV removal (they're commonly left behind
+//     deliberately, since other CSVs/consumers may still need them), but
+//     this strip is cheap insurance against the alternative: deleting a
+//     CRD deletes every custom resource of that type cluster-wide,
+//     including the live MCPGatewayExtension instance in
+//     mcpGatewayNamespace, which would be real data loss.
+//  2. If the strip above fails, stop and return the error without touching
+//     the Subscription/CSV — deleting them first would cascade-delete the
+//     CRDs step 1 was protecting.
+//  3. Delete the "mcp-gateway" Subscription in mcpGatewayNamespace, if one
+//     exists. Matched by its spec.name field, since Subscription object
+//     names are catalog-generated, not predictable.
+//  4. Delete the mcp-gateway ClusterServiceVersion in mcpGatewayNamespace,
+//     if one exists (matched by the "mcp-gateway." CSV name prefix
+//     convention). Deleting it is what allows the old Deployment (and
+//     ServiceAccount, RBAC, everything else OLM created for mcp-gateway in
+//     mcpGatewayNamespace) to be garbage-collected.
+//
+// NOTE: steps 3-4 currently require Subscription/CSV RBAC in
+// mcpGatewayNamespace, which config/rbac/olm_migration_role.yaml does not
+// yet grant (it's namespace-scoped to the operator's own install namespace).
+// Until that's resolved, those steps fail with Forbidden here — reported as
+// a per-component error by Cleanup() without blocking other components'
+// migrations. Step 1 (the one that actually prevents data loss) does not
+// depend on that RBAC and works today.
+func (c *OLMCleaner) migrateMCPGateway(ctx context.Context) (ComponentCleanupResult, error) {
+	const pkg = "mcp-gateway"
+	result := ComponentCleanupResult{Package: pkg, Namespace: mcpGatewayNamespace}
+
+	for _, crd := range []string{
+		"mcpgatewayextensions.mcp.kuadrant.io",
+		"mcpserverregistrations.mcp.kuadrant.io",
+		"mcpvirtualservers.mcp.kuadrant.io",
+	} {
+		if err := c.stripResource(ctx, crdGVR, "", crd); err != nil {
+			return result, fmt.Errorf("stripping CRD %s: %w", crd, err)
+		}
+	}
+
+	subName, err := c.deleteSubscriptionForPackage(ctx, mcpGatewayNamespace, pkg)
+	if err != nil {
+		return result, fmt.Errorf("deleting Subscription: %w", err)
+	}
+	result.SubscriptionName = subName
+
+	csvName, err := c.deleteCSVForPackage(ctx, mcpGatewayNamespace, pkg)
 	if err != nil {
 		return result, fmt.Errorf("deleting CSV: %w", err)
 	}
@@ -321,11 +402,11 @@ func (c *OLMCleaner) stripOLMLabels(obj *unstructured.Unstructured) bool {
 }
 
 // deleteSubscriptionForPackage deletes the Subscription for the given OLM
-// package in this namespace, if one exists. Returns the deleted
-// Subscription's name, or "" if none was found. The object's own name is
-// catalog-generated, so it's found by matching its spec.name field instead.
-func (c *OLMCleaner) deleteSubscriptionForPackage(ctx context.Context, pkg string) (string, error) {
-	subs, err := c.client.Resource(subscriptionGVR).Namespace(c.namespace).List(ctx, metav1.ListOptions{})
+// package in namespace, if one exists. Returns the deleted Subscription's
+// name, or "" if none was found. The object's own name is catalog-generated,
+// so it's found by matching its spec.name field instead.
+func (c *OLMCleaner) deleteSubscriptionForPackage(ctx context.Context, namespace, pkg string) (string, error) {
+	subs, err := c.client.Resource(subscriptionGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", fmt.Errorf("listing subscriptions: %w", err)
 	}
@@ -337,7 +418,7 @@ func (c *OLMCleaner) deleteSubscriptionForPackage(ctx context.Context, pkg strin
 			continue
 		}
 		c.logger.Info("deleting OLM Subscription", "name", sub.GetName(), "package", pkg)
-		if err := c.client.Resource(subscriptionGVR).Namespace(c.namespace).Delete(ctx, sub.GetName(), metav1.DeleteOptions{}); err != nil {
+		if err := c.client.Resource(subscriptionGVR).Namespace(namespace).Delete(ctx, sub.GetName(), metav1.DeleteOptions{}); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
@@ -349,10 +430,10 @@ func (c *OLMCleaner) deleteSubscriptionForPackage(ctx context.Context, pkg strin
 }
 
 // deleteCSVForPackage deletes the ClusterServiceVersion for the given OLM
-// package in this namespace, if one exists. Returns the deleted CSV's name,
-// or "" if none was found.
-func (c *OLMCleaner) deleteCSVForPackage(ctx context.Context, pkg string) (string, error) {
-	csvs, err := c.client.Resource(csvGVR).Namespace(c.namespace).List(ctx, metav1.ListOptions{})
+// package in namespace, if one exists. Returns the deleted CSV's name, or ""
+// if none was found.
+func (c *OLMCleaner) deleteCSVForPackage(ctx context.Context, namespace, pkg string) (string, error) {
+	csvs, err := c.client.Resource(csvGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return "", fmt.Errorf("listing CSVs: %w", err)
 	}
@@ -363,7 +444,7 @@ func (c *OLMCleaner) deleteCSVForPackage(ctx context.Context, pkg string) (strin
 			continue
 		}
 		c.logger.Info("deleting OLM CSV", "name", name)
-		if err := c.client.Resource(csvGVR).Namespace(c.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		if err := c.client.Resource(csvGVR).Namespace(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}

--- a/internal/controlplane/olm_cleanup_test.go
+++ b/internal/controlplane/olm_cleanup_test.go
@@ -264,30 +264,12 @@ func TestMigrateDNSOperator_EndToEnd(t *testing.T) {
 
 	deployment := newTestDeployment(olmLabels, olmOwnerRefs)
 
-	newOwnedObj := func(gvr schema.GroupVersionResource, kind, name, namespace string) *unstructured.Unstructured {
-		obj := &unstructured.Unstructured{
-			Object: map[string]interface{}{
-				"apiVersion": gvr.GroupVersion().String(),
-				"kind":       kind,
-				"metadata": map[string]interface{}{
-					"name": name,
-				},
-			},
-		}
-		if namespace != "" {
-			obj.SetNamespace(namespace)
-		}
-		obj.SetLabels(olmLabels)
-		_ = unstructured.SetNestedSlice(obj.Object, olmOwnerRefs, "metadata", "ownerReferences")
-		return obj
-	}
-
-	dnsrecordsCRD := newOwnedObj(crdGVR, "CustomResourceDefinition", "dnsrecords.kuadrant.io", "")
-	probesCRD := newOwnedObj(crdGVR, "CustomResourceDefinition", "dnshealthcheckprobes.kuadrant.io", "")
+	dnsrecordsCRD := newOwnedObj(crdGVR, "CustomResourceDefinition", "dnsrecords.kuadrant.io", "", olmLabels, olmOwnerRefs)
+	probesCRD := newOwnedObj(crdGVR, "CustomResourceDefinition", "dnshealthcheckprobes.kuadrant.io", "", olmLabels, olmOwnerRefs)
 
 	// User-added data must survive the strip untouched -- only OLM ownership
 	// metadata should be removed, never the ConfigMap's own content.
-	controllerEnv := newOwnedObj(configMapGVR, "ConfigMap", "dns-operator-controller-env", "kuadrant-system")
+	controllerEnv := newOwnedObj(configMapGVR, "ConfigMap", "dns-operator-controller-env", "kuadrant-system", olmLabels, olmOwnerRefs)
 	_ = unstructured.SetNestedField(controllerEnv.Object, "info", "data", "LOG_LEVEL")
 
 	subscription := &unstructured.Unstructured{
@@ -384,6 +366,146 @@ func TestMigrateDNSOperator_EndToEnd(t *testing.T) {
 		t.Errorf("expected Subscription to be deleted, got err: %v", err)
 	}
 	if _, err := client.Resource(csvGVR).Namespace("kuadrant-system").Get(context.Background(), "dns-operator.v0.8.0", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("expected CSV to be deleted, got err: %v", err)
+	}
+}
+
+// newOwnedObj builds a minimal unstructured object carrying the given
+// labels and ownerReferences, as a stand-in for a resource OLM stamped
+// during a pre-consolidation install.
+func newOwnedObj(gvr schema.GroupVersionResource, kind, name, namespace string, labels map[string]string, ownerRefs []interface{}) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": gvr.GroupVersion().String(),
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name": name,
+			},
+		},
+	}
+	if namespace != "" {
+		obj.SetNamespace(namespace)
+	}
+	obj.SetLabels(labels)
+	_ = unstructured.SetNestedSlice(obj.Object, ownerRefs, "metadata", "ownerReferences")
+	return obj
+}
+
+// TestMigrateMCPGateway_EndToEnd exercises the full sequence documented on
+// migrateMCPGateway: unlike dns-operator, its Deployment is deliberately
+// left untouched (nothing owns it that needs protecting, and the
+// consolidated operator replaces it from its own namespace), while its
+// Subscription/CSV lookups target mcpGatewayNamespace rather than the
+// operator's own namespace ("kuadrant-system") -- mcp-gateway's
+// pre-consolidation install lives in its own dedicated namespace.
+func TestMigrateMCPGateway_EndToEnd(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+
+	olmLabels := map[string]string{
+		"control-plane":  "mcp-gateway-controller",
+		"olm.owner":      "mcp-gateway.v0.8.0",
+		"olm.owner.kind": "ClusterServiceVersion",
+	}
+	olmOwnerRefs := []interface{}{
+		map[string]interface{}{
+			"apiVersion": "operators.coreos.com/v1alpha1",
+			"kind":       "ClusterServiceVersion",
+			"name":       "mcp-gateway.v0.8.0",
+		},
+	}
+
+	deployment := newOwnedObj(deploymentGVR, "Deployment", "mcp-gateway-controller", mcpGatewayNamespace, olmLabels, olmOwnerRefs)
+
+	crdNames := []string{
+		"mcpgatewayextensions.mcp.kuadrant.io",
+		"mcpserverregistrations.mcp.kuadrant.io",
+		"mcpvirtualservers.mcp.kuadrant.io",
+	}
+	objs := []runtime.Object{deployment}
+	for _, crd := range crdNames {
+		objs = append(objs, newOwnedObj(crdGVR, "CustomResourceDefinition", crd, "", olmLabels, olmOwnerRefs))
+	}
+
+	subscription := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "operators.coreos.com/v1alpha1",
+			"kind":       "Subscription",
+			"metadata": map[string]interface{}{
+				"name":      "mcp-gateway-preview-kuadrant-operator-catalog-mcp-gateway",
+				"namespace": mcpGatewayNamespace,
+			},
+			"spec": map[string]interface{}{
+				"name": "mcp-gateway",
+			},
+		},
+	}
+	csv := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "operators.coreos.com/v1alpha1",
+			"kind":       "ClusterServiceVersion",
+			"metadata": map[string]interface{}{
+				"name":      "mcp-gateway.v0.8.0",
+				"namespace": mcpGatewayNamespace,
+			},
+		},
+	}
+	objs = append(objs, subscription, csv)
+
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		deploymentGVR:   "DeploymentList",
+		crdGVR:          "CustomResourceDefinitionList",
+		subscriptionGVR: "SubscriptionList",
+		csvGVR:          "ClusterServiceVersionList",
+	}
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...)
+
+	// namespace is the operator's own namespace, deliberately different from
+	// mcpGatewayNamespace -- proves migrateMCPGateway doesn't fall back to it.
+	cleaner := &OLMCleaner{client: client, namespace: "kuadrant-system", logger: logr.Discard()}
+
+	result, err := cleaner.migrateMCPGateway(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Namespace != mcpGatewayNamespace {
+		t.Errorf("Namespace = %q, want %q", result.Namespace, mcpGatewayNamespace)
+	}
+	if result.SubscriptionName != subscription.GetName() {
+		t.Errorf("SubscriptionName = %q, want %q", result.SubscriptionName, subscription.GetName())
+	}
+	if result.CSVName != "mcp-gateway.v0.8.0" {
+		t.Errorf("CSVName = %q, want %q", result.CSVName, "mcp-gateway.v0.8.0")
+	}
+
+	// The Deployment is deliberately left untouched -- migrateMCPGateway
+	// doesn't strip it, so its original OLM labels/ownerReferences survive
+	// unchanged (it's meant to cascade-delete along with the CSV).
+	got, err := client.Resource(deploymentGVR).Namespace(mcpGatewayNamespace).Get(context.Background(), "mcp-gateway-controller", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error re-fetching Deployment: %v", err)
+	}
+	if _, ok := got.GetLabels()["olm.owner.kind"]; !ok {
+		t.Error("Deployment: OLM labels should NOT have been stripped")
+	}
+	if refs, _, _ := unstructured.NestedSlice(got.Object, "metadata", "ownerReferences"); len(refs) == 0 {
+		t.Error("Deployment: CSV ownerReference should NOT have been stripped")
+	}
+
+	for _, crd := range crdNames {
+		got, err := client.Resource(crdGVR).Get(context.Background(), crd, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("expected CRD %s to survive, got error: %v", crd, err)
+		}
+		if _, ok := got.GetLabels()["olm.owner.kind"]; ok {
+			t.Errorf("CRD %s: OLM labels should have been stripped", crd)
+		}
+	}
+
+	if _, err := client.Resource(subscriptionGVR).Namespace(mcpGatewayNamespace).Get(context.Background(), subscription.GetName(), metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("expected Subscription to be deleted, got err: %v", err)
+	}
+	if _, err := client.Resource(csvGVR).Namespace(mcpGatewayNamespace).Get(context.Background(), "mcp-gateway.v0.8.0", metav1.GetOptions{}); !apierrors.IsNotFound(err) {
 		t.Errorf("expected CSV to be deleted, got err: %v", err)
 	}
 }

--- a/make/integration-tests.mk
+++ b/make/integration-tests.mk
@@ -11,7 +11,7 @@ test-bare-k8s-integration: clean-cov generate fmt vet ginkgo ## Requires only ba
 	mkdir -p $(PROJECT_PATH)/coverage/bare-k8s-integration
 #	Check `ginkgo help run` for command line options. For example to filtering tests.
 # Run in series as limit of 1 Kuadrant CR (procs=1)
-	OPERATOR_NAMESPACE=kuadrant-system CHARTS_PATH=$(PROJECT_PATH)/component-charts RELATED_IMAGE_DNS_OPERATOR=$(RELATED_IMAGE_DNS_OPERATOR) $(GINKGO) \
+	$(GINKGO) \
 		--coverpkg $(INTEGRATION_COVER_PKGS) \
 		--output-dir $(PROJECT_PATH)/coverage/bare-k8s-integration \
 		--coverprofile cover.out \
@@ -31,7 +31,7 @@ test-bare-k8s-integration: clean-cov generate fmt vet ginkgo ## Requires only ba
 test-gatewayapi-env-integration: clean-cov generate fmt vet ginkgo ## Requires kubernetes cluster with GatewayAPI installed.
 	mkdir -p $(PROJECT_PATH)/coverage/gatewayapi-integration
 #	Check `ginkgo help run` for command line options. For example to filtering tests.
-	OPERATOR_NAMESPACE=kuadrant-system CHARTS_PATH=$(PROJECT_PATH)/component-charts RELATED_IMAGE_DNS_OPERATOR=$(RELATED_IMAGE_DNS_OPERATOR) $(GINKGO) \
+	$(GINKGO) \
 		--coverpkg $(INTEGRATION_COVER_PKGS) \
 		--output-dir $(PROJECT_PATH)/coverage/gatewayapi-integration \
 		--coverprofile cover.out \
@@ -51,7 +51,7 @@ test-gatewayapi-env-integration: clean-cov generate fmt vet ginkgo ## Requires k
 test-istio-env-integration: clean-cov generate fmt vet ginkgo ## Requires kubernetes cluster with GatewayAPI and Istio installed.
 	mkdir -p $(PROJECT_PATH)/coverage/istio-integration
 #	Check `ginkgo help run` for command line options. For example to filtering tests.
-	GATEWAYAPI_PROVIDER=istio OPERATOR_NAMESPACE=kuadrant-system CHARTS_PATH=$(PROJECT_PATH)/component-charts RELATED_IMAGE_DNS_OPERATOR=$(RELATED_IMAGE_DNS_OPERATOR) $(GINKGO) \
+	GATEWAYAPI_PROVIDER=istio $(GINKGO) \
 		--coverpkg $(INTEGRATION_COVER_PKGS) \
 		--output-dir $(PROJECT_PATH)/coverage/istio-integration \
 		--coverprofile cover.out \
@@ -70,7 +70,7 @@ test-istio-env-integration: clean-cov generate fmt vet ginkgo ## Requires kubern
 test-envoygateway-env-integration: clean-cov generate fmt vet ginkgo ## Requires kubernetes cluster with GatewayAPI and EnvoyGateway installed.
 	mkdir -p $(PROJECT_PATH)/coverage/envoygateway-integration
 #	Check `ginkgo help run` for command line options. For example to filtering tests.
-	GATEWAYAPI_PROVIDER=envoygateway OPERATOR_NAMESPACE=kuadrant-system CHARTS_PATH=$(PROJECT_PATH)/component-charts RELATED_IMAGE_DNS_OPERATOR=$(RELATED_IMAGE_DNS_OPERATOR) $(GINKGO) \
+	GATEWAYAPI_PROVIDER=envoygateway $(GINKGO) \
 		--coverpkg $(INTEGRATION_COVER_PKGS) \
 		--output-dir $(PROJECT_PATH)/coverage/envoygateway-integration \
 		--coverprofile cover.out \
@@ -90,7 +90,7 @@ test-envoygateway-env-integration: clean-cov generate fmt vet ginkgo ## Requires
 test-integration: clean-cov generate fmt vet ginkgo ## Requires kubernetes cluster with at least one GatewayAPI provider installed.
 	mkdir -p $(PROJECT_PATH)/coverage/integration
 #	Check `ginkgo help run` for command line options. For example to filtering tests.
-	GATEWAYAPI_PROVIDER=$(GATEWAYAPI_PROVIDER) OPERATOR_NAMESPACE=kuadrant-system CHARTS_PATH=$(PROJECT_PATH)/component-charts RELATED_IMAGE_DNS_OPERATOR=$(RELATED_IMAGE_DNS_OPERATOR) $(GINKGO) \
+	GATEWAYAPI_PROVIDER=$(GATEWAYAPI_PROVIDER) $(GINKGO) \
 		--coverpkg $(INTEGRATION_COVER_PKGS) \
 		--output-dir $(PROJECT_PATH)/coverage/integration \
 		--coverprofile cover.out \

--- a/release.yaml
+++ b/release.yaml
@@ -11,5 +11,6 @@ dependencies:
   console-plugin: "0.0.0"
   developer-portal-controller: "0.0.0"
   dns-operator: "0.0.0"
+  mcp-gateway: "0.0.0"
   limitador-operator: "0.0.0"
   wasm-shim: "0.0.0"

--- a/tests/common/controlplane/controlplane_controller_test.go
+++ b/tests/common/controlplane/controlplane_controller_test.go
@@ -161,6 +161,30 @@ var _ = Describe("KuadrantControlPlane controller", Serial, func() {
 			}).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
 
+		It("reports mcp-gateway image status", func(ctx SpecContext) {
+			Eventually(func(g Gomega) {
+				cp := &kuadrantv1alpha1.KuadrantControlPlane{}
+				g.Expect(testClient().Get(ctx, client.ObjectKey{Name: kuadrantv1alpha1.KuadrantControlPlaneDefaultName}, cp)).To(Succeed())
+
+				var mcp *kuadrantv1alpha1.ComponentStatus
+				for i := range cp.Status.Components {
+					if cp.Status.Components[i].Name == "mcp-gateway" {
+						mcp = &cp.Status.Components[i]
+						break
+					}
+				}
+				g.Expect(mcp).ToNot(BeNil(), "mcp-gateway component not found in status")
+				g.Expect(mcp.Images).ToNot(BeEmpty())
+
+				imageNames := map[string]bool{}
+				for _, img := range mcp.Images {
+					g.Expect(img.Image).ToNot(BeEmpty())
+					imageNames[img.Name] = true
+				}
+				g.Expect(imageNames).To(HaveKey("mcp-controller"))
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+
 	})
 
 	Context("self-healing on deletion", func() {

--- a/utils/release/operator/make_bundles.sh
+++ b/utils/release/operator/make_bundles.sh
@@ -31,6 +31,11 @@ cd $env
 dns_operator_version=$(mod_version $DNS_OPERATOR_VERSION)
 dns_operator_image="quay.io/kuadrant/dns-operator:$dns_operator_version"
 
+# Set desired mcp-gateway images
+mcp_gateway_version=$(mod_version $MCP_GATEWAY_VERSION)
+mcp_gateway_image="ghcr.io/kuadrant/mcp-controller:$mcp_gateway_version"
+mcp_gateway_broker_image="ghcr.io/kuadrant/mcp-gateway:$mcp_gateway_version"
+
 # Set desired Wasm-shim image
 wasm_shim=$(mod_version $WASM_SHIM_VERSION)
 wasm_shim_image="quay.io/kuadrant/wasm-shim:$wasm_shim"
@@ -63,6 +68,8 @@ make bundle \
   BUNDLE_METADATA_OPTS="--channels $OLM_CHANNELS $default_channel_opt" \
   IMG=$operator_image \
   RELATED_IMAGE_DNS_OPERATOR=$dns_operator_image \
+  RELATED_IMAGE_MCP_GATEWAY=$mcp_gateway_image \
+  RELATED_IMAGE_MCP_GATEWAY_BROKER=$mcp_gateway_broker_image \
   RELATED_IMAGE_WASMSHIM=$wasm_shim_image \
   RELATED_IMAGE_DEVELOPERPORTAL=$developerportal_image \
   RELATED_IMAGE_CONSOLE_PLUGIN_LATEST=$consoleplugin_image \
@@ -71,6 +78,7 @@ make bundle \
   AUTHORINO_OPERATOR_VERSION=$(mod_version_for_make $AUTHORINO_OPERATOR_VERSION) \
   LIMITADOR_OPERATOR_VERSION=$(mod_version_for_make $LIMITADOR_OPERATOR_VERSION) \
   DNS_OPERATOR_VERSION=$(mod_version_for_make $DNS_OPERATOR_VERSION) \
+  MCP_GATEWAY_VERSION=$(mod_version_for_make $MCP_GATEWAY_VERSION) \
   DEVELOPERPORTAL_VERSION=$(mod_version_for_make $DEVELOPERPORTAL_VERSION)
 
 operator-sdk bundle validate $env/bundle

--- a/utils/release/operator/make_chart.sh
+++ b/utils/release/operator/make_chart.sh
@@ -33,6 +33,15 @@ dns_operator_image="quay.io/kuadrant/dns-operator:$dns_operator_version"
 V=$dns_operator_image \
 yq eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_DNS_OPERATOR").value) = strenv(V)' --inplace $env/config/manager/manager.yaml
 
+# Set desired mcp-gateway images
+mcp_gateway_version=$(mod_version $(yq '.dependencies.mcp-gateway' $env/release.yaml))
+mcp_gateway_image="ghcr.io/kuadrant/mcp-controller:$mcp_gateway_version"
+V=$mcp_gateway_image \
+yq eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_MCP_GATEWAY").value) = strenv(V)' --inplace $env/config/manager/manager.yaml
+mcp_gateway_broker_image="ghcr.io/kuadrant/mcp-gateway:$mcp_gateway_version"
+V=$mcp_gateway_broker_image \
+yq eval '(select(.kind == "Deployment").spec.template.spec.containers[].env[] | select(.name == "RELATED_IMAGE_MCP_GATEWAY_BROKER").value) = strenv(V)' --inplace $env/config/manager/manager.yaml
+
 # Set desired operator image
 cd $env/config/manager
 operator_version=$(mod_version $(yq '.kuadrant-operator.version' $env/release.yaml))

--- a/utils/release/shared.sh
+++ b/utils/release/shared.sh
@@ -37,6 +37,7 @@ AUTHORINO_OPERATOR_VERSION=$(yq '.dependencies.authorino-operator' $env/release.
 CONSOLEPLUGIN_VERSION=$(yq '.dependencies.console-plugin' $env/release.yaml)
 DEVELOPERPORTAL_VERSION=$(yq '.dependencies.developer-portal-controller' $env/release.yaml)
 DNS_OPERATOR_VERSION=$(yq '.dependencies.dns-operator' $env/release.yaml)
+MCP_GATEWAY_VERSION=$(yq '.dependencies.mcp-gateway' $env/release.yaml)
 LIMITADOR_OPERATOR_VERSION=$(yq '.dependencies.limitador-operator' $env/release.yaml)
 WASM_SHIM_VERSION=$(yq '.dependencies.wasm-shim' $env/release.yaml)
 KUADRANT_OPERATOR_VERSION="$(yq '.kuadrant-operator.version' $env/release.yaml)"


### PR DESCRIPTION
## Summary

Sync mcp-gateway Helm chart and register it as a second managed component under RFC 0019, following the same pattern established in #2178: deployed as a child controller managed by kuadrant-operator at runtime via Helm chart rendering.

- Uses `ImageSplitValue` chart-value overrides for the controller and broker images (`RELATED_IMAGE_MCP_GATEWAY`, `RELATED_IMAGE_MCP_GATEWAY_BROKER`)
- RBAC, RELATED_IMAGE env vars, and component-specific integration tests
- Dedupe local `run`/`test-*-integration` env vars into a single `LOCAL_RUN_ENV` Makefile macro, since these targets were repeating the same `OPERATOR_NAMESPACE`/`CHARTS_PATH`/`RELATED_IMAGE_*` vars inline (and some were missing several of them)
- Add `migrateMCPGateway` to the OLM migration cleanup: mcp-gateway's pre-consolidation install lived in its own dedicated namespace (`mcp-system`), not alongside kuadrant-operator, so its Subscription/CSV cleanup targets that namespace explicitly. Its Deployment is deliberately *not* protected from cascade-delete — nothing owns it (the mcp-gateway operator sets `ownerReferences` on everything it manages to the `MCPGatewayExtension` CR, never to its own Deployment), so it's safe to let it go away with its CSV. CRDs are still stripped from OLM ownership as insurance against cluster-wide data loss.
  - **Note:** cleaning up the Subscription/CSV in `mcp-system` currently requires RBAC this PR doesn't grant (`config/rbac/olm_migration_role.yaml` is scoped to the operator's own namespace only) — reaching a fixed namespace like `mcp-system` would require widening that to a cluster-scoped `ClusterRole`/`ClusterRoleBinding`. Deferring that RBAC decision to review.
- Quiet `KuadrantControlPlane` status-update conflicts: a conflict just means a concurrent writer raced ahead, and requeuing succeeds normally on the next reconcile, so it's no longer logged as an ERROR-level "Reconciler error".

closes #2157 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the MCP Gateway component and Helm chart for deploying and configuring MCP gateway services.
  - Added MCP Gateway custom resources for extensions, server registrations and virtual servers.
  - Added Gateway, NodePort, controller, RBAC, networking and health-check configuration options.
  - Added MCP Gateway images to operator bundles and runtime configuration.
- **Bug Fixes**
  - Improved reconciliation by retrying status updates after conflicts.
- **Documentation**
  - Added post-install guidance for checking gateway status, endpoints and logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->