### PR TITLE
Drop supersedingHostSubsets from Authorino CR

### DIFF
--- a/config/install/configure/standard/authorino.yaml
+++ b/config/install/configure/standard/authorino.yaml
@@ -11,7 +11,6 @@ spec:
   oidcServer:
     tls:
       enabled: false
-  supersedingHostSubsets: true
   tracing:
     endpoint: ''
   replicas: 1

--- a/internal/controller/authorino_reconciler.go
+++ b/internal/controller/authorino_reconciler.go
@@ -170,8 +170,7 @@ func (r *AuthorinoReconciler) Reconcile(ctx context.Context, _ []controller.Reso
 			},
 		},
 		Spec: authorinoopapi.AuthorinoSpec{
-			ClusterWide:            true,
-			SupersedingHostSubsets: true,
+			ClusterWide: true,
 			Listener: authorinoopapi.Listener{
 				Tls: authorinoopapi.Tls{
 					Enabled: ptr.To(false),


### PR DESCRIPTION
## What

The Kuadrant Operator no longer sets `supersedingHostSubsets: true` on the Authorino CR it manages. It falls back to the Authorino default (`false`).

- `internal/controller/authorino_reconciler.go` — removed `SupersedingHostSubsets: true` from the Authorino CR the operator creates.
- `config/install/configure/standard/authorino.yaml` — removed `supersedingHostSubsets: true` from the static install manifest.

## Why

`supersedingHostSubsets` was introduced in Authorino specifically for Kuadrant back when the operator configured callouts to Authorino via Istio `AuthorizationPolicy` CRs, performed directly by the proxy. In that model, AuthConfigs were looked up by the contextual request hostname, and a wildcard AuthConfig could claim a set of hostnames in the Authorino index during reconciliation and block the acceptance of more-specific AuthConfigs specifying subsets of that wildcard — depending purely on reconcile ordering. `supersedingHostSubsets` disabled that standard Authorino behaviour (which was itself flagged as a security risk).

That overlap no longer exists:

- AuthConfigs are created with `Hosts` set to `AuthConfigNameForPath(pathID)` = `hex(sha256(pathID))` — a unique 64-char hash per topological path (`internal/controller/authconfigs_reconciler.go`, `internal/controller/auth_workflow_helpers.go`).
- The wasm-shim resolves the AuthConfig by the same hash used as its action `Scope`, after matching HTTP route matchers — not by request hostname.
- These hashes never overlap and contain no wildcards, so host subset superseding can never occur.

Since the field's behaviour is unreachable and was flagged as a security risk, the operator drops it.

## Notes

The field was only set on the AuthConfig/Authorino **create** path; the update/patch path never touched it. Existing clusters with an Authorino CR already carrying `supersedingHostSubsets: true` will not be flipped back to `false` by the operator and would need a manual edit if cleanup is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification steps

Setup:

```sh
make local-setup
```

```sh
kubectl apply -f - <<EOF
apiVersion: kuadrant.io/v1beta1
kind: Kuadrant
metadata:
  name: kuadrant
  namespace: kuadrant-system
spec: {}
EOF
```

Verify the `--allow-superseding-host-subsets` is absent in the Authorino command-line:

```sh
if kubectl get $(kubectl get pods -l authorino-resource=authorino -n kuadrant-system -o name) -n kuadrant-system -o jsonpath='{.spec.containers[0].args}' | grep -q -- '--allow-superseding-host-subsets'; then
  echo "PRESENT: --allow-superseding-host-subsets is set in the Authorino pod spec"
else
  echo "ABSENT: --allow-superseding-host-subsets is NOT set in the Authorino pod spec"
fi
# ABSENT: --allow-superseding-host-subsets is NOT set in the Authorino pod spec
```

<br/>

(Rest of the steps are optional, included only to smoke test nothing is broken regarding AuthPolicy enforcement for overlapping hostnames after the changes.)

<br/>

Patch the gateway listener to use a hostname wildcard:

```sh
kubectl patch gateway kuadrant-ingressgateway -n gateway-system --type=json \
  -p='[{"op":"replace","path":"/spec/listeners/0/hostname","value":"*.nip.io"}]'
```

Deploy a backend service:

```sh
kubectl apply -f https://raw.githubusercontent.com/Kuadrant/kuadrant-operator/refs/heads/main/examples/x509-authentication/httpbin.yaml
```

Create ingress routes leading to the service – one with a specific hostname and another to catch the complement:

```sh
export GATEWAY_IP=$(kubectl get gateway kuadrant-ingressgateway -n gateway-system -o jsonpath='{.status.addresses[0].value}') && echo "Gateway IP: $GATEWAY_IP"

kubectl apply -f - <<EOF
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: httpbin
spec:
  parentRefs:
  - name: kuadrant-ingressgateway
    namespace: gateway-system
  hostnames:
  - "httpbin.$GATEWAY_IP.nip.io"
  rules:
  - backendRefs:
    - name: httpbin
      port: 80
---
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: other-hostnames
spec:
  parentRefs:
  - name: kuadrant-ingressgateway
    namespace: gateway-system
  rules:
  - backendRefs:
    - name: httpbin
      port: 80
EOF
```

Verify both routes are open:

```sh
curl "http://httpbin.$GATEWAY_IP.nip.io/status/200" -i
# 200
```

```sh
curl "http://other.$GATEWAY_IP.nip.io/status/200" -i
# 200
```

Attach a deny-all policy to the listener:

```sh
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1
kind: AuthPolicy
metadata:
  name: default-deny
  namespace: gateway-system
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: Gateway
    name: kuadrant-ingressgateway
    sectionName: http
  rules:
    authentication:
      anonymous:
        anonymous: {}  
    authorization:
      deny-all:
        opa:
          rego: allow = false
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
            }
EOF
```

Verify both routes are closed:

```sh
curl "http://httpbin.$GATEWAY_IP.nip.io/status/200" -i
# 403
```

```sh
curl "http://other.$GATEWAY_IP.nip.io/status/200" -i
# 403
```

Attach a policy to the specific-hostname route:

```sh
kubectl apply -f -<<EOF
apiVersion: kuadrant.io/v1
kind: AuthPolicy
metadata:
  name: httpbin
spec:
  targetRef:
    group: gateway.networking.k8s.io
    kind: HTTPRoute
    name: httpbin
  rules:
    authentication:
      anonymous:
        anonymous: {}  
    authorization:
      required-header:
        patternMatching:
          patterns:
          - predicate: request.headers.exists(h, h == 'x-required') && request.headers['x-required'] != ''
    response:
      unauthorized:
        headers:
          "content-type":
            value: application/json
        body:
          value: |
            {
              "error": "Forbidden",
              "message": "Missing required header x-required"
            }
EOF
```

Verify both policies are enforced as expected:

```sh
curl "http://httpbin.$GATEWAY_IP.nip.io/status/200" -i
# 403
```

```sh
curl "http://httpbin.$GATEWAY_IP.nip.io/status/200" -H 'x-required: ok' -i
# 200
```

```sh
curl "http://other.$GATEWAY_IP.nip.io/status/200" -i
# 403
```

Verify AuthConfig hosts are disjoint sets (precondition for the proposed changes):

```sh
kubectl get authconfigs -A -o json | jq '.items[].spec.hosts'
# [
#   "559614ea74ac407c4319cad73493f0bffd6cc5c163f7a54f0f7782f9b914c497"
# ]
# [
#   "6f119ebfc3b5e42e5aaa8df764ada84415a66e43934d6af75ddae128502c1f1f"
# ]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the superseding host subsets setting from the standard Authorino installation configuration.
  * New Authorino resources no longer enable superseding host subsets by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
