### PR TITLE
chore(deps): update mcp-gateway chart on main to caf6847

### DIFF
--- a/component-charts/mcp-gateway/templates/rbac.yaml
+++ b/component-charts/mcp-gateway/templates/rbac.yaml
@@ -29,6 +29,14 @@ rules:
       - update
       - watch
   - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - deployments

--- a/component-charts/sync.yaml
+++ b/component-charts/sync.yaml
@@ -32,5 +32,5 @@ components:
     repo: Kuadrant/mcp-gateway
     chart-path: charts/mcp-gateway
     tracked-branch: main
-    ref: 9552329dcf51846db61befe32d08c7b38d26c9af
+    ref: caf684710a73979dc9704807ce33eeaebc293420
     auto-merge: false


### PR DESCRIPTION
Sync mcp-gateway chart from upstream into `main`.

**Component:** mcp-gateway
**Target branch:** `main`
**Previous ref:** `9552329dcf51846db61befe32d08c7b38d26c9af`
**New ref:** `caf684710a73979dc9704807ce33eeaebc293420`
**Triggered by:** @Patryk-Stefanski (approved by @david-martin) via https://github.com/Kuadrant/mcp-gateway/pull/1476 (https://github.com/Kuadrant/mcp-gateway/commit/caf684710a73979dc9704807ce33eeaebc293420)

[Upstream changes](https://github.com/Kuadrant/mcp-gateway/compare/9552329dcf51846db61befe32d08c7b38d26c9af...caf684710a73979dc9704807ce33eeaebc293420)

Auto-generated by https://github.com/Kuadrant/kuadrant-operator/actions/runs/34130951618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved controller access to Kubernetes custom resource definitions, supporting more reliable operation across cluster environments.

- **Maintenance**
  - Updated the bundled MCP Gateway Helm chart to a newer verified revision, incorporating the latest available chart changes and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->