### PR TITLE
ADD: Operator network policies

### DIFF
--- a/api/v1beta1/topology.go
+++ b/api/v1beta1/topology.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"slices"
+
 	authorinooperatorv1beta1 "github.com/kuadrant/authorino-operator/api/v1beta1"
 	limitadorv1alpha1 "github.com/kuadrant/limitador-operator/api/v1alpha1"
 	"github.com/kuadrant/policy-machinery/controller"
@@ -168,6 +170,42 @@ func LinkLimitadorToNetworkPolicy(objs controller.Store) machinery.LinkFunc {
 		Func: func(networkPolicy machinery.Object) []machinery.Object {
 			return lo.Filter(limitadors, func(limitador machinery.Object, _ int) bool {
 				return limitador.GetNamespace() == networkPolicy.GetNamespace() && networkPolicy.GetName() == "kuadrant-limitador"
+			})
+		},
+	}
+}
+
+func LinkDeploymentToNetworkPolicy(objs controller.Store) machinery.LinkFunc {
+	deployments := utils.Map(objs.FilterByGroupKind(DeploymentGroupKind), ControllerObjectToMachineryObject)
+
+	return machinery.LinkFunc{
+		From: DeploymentGroupKind,
+		To:   NetworkPolicyGroupKind,
+		Func: func(networkPolicy machinery.Object) []machinery.Object {
+			return lo.Filter(deployments, func(deployment machinery.Object, _ int) bool {
+				return deployment.GetNamespace() == networkPolicy.GetNamespace() && deployment.GetName() == networkPolicy.GetName()
+			})
+		},
+	}
+}
+
+func LinkSubDeploymentsToKuadrantDeployment(objs controller.Store) machinery.LinkFunc {
+	deployments := utils.Map(objs.FilterByGroupKind(DeploymentGroupKind), ControllerObjectToMachineryObject)
+	allowedDeployments := []string{
+		"authorino-operator",
+		"dns-operator-controller-manager",
+		"limitador-operator-controller-manager",
+	}
+
+	return machinery.LinkFunc{
+		From: DeploymentGroupKind,
+		To:   DeploymentGroupKind,
+		Func: func(deployment machinery.Object) []machinery.Object {
+			return lo.Filter(deployments, func(existingDeployment machinery.Object, _ int) bool {
+				if existingDeployment.GetName() != "kuadrant-operator-controller-manager" {
+					return false
+				}
+				return existingDeployment.GetNamespace() == deployment.GetNamespace() && slices.Contains(allowedDeployments, deployment.GetName())
 			})
 		},
 	}

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     categories: Integration & Delivery
     console.openshift.io/plugins: '["kuadrant-console-plugin"]'
     containerImage: quay.io/kuadrant/kuadrant-operator:latest
-    createdAt: "2026-09-01T08:36:51Z"
+    createdAt: "2026-09-01T10:29:19Z"
     description: A Kubernetes Operator to manage the lifecycle of the Kuadrant system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/internal/controller/operator_networkpolicy_reconciler.go
+++ b/internal/controller/operator_networkpolicy_reconciler.go
@@ -1,0 +1,394 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	"github.com/samber/lo"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	appsv1 "k8s.io/api/apps/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kuadrant/kuadrant-operator/api/v1beta1"
+)
+
+const (
+	NetworkPolicyReconcilerBName = "NetworkPolicyReconciler.operators"
+
+	authorinoOperatorDeployment = "authorino-operator"
+	dnsOperatorDeployment       = "dns-operator-controller-manager"
+	kuadrantOperatorDeployment  = "kuadrant-operator-controller-manager"
+	limitadorOperatorDeployment = "limitador-operator-controller-manager"
+)
+
+type OperatorNetworkPolicyReconciler struct {
+	Client *dynamic.DynamicClient
+}
+
+type response struct {
+	Policy *networkingv1.NetworkPolicy
+	Check  writeChecks
+}
+
+//+kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
+
+func NewOperatorNetworkPolicyReconciler(client *dynamic.DynamicClient) *OperatorNetworkPolicyReconciler {
+	return &OperatorNetworkPolicyReconciler{Client: client}
+}
+
+func (r *OperatorNetworkPolicyReconciler) Subscription() *controller.Subscription {
+	return &controller.Subscription{
+		ReconcileFunc: r.Reconcile,
+		Events: []controller.ResourceEventMatcher{
+			{Kind: &v1beta1.NetworkPolicyGroupKind},
+			{Kind: &v1beta1.DeploymentGroupKind},
+		},
+	}
+}
+
+func (r *OperatorNetworkPolicyReconciler) Reconcile(ctx context.Context, _ []controller.ResourceEvent, topology *machinery.Topology, _ error, _ *sync.Map) error {
+	span := trace.SpanFromContext(ctx)
+	defer span.End()
+
+	logger := controller.LoggerFromContext(ctx).WithName(NetworkPolicyReconcilerBName)
+	logger.Info("reconciling networkPolicy resources for operators", "status", "started")
+	defer logger.Info("reconciling networkPolicy resources for operators", "status", "completed")
+
+	var errs []error
+
+	rootDeployment := getRootDeployment(topology)
+	if rootDeployment == nil {
+		logger.Info("no kuadrant deployment found, not creating network policies")
+		return nil
+	}
+
+	deployments := lo.FilterMap(topology.All().Children(&controller.RuntimeObject{Object: rootDeployment}), func(child machinery.Object, _ int) (*appsv1.Deployment, bool) {
+		if child.GroupVersionKind().GroupKind() != v1beta1.DeploymentGroupKind {
+			return nil, false
+		}
+		runtimeObj, ok := child.(*controller.RuntimeObject)
+		if !ok {
+			return nil, false
+		}
+		deployment, ok := runtimeObj.Object.(*appsv1.Deployment)
+		return deployment, ok
+	})
+
+	deployments = append(deployments, rootDeployment)
+	for _, deployment := range deployments {
+		logger.Info("Processing deployment", "deployment", deployment.GetName())
+		response, err := processDeployment(logger, deployment, topology)
+		if err != nil {
+			logger.Error(err, "error processing deployment", "deployment", deployment.GetName())
+			errs = append(errs, err)
+			continue
+		}
+		err = r.writePolicyToCluster(ctx, logger, span, response.Policy, response.Check)
+		if err != nil {
+			logger.Error(err, "error writing to cluster", "deployment", deployment.GetName())
+			errs = append(errs, err)
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		span.SetStatus(codes.Error, "reconciliation completed with errors")
+		for _, err := range errs {
+			logger.Error(err, "reconciliation error")
+		}
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	// Don't return errors as it can cancel the context of workflows running in parallel.
+	return nil
+}
+
+func (r *OperatorNetworkPolicyReconciler) writePolicyToCluster(ctx context.Context, logger logr.Logger, span trace.Span, networkPolicy *networkingv1.NetworkPolicy, check writeChecks) error {
+	if networkPolicy == nil {
+		return fmt.Errorf("networkPolicy is nil")
+	}
+
+	desiredNetworkPolicyUnstructured, err := controller.Destruct(networkPolicy)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to destruct NetworkPolicy")
+		logger.Error(err, "failed to destruct NetworkPolicy object", "networkPolicy", networkPolicy, "check", check)
+		return err
+	}
+	if check.Create {
+		logger.Info("creating network policy")
+		if _, err = r.Client.Resource(v1beta1.NetworkPolicyResource).Namespace(networkPolicy.GetNamespace()).Create(ctx, desiredNetworkPolicyUnstructured, metav1.CreateOptions{}); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "failed to create NetworkPolicy")
+			logger.Error(err, "failed to create NetworkPolicy object", "networkPolicy", desiredNetworkPolicyUnstructured.Object, "check", check)
+			return err
+		}
+	} else if check.Update {
+		if _, err = r.Client.Resource(v1beta1.NetworkPolicyResource).Namespace(networkPolicy.GetNamespace()).Update(ctx, desiredNetworkPolicyUnstructured, metav1.UpdateOptions{}); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "failed to update NetworkPolicy")
+			logger.Error(err, "failed to update NetworkPolicy object", "networkPolicy", desiredNetworkPolicyUnstructured.Object, "check", check)
+			return err
+		}
+	}
+	return nil
+}
+
+func processDeployment(logger logr.Logger, deployment *appsv1.Deployment, topology *machinery.Topology) (response, error) {
+	switch deployment.GetName() {
+	case kuadrantOperatorDeployment:
+		return kuadrantOperatorPolicy(logger, deployment, topology)
+	case authorinoOperatorDeployment, dnsOperatorDeployment, limitadorOperatorDeployment:
+		return commonOperatorPolicy(logger, deployment, topology)
+	default:
+		err := fmt.Errorf("no default function found")
+		logger.Error(err, "no default function found to handle deployment", "deployment", deployment.GetName())
+		return response{}, err
+	}
+}
+
+func commonOperatorPolicy(logger logr.Logger, deployment *appsv1.Deployment, topology *machinery.Topology) (response, error) {
+	checks := writeChecks{Create: false, Update: false}
+	existingPolicy := getExistingPolicy(deployment, topology)
+	if existingPolicy == nil {
+		checks.Create = true
+	}
+
+	labels := deployment.Spec.Template.GetLabels()
+
+	if labels == nil {
+		labels = map[string]string{"kuadrant.io/managed": "true"}
+	}
+
+	var errs []error
+	metricsPort, err := getManagerPortValue("metrics", deployment)
+	if err != nil {
+		errs = append(errs, err)
+		metricsPort = 8080
+	}
+
+	desiredPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployment.GetName(),
+			Namespace: deployment.GetNamespace(),
+			Labels:    CommonLabels(),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			PolicyTypes: []networkingv1.PolicyType{"Ingress"},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				ingressRule([]networkingv1.NetworkPolicyPeer{}, metricsPort),
+			},
+		},
+	}
+
+	policy, update := mergeNetworkPolicy(*desiredPolicy, existingPolicy)
+	checks.Update = update
+
+	updateRef, err := setOwnerRef(policy, existingPolicy, deployment)
+	if err != nil {
+		logger.Error(err, "error setting ownerRef on policy", "policy_name", policy.GetName())
+		errs = append(errs, err)
+	}
+
+	if updateRef {
+		checks.Update = updateRef
+	}
+
+	err = nil
+	if len(errs) > 0 {
+		err = errors.Join(errs...)
+	}
+
+	return response{Policy: policy, Check: checks}, err
+}
+
+func kuadrantOperatorPolicy(logger logr.Logger, deployment *appsv1.Deployment, topology *machinery.Topology) (response, error) {
+	checks := writeChecks{Create: false, Update: false}
+	existingPolicy := getExistingPolicy(deployment, topology)
+	if existingPolicy == nil {
+		checks.Create = true
+	}
+	fromNamespaces := gatewayNamespacePeers(topology)
+
+	labels := deployment.Spec.Template.GetLabels()
+
+	if labels == nil {
+		labels = map[string]string{"kuadrant.io/managed": "true"}
+	}
+
+	var errs []error
+	metricsPort, err := getManagerPortValue("metrics", deployment)
+	if err != nil {
+		errs = append(errs, err)
+		metricsPort = 8080
+	}
+
+	gRPCport, err := getManagerPortValue("grpc", deployment)
+	if err != nil {
+		errs = append(errs, err)
+		gRPCport = 50051
+	}
+
+	wasmPort, err := getManagerPortValue("wasm", deployment)
+	if err != nil {
+		errs = append(errs, err)
+		wasmPort = 8082
+	}
+
+	ingress := []networkingv1.NetworkPolicyIngressRule{
+		ingressRule([]networkingv1.NetworkPolicyPeer{}, metricsPort),
+	}
+
+	if len(fromNamespaces) > 0 {
+		ingress = append(ingress, ingressRule(fromNamespaces, gRPCport))
+		ingress = append(ingress, ingressRule(fromNamespaces, wasmPort))
+	}
+
+	desiredPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployment.GetName(),
+			Namespace: deployment.GetNamespace(),
+			Labels:    CommonLabels(),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			PolicyTypes: []networkingv1.PolicyType{"Ingress"},
+			Ingress:     ingress,
+		},
+	}
+
+	policy, update := mergeNetworkPolicy(*desiredPolicy, existingPolicy)
+	checks.Update = update
+
+	updateRef, err := setOwnerRef(policy, existingPolicy, deployment)
+	if err != nil {
+		logger.Error(err, "error setting ownerRef on policy", "policy_name", policy.GetName())
+		errs = append(errs, err)
+	}
+
+	if updateRef {
+		checks.Update = updateRef
+	}
+
+	err = nil
+	if len(errs) > 0 {
+		err = errors.Join(errs...)
+	}
+
+	return response{Policy: policy, Check: checks}, err
+}
+
+func getManagerPortValue(name string, deployment *appsv1.Deployment) (int, error) {
+	// containerName is always manager in how we have operators configured.
+	containerName := "manager"
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == containerName {
+			for _, port := range container.Ports {
+				if port.Name == name {
+					return int(port.ContainerPort), nil
+				}
+			}
+		}
+	}
+	return 0, fmt.Errorf("no port value found")
+}
+
+func getRootDeployment(topology *machinery.Topology) *appsv1.Deployment {
+	deployments := getDeployments(topology)
+	for _, deployment := range deployments {
+		if deployment.GetName() == kuadrantOperatorDeployment {
+			return deployment
+		}
+	}
+	return nil
+}
+
+func getDeployments(topology *machinery.Topology) []*appsv1.Deployment {
+	deployments := topology.Objects().Items(func(object machinery.Object) bool {
+		return object.GroupVersionKind().GroupKind().Kind == v1beta1.DeploymentGroupKind.Kind
+	})
+
+	if deployments == nil {
+		return nil
+	}
+
+	output := make([]*appsv1.Deployment, len(deployments))
+
+	for idx, policy := range deployments {
+		p, ok := policy.(*controller.RuntimeObject).Object.(*appsv1.Deployment)
+		if ok && p != nil {
+			output[idx] = p
+		}
+	}
+
+	return output
+}
+
+func setOwnerRef(policy, existingPolicy *networkingv1.NetworkPolicy, deployment *appsv1.Deployment) (bool, error) {
+	if policy == nil {
+		return false, fmt.Errorf("nil policy found")
+	}
+
+	update := false
+	ownerRef := metav1.OwnerReference{
+		APIVersion:         deployment.GroupVersionKind().GroupVersion().String(),
+		Kind:               deployment.Kind,
+		Name:               deployment.GetName(),
+		UID:                deployment.GetUID(),
+		BlockOwnerDeletion: new(true),
+		Controller:         new(true),
+	}
+
+	if len(policy.GetOwnerReferences()) == 0 {
+		update = true
+	}
+
+	var existingOwnerRefs []metav1.OwnerReference
+
+	if existingPolicy != nil {
+		existingOwnerRefs = existingPolicy.GetOwnerReferences()
+	}
+	if !slices.ContainsFunc(existingOwnerRefs, func(ref metav1.OwnerReference) bool {
+		return ref.UID == ownerRef.UID
+	}) {
+		existingOwnerRefs = append(existingOwnerRefs, ownerRef)
+		update = true
+	}
+
+	policy.SetOwnerReferences(existingOwnerRefs)
+
+	return update, nil
+}
+
+func getExistingPolicy(deployment *appsv1.Deployment, topology *machinery.Topology) *networkingv1.NetworkPolicy {
+	policies := lo.FilterMap(topology.All().Children(&controller.RuntimeObject{Object: deployment}), func(child machinery.Object, _ int) (*networkingv1.NetworkPolicy, bool) {
+		if child.GroupVersionKind().GroupKind() != v1beta1.NetworkPolicyGroupKind || child.GetName() != deployment.GetName() {
+			return nil, false
+		}
+		runtimeObj, ok := child.(*controller.RuntimeObject)
+		if !ok {
+			return nil, false
+		}
+		policy, ok := runtimeObj.Object.(*networkingv1.NetworkPolicy)
+		return policy, ok
+	})
+
+	if len(policies) == 1 {
+		return policies[0]
+	}
+	return nil
+}

--- a/internal/controller/operator_networkpolicy_reconciler_test.go
+++ b/internal/controller/operator_networkpolicy_reconciler_test.go
@@ -1,0 +1,746 @@
+//go:build unit
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/kuadrant/policy-machinery/controller"
+	"github.com/kuadrant/policy-machinery/machinery"
+	"gotest.tools/assert"
+	is "gotest.tools/assert/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	kuadrantv1beta1 "github.com/kuadrant/kuadrant-operator/api/v1beta1"
+)
+
+func testLogger() logr.Logger {
+	return logr.Discard()
+}
+
+func TestNewNetworkPolicyReconcilerB(t *testing.T) {
+	t.Run("constructor returns non-nil", func(t *testing.T) {
+		reconciler := NewOperatorNetworkPolicyReconciler(nil)
+		assert.Assert(t, reconciler != nil)
+	})
+
+	t.Run("subscription has 2 events", func(t *testing.T) {
+		reconciler := NewOperatorNetworkPolicyReconciler(nil)
+		subscription := reconciler.Subscription()
+
+		assert.Assert(t, subscription != nil)
+		assert.Assert(t, is.Len(subscription.Events, 2))
+	})
+
+	t.Run("events match expected kinds", func(t *testing.T) {
+		reconciler := NewOperatorNetworkPolicyReconciler(nil)
+		subscription := reconciler.Subscription()
+		events := subscription.Events
+
+		assert.DeepEqual(t, events[0].Kind, &kuadrantv1beta1.NetworkPolicyGroupKind)
+		assert.DeepEqual(t, events[1].Kind, &kuadrantv1beta1.DeploymentGroupKind)
+	})
+}
+
+func TestGetManagerPortValue(t *testing.T) {
+	t.Run("port found", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "manager",
+								Ports: []corev1.ContainerPort{
+									{Name: "metrics", ContainerPort: 8080},
+									{Name: "grpc", ContainerPort: 50051},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		port, err := getManagerPortValue("metrics", deployment)
+		assert.NilError(t, err)
+		assert.Equal(t, port, 8080)
+
+		port, err = getManagerPortValue("grpc", deployment)
+		assert.NilError(t, err)
+		assert.Equal(t, port, 50051)
+	})
+
+	t.Run("port not found", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "manager",
+								Ports: []corev1.ContainerPort{},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := getManagerPortValue("metrics", deployment)
+		assert.ErrorContains(t, err, "no port value found")
+	})
+
+	t.Run("no manager container", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "sidecar",
+								Ports: []corev1.ContainerPort{
+									{Name: "metrics", ContainerPort: 8080},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := getManagerPortValue("metrics", deployment)
+		assert.ErrorContains(t, err, "no port value found")
+	})
+
+	t.Run("multiple containers only manager checked", func(t *testing.T) {
+		deployment := &appsv1.Deployment{
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "sidecar",
+								Ports: []corev1.ContainerPort{
+									{Name: "metrics", ContainerPort: 9999},
+								},
+							},
+							{
+								Name: "manager",
+								Ports: []corev1.ContainerPort{
+									{Name: "metrics", ContainerPort: 8080},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		port, err := getManagerPortValue("metrics", deployment)
+		assert.NilError(t, err)
+		assert.Equal(t, port, 8080)
+	})
+}
+
+func makeDeployment(name, namespace string, labels map[string]string, ports []corev1.ContainerPort) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+			UID:       types.UID(name + "-uid"),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "manager",
+							Ports: ports,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func makeTopologyWithDeployments(deployments []*appsv1.Deployment, gateways []*gatewayapiv1.Gateway) *machinery.Topology {
+	var objs []machinery.Object
+	for _, d := range deployments {
+		objs = append(objs, &controller.RuntimeObject{Object: d})
+	}
+
+	store := make(controller.Store)
+	for _, obj := range objs {
+		store[string(obj.(metav1.Object).GetUID())] = obj.(*controller.RuntimeObject)
+	}
+
+	opts := []machinery.TopologyOptionsFunc{
+		machinery.WithObjects(objs...),
+		machinery.WithLinks(kuadrantv1beta1.LinkDeploymentToNetworkPolicy(store)),
+		machinery.WithLinks(kuadrantv1beta1.LinkSubDeploymentsToKuadrantDeployment(store)),
+	}
+
+	for _, gw := range gateways {
+		opts = append(opts, machinery.WithTargetables(&machinery.Gateway{Gateway: gw}))
+	}
+
+	topology, _ := machinery.NewTopology(opts...)
+	return topology
+}
+
+func TestGetRootDeployment(t *testing.T) {
+	t.Run("finds kuadrant operator deployment", func(t *testing.T) {
+		kuadrantDeploy := makeDeployment(kuadrantOperatorDeployment, "kuadrant-system", map[string]string{"app": "kuadrant"}, nil)
+		otherDeploy := makeDeployment("other", "kuadrant-system", nil, nil)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{kuadrantDeploy, otherDeploy}, nil)
+
+		result := getRootDeployment(topology)
+		assert.Assert(t, result != nil)
+		assert.Equal(t, result.GetName(), kuadrantOperatorDeployment)
+	})
+
+	t.Run("returns nil when not found", func(t *testing.T) {
+		otherDeploy := makeDeployment("other", "kuadrant-system", nil, nil)
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{otherDeploy}, nil)
+
+		result := getRootDeployment(topology)
+		assert.Assert(t, result == nil)
+	})
+
+	t.Run("empty topology", func(t *testing.T) {
+		topology := makeTopologyWithDeployments(nil, nil)
+
+		result := getRootDeployment(topology)
+		assert.Assert(t, result == nil)
+	})
+}
+
+func TestGetDeployments(t *testing.T) {
+	t.Run("empty topology", func(t *testing.T) {
+		topology := makeTopologyWithDeployments(nil, nil)
+
+		result := getDeployments(topology)
+		assert.Assert(t, is.Len(result, 0))
+	})
+
+	t.Run("single deployment", func(t *testing.T) {
+		deploy := makeDeployment("test-deploy", "ns", nil, nil)
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deploy}, nil)
+
+		result := getDeployments(topology)
+		assert.Assert(t, is.Len(result, 1))
+		assert.Equal(t, result[0].GetName(), "test-deploy")
+	})
+
+	t.Run("multiple deployments", func(t *testing.T) {
+		d1 := makeDeployment("deploy-1", "ns", nil, nil)
+		d2 := makeDeployment("deploy-2", "ns", nil, nil)
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{d1, d2}, nil)
+
+		result := getDeployments(topology)
+		assert.Assert(t, is.Len(result, 2))
+	})
+}
+
+func TestSetOwnerRef(t *testing.T) {
+	t.Run("nil policy returns error", func(t *testing.T) {
+		deployment := makeDeployment("test", "ns", nil, nil)
+		_, err := setOwnerRef(nil, nil, deployment)
+		assert.ErrorContains(t, err, "nil policy found")
+	})
+
+	t.Run("new policy gets owner ref and update=true", func(t *testing.T) {
+		deployment := makeDeployment("test", "ns", nil, nil)
+		deployment.Kind = "Deployment"
+		policy := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "ns",
+			},
+		}
+
+		update, err := setOwnerRef(policy, nil, deployment)
+		assert.NilError(t, err)
+		assert.Assert(t, update, "should return update=true for new owner ref")
+		assert.Assert(t, is.Len(policy.GetOwnerReferences(), 1))
+		assert.Equal(t, policy.GetOwnerReferences()[0].Name, "test")
+	})
+
+	t.Run("existing policy with same owner ref - no duplicate added", func(t *testing.T) {
+		deployment := makeDeployment("test", "ns", nil, nil)
+		deployment.Kind = "Deployment"
+
+		existingPolicy := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "ns",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Name: "test",
+						UID:  types.UID("test-uid"),
+					},
+				},
+			},
+		}
+		policy := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "ns",
+			},
+		}
+
+		update, err := setOwnerRef(policy, existingPolicy, deployment)
+		assert.NilError(t, err)
+		// update is true because policy has no owner refs (line 380 check)
+		assert.Assert(t, update)
+		// but the ref should not be duplicated
+		assert.Assert(t, is.Len(policy.GetOwnerReferences(), 1))
+	})
+
+	t.Run("existing policy with different owner ref - appends", func(t *testing.T) {
+		deployment := makeDeployment("test", "ns", nil, nil)
+		deployment.Kind = "Deployment"
+
+		existingPolicy := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "ns",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Name: "other-owner",
+						UID:  types.UID("other-uid"),
+					},
+				},
+			},
+		}
+		policy := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "ns",
+			},
+		}
+
+		update, err := setOwnerRef(policy, existingPolicy, deployment)
+		assert.NilError(t, err)
+		assert.Assert(t, update, "should update when adding new owner ref")
+		assert.Assert(t, is.Len(policy.GetOwnerReferences(), 2))
+	})
+}
+
+func TestProcessDeployment(t *testing.T) {
+	logger := testLogger()
+	topology := makeTopologyWithDeployments(nil, nil)
+
+	t.Run("kuadrant operator deployment", func(t *testing.T) {
+		deployment := makeDeployment(kuadrantOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "kuadrant"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+				{Name: "grpc", ContainerPort: 50051},
+				{Name: "wasm", ContainerPort: 8082},
+			},
+		)
+
+		resp, err := processDeployment(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, resp.Policy != nil)
+		assert.Equal(t, resp.Policy.GetName(), kuadrantOperatorDeployment)
+	})
+
+	t.Run("authorino operator deployment", func(t *testing.T) {
+		deployment := makeDeployment(authorinoOperatorDeployment, "kuadrant-system",
+			map[string]string{"control-plane": "authorino-operator"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+			},
+		)
+
+		resp, err := processDeployment(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, resp.Policy != nil)
+		assert.Equal(t, resp.Policy.GetName(), authorinoOperatorDeployment)
+	})
+
+	t.Run("dns operator deployment", func(t *testing.T) {
+		deployment := makeDeployment(dnsOperatorDeployment, "kuadrant-system",
+			map[string]string{"control-plane": "dns-operator-controller-manager"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+			},
+		)
+
+		resp, err := processDeployment(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, resp.Policy != nil)
+		assert.Equal(t, resp.Policy.GetName(), dnsOperatorDeployment)
+	})
+
+	t.Run("limitador operator deployment", func(t *testing.T) {
+		deployment := makeDeployment(limitadorOperatorDeployment, "kuadrant-system",
+			map[string]string{"control-plane": "limitador-operator-controller-manager"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+			},
+		)
+
+		resp, err := processDeployment(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, resp.Policy != nil)
+		assert.Equal(t, resp.Policy.GetName(), limitadorOperatorDeployment)
+	})
+
+	t.Run("unknown deployment returns error", func(t *testing.T) {
+		deployment := makeDeployment("unknown-deployment", "kuadrant-system", nil, nil)
+
+		_, err := processDeployment(logger, deployment, topology)
+		assert.ErrorContains(t, err, "no default function found")
+	})
+}
+
+func TestCommonOperatorPolicy(t *testing.T) {
+	logger := testLogger()
+
+	t.Run("creates policy with metrics ingress rule", func(t *testing.T) {
+		deployment := makeDeployment(authorinoOperatorDeployment, "kuadrant-system",
+			map[string]string{"control-plane": "authorino-operator"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8443},
+			},
+		)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := commonOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, resp.Policy != nil)
+		assert.Equal(t, resp.Policy.GetName(), authorinoOperatorDeployment)
+		assert.Equal(t, resp.Policy.GetNamespace(), "kuadrant-system")
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress, 1), "should have one ingress rule for metrics")
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[0].Ports[0].Port, new(intstr.FromInt(8443)))
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress[0].From, 0), "metrics should not have peers")
+	})
+
+	t.Run("uses default metrics port when not found", func(t *testing.T) {
+		deployment := makeDeployment(dnsOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "dns"},
+			[]corev1.ContainerPort{},
+		)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := commonOperatorPolicy(logger, deployment, topology)
+		assert.Assert(t, err != nil, "should return error for missing port")
+		assert.Assert(t, resp.Policy != nil)
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[0].Ports[0].Port, new(intstr.FromInt(8080)))
+	})
+
+	t.Run("sets common labels", func(t *testing.T) {
+		deployment := makeDeployment(authorinoOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "authorino"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+			},
+		)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := commonOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+
+		commonLabels := CommonLabels()
+		for key, value := range commonLabels {
+			assert.Equal(t, resp.Policy.Labels[key], value, "common label %s should be set", key)
+		}
+	})
+
+	t.Run("uses pod template labels for pod selector", func(t *testing.T) {
+		podLabels := map[string]string{"app": "my-operator", "version": "v1"}
+		deployment := makeDeployment(authorinoOperatorDeployment, "kuadrant-system",
+			map[string]string{"different": "deployment-label"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+			},
+		)
+		deployment.Spec.Template.Labels = podLabels
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := commonOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, resp.Policy.Spec.PodSelector.MatchLabels, podLabels)
+	})
+
+	t.Run("nil deployment labels uses default", func(t *testing.T) {
+		deployment := makeDeployment(authorinoOperatorDeployment, "kuadrant-system",
+			nil,
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+			},
+		)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := commonOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, resp.Policy.Spec.PodSelector.MatchLabels, map[string]string{"kuadrant.io/managed": "true"})
+	})
+
+	t.Run("check flags set to create when no existing policy", func(t *testing.T) {
+		deployment := makeDeployment(authorinoOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "authorino"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+			},
+		)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := commonOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, resp.Check.Create, "should be set to create")
+	})
+
+	t.Run("check flags set to update when existing policy in topology", func(t *testing.T) {
+		deployment := makeDeployment(authorinoOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "authorino"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+			},
+		)
+
+		existingPolicy := &networkingv1.NetworkPolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "NetworkPolicy",
+				APIVersion: "networking.k8s.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      authorinoOperatorDeployment,
+				Namespace: "kuadrant-system",
+				UID:       "existing-policy-uid",
+				Labels:    CommonLabels(),
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "authorino"},
+				},
+				PolicyTypes: []networkingv1.PolicyType{"Ingress"},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					ingressRule([]networkingv1.NetworkPolicyPeer{}, 8080),
+				},
+			},
+		}
+
+		deploymentObj := &controller.RuntimeObject{Object: deployment}
+		policyObj := &controller.RuntimeObject{Object: existingPolicy}
+
+		store := make(controller.Store)
+		store[string(deploymentObj.GetUID())] = deploymentObj
+		store[string(policyObj.GetUID())] = policyObj
+
+		topology, err := machinery.NewTopology(
+			machinery.WithObjects(deploymentObj, policyObj),
+			machinery.WithLinks(kuadrantv1beta1.LinkDeploymentToNetworkPolicy(store)),
+		)
+		assert.NilError(t, err)
+
+		resp, err := commonOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, !resp.Check.Create, "should not create when policy exists")
+	})
+}
+
+func TestKuadrantOperatorPolicy(t *testing.T) {
+	logger := testLogger()
+
+	t.Run("creates policy with metrics only when no gateways", func(t *testing.T) {
+		deployment := makeDeployment(kuadrantOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "kuadrant"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+				{Name: "grpc", ContainerPort: 50051},
+				{Name: "wasm", ContainerPort: 8082},
+			},
+		)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := kuadrantOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, resp.Policy != nil)
+		assert.Equal(t, resp.Policy.GetName(), kuadrantOperatorDeployment)
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress, 1), "should have only metrics ingress without gateways")
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[0].Ports[0].Port, new(intstr.FromInt(8080)))
+	})
+
+	t.Run("creates policy with metrics, grpc, wasm when gateways present", func(t *testing.T) {
+		deployment := makeDeployment(kuadrantOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "kuadrant"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+				{Name: "grpc", ContainerPort: 50051},
+				{Name: "wasm", ContainerPort: 8082},
+			},
+		)
+
+		gateway := &gatewayapiv1.Gateway{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Gateway",
+				APIVersion: "gateway.networking.k8s.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gw1",
+				Namespace: "gateway-ns",
+			},
+		}
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, []*gatewayapiv1.Gateway{gateway})
+
+		resp, err := kuadrantOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress, 3), "should have 3 ingress rules with gateways")
+
+		// metrics - no peers
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[0].Ports[0].Port, new(intstr.FromInt(8080)))
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress[0].From, 0), "metrics should not have peers")
+
+		// grpc - gateway peers
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[1].Ports[0].Port, new(intstr.FromInt(50051)))
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress[1].From, 1), "grpc should have gateway peer")
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[1].From[0].NamespaceSelector.MatchLabels,
+			map[string]string{"kubernetes.io/metadata.name": "gateway-ns"})
+
+		// wasm - gateway peers
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[2].Ports[0].Port, new(intstr.FromInt(8082)))
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress[2].From, 1), "wasm should have gateway peer")
+	})
+
+	t.Run("uses default ports when container ports missing", func(t *testing.T) {
+		deployment := makeDeployment(kuadrantOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "kuadrant"},
+			[]corev1.ContainerPort{},
+		)
+
+		gateway := &gatewayapiv1.Gateway{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Gateway",
+				APIVersion: "gateway.networking.k8s.io/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gw1",
+				Namespace: "gateway-ns",
+			},
+		}
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, []*gatewayapiv1.Gateway{gateway})
+
+		resp, err := kuadrantOperatorPolicy(logger, deployment, topology)
+		assert.Assert(t, err != nil, "should return errors for missing ports")
+		assert.Assert(t, resp.Policy != nil)
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress, 3))
+
+		// defaults: metrics=8080, grpc=50051, wasm=8082
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[0].Ports[0].Port, new(intstr.FromInt(8080)))
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[1].Ports[0].Port, new(intstr.FromInt(50051)))
+		assert.DeepEqual(t, resp.Policy.Spec.Ingress[2].Ports[0].Port, new(intstr.FromInt(8082)))
+	})
+
+	t.Run("multiple gateways different namespaces", func(t *testing.T) {
+		deployment := makeDeployment(kuadrantOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "kuadrant"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+				{Name: "grpc", ContainerPort: 50051},
+				{Name: "wasm", ContainerPort: 8082},
+			},
+		)
+
+		gw1 := &gatewayapiv1.Gateway{
+			TypeMeta:   metav1.TypeMeta{Kind: "Gateway", APIVersion: "gateway.networking.k8s.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "gw1", Namespace: "ns1"},
+		}
+		gw2 := &gatewayapiv1.Gateway{
+			TypeMeta:   metav1.TypeMeta{Kind: "Gateway", APIVersion: "gateway.networking.k8s.io/v1"},
+			ObjectMeta: metav1.ObjectMeta{Name: "gw2", Namespace: "ns2"},
+		}
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, []*gatewayapiv1.Gateway{gw1, gw2})
+
+		resp, err := kuadrantOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+
+		// grpc and wasm rules should both have 2 peers
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress[1].From, 2), "grpc should have 2 gateway peers")
+		assert.Assert(t, is.Len(resp.Policy.Spec.Ingress[2].From, 2), "wasm should have 2 gateway peers")
+	})
+
+	t.Run("sets common labels", func(t *testing.T) {
+		deployment := makeDeployment(kuadrantOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "kuadrant"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+				{Name: "grpc", ContainerPort: 50051},
+				{Name: "wasm", ContainerPort: 8082},
+			},
+		)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := kuadrantOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+
+		commonLabels := CommonLabels()
+		for key, value := range commonLabels {
+			assert.Equal(t, resp.Policy.Labels[key], value, "common label %s should be set", key)
+		}
+	})
+
+	t.Run("nil deployment labels uses default", func(t *testing.T) {
+		deployment := makeDeployment(kuadrantOperatorDeployment, "kuadrant-system",
+			nil,
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+				{Name: "grpc", ContainerPort: 50051},
+				{Name: "wasm", ContainerPort: 8082},
+			},
+		)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := kuadrantOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, resp.Policy.Spec.PodSelector.MatchLabels, map[string]string{"kuadrant.io/managed": "true"})
+	})
+
+	t.Run("sets Ingress policy type", func(t *testing.T) {
+		deployment := makeDeployment(kuadrantOperatorDeployment, "kuadrant-system",
+			map[string]string{"app": "kuadrant"},
+			[]corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 8080},
+				{Name: "grpc", ContainerPort: 50051},
+				{Name: "wasm", ContainerPort: 8082},
+			},
+		)
+
+		topology := makeTopologyWithDeployments([]*appsv1.Deployment{deployment}, nil)
+
+		resp, err := kuadrantOperatorPolicy(logger, deployment, topology)
+		assert.NilError(t, err)
+		assert.Assert(t, is.Len(resp.Policy.Spec.PolicyTypes, 1))
+		assert.Equal(t, resp.Policy.Spec.PolicyTypes[0], networkingv1.PolicyType("Ingress"))
+	})
+}

--- a/internal/controller/state_of_the_world.go
+++ b/internal/controller/state_of_the_world.go
@@ -165,6 +165,34 @@ func NewPolicyMachineryController(manager ctrlruntime.Manager, client *dynamic.D
 			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*appsv1.Deployment]{}),
 			controller.FilterResourcesByField[*appsv1.Deployment]("metadata.name=authorino"),
 		)),
+		controller.WithRunnable("kuadrant-operator deployment watcher", controller.Watch(
+			&appsv1.Deployment{},
+			kuadrantv1beta1.DeploymentsResource,
+			metav1.NamespaceAll,
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*appsv1.Deployment]{}),
+			controller.FilterResourcesByLabel[*appsv1.Deployment]("app=kuadrant"),
+		)),
+		controller.WithRunnable("dns-operator deployment watcher", controller.Watch(
+			&appsv1.Deployment{},
+			kuadrantv1beta1.DeploymentsResource,
+			metav1.NamespaceAll,
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*appsv1.Deployment]{}),
+			controller.FilterResourcesByLabel[*appsv1.Deployment]("control-plane=dns-operator-controller-manager"),
+		)),
+		controller.WithRunnable("authorino-operator deployment watcher", controller.Watch(
+			&appsv1.Deployment{},
+			kuadrantv1beta1.DeploymentsResource,
+			metav1.NamespaceAll,
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*appsv1.Deployment]{}),
+			controller.FilterResourcesByField[*appsv1.Deployment]("metadata.name=authorino-operator"),
+		)),
+		controller.WithRunnable("limitador-operator deployment watcher", controller.Watch(
+			&appsv1.Deployment{},
+			kuadrantv1beta1.DeploymentsResource,
+			metav1.NamespaceAll,
+			controller.WithPredicates(&ctrlruntimepredicate.TypedGenerationChangedPredicate[*appsv1.Deployment]{}),
+			controller.FilterResourcesByField[*appsv1.Deployment]("metadata.name=limitador-operator-controller-manager"),
+		)),
 		controller.WithRunnable("networkPolicy watcher", controller.Watch(
 			&networkingv1.NetworkPolicy{},
 			kuadrantv1beta1.NetworkPolicyResource,
@@ -187,6 +215,8 @@ func NewPolicyMachineryController(manager ctrlruntime.Manager, client *dynamic.D
 		),
 		controller.WithObjectLinks(
 			kuadrantv1beta1.LinkKuadrantToGatewayClasses,
+			kuadrantv1beta1.LinkDeploymentToNetworkPolicy,
+			kuadrantv1beta1.LinkSubDeploymentsToKuadrantDeployment,
 		),
 	}
 
@@ -832,6 +862,7 @@ func (b *BootOptionsBuilder) Reconciler() controller.ReconcileFunc {
 			traceReconcileFunc("workflow.observability", NewObservabilityReconciler(b.client, b.manager, operatorNamespace).Subscription().Reconcile),
 			traceReconcileFunc("workflow.developer_portal", NewDeveloperPortalReconciler(b.manager).Subscription().Reconcile),
 			traceReconcileFunc("workflow.networkpolicy", NewNetworkPolicyReconciler(b.client).Subscription().Reconcile),
+			traceReconcileFunc("workflow.networkpolicyB", NewOperatorNetworkPolicyReconciler(b.client).Subscription().Reconcile),
 		},
 		Postcondition: traceReconcileFunc("workflow.finalize", b.finalStepsWorkflow().Run),
 	}


### PR DESCRIPTION
# Summary

- Adds a new `OperatorNetworkPolicyReconciler` that creates and manages Kubernetes NetworkPolicy resources for the Kuadrant operator control plane deployments (kuadrant-operator, authorino-operator, dns-operator, limitador-operator)
- The kuadrant-operator deployment gets ingress rules for metrics (open), gRPC, and wasm ports (restricted to gateway namespaces), while sub-operator deployments only expose a metrics port
- Deployment watchers are registered for each operator deployment so the reconciler reacts to deployment lifecycle events
- Topology links connect operator deployments to their network policies and establish a parent-child relationship between the kuadrant-operator deployment and the sub-operator deployments
- Ports are read dynamically from the deployment container spec with sensible defaults if not found
- Owner references are set on each NetworkPolicy pointing to its corresponding deployment for garbage collection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic network policy management for Kuadrant operator deployments.
  - Network policies now secure metrics traffic for supported operators.
  - Kuadrant operator policies also support gRPC and WebAssembly traffic where required.
  - Gateway namespace access is configured automatically for relevant traffic.
  - Policies are created or updated as deployments and their associated resources change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->