### PR TITLE
release: validate and expose mcp-gateway version

### DIFF
--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -28,6 +28,10 @@ on:
         description: Limitador Operator bundle version (semver)
         default: 0.0.0
         type: string
+      mcpGatewayVersion:
+        description: MCP Gateway version (semver)
+        default: 0.0.0
+        type: string
       wasmShimVersion:
         description: WASM Shim version (semver)
         default: 0.0.0
@@ -104,6 +108,7 @@ jobs:
           AUTHORINO_OPERATOR_VERSION=${{ github.event.inputs.authorinoOperatorVersion }} \
           DNS_OPERATOR_VERSION=${{ github.event.inputs.dnsOperatorVersion }} \
           LIMITADOR_OPERATOR_VERSION=${{ github.event.inputs.limitadorOperatorVersion }} \
+          MCP_GATEWAY_VERSION=${{ github.event.inputs.mcpGatewayVersion }} \
           CONSOLE_PLUGIN_VERSION=${{ github.event.inputs.consolePluginVersion }} \
           WASM_SHIM_VERSION=${{ github.event.inputs.wasmShimVersion }} \
           DEVELOPERPORTAL_VERSION=${{ github.event.inputs.developerPortalControllerVersion }} \
@@ -112,6 +117,7 @@ jobs:
             (.dependencies.authorino-operator = strenv(AUTHORINO_OPERATOR_VERSION)) |
             (.dependencies.dns-operator = strenv(DNS_OPERATOR_VERSION)) |
             (.dependencies.limitador-operator = strenv(LIMITADOR_OPERATOR_VERSION)) |
+            (.dependencies.mcp-gateway = strenv(MCP_GATEWAY_VERSION)) |
             (.dependencies.console-plugin = strenv(CONSOLE_PLUGIN_VERSION)) |
             (.dependencies.wasm-shim = strenv(WASM_SHIM_VERSION)) |
             (.dependencies.developer-portal-controller = strenv(DEVELOPERPORTAL_VERSION)) |
@@ -145,6 +151,7 @@ jobs:
             - Authorino Operator version ${{ github.event.inputs.authorinoOperatorVersion }}
             - DNS Operator version ${{ github.event.inputs.dnsOperatorVersion }}
             - Limitador Operator version ${{ github.event.inputs.limitadorOperatorVersion }}
+            - MCP Gateway version ${{ github.event.inputs.mcpGatewayVersion }}
             - Console Plugin version ${{ github.event.inputs.consolePluginVersion }}
             - WASM Shim version ${{ github.event.inputs.wasmShimVersion }}
             - Developer Portal Controller version ${{ github.event.inputs.developerPortalControllerVersion }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,6 +38,7 @@ A release follows two sequential PR phases:
    - `authorinoOperatorVersion`: Authorino Operator version (X.Y.Z)
    - `limitadorOperatorVersion`: Limitador Operator version (X.Y.Z)
    - `dnsOperatorVersion`: DNS Operator version (X.Y.Z)
+   - `mcpGatewayVersion`: MCP Gateway version (X.Y.Z)
    - `wasmShimVersion`: WASM Shim version (X.Y.Z)
    - `consolePluginVersion`: ConsolePlugin version (X.Y.Z)
    - `developerPortalControllerVersion`: Developer Portal Controller version (X.Y.Z)
@@ -142,6 +143,7 @@ dependencies:
   developer-portal-controller: "0.1.0"
   dns-operator: "0.12.0"
   limitador-operator: "0.12.1"
+  mcp-gateway: "0.9.0"
   wasm-shim: "0.8.1"
 ```
 
@@ -157,6 +159,7 @@ The `dependencies` section relates to the released versions of the subcomponents
    * [Authorino Operator](https://github.com/Kuadrant/authorino-operator/blob/main/RELEASE.md)
    * [Limitador Operator](https://github.com/Kuadrant/limitador-operator/blob/main/RELEASE.md)
    * [DNS Operator](https://github.com/Kuadrant/dns-operator/blob/main/docs/RELEASE.md)
+   * [MCP Gateway](https://github.com/Kuadrant/mcp-gateway)
    * [WASM Shim](https://github.com/Kuadrant/wasm-shim/)
    * [Console Plugin](https://github.com/Kuadrant/kuadrant-console-plugin)
    * [Developer Portal Controller](https://github.com/Kuadrant/developer-portal-controller/blob/main/RELEASE.md)

--- a/utils/release/github-release-changelog.sh
+++ b/utils/release/github-release-changelog.sh
@@ -29,7 +29,7 @@ EOF
 data=$(curl -L "https://api.github.com/repos/kuadrant/kuadrant-operator/releases/generate-notes" -X POST -H "Accept: apllication/vnd.github+json" -H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28" -d "$payload")
 
 release_body_data=$(echo $data | yq '.body')
-release_body="**This release enables installations of Authorino Operator v$AUTHORINO_OPERATOR_VERSION, Limitador Operator v$LIMITADOR_OPERATOR_VERSION, DNS Operator v$DNS_OPERATOR_VERSION, WASM Shim v$WASM_SHIM_VERSION, ConsolePlugin v$CONSOLEPLUGIN_VERSION and Developer Portal Controller v$DEVELOPERPORTAL_VERSION**$release_body_data"
+release_body="**This release enables installations of Authorino Operator v$AUTHORINO_OPERATOR_VERSION, Limitador Operator v$LIMITADOR_OPERATOR_VERSION, DNS Operator v$DNS_OPERATOR_VERSION, MCP Gateway v$MCP_GATEWAY_VERSION, WASM Shim v$WASM_SHIM_VERSION, ConsolePlugin v$CONSOLEPLUGIN_VERSION and Developer Portal Controller v$DEVELOPERPORTAL_VERSION**$release_body_data"
 
 if [[ $_log == "1" ]]; then
   log "releaseBody=$release_body"

--- a/utils/release/load_github_envvar.sh
+++ b/utils/release/load_github_envvar.sh
@@ -20,6 +20,7 @@ if [[ $_log == "1" ]]; then
   log "limitadorOperatorVersion=$LIMITADOR_OPERATOR_VERSION"
   log "authorinoOperatorVersion=$AUTHORINO_OPERATOR_VERSION"
   log "dnsOperatorVersion=$DNS_OPERATOR_VERSION"
+  log "mcpGatewayVersion=$MCP_GATEWAY_VERSION"
   log "developerPortalVersion=$DEVELOPERPORTAL_VERSION"
 fi
 
@@ -30,5 +31,6 @@ if [[ $dry_run == "0" ]]; then
   echo "limitadorOperatorVersion=$LIMITADOR_OPERATOR_VERSION" >> "$GITHUB_ENV"
   echo "authorinoOperatorVersion=$AUTHORINO_OPERATOR_VERSION" >> "$GITHUB_ENV"
   echo "dnsOperatorVersion=$DNS_OPERATOR_VERSION" >> "$GITHUB_ENV"
+  echo "mcpGatewayVersion=$MCP_GATEWAY_VERSION" >> "$GITHUB_ENV"
   echo "developerPortalVersion=$DEVELOPERPORTAL_VERSION" >> "$GITHUB_ENV"
 fi

--- a/utils/release/pre-validation/verify_dependencies.sh
+++ b/utils/release/pre-validation/verify_dependencies.sh
@@ -2,7 +2,7 @@
 
 echo "Verifying if the dependencies have been already released"
 file=$env/release.yaml
-dependencies=("authorino-operator" "console-plugin" "developer-portal-controller" "dns-operator" "limitador-operator" "wasm-shim")
+dependencies=("authorino-operator" "console-plugin" "developer-portal-controller" "dns-operator" "limitador-operator" "mcp-gateway" "wasm-shim")
 
 auth_header=""
 if [[ $GITHUB_TOKEN ]]; then

--- a/utils/release/pre-validation/verify_release_file.sh
+++ b/utils/release/pre-validation/verify_release_file.sh
@@ -26,6 +26,7 @@ check_field ".dependencies.console-plugin" "dependencies.console-plugin"
 check_field ".dependencies.developer-portal-controller" "dependencies.developer-portal-controller"
 check_field ".dependencies.dns-operator" "dependencies.dns-operator"
 check_field ".dependencies.limitador-operator" "dependencies.limitador-operator"
+check_field ".dependencies.mcp-gateway" "dependencies.mcp-gateway"
 check_field ".dependencies.wasm-shim" "dependencies.wasm-shim"
 
 exit $has_error


### PR DESCRIPTION
## Summary

`mcp-gateway` was already wired into `release.yaml`, `shared.sh`, and the `make_bundles`/`make_chart` release scripts, but the surrounding release automation was incomplete:

- Pre-release validation never required `dependencies.mcp-gateway` to be set (`verify_release_file.sh`), nor checked that the version had actually been released upstream (`verify_dependencies.sh`).
- The automated release workflow had no `mcpGatewayVersion` input at all, so there was no way to set it via that path.

This PR:
- Adds `mcp-gateway` to `verify_release_file.sh` and `verify_dependencies.sh`.
- Adds a `mcpGatewayVersion` input to `automated-release.yaml`, wired into the `release.yaml` update and the generated PR body.
- Surfaces the version in `load_github_envvar.sh` and the generated GitHub release notes (`github-release-changelog.sh`), and documents it in `RELEASE.md`, matching the existing pattern for every other dependency.

Note: mcp-gateway ships both a controller and broker image from a single repo/release (confirmed against upstream releases — one tag, one version bump per release), so a single `mcpGatewayVersion` correctly drives both `RELATED_IMAGE_MCP_GATEWAY` and `RELATED_IMAGE_MCP_GATEWAY_BROKER`.

## Test plan

- [x] `bash -n` on all modified shell scripts
- [x] `yq` validation of the modified YAML files
- [ ] Dry run of `make prepare-release` with `MCP_GATEWAY_VERSION` set, to confirm the bundle/chart pick up the version correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Release preparation now includes the MCP Gateway version alongside other component versions.
  * Release validation checks that the MCP Gateway dependency is specified and matches an available release.

* **Documentation**
  * Release documentation now lists MCP Gateway as a dependency, including its version configuration and repository reference.
  * Generated release notes now display the MCP Gateway version for improved release visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->