### PR TITLE
Fix test flakes

### DIFF
--- a/internal/extension/oop_test.go
+++ b/internal/extension/oop_test.go
@@ -18,6 +18,7 @@ package extension
 
 import (
 	"io"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -26,10 +27,23 @@ import (
 	"gotest.tools/assert"
 )
 
+const oopTestHelperEnv = "KUADRANT_OOP_TEST_HELPER"
+
+// When oopTestHelperEnv is set, re-executions of this binary block until killed
+// rather than running the suite, providing a long-lived managed process.
+func TestMain(m *testing.M) {
+	if os.Getenv(oopTestHelperEnv) != "" {
+		select {}
+	}
+	os.Exit(m.Run())
+}
+
 func TestOOPExtensionManagesExternalProcess(t *testing.T) {
+	t.Setenv(oopTestHelperEnv, "1")
+
 	oop := OOPExtension{
 		name:       "test",
-		executable: "/bin/cat",
+		executable: os.Args[0],
 		logger:     logr.Discard(),
 	}
 

--- a/tests/bare_k8s/kuadrant_controller_test.go
+++ b/tests/bare_k8s/kuadrant_controller_test.go
@@ -31,13 +31,13 @@ import (
 var _ = Describe("Kuadrant controller when Gateway API is missing", func() {
 	var (
 		testNamespace    string
-		testTimeOut      = SpecTimeout(30 * time.Second)
+		testTimeOut      = NodeTimeout(30 * time.Second)
 		afterEachTimeOut = NodeTimeout(3 * time.Minute)
 	)
 
 	BeforeEach(func(ctx SpecContext) {
 		testNamespace = tests.CreateNamespace(ctx, testClient())
-	})
+	}, testTimeOut)
 
 	AfterEach(func(ctx SpecContext) {
 		tests.DeleteNamespace(ctx, testClient(), testNamespace)
@@ -58,7 +58,7 @@ var _ = Describe("Kuadrant controller when Gateway API is missing", func() {
 				},
 			}
 			Expect(testClient().Create(ctx, kuadrantCR)).ToNot(HaveOccurred())
-		})
+		}, testTimeOut)
 
 		It("Status is populated with missing Gateway API", func(ctx SpecContext) {
 			Eventually(func(g Gomega) {
@@ -282,7 +282,7 @@ var _ = Describe("Kuadrant controller when Gateway API is missing", func() {
 				},
 			}
 			Expect(testClient().Create(ctx, kuadrantCR)).To(Succeed())
-		})
+		}, testTimeOut)
 
 		It("Propagated to limitador and authorino", func(ctx SpecContext) {
 			assertTracingIsNotConfigured := func(g Gomega) {
@@ -454,7 +454,7 @@ var _ = Describe("Kuadrant controller when Gateway API is missing", func() {
 	Context("TLS profile configuration", func() {
 		var kuadrantCR *kuadrantv1beta1.Kuadrant
 
-		tlsTestTimeOut := SpecTimeout(60 * time.Second)
+		tlsTestTimeOut := NodeTimeout(60 * time.Second)
 
 		BeforeEach(func(ctx SpecContext) {
 			kuadrantCR = &kuadrantv1beta1.Kuadrant{
@@ -468,7 +468,7 @@ var _ = Describe("Kuadrant controller when Gateway API is missing", func() {
 				},
 			}
 			Expect(testClient().Create(ctx, kuadrantCR)).To(Succeed())
-		})
+		}, testTimeOut)
 
 		enableTLS := func(ctx context.Context) {
 			authorino := &authorinoopapi.Authorino{}

--- a/tests/bare_k8s/observability_reconciler_test.go
+++ b/tests/bare_k8s/observability_reconciler_test.go
@@ -19,7 +19,7 @@ import (
 var _ = Describe("Observabiltity monitors for kuadrant components", func() {
 	var (
 		testNamespace    string
-		testTimeOut      = SpecTimeout(30 * time.Second)
+		testTimeOut      = NodeTimeout(30 * time.Second)
 		afterEachTimeOut = NodeTimeout(3 * time.Minute)
 	)
 
@@ -27,7 +27,7 @@ var _ = Describe("Observabiltity monitors for kuadrant components", func() {
 
 	BeforeEach(func(ctx SpecContext) {
 		testNamespace = tests.CreateNamespace(ctx, testClient())
-	})
+	}, testTimeOut)
 
 	AfterEach(func(ctx SpecContext) {
 		tests.DeleteNamespace(ctx, testClient(), testNamespace)


### PR DESCRIPTION
Attempting to fix a couple flakes


#### OOPExtension test
Example: https://github.com/Kuadrant/kuadrant-operator/actions/runs/33011518891/job/98433656281)

Couldn't get this one to fail locally, but the example used cat which exits immediately whereas we need a process to wait - I've added a wrapper for the test itself so we can re-execute and it'll wait to be killed

#### bare_k8s integration tests
Examples:
- https://github.com/Kuadrant/kuadrant-operator/actions/runs/33034603027/job/98394509267
- https://github.com/Kuadrant/kuadrant-operator/actions/runs/32970859353/job/98184538870
- https://github.com/Kuadrant/kuadrant-operator/actions/runs/32969461549/job/98179580486
- https://github.com/Kuadrant/kuadrant-operator/actions/runs/32965987585/job/98168513492

We've got a little bit of a conflict where we set test timeouts using `SpecTimeout` and the after each timeout using `NodeTimeout`. The `SpecTimeout` limits the time for the entire test including the after each and it's a tight 30s on the bare_k8s tests so I think this is why we're seeing a lot of failures in the after each cleanup. The afterEach timeout of 3m is redundant (it'll get killed partway into the aftereach as soon as 30s total is reached). We actually have this same behaviour on our other e2e tests but the test timeout and aftereach are both 3m so they're a bit more lenient. I'm wondering if I should change those now too, but given we're not seeing as many failures on those it might be worth leaving alone. I've re-used the same 30s timeout in the `BeforeEach` blocks to make sure they're not unbounded, but perhaps we'd prefer a new timeout for these that's less than 30s. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved external process test handling to prevent unintended test re-execution.
  * Updated integration test timeouts for more reliable execution of gateway, TLS, and observability scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->