### PR TITLE
chore(deps): update mcp-gateway chart on main to d5f4c63

### DIFF
--- a/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
+++ b/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpserverregistrations.yaml
@@ -294,6 +294,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -580,6 +582,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: false
     storage: false

--- a/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpvirtualservers.yaml
+++ b/component-charts/mcp-gateway/crds/mcp.kuadrant.io_mcpvirtualservers.yaml
@@ -144,6 +144,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: true
     storage: true
@@ -280,6 +282,8 @@ spec:
                 - type
                 x-kubernetes-list-type: map
             type: object
+        required:
+        - spec
         type: object
     served: false
     storage: false

--- a/component-charts/mcp-gateway/templates/deployment-controller.yaml
+++ b/component-charts/mcp-gateway/templates/deployment-controller.yaml
@@ -18,8 +18,20 @@ spec:
         {{- include "mcp-gateway.controllerSelectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "mcp-gateway.controllerServiceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: mcp-controller
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           image: {{ include "mcp-controller.image" . }}
           imagePullPolicy: {{ .Values.imageController.pullPolicy }}
           command:

--- a/component-charts/mcp-gateway/templates/mcpgatewayextension.yaml
+++ b/component-charts/mcp-gateway/templates/mcpgatewayextension.yaml
@@ -18,7 +18,9 @@ spec:
   {{- if .Values.gateway.publicHost }}
   publicHost: {{ .Values.gateway.publicHost | quote }}
   {{- end }}
-  privateHost: {{ printf "%s-%s.%s.svc.cluster.local:%v" .Values.gateway.name .Values.gateway.gatewayClassName .Values.gateway.namespace .Values.gateway.port | quote }}
+  {{- with .Values.mcpGatewayExtension.privateHost }}
+  privateHost: {{ . | quote }}
+  {{- end }}
   {{- if .Values.broker.pollInterval }}
   backendPingIntervalSeconds: {{ .Values.broker.pollInterval }}
   {{- end }}

--- a/component-charts/mcp-gateway/templates/rbac.yaml
+++ b/component-charts/mcp-gateway/templates/rbac.yaml
@@ -37,6 +37,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - httproutes.gateway.networking.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
       - apps
     resources:
       - deployments

--- a/component-charts/mcp-gateway/templates/referencegrant.yaml
+++ b/component-charts/mcp-gateway/templates/referencegrant.yaml
@@ -1,9 +1,11 @@
 {{- if and .Values.mcpGatewayExtension.create .Values.mcpGatewayExtension.gatewayRef.namespace }}
 {{- if ne .Values.mcpGatewayExtension.gatewayRef.namespace .Release.Namespace }}
+{{- $grantKey := printf "%s/%s/%s" .Release.Name .Release.Namespace .Values.mcpGatewayExtension.gatewayRef.name }}
+{{- $grantHash := $grantKey | sha256sum | trunc 16 }}
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: allow-{{ .Values.mcpGatewayExtension.gatewayRef.name }}
+  name: {{ printf "allow-%s-%s" .Release.Namespace $grantHash }}
   namespace: {{ .Values.mcpGatewayExtension.gatewayRef.namespace }}
   labels:
     {{- include "mcp-gateway.labels" . | nindent 4 }}
@@ -15,5 +17,6 @@ spec:
   to:
     - group: gateway.networking.k8s.io
       kind: Gateway
+      name: {{ .Values.mcpGatewayExtension.gatewayRef.name }}
 {{- end }}
 {{- end }}

--- a/component-charts/mcp-gateway/values.yaml
+++ b/component-charts/mcp-gateway/values.yaml
@@ -83,6 +83,8 @@ mcpGatewayExtension:
     namespace: gateway-system
     # Name of the listener on the Gateway to target (required)
     sectionName: mcp
+  # Optional override for the controller-discovered internal Gateway host
+  privateHost: ""
   
   # advanced configuration fields
   

--- a/component-charts/sync.yaml
+++ b/component-charts/sync.yaml
@@ -32,5 +32,5 @@ components:
     repo: Kuadrant/mcp-gateway
     chart-path: charts/mcp-gateway
     tracked-branch: main
-    ref: caf684710a73979dc9704807ce33eeaebc293420
+    ref: d5f4c635160ca7bee863a2ee537ab32b54531da7
     auto-merge: false


### PR DESCRIPTION
Sync mcp-gateway chart from upstream into `main`.

**Component:** mcp-gateway
**Target branch:** `main`
**Previous ref:** `caf684710a73979dc9704807ce33eeaebc293420`
**New ref:** `d5f4c635160ca7bee863a2ee537ab32b54531da7`
**Triggered by:** @maleck13 (approved by @david-martin) via https://github.com/Kuadrant/mcp-gateway/pull/1479 (https://github.com/Kuadrant/mcp-gateway/commit/d5f4c635160ca7bee863a2ee537ab32b54531da7)

[Upstream changes](https://github.com/Kuadrant/mcp-gateway/compare/caf684710a73979dc9704807ce33eeaebc293420...d5f4c635160ca7bee863a2ee537ab32b54531da7)

Auto-generated by https://github.com/Kuadrant/kuadrant-operator/actions/runs/34499323372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional private host override for MCP Gateway extensions.
  - Improved ReferenceGrant targeting to apply only to the configured Gateway.
  - Added the permissions required to read HTTPRoute resource definitions.

- **Security**
  - Strengthened controller pod security by enforcing non-root execution, a read-only filesystem, restricted privilege escalation, dropped capabilities, and a default seccomp profile.

- **Validation**
  - MCP server registrations and virtual servers now require the top-level `spec` field across supported API versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->