### PR TITLE
release 1.4.7 GA

### DIFF
--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -224,14 +224,14 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.7-rc1
-    createdAt: "2026-08-31T13:47:35Z"
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.7
+    createdAt: "2026-08-31T15:52:39Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.7-rc1
+  name: kuadrant-operator.v1.4.7
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -753,7 +753,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/kuadrant/kuadrant-operator:v1.4.7-rc1
+                image: quay.io/kuadrant/kuadrant-operator:v1.4.7
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -906,4 +906,4 @@ spec:
     name: console-plugin-latest
   - image: quay.io/kuadrant/console-plugin:v0.1.5
     name: console-plugin-pf5
-  version: 1.4.7-rc1
+  version: 1.4.7

--- a/charts/kuadrant-operator/Chart.yaml
+++ b/charts/kuadrant-operator/Chart.yaml
@@ -20,8 +20,8 @@ sources:
 kubeVersion: ">=1.19.0-0"
 type: application
 # The chart version and dependencies will be properly set when the chart is released matching the operator version
-version: "1.4.7-rc1"
-appVersion: "1.4.7-rc1"
+version: "1.4.7"
+appVersion: "1.4.7"
 dependencies:
   - name: authorino-operator
     version: 0.23.5

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -14059,7 +14059,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/kuadrant/kuadrant-operator:v1.4.7-rc1
+        image: quay.io/kuadrant/kuadrant-operator:v1.4.7
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/deploy/olm/catalogsource.yaml
+++ b/config/deploy/olm/catalogsource.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator-catalog
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.7-rc1
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.7
   displayName: Kuadrant Operators
   grpcPodConfig:
     securityContextConfig: restricted

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -10,4 +10,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/kuadrant/kuadrant-operator
-  newTag: v1.4.7-rc1
+  newTag: v1.4.7

--- a/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kuadrant-operator.clusterserviceversion.yaml
@@ -6,13 +6,13 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
-    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.7-rc1
+    containerImage: quay.io/kuadrant/kuadrant-operator:v1.4.7
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.9.0
     operators.operatorframework.io/project_layout: unknown
     repository: https://github.com/Kuadrant/kuadrant-operator
     support: kuadrant
-  name: kuadrant-operator.v1.4.7-rc1
+  name: kuadrant-operator.v1.4.7
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -88,4 +88,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/Kuadrant/kuadrant-operator
-  version: 1.4.7-rc1
+  version: 1.4.7

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 kuadrant-operator:
-  version: "1.4.7-rc1"
+  version: "1.4.7"
 olm:
   channels:
     - "stable"


### PR DESCRIPTION
## Summary
- Bumps version from 1.4.7-rc1 to 1.4.7 for GA release
- Pending QE sign-off on v1.4.7-rc1

## Component versions
- authorino-operator: v0.23.5
- console-plugin: v0.3.8
- developer-portal-controller: v0.1.2
- dns-operator: v0.16.4
- limitador-operator: v0.17.4
- wasm-shim: v0.12.4