### PR TITLE
test: restore dev DNS provider config after KuadrantControlPlane deletion

### DIFF
--- a/tests/common/controlplane/controlplane_controller_test.go
+++ b/tests/common/controlplane/controlplane_controller_test.go
@@ -3,6 +3,8 @@
 package controlplane
 
 import (
+	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -14,15 +16,48 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	corev1apply "k8s.io/client-go/applyconfigurations/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 
 	kuadrantv1alpha1 "github.com/kuadrant/kuadrant-operator/api/v1alpha1"
 )
 
 const (
-	operatorNamespace     = "kuadrant-system"
-	dnsOperatorDeployment = "dns-operator-controller-manager"
+	operatorNamespace       = "kuadrant-system"
+	dnsOperatorDeployment   = "dns-operator-controller-manager"
+	dnsOperatorEnvConfigMap = "dns-operator-controller-env"
+	devSetupFieldOwner      = "dev-setup"
 )
+
+// devDNSOperatorConfigMapPath is the same file make local-env-setup applies
+// (see make/development-environments.mk's deploy-dependencies target) to
+// enable the "inmemory" DNS provider for local development and this test
+// suite. The dns-operator chart renders this ConfigMap with no "data" at
+// all, so normal reconciles never touch it -- but tests that delete the
+// KuadrantControlPlane cascade-delete it along with everything else it owns,
+// and the deployer's redeploy re-creates it blank. restoreDevEnvOverrides
+// (called from AfterEach) re-applies it so a destructive test here doesn't
+// silently break dnspolicy tests relying on the inmemory provider.
+var devDNSOperatorConfigMapPath = filepath.Join("..", "..", "..", "config", "dev", "dns-operator-configmap.yaml")
+
+func restoreDevEnvOverrides(ctx SpecContext) {
+	data, err := os.ReadFile(devDNSOperatorConfigMapPath)
+	Expect(err).ToNot(HaveOccurred())
+
+	want := &corev1.ConfigMap{}
+	Expect(yaml.Unmarshal(data, want)).To(Succeed())
+	want.Namespace = operatorNamespace
+
+	applyConfig := corev1apply.ConfigMap(want.Name, want.Namespace).WithData(want.Data)
+
+	Expect(testClient().Apply(ctx, applyConfig,
+		client.ForceOwnership, client.FieldOwner(devSetupFieldOwner))).To(Succeed())
+
+	got := &corev1.ConfigMap{}
+	Expect(testClient().Get(ctx, client.ObjectKey{Namespace: operatorNamespace, Name: want.Name}, got)).To(Succeed())
+	Expect(got.Data).To(Equal(want.Data))
+}
 
 // Serial: KuadrantControlPlane is a cluster-scoped singleton. Destructive tests
 // (deletion, drift) must not run in parallel with status or deployment tests.
@@ -37,6 +72,20 @@ var _ = Describe("KuadrantControlPlane controller", Serial, func() {
 		cp := &kuadrantv1alpha1.KuadrantControlPlane{}
 		err := testClient().Get(ctx, client.ObjectKey{Name: kuadrantv1alpha1.KuadrantControlPlaneDefaultName}, cp)
 		if apierrors.IsNotFound(err) {
+			// The same deletion that took out the CR cascade-deleted
+			// everything it owned, including dns-operator's env ConfigMap
+			// carrying the local-dev "inmemory" provider override. GC
+			// processes that cascade asynchronously, so wait for the old
+			// ConfigMap to actually be gone before restoring the override.
+			Eventually(func(g Gomega) {
+				cm := &corev1.ConfigMap{}
+				err := testClient().Get(ctx, client.ObjectKey{Namespace: operatorNamespace, Name: dnsOperatorEnvConfigMap}, cm)
+				g.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "expected dns-operator env ConfigMap to be cascade-deleted, got error: %v", err)
+			}).WithContext(ctx).Should(Succeed())
+
+			// Restore the override before recreating the CR.
+			restoreDevEnvOverrides(ctx)
+
 			cp = &kuadrantv1alpha1.KuadrantControlPlane{
 				ObjectMeta: metav1.ObjectMeta{Name: kuadrantv1alpha1.KuadrantControlPlaneDefaultName},
 			}


### PR DESCRIPTION
## Summary

Regression caused by #2236: deleting the `KuadrantControlPlane` now cascade-deletes every non-CRD resource it owns, including the `dns-operator-controller-env` ConfigMap. That ConfigMap carries `make local-env-setup`'s `inmemory` DNS provider override (the dns-operator chart itself renders it with no `data` at all, so normal reconciles never touch it — only a full delete+recreate cycle wipes it).

The `controlplane` integration suite has a test that deletes the KCP to verify the new cascade-delete behavior. Once it does, the ConfigMap comes back blank on redeploy, silently breaking any other integration suite in the same run (e.g. `dnspolicy`) that relies on the `inmemory` provider — causing flaky test runs.

## Fix

Extend the suite's existing `AfterEach` (which already restores the CR when a test deletes it) to also re-apply `config/dev/dns-operator-configmap.yaml` via the same `dev-setup` server-side-apply field manager used by `local-env-setup`, reading directly from that file so it can't drift from the Makefile's source of truth. This runs exactly when a test caused the KCP (and therefore the cascade) to be deleted.

## Test plan

- [x] `gofmt`, `go vet -tags integration`, `go build -tags integration ./tests/...`
- [x] `make test-integration` — confirm the `controlplane` suite no longer leaves the `inmemory` DNS provider missing for later suites


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved integration test reliability by waiting for asynchronously deleted DNS configuration to be fully removed before restoring the development configuration.
  - Reapplied the configuration before recreating control-plane resources, reducing test interference and making subsequent test runs more consistent and dependable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->