### PR TITLE
fix: reject response-only token limit predicates

### DIFF
--- a/internal/cel/kuadrant_validator.go
+++ b/internal/cel/kuadrant_validator.go
@@ -1,9 +1,12 @@
 package cel
 
 import (
+	"fmt"
+
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/samber/lo"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 
 	"github.com/kuadrant/kuadrant-operator/internal/wasm"
 )
@@ -96,7 +99,6 @@ func NewRootValidatorBuilder() *ValidatorBuilder {
 			// just for parsing and checking purposes, not evaluation
 			return nil
 		},
-		),
 	)
 	builder.AddFunction("responseBodyJSON", responseBodyJSON)
 
@@ -106,18 +108,93 @@ func NewRootValidatorBuilder() *ValidatorBuilder {
 func ValidateWasmActionSpec(spec wasm.ActionSpec, validator *Validator) error {
 	pol := policyKindFromWasmServiceName(spec.ServiceName)
 	for _, predicate := range spec.Predicates {
-		if _, err := validator.Validate(pol, predicate); err != nil {
+		if err := validatePredicate(spec, pol, predicate, validator); err != nil {
 			return err
 		}
 	}
 	for _, conditionalData := range spec.ConditionalData {
 		for _, predicate := range conditionalData.Predicates {
-			if _, err := validator.Validate(pol, predicate); err != nil {
+			if err := validatePredicate(spec, pol, predicate, validator); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+func validatePredicate(spec wasm.ActionSpec, policyKind, predicate string, validator *Validator) error {
+	ast, err := validator.Validate(policyKind, predicate)
+	if err != nil {
+		return err
+	}
+
+	// Token rate limit predicates are shared by both the pre-request check and
+	// post-response report. A response-only function in the guard therefore
+	// cannot be evaluated when the limit decision is made and may silently
+	// bypass enforcement at runtime.
+	if policyKind == TokenRateLimitPolicyKind && spec.IsGuard() {
+		usesResponseBody, err := astCallsFunction(ast, "responseBodyJSON")
+		if err != nil {
+			return fmt.Errorf("failed to inspect CEL predicate: %w", err)
+		}
+		if usesResponseBody {
+			return fmt.Errorf("responseBodyJSON is not available in TokenRateLimitPolicy when predicates because they are evaluated during the request phase")
+		}
+	}
+
+	return nil
+}
+
+func astCallsFunction(ast *cel.Ast, function string) (bool, error) {
+	parsed, err := cel.AstToParsedExpr(ast)
+	if err != nil {
+		return false, err
+	}
+	return exprCallsFunction(parsed.GetExpr(), function), nil
+}
+
+func exprCallsFunction(expr *exprpb.Expr, function string) bool {
+	if expr == nil {
+		return false
+	}
+
+	switch kind := expr.ExprKind.(type) {
+	case *exprpb.Expr_CallExpr:
+		if kind.CallExpr.GetFunction() == function {
+			return true
+		}
+		if exprCallsFunction(kind.CallExpr.GetTarget(), function) {
+			return true
+		}
+		for _, arg := range kind.CallExpr.GetArgs() {
+			if exprCallsFunction(arg, function) {
+				return true
+			}
+		}
+	case *exprpb.Expr_SelectExpr:
+		return exprCallsFunction(kind.SelectExpr.GetOperand(), function)
+	case *exprpb.Expr_ListExpr:
+		for _, element := range kind.ListExpr.GetElements() {
+			if exprCallsFunction(element, function) {
+				return true
+			}
+		}
+	case *exprpb.Expr_StructExpr:
+		for _, entry := range kind.StructExpr.GetEntries() {
+			if exprCallsFunction(entry.GetMapKey(), function) || exprCallsFunction(entry.GetValue(), function) {
+				return true
+			}
+		}
+	case *exprpb.Expr_ComprehensionExpr:
+		c := kind.ComprehensionExpr
+		return exprCallsFunction(c.GetIterRange(), function) ||
+			exprCallsFunction(c.GetAccuInit(), function) ||
+			exprCallsFunction(c.GetLoopCondition(), function) ||
+			exprCallsFunction(c.GetLoopStep(), function) ||
+			exprCallsFunction(c.GetResult(), function)
+	}
+
+	return false
 }
 
 func policyKindFromWasmServiceName(serviceName string) string {

--- a/internal/cel/kuadrant_validator_test.go
+++ b/internal/cel/kuadrant_validator_test.go
@@ -90,6 +90,86 @@ func TestValidateWasmActionValid(t *testing.T) {
 	assert.NilError(t, ValidateWasmActionSpec(wasmAction, validator))
 }
 
+func TestValidateTokenRateLimitGuardRejectsResponseBodyPredicate(t *testing.T) {
+	wasmAction := wasm.ActionSpec{
+		ServiceName: wasm.RateLimitCheckServiceName,
+		Scope:       "scope",
+		ConditionalData: []wasm.ConditionalData{
+			{
+				Predicates: []string{`responseBodyJSON("/object") != "error"`},
+			},
+		},
+	}
+	builder := NewRootValidatorBuilder()
+	builder.PushPolicyBinding(TokenRateLimitPolicyKind, RateLimitName, cel.AnyType)
+	validator, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.ErrorContains(t, ValidateWasmActionSpec(wasmAction, validator), "responseBodyJSON is not available in TokenRateLimitPolicy when predicates")
+}
+
+func TestValidateTokenRateLimitGuardAllowsRequestBodyPredicate(t *testing.T) {
+	wasmAction := wasm.ActionSpec{
+		ServiceName: wasm.RateLimitCheckServiceName,
+		Scope:       "scope",
+		ConditionalData: []wasm.ConditionalData{
+			{
+				Predicates: []string{`requestBodyJSON("/model") == "gpt-4"`},
+			},
+		},
+	}
+	builder := NewRootValidatorBuilder()
+	builder.PushPolicyBinding(TokenRateLimitPolicyKind, RateLimitName, cel.AnyType)
+	validator, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NilError(t, ValidateWasmActionSpec(wasmAction, validator))
+}
+
+func TestValidateTokenRateLimitReportAllowsResponseBodyPredicate(t *testing.T) {
+	wasmAction := wasm.ActionSpec{
+		ServiceName: wasm.RateLimitReportServiceName,
+		Scope:       "scope",
+		ConditionalData: []wasm.ConditionalData{
+			{
+				Predicates: []string{`responseBodyJSON("/object") != "error"`},
+			},
+		},
+	}
+	builder := NewRootValidatorBuilder()
+	builder.PushPolicyBinding(TokenRateLimitPolicyKind, RateLimitName, cel.AnyType)
+	validator, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NilError(t, ValidateWasmActionSpec(wasmAction, validator))
+}
+
+func TestValidateTokenRateLimitGuardDoesNotMatchFunctionNameInStringLiteral(t *testing.T) {
+	wasmAction := wasm.ActionSpec{
+		ServiceName: wasm.RateLimitCheckServiceName,
+		Scope:       "scope",
+		ConditionalData: []wasm.ConditionalData{
+			{
+				Predicates: []string{`"responseBodyJSON('/object')" == "responseBodyJSON('/object')"`},
+			},
+		},
+	}
+	builder := NewRootValidatorBuilder()
+	builder.PushPolicyBinding(TokenRateLimitPolicyKind, RateLimitName, cel.AnyType)
+	validator, err := builder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.NilError(t, ValidateWasmActionSpec(wasmAction, validator))
+}
+
 func TestNewIssue(t *testing.T) {
 	action := wasm.ActionSpec{
 		ServiceName: wasm.RateLimitServiceName,


### PR DESCRIPTION
## Summary

Reject `responseBodyJSON(...)` when it is used in `TokenRateLimitPolicy` `when` predicates that participate in the pre-request rate-limit guard.

A token limit's predicates are shared by both its request-phase check and its response-phase report. The request-phase check runs before an upstream response exists, so a predicate that depends on `responseBodyJSON` cannot be evaluated coherently and can result in rate limiting being silently bypassed while the policy appears enforced.

The validation is phase-aware and operates on the checked CEL AST rather than matching expression text. This means:

* `responseBodyJSON(...)` is rejected in TokenRateLimitPolicy guard predicates;
* `requestBodyJSON(...)` remains valid in those predicates;
* response-phase report expressions remain valid;
* string literals that merely contain the text `responseBodyJSON(...)` are not false positives.

No API or CRD changes are required.

## Testing

Added unit coverage for:

* rejecting a real `responseBodyJSON` call in a token-rate-limit guard predicate;
* allowing `requestBodyJSON` in the same phase;
* allowing `responseBodyJSON` in response-phase report predicates;
* avoiding false positives when the function name appears only inside a CEL string literal.

## Why this matters

`TokenRateLimitPolicy` is an enforcement API. Accepting a predicate that cannot exist during the pre-flight decision is worse than returning a validation error because it can give operators a false sense that a token budget is being enforced.

Failing the expression through the existing CEL validation pipeline also means the policy status can surface the configuration problem instead of deferring it to a runtime wasm failure.

Fixes #2145


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for TokenRateLimit policy predicates.
  * Prevented unsupported response-body data from being used in request-phase guard predicates.
  * Continued to allow request-body data for guard predicates and response-body data for report predicates.
  * Improved detection to avoid rejecting predicates when function names appear only within text strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->