### PR TITLE
Own deployer-applied resources with KuadrantControlPlane

### DIFF
--- a/api/v1alpha1/kuadrantcontrolplane_types.go
+++ b/api/v1alpha1/kuadrantcontrolplane_types.go
@@ -23,8 +23,11 @@ const (
 //+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // KuadrantControlPlane manages the lifecycle of Kuadrant component operators.
-// The operator auto-creates a singleton named "default" on startup.
-// Deleting this resource is a no-op — the operator re-creates it immediately.
+// The operator auto-creates a singleton named "default" once at manager
+// startup. Every resource the deployer applies (except CRDs) is owned by
+// this CR, so deleting it cascade-deletes all managed components; it's
+// re-created only on the next manager restart, not by the ongoing reconcile
+// loop.
 type KuadrantControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kuadrant-operator.clusterserviceversion.yaml
@@ -801,6 +801,7 @@ spec:
           - clusterroles
           verbs:
           - bind
+          - delete
           - escalate
           - get
           - patch

--- a/bundle/manifests/kuadrant.io_kuadrantcontrolplanes.yaml
+++ b/bundle/manifests/kuadrant.io_kuadrantcontrolplanes.yaml
@@ -33,8 +33,11 @@ spec:
       openAPIV3Schema:
         description: |-
           KuadrantControlPlane manages the lifecycle of Kuadrant component operators.
-          The operator auto-creates a singleton named "default" on startup.
-          Deleting this resource is a no-op — the operator re-creates it immediately.
+          The operator auto-creates a singleton named "default" once at manager
+          startup. Every resource the deployer applies (except CRDs) is owned by
+          this CR, so deleting it cascade-deletes all managed components; it's
+          re-created only on the next manager restart, not by the ongoing reconcile
+          loop.
         properties:
           apiVersion:
             description: |-

--- a/charts/kuadrant-operator/templates/manifests.yaml
+++ b/charts/kuadrant-operator/templates/manifests.yaml
@@ -11580,8 +11580,11 @@ spec:
       openAPIV3Schema:
         description: |-
           KuadrantControlPlane manages the lifecycle of Kuadrant component operators.
-          The operator auto-creates a singleton named "default" on startup.
-          Deleting this resource is a no-op — the operator re-creates it immediately.
+          The operator auto-creates a singleton named "default" once at manager
+          startup. Every resource the deployer applies (except CRDs) is owned by
+          this CR, so deleting it cascade-deletes all managed components; it's
+          re-created only on the next manager restart, not by the ongoing reconcile
+          loop.
         properties:
           apiVersion:
             description: |-
@@ -14873,6 +14876,7 @@ rules:
   - clusterroles
   verbs:
   - bind
+  - delete
   - escalate
   - get
   - patch

--- a/config/crd/bases/kuadrant.io_kuadrantcontrolplanes.yaml
+++ b/config/crd/bases/kuadrant.io_kuadrantcontrolplanes.yaml
@@ -31,8 +31,11 @@ spec:
       openAPIV3Schema:
         description: |-
           KuadrantControlPlane manages the lifecycle of Kuadrant component operators.
-          The operator auto-creates a singleton named "default" on startup.
-          Deleting this resource is a no-op — the operator re-creates it immediately.
+          The operator auto-creates a singleton named "default" once at manager
+          startup. Every resource the deployer applies (except CRDs) is owned by
+          this CR, so deleting it cascade-deletes all managed components; it's
+          re-created only on the next manager restart, not by the ongoing reconcile
+          loop.
         properties:
           apiVersion:
             description: |-

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -408,6 +408,7 @@ rules:
   - clusterroles
   verbs:
   - bind
+  - delete
   - escalate
   - get
   - patch

--- a/internal/controlplane/bootstrap.go
+++ b/internal/controlplane/bootstrap.go
@@ -17,8 +17,9 @@ import (
 )
 
 // BootstrapRunnable executes one-time startup tasks after the manager starts
-// and leader election is acquired. It ensures the default KuadrantControlPlane
-// CR exists and cleans up orphaned OLM resources from pre-consolidation installs.
+// and leader election is acquired. It is the sole place that creates the
+// default KuadrantControlPlane CR if missing. It also cleans up
+// orphaned OLM resources from pre-consolidation installs.
 type BootstrapRunnable struct {
 	restConfig *rest.Config
 	scheme     *runtime.Scheme

--- a/internal/controlplane/deployer.go
+++ b/internal/controlplane/deployer.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -172,7 +173,7 @@ func (d *Deployer) ApplyCRDsForComponents(ctx context.Context, components []Comp
 		}
 
 		d.logger.Info("applying CRDs", "component", component.Name, "count", len(rendered.CRDs))
-		if err := applier.ApplyResources(ctx, rendered.CRDs); err != nil {
+		if err := applier.ApplyResources(ctx, rendered.CRDs, nil); err != nil {
 			return fmt.Errorf("applying CRDs for %s: %w", component.Name, err)
 		}
 		if err := applier.WaitForCRDs(ctx, CRDNames(rendered.CRDs)); err != nil {
@@ -182,7 +183,11 @@ func (d *Deployer) ApplyCRDsForComponents(ctx context.Context, components []Comp
 	return nil
 }
 
-func (d *Deployer) DeployComponent(ctx context.Context, component Component) error {
+// DeployComponent renders and applies a single component's chart. ownerRef,
+// if non-nil, is set on every applied resource except CRDs (see
+// ApplyResources), so deleting the KuadrantControlPlane CR cascade-deletes
+// everything the deployer created for this component.
+func (d *Deployer) DeployComponent(ctx context.Context, component Component, ownerRef *metav1.OwnerReference) error {
 	applier := d.applier
 
 	rendered, err := d.renderComponent(component)
@@ -193,7 +198,7 @@ func (d *Deployer) DeployComponent(ctx context.Context, component Component) err
 	d.chartVersions[component.Name] = rendered.ChartVersion
 
 	if len(rendered.CRDs) > 0 {
-		if err := applier.ApplyResources(ctx, rendered.CRDs); err != nil {
+		if err := applier.ApplyResources(ctx, rendered.CRDs, nil); err != nil {
 			return fmt.Errorf("applying CRDs for %s: %w", component.Name, err)
 		}
 		if err := applier.WaitForCRDs(ctx, CRDNames(rendered.CRDs)); err != nil {
@@ -213,7 +218,7 @@ func (d *Deployer) DeployComponent(ctx context.Context, component Component) err
 
 	d.deployedImages[component.Name] = extractDeploymentImages(rendered.Resources)
 
-	if err := applier.ApplyResources(ctx, rendered.Resources); err != nil {
+	if err := applier.ApplyResources(ctx, rendered.Resources, ownerRef); err != nil {
 		return fmt.Errorf("applying resources for %s: %w", component.Name, err)
 	}
 

--- a/internal/controlplane/kuadrant_control_plane_controller.go
+++ b/internal/controlplane/kuadrant_control_plane_controller.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,7 +33,7 @@ const requeueInterval = 5 * time.Minute
 
 // Component deployer RBAC — ClusterRole management
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=dns-operator-manager-role;dns-operator-remote-cluster-role;mcp-gateway-controller,verbs=get;update;patch;bind;escalate
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,resourceNames=dns-operator-manager-role;dns-operator-remote-cluster-role;mcp-gateway-controller,verbs=delete;get;update;patch;bind;escalate
 
 // Component deployer RBAC — ClusterRoleBinding management
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create
@@ -72,8 +73,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	cp := &kuadrantv1alpha1.KuadrantControlPlane{}
 	if err := r.Get(ctx, req.NamespacedName, cp); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.logger.Info("KuadrantControlPlane deleted, re-creating")
-			return r.ensureDefaultCR(ctx)
+			r.logger.Info("KuadrantControlPlane not found")
+			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
@@ -83,7 +84,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
-	deployErr := deployComponents(ctx, r.deployer.EnabledComponents(), r.deployer.DeployComponent, func(component Component, err error) {
+	ownerRef := kcpOwnerReference(cp)
+	deploy := func(ctx context.Context, component Component) error {
+		return r.deployer.DeployComponent(ctx, component, ownerRef)
+	}
+	deployErr := deployComponents(ctx, r.deployer.EnabledComponents(), deploy, func(component Component, err error) {
 		r.logger.Error(err, "failed to deploy component", "component", component.Name)
 		if r.recorder != nil {
 			r.recorder.Eventf(cp, componentReference(component.Name), corev1.EventTypeWarning, "ComponentDeployFailed", "ComponentDeploy", "failed to deploy component %s: %s", component.Name, err)
@@ -173,11 +178,18 @@ func (r *Reconciler) childDeploymentPredicate() predicate.Predicate {
 	})
 }
 
-func (r *Reconciler) ensureDefaultCR(ctx context.Context) (ctrl.Result, error) {
-	if err := ensureDefaultControlPlane(ctx, r.Client, r.recorder, r.logger); err != nil {
-		return ctrl.Result{}, err
+// kcpOwnerReference builds the ownerReference set on every resource the
+// deployer applies for cp, except CRDs (see ResourceApplier.ApplyResources).
+// KuadrantControlPlane is cluster-scoped, so it can own both namespaced
+// and cluster-scoped child resources.
+func kcpOwnerReference(cp *kuadrantv1alpha1.KuadrantControlPlane) *metav1.OwnerReference {
+	return &metav1.OwnerReference{
+		APIVersion: kuadrantv1alpha1.GroupVersion.String(),
+		Kind:       "KuadrantControlPlane",
+		Name:       cp.Name,
+		UID:        cp.UID,
+		Controller: ptr.To(true),
 	}
-	return ctrl.Result{RequeueAfter: time.Second}, nil
 }
 
 func ensureDefaultControlPlane(ctx context.Context, c client.Client, recorder events.EventRecorder, logger logr.Logger) error {

--- a/internal/controlplane/kuadrant_control_plane_controller_test.go
+++ b/internal/controlplane/kuadrant_control_plane_controller_test.go
@@ -7,6 +7,15 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kuadrantv1alpha1 "github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 )
 
 func TestEnabledComponents_ReturnsAllComponents(t *testing.T) {
@@ -100,6 +109,65 @@ func TestGetImageStatuses(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestKCPOwnerReference(t *testing.T) {
+	cp := &kuadrantv1alpha1.KuadrantControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kuadrantv1alpha1.KuadrantControlPlaneDefaultName,
+			UID:  "test-uid",
+		},
+	}
+
+	ref := kcpOwnerReference(cp)
+
+	if ref.APIVersion != kuadrantv1alpha1.GroupVersion.String() {
+		t.Errorf("APIVersion = %q, want %q", ref.APIVersion, kuadrantv1alpha1.GroupVersion.String())
+	}
+	if ref.Kind != "KuadrantControlPlane" {
+		t.Errorf("Kind = %q, want %q", ref.Kind, "KuadrantControlPlane")
+	}
+	if ref.Name != cp.Name {
+		t.Errorf("Name = %q, want %q", ref.Name, cp.Name)
+	}
+	if ref.UID != cp.UID {
+		t.Errorf("UID = %q, want %q", ref.UID, cp.UID)
+	}
+	if ref.Controller == nil || !*ref.Controller {
+		t.Error("Controller = false or nil, want true")
+	}
+	if ref.BlockOwnerDeletion != nil {
+		t.Errorf("BlockOwnerDeletion = %v, want nil (requires finalizers RBAC on the owner we don't have or need)", *ref.BlockOwnerDeletion)
+	}
+}
+
+func TestReconcile_MissingKCP_DoesNotRecreate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := kuadrantv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme() error = %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{
+		Client:   fakeClient,
+		deployer: &Deployer{components: nil},
+	}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: kuadrantv1alpha1.KuadrantControlPlaneDefaultName},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("RequeueAfter = %v, want 0 (no self-heal requeue)", res.RequeueAfter)
+	}
+
+	cp := &kuadrantv1alpha1.KuadrantControlPlane{}
+	err = fakeClient.Get(context.Background(), client.ObjectKey{Name: kuadrantv1alpha1.KuadrantControlPlaneDefaultName}, cp)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected KuadrantControlPlane to remain absent, got error = %v", err)
 	}
 }
 

--- a/internal/controlplane/resources.go
+++ b/internal/controlplane/resources.go
@@ -82,20 +82,27 @@ func kindOrder(kind string) int {
 	return len(installOrder)
 }
 
-func (a *ResourceApplier) ApplyResources(ctx context.Context, objects []*unstructured.Unstructured) error {
+// ApplyResources applies each object via server-side apply. If ownerRef is
+// non-nil, it's set on every object first, so deleting the owner (the
+// KuadrantControlPlane CR) cascade-deletes everything the deployer applied.
+func (a *ResourceApplier) ApplyResources(ctx context.Context, objects []*unstructured.Unstructured, ownerRef *metav1.OwnerReference) error {
 	for _, obj := range objects {
-		if err := a.applyResource(ctx, obj); err != nil {
+		if err := a.applyResource(ctx, obj, ownerRef); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (a *ResourceApplier) applyResource(ctx context.Context, obj *unstructured.Unstructured) error {
+func (a *ResourceApplier) applyResource(ctx context.Context, obj *unstructured.Unstructured, ownerRef *metav1.OwnerReference) error {
 	gvk := obj.GroupVersionKind()
 	mapping, err := a.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return fmt.Errorf("mapping GVK %s: %w", gvk, err)
+	}
+
+	if ownerRef != nil {
+		obj.SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
 	}
 
 	var rc dynamic.ResourceInterface

--- a/internal/controlplane/resources_test.go
+++ b/internal/controlplane/resources_test.go
@@ -3,9 +3,17 @@
 package controlplane
 
 import (
+	"context"
 	"testing"
 
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
 func newUnstructured(kind, name string) *unstructured.Unstructured {
@@ -182,6 +190,70 @@ func TestPatchDeploymentImage(t *testing.T) {
 				got := container["image"].(string)
 				if got != tt.wantImage {
 					t.Errorf("image = %q, want %q", got, tt.wantImage)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyResources_OwnerReference(t *testing.T) {
+	ownerRef := &metav1.OwnerReference{
+		APIVersion: "kuadrant.io/v1alpha1",
+		Kind:       "KuadrantControlPlane",
+		Name:       "default",
+		UID:        "test-uid",
+	}
+
+	tests := []struct {
+		name       string
+		object     *unstructured.Unstructured
+		ownerRef   *metav1.OwnerReference
+		wantOwners int
+	}{
+		{
+			name:       "sets ownerReference when provided",
+			object:     newUnstructured("ServiceAccount", "test-sa"),
+			ownerRef:   ownerRef,
+			wantOwners: 1,
+		},
+		{
+			name:       "leaves no ownerReference when nil (CRDs)",
+			object:     newUnstructured("ServiceAccount", "test-sa"),
+			ownerRef:   nil,
+			wantOwners: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			_ = appsv1.AddToScheme(scheme)
+
+			client := dynamicfake.NewSimpleDynamicClient(scheme)
+			applier := &ResourceApplier{
+				client:    client,
+				mapper:    testrestmapper.TestOnlyStaticRESTMapper(scheme),
+				logger:    logr.Discard(),
+				namespace: "kuadrant-system",
+			}
+
+			// The fake dynamic client's server-side apply support can't
+			// round-trip a plain *unstructured.Unstructured (it needs a
+			// registered Go type to structurally merge against), so the
+			// apply call itself is expected to error here. That's not what
+			// this test checks: applyResource sets ownerRef on obj before
+			// ever calling Apply, so the mutation is observable regardless.
+			_ = applier.ApplyResources(context.Background(), []*unstructured.Unstructured{tt.object}, tt.ownerRef)
+
+			refs, _, _ := unstructured.NestedSlice(tt.object.Object, "metadata", "ownerReferences")
+			if len(refs) != tt.wantOwners {
+				t.Fatalf("ownerReferences = %v, want %d entries", refs, tt.wantOwners)
+			}
+			if tt.wantOwners > 0 {
+				ref := refs[0].(map[string]interface{})
+				if ref["name"] != ownerRef.Name || ref["uid"] != string(ownerRef.UID) {
+					t.Errorf("ownerReference = %v, want name=%q uid=%q", ref, ownerRef.Name, ownerRef.UID)
 				}
 			}
 		})

--- a/tests/common/controlplane/controlplane_controller_test.go
+++ b/tests/common/controlplane/controlplane_controller_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,6 +93,25 @@ var _ = Describe("KuadrantControlPlane controller", Serial, func() {
 					Namespace: operatorNamespace,
 					Name:      dnsOperatorDeployment,
 				}, deploy)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+
+		It("sets a controller ownerReference to the KuadrantControlPlane on dns-operator Deployment", func(ctx SpecContext) {
+			cp := &kuadrantv1alpha1.KuadrantControlPlane{}
+			Expect(testClient().Get(ctx, client.ObjectKey{Name: kuadrantv1alpha1.KuadrantControlPlaneDefaultName}, cp)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				deploy := &appsv1.Deployment{}
+				g.Expect(testClient().Get(ctx, client.ObjectKey{
+					Namespace: operatorNamespace,
+					Name:      dnsOperatorDeployment,
+				}, deploy)).To(Succeed())
+
+				owner := metav1.GetControllerOf(deploy)
+				g.Expect(owner).ToNot(BeNil())
+				g.Expect(owner.Kind).To(Equal("KuadrantControlPlane"))
+				g.Expect(owner.Name).To(Equal(cp.Name))
+				g.Expect(owner.UID).To(Equal(cp.GetUID()))
 			}).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
 	})
@@ -187,46 +207,62 @@ var _ = Describe("KuadrantControlPlane controller", Serial, func() {
 
 	})
 
-	Context("self-healing on deletion", func() {
-		It("re-creates KuadrantControlPlane CR when deleted", func(ctx SpecContext) {
+	Context("deletion", func() {
+		It("does not recreate KuadrantControlPlane CR when deleted", func(ctx SpecContext) {
 			cpKey := client.ObjectKey{Name: kuadrantv1alpha1.KuadrantControlPlaneDefaultName}
 
 			cp := &kuadrantv1alpha1.KuadrantControlPlane{}
 			Expect(testClient().Get(ctx, cpKey, cp)).To(Succeed())
-			originalUID := cp.GetUID()
 
 			Expect(testClient().Delete(ctx, cp)).To(Succeed())
 
-			Eventually(func(g Gomega) {
-				recreated := &kuadrantv1alpha1.KuadrantControlPlane{}
-				g.Expect(testClient().Get(ctx, cpKey, recreated)).To(Succeed())
-				g.Expect(recreated.GetUID()).ToNot(Equal(originalUID), "expected a new CR, not the old one")
-			}).WithContext(ctx).Should(Succeed())
+			// The reconcile loop no longer self-heals a deleted CR -- only the
+			// one-shot BootstrapRunnable creates it, at manager startup. Since
+			// the manager is already running for the whole test suite, deleting
+			// it here must not bring it back on its own.
+			Consistently(func(g Gomega) {
+				got := &kuadrantv1alpha1.KuadrantControlPlane{}
+				err := testClient().Get(ctx, cpKey, got)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected KuadrantControlPlane to remain deleted, got error: %v", err)
+			}, 5*time.Second, 1*time.Second).WithContext(ctx).Should(Succeed())
 		}, testTimeOut)
 
-		It("child Deployments survive KuadrantControlPlane deletion", func(ctx SpecContext) {
+		It("cascade-deletes child Deployments when KuadrantControlPlane is deleted", func(ctx SpecContext) {
 			deployKey := client.ObjectKey{Namespace: operatorNamespace, Name: dnsOperatorDeployment}
 
-			// Ensure dns-operator is running and capture its UID
-			var originalUID types.UID
+			// Ensure dns-operator is running and owned by the KuadrantControlPlane
+			var cpUID types.UID
 			Eventually(func(g Gomega) {
 				deploy := &appsv1.Deployment{}
 				g.Expect(testClient().Get(ctx, deployKey, deploy)).To(Succeed())
 				g.Expect(deploy.Status.ReadyReplicas).To(BeNumerically(">", 0))
-				originalUID = deploy.GetUID()
+
+				owner := metav1.GetControllerOf(deploy)
+				g.Expect(owner).ToNot(BeNil(), "expected dns-operator Deployment to have a controller ownerReference")
+				g.Expect(owner.Kind).To(Equal("KuadrantControlPlane"))
+				cpUID = owner.UID
 			}).WithContext(ctx).Should(Succeed())
 
-			// Delete the CR
 			cp := &kuadrantv1alpha1.KuadrantControlPlane{}
 			Expect(testClient().Get(ctx, client.ObjectKey{Name: kuadrantv1alpha1.KuadrantControlPlaneDefaultName}, cp)).To(Succeed())
+			Expect(cp.GetUID()).To(Equal(cpUID), "expected Deployment to be owned by the current KuadrantControlPlane instance")
 			Expect(testClient().Delete(ctx, cp)).To(Succeed())
 
-			// Deployment should still exist with the same UID (preserved, not recreated)
-			Consistently(func(g Gomega) {
+			// Garbage collection cascade-deletes the Deployment once its owner is gone.
+			Eventually(func(g Gomega) {
 				deploy := &appsv1.Deployment{}
-				g.Expect(testClient().Get(ctx, deployKey, deploy)).To(Succeed())
-				g.Expect(deploy.GetUID()).To(Equal(originalUID))
-			}, 5*time.Second, 1*time.Second).WithContext(ctx).Should(Succeed())
+				err := testClient().Get(ctx, deployKey, deploy)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected dns-operator Deployment to be cascade-deleted, got error: %v", err)
+			}).WithContext(ctx).Should(Succeed())
+		}, testTimeOut)
+
+		It("does not set an ownerReference on CRDs", func(ctx SpecContext) {
+			// Deleting a CRD deletes every custom resource of that type
+			// cluster-wide, so CRDs must never be tied to the KCP's lifecycle
+			// regardless of what happens to Deployments/Services/etc.
+			crd := &apiextensionsv1.CustomResourceDefinition{}
+			Expect(testClient().Get(ctx, client.ObjectKey{Name: "dnsrecords.kuadrant.io"}, crd)).To(Succeed())
+			Expect(crd.OwnerReferences).To(BeEmpty(), "CRDs must not have owner references")
 		}, testTimeOut)
 	})
 


### PR DESCRIPTION
## Summary

- Set an `ownerReference` from the `KuadrantControlPlane` CR onto every resource the deployer applies, except CRDs (deleting a CRD deletes every custom resource of that type cluster-wide, so CRDs must never be owned by the KCP). Deleting the KCP now cascade-deletes the resources it manages.
- Drop `KuadrantControlPlane` self-heal from the reconcile loop. `BootstrapRunnable` is now the sole place that creates the default CR, and only once at manager startup — a deleted KCP is no longer immediately recreated by the watch-driven reconcile loop.
- Add `delete` to the `clusterroles` RBAC marker: setting an `ownerReference` on a resource requires `delete` permission on that resource type (`OwnerReferencesPermissionEnforcement` admission).
- Leave `BlockOwnerDeletion` unset on the ownerReference: setting it to `true` would require `update` permission on `kuadrantcontrolplanes/finalizers`, which isn't needed since the KCP carries no finalizer.

Closes #2219

## Test plan

- [x] `make test-unit` — new/updated coverage in `internal/controlplane/resources_test.go` and `internal/controlplane/kuadrant_control_plane_controller_test.go`
- [x] `make run-lint`
- [x] Manual verification against a local cluster:
  1. `make local-env-setup`
  2. `make run`
  3. Watch the `KuadrantControlPlane` CR get created (`kubectl get kcp default -w`)
  4. Check the deployed component Deployments exist and are owned by the KCP (`kubectl get deploy -n kuadrant-system -o yaml` — confirm `metadata.ownerReferences` points at the KCP)
  5. Delete the KCP (`kubectl delete kcp default`)
  6. Check the component Deployments are gone (cascade-deleted via the ownerReference)
  7. Restart the operator (`make run` again)
  8. Check the KCP comes back (re-created once by `BootstrapRunnable` at startup) and the component Deployments are re-deployed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deleting the default `KuadrantControlPlane` now cascade-deletes its managed components, excluding CRDs.
  * The default resource is recreated only after the operator restarts, rather than immediately during reconciliation.

* **Bug Fixes**
  * Updated operator permissions to support deleting managed cluster roles.

* **Documentation**
  * Clarified the default resource’s lifecycle, ownership and cascade-deletion behaviour across Kubernetes resource documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->